### PR TITLE
Phase 5a: bridge postTradeEvent retry + timeout (issue #6 subset)

### DIFF
--- a/bridge/grpc/index.test.ts
+++ b/bridge/grpc/index.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest'
+import { postTradeEvent } from './index'
+
+const env = {
+  workerBaseUrl: 'https://worker.example.com',
+  ingestSecret: 'test-secret',
+}
+
+const payload = {
+  event: {
+    orderId: 'order-1',
+  },
+} as Parameters<typeof postTradeEvent>[1]
+
+describe('postTradeEvent', () => {
+  it('posts once on an immediate 200 response', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 200 }))
+
+    await postTradeEvent(env, payload, fetchImpl, {
+      backoffMs: 0,
+      jitter: 0,
+    })
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries once after a transient 500 before succeeding', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 500 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+
+    await postTradeEvent(env, payload, fetchImpl, {
+      backoffMs: 0,
+      jitter: 0,
+    })
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+  })
+
+  it('throws with the last status after exhausting retries', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(null, { status: 500 }))
+
+    await expect(
+      postTradeEvent(env, payload, fetchImpl, {
+        backoffMs: 0,
+        jitter: 0,
+      }),
+    ).rejects.toThrow(/status 500/)
+
+    expect(fetchImpl).toHaveBeenCalledTimes(3)
+  })
+})

--- a/bridge/grpc/index.ts
+++ b/bridge/grpc/index.ts
@@ -8,6 +8,29 @@ export interface BridgeRuntimeEnv {
   grpcEndpoint: string
 }
 
+interface PostTradeEventRetryOptions {
+  timeoutMs?: number
+  maxAttempts?: number
+  backoffMs?: number
+  multiplier?: number
+  jitter?: number
+}
+
+interface RetryDelayOptions {
+  attempt: number
+  backoffMs: number
+  multiplier: number
+  jitter: number
+}
+
+const DEFAULT_TIMEOUT_MS = 5_000
+const DEFAULT_MAX_ATTEMPTS = 3
+const DEFAULT_BACKOFF_MS = 200
+const DEFAULT_BACKOFF_MULTIPLIER = 2
+const DEFAULT_JITTER = 0.25
+
+class PermanentTradeEventIngestError extends Error {}
+
 export async function startTradeEventBridge(env: BridgeRuntimeEnv): Promise<void> {
   const client = createWebullGrpcTradeEventClient({ endpoint: env.grpcEndpoint })
 
@@ -25,20 +48,93 @@ export async function postTradeEvent(
   env: Pick<BridgeRuntimeEnv, 'workerBaseUrl' | 'ingestSecret'>,
   payload: TradeEventIngestRequest,
   fetchImpl: typeof fetch = fetch,
+  options: PostTradeEventRetryOptions = {},
 ): Promise<void> {
-  // TODO(phase-5/#6): add timeout and retry handling for transient ingest failures.
-  const response = await fetchImpl(new URL('/events/trade', env.workerBaseUrl), {
-    method: 'POST',
-    headers: {
-      'content-type': 'application/json',
-      [TRADE_EVENT_INGEST_SECRET_HEADER]: env.ingestSecret,
-    },
-    body: JSON.stringify(payload),
-  })
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  const maxAttempts = options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS
+  const backoffMs = options.backoffMs ?? DEFAULT_BACKOFF_MS
+  const multiplier = options.multiplier ?? DEFAULT_BACKOFF_MULTIPLIER
+  const jitter = options.jitter ?? DEFAULT_JITTER
 
-  if (!response.ok) {
-    throw new Error(`Trade event ingest failed with status ${response.status}`)
+  let lastFailure: Error | undefined
+  let lastStatus: number | undefined
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const controller = new AbortController()
+    const timeoutHandle = setTimeout(() => controller.abort(), timeoutMs)
+    let shouldRetry = false
+
+    try {
+      const response = await fetchImpl(new URL('/events/trade', env.workerBaseUrl), {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          [TRADE_EVENT_INGEST_SECRET_HEADER]: env.ingestSecret,
+        },
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+      })
+
+      if (response.ok) {
+        return
+      }
+
+      lastStatus = response.status
+      lastFailure = new Error(`Trade event ingest failed with status ${response.status}`)
+
+      if (response.status < 500) {
+        throw new PermanentTradeEventIngestError(
+          `Trade event ingest failed permanently with status ${response.status}`,
+        )
+      }
+
+      shouldRetry = true
+    } catch (error) {
+      const normalizedError = error instanceof Error ? error : new Error(String(error))
+      lastFailure = normalizedError
+
+      shouldRetry = isRetryableFetchError(normalizedError)
+      if (!shouldRetry) {
+        throw normalizedError
+      }
+    } finally {
+      clearTimeout(timeoutHandle)
+    }
+
+    if (shouldRetry && attempt < maxAttempts) {
+      const delayMs = getRetryDelayMs({ attempt, backoffMs, multiplier, jitter })
+      if (delayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, delayMs))
+      }
+    }
   }
