### PR TITLE
fix: audit logger reports HTTPException status instead of 500

### DIFF
--- a/src/infrastructure/logger/AuditLogger.ts
+++ b/src/infrastructure/logger/AuditLogger.ts
@@ -1,4 +1,5 @@
 import type { MiddlewareHandler } from 'hono'
+import { HTTPException } from 'hono/http-exception'
 
 export interface AuditRecord {
   requestId: string
@@ -13,12 +14,15 @@ export function auditLogger(): MiddlewareHandler<{ Variables: { requestId: strin
   return async (c, next) => {
     const requestId = crypto.randomUUID()
     const started = Date.now()
+    let status = 200
     c.set('requestId', requestId)
     try {
       await next()
+      status = c.res.status
+    } catch (err) {
+      status = err instanceof HTTPException ? err.status : 500
+      throw err
     } finally {
-      const status = c.error ? 500 : (c.res?.status ?? 200)
-
       const record: AuditRecord = {
         requestId,
         timestamp: new Date().toISOString(),

--- a/test/infrastructure/logger/auditLogger.test.ts
+++ b/test/infrastructure/logger/auditLogger.test.ts
@@ -1,0 +1,61 @@
+import { Hono } from 'hono'
+import { HTTPException } from 'hono/http-exception'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { auditLogger } from '../../../src/infrastructure/logger/AuditLogger'
+
+describe('auditLogger', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('emits status 200 for a normal route', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const app = new Hono()
+    app.use('*', auditLogger())
+    app.get('/ok', (c) => c.json({ ok: true }))
+
+    const response = await app.request('/ok')
+
+    expect(response.status).toBe(200)
+    expect(JSON.parse(logSpy.mock.calls[0]?.[0] ?? '')).toMatchObject({ status: 200, path: '/ok', method: 'GET' })
+  })
+
+  it('emits status 400 for an HTTPException route', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const app = new Hono()
+    app.use('*', auditLogger())
+    app.onError((err, c) => {
+      if (err instanceof HTTPException) {
+        return err.getResponse()
+      }
+      return c.text('internal error', 500)
+    })
+    app.get('/bad-request', () => {
+      throw new HTTPException(400, { message: 'bad request' })
+    })
+
+    const response = await app.request('/bad-request')
+
+    expect(response.status).toBe(400)
+    expect(JSON.parse(logSpy.mock.calls[0]?.[0] ?? '')).toMatchObject({
+      status: 400,
+      path: '/bad-request',
+      method: 'GET',
+    })
+  })
+
+  it('emits status 500 for a generic error route', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const app = new Hono()
+    app.use('*', auditLogger())
+    app.onError((_err, c) => c.text('internal error', 500))
+    app.get('/boom', () => {
+      throw new Error('boom')
+    })
+
+    const response = await app.request('/boom')
+
+    expect(response.status).toBe(500)
+    expect(JSON.parse(logSpy.mock.calls[0]?.[0] ?? '')).toMatchObject({ status: 500, path: '/boom', method: 'GET' })
+  })
+})


### PR DESCRIPTION
> **Phase 1 carryover bug。** セキュリティ/correctness なので Phase 不問で採用 (`phase-scope` skill 準拠)。

## Problem

`src/infrastructure/logger/AuditLogger.ts` は現状:

```ts
const status = c.res.status || (c.error ? 500 : 200)
```

Hono の `basicAuth` や `HTTPException` 投擲時、finally 到達時点で `c.res` はまだエラーレスポンスに差し替わっていない (Hono の error handler は middleware unwind の後に動く)。結果:

- `/trade/*` without auth → 応答 401 / **audit log status 500**
- `/trade/decide` with empty symbol → 応答 400 / **audit log status 500**

監査ログが真の HTTP status を隠してしまう = observability 事故。

## Fix

try/catch で `HTTPException.status` を明示的に拾う:

```ts
let status = 200
try {
  await next()
  status = c.res.status
} catch (err) {
  status = err instanceof HTTPException ? err.status : 500
  throw err
} finally {
  // audit record with status
}
```

- 正常完了 → `c.res.status`
- `HTTPException(401 | 400 | ...)` → その status
- 一般 Error → 500
- finally で必ず audit 行出力、例外は常に再 throw (Hono の error pipeline 温存)

## Test

新規 `test/infrastructure/logger/auditLogger.test.ts`:
1. 200 正常
2. `throw new HTTPException(400)` → audit log status=400
3. `throw new Error('boom')` → audit log status=500

`vi.spyOn(console, 'log')` で audit line を捕まえて `toMatchObject` で検証。

## Test plan

- [x] `pnpm run typecheck` pass
- [x] `pnpm test` pass (10 files / 41 tests)

## Scope

- Only `src/infrastructure/logger/AuditLogger.ts` + new test
- 並列稼働の Track A (Phase 3) / Track C (bridge retry) と無衝突

Refs: Phase 1 scaffold PR #2 (bug origin)