+
+  if (lastStatus !== undefined) {
+    throw new Error(`Trade event ingest failed after ${maxAttempts} attempts with status ${lastStatus}`)
+  }
+
+  if (lastFailure) {
+    throw new Error(
+      `Trade event ingest failed after ${maxAttempts} attempts: ${lastFailure.message}`,
+    )
+  }
+
+  throw new Error(`Trade event ingest failed after ${maxAttempts} attempts`)
+}
+
+function isRetryableFetchError(error: Error): boolean {
+  return !(error instanceof PermanentTradeEventIngestError)
+}
+
+function getRetryDelayMs({
+  attempt,
+  backoffMs,
+  multiplier,
+  jitter,
+}: RetryDelayOptions): number {
+  const exponentialDelay = backoffMs * multiplier ** (attempt - 1)
+  const jitterFactor = jitter <= 0 ? 1 : 1 + (Math.random() * 2 - 1) * jitter
+  return Math.max(0, Math.round(exponentialDelay * jitterFactor))
 }
 
 if (import.meta.main) {

--- a/bridge/grpc/index.ts
+++ b/bridge/grpc/index.ts
@@ -56,6 +56,10 @@ export async function postTradeEvent(
   const multiplier = options.multiplier ?? DEFAULT_BACKOFF_MULTIPLIER
   const jitter = options.jitter ?? DEFAULT_JITTER
 
+  // Prepare URL and body before retry loop - these should fail fast if invalid
+  const url = new URL('/events/trade', env.workerBaseUrl)
+  const body = JSON.stringify(payload)
+
   let lastFailure: Error | undefined
   let lastStatus: number | undefined
 
@@ -65,13 +69,13 @@ export async function postTradeEvent(
     let shouldRetry = false
 
     try {
-      const response = await fetchImpl(new URL('/events/trade', env.workerBaseUrl), {
+      const response = await fetchImpl(url, {
         method: 'POST',
         headers: {
           'content-type': 'application/json',
           [TRADE_EVENT_INGEST_SECRET_HEADER]: env.ingestSecret,
         },
-        body: JSON.stringify(payload),
+        body,
         signal: controller.signal,
       })
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    include: ['test/**/*.test.ts'],
+    include: ['test/**/*.test.ts', 'bridge/**/*.test.ts'],
   },
 })


### PR DESCRIPTION
> **Phase 5 (#6) の bridge 側だけ先行。** Webull retry / symbol 別 config は Phase 3 merge 後に続ける。

## Summary

Phase 4 (#5, merged) で追加された `bridge/grpc/index.ts::postTradeEvent` は timeout / retry 無しだったので、Phase 5 scope の bridge 側だけ先行で対応。

### Changes

- `postTradeEvent` に `AbortController` ベースのタイムアウト (default **5000ms**)
- 同関数内にローカルな exponential backoff retry (max 3 attempts / base 200ms / multiplier 2 / jitter ±25%)
- **Retryable**: fetch reject / timeout (AbortError) / 5xx
- **Non-retryable**: 4xx (permanent)
- 枯渇時は last status / cause を含むエラー throw
- retry lib は導入しない (bridge deps 据え置き)

### Tests

`bridge/grpc/index.test.ts` 新規: (1) happy (1 call)、(2) 500→200 で 2 calls、(3) 500×3 で throw。

`vitest.config.ts` の include glob に `bridge/**/*.test.ts` を追加して、root `pnpm test` で bridge も検査される。

## Scope

### In scope
- `bridge/grpc/index.ts` のみ修正
- `bridge/grpc/index.test.ts` 新規
- `vitest.config.ts` glob 拡張

### Out of scope
- Webull 側 retry / timeout → Phase 3 (#4) merge 後に Phase 5 本編で
- symbol 別 config → Phase 5 本編
- audit log 構造化強化 → Phase 5 本編 ([PR #12](https://github.com/ochanuco/webull-trading/pull/12) の audit fix merge 後)

## Test plan

- [x] `pnpm run typecheck` pass
- [x] `pnpm test` pass (10 files / 41 tests)
- [x] `cd bridge && pnpm exec tsc --noEmit -p .` pass

Refs: #5 (Phase 4), #6 (Phase 5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * トレードイベント送信時の自動再試行機能を追加しました。一時的なネットワークエラー時に自動的に再接続を試みるようになります。

* **テスト**
  * 再試行機能と失敗処理の動作検証テストを追加しました。成功・リトライ・エラーハンドリングの各シナリオをカバーしています。

* **Chores**
  * テスト設定を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->