### PR TITLE
Phase 5: audit log errorClass / errorMessage (scrubbed)

### DIFF
--- a/src/infrastructure/logger/AuditLogger.ts
+++ b/src/infrastructure/logger/AuditLogger.ts
@@ -16,7 +16,7 @@ function scrubSecret(message: string): string {
   return message
     .replace(/bearer\s+\S+/gi, '[redacted]')
     .replace(/basic\s+\S+/gi, '[redacted]')
-    .replace(/sk_[A-Za-z0-9_-]{10,}/g, '[redacted]')
+    .replace(/sk[-_][A-Za-z0-9_-]{10,}/g, '[redacted]')
     .replace(/[A-Za-z0-9_-]{32,}/g, '[redacted]')
     .slice(0, 200)
 }

--- a/src/infrastructure/logger/AuditLogger.ts
+++ b/src/infrastructure/logger/AuditLogger.ts
@@ -8,6 +8,17 @@ export interface AuditRecord {
   path: string
   status: number
   durationMs: number
+  errorClass?: string
+  errorMessage?: string
+}
+
+function scrubSecret(message: string): string {
+  return message
+    .replace(/bearer\s+\S+/gi, '[redacted]')
+    .replace(/basic\s+\S+/gi, '[redacted]')
+    .replace(/sk_[A-Za-z0-9_-]{10,}/g, '[redacted]')
+    .replace(/[A-Za-z0-9_-]{32,}/g, '[redacted]')
+    .slice(0, 200)
 }
 
 export function auditLogger(): MiddlewareHandler<{ Variables: { requestId: string } }> {
@@ -15,12 +26,20 @@ export function auditLogger(): MiddlewareHandler<{ Variables: { requestId: strin
     const requestId = crypto.randomUUID()
     const started = Date.now()
     let status = 200
+    let errorClass: string | undefined
+    let errorMessage: string | undefined
     c.set('requestId', requestId)
     try {
       await next()
       status = c.res.status
     } catch (err) {
       status = err instanceof HTTPException ? err.status : 500
+      if (err instanceof Error) {
+        errorClass = err.constructor.name
+        errorMessage = scrubSecret(err.message.split('\n')[0]?.trim() ?? '')
+      } else {
+        errorClass = err?.constructor?.name ?? typeof err
+      }
       throw err
     } finally {
       const record: AuditRecord = {
@@ -30,6 +49,8 @@ export function auditLogger(): MiddlewareHandler<{ Variables: { requestId: strin
         path: new URL(c.req.url).pathname,
         status,
         durationMs: Date.now() - started,
+        errorClass,
+        errorMessage,
       }
       console.log(JSON.stringify(record))
     }

--- a/test/infrastructure/logger/auditLogger.test.ts
+++ b/test/infrastructure/logger/auditLogger.test.ts
@@ -117,4 +117,21 @@ describe('auditLogger', () => {
     expect(record.errorMessage).toContain('[redacted]')
     expect(record.errorMessage).not.toContain('sk-abcdef1234567890ABCDEF')
   })
+
+  it('redacts bare sk- / sk_ tokens without the bearer prefix', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const middleware = auditLogger()
+    const c = createMockContext()
+
+    await expect(
+      middleware(c as never, async () => {
+        throw new Error('token sk-dashed1234567890 and sk_undersc1234567890 leaked')
+      }),
+    ).rejects.toBeInstanceOf(Error)
+
+    const record = JSON.parse(logSpy.mock.calls[0]?.[0] ?? '')
+    expect(record.errorMessage).not.toContain('sk-dashed')
+    expect(record.errorMessage).not.toContain('sk_undersc')
+    expect(record.errorMessage).toContain('[redacted]')
+  })
 })

--- a/test/infrastructure/logger/auditLogger.test.ts
+++ b/test/infrastructure/logger/auditLogger.test.ts
@@ -3,6 +3,19 @@ import { HTTPException } from 'hono/http-exception'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { auditLogger } from '../../../src/infrastructure/logger/AuditLogger'
 
+function createMockContext() {
+  return {
+    req: {
+      method: 'GET',
+      url: 'http://localhost/test',
+    },
+    res: {
+      status: 200,
+    },
+    set: vi.fn(),
+  }
+}
+
 describe('auditLogger', () => {
   afterEach(() => {
     vi.restoreAllMocks()
@@ -50,12 +63,58 @@ describe('auditLogger', () => {
     app.use('*', auditLogger())
     app.onError((_err, c) => c.text('internal error', 500))
     app.get('/boom', () => {
-      throw new Error('boom')
+      throw new Error('bearer sk-abcdef1234567890ABCDEF failed')
     })
 
     const response = await app.request('/boom')
 
     expect(response.status).toBe(500)
     expect(JSON.parse(logSpy.mock.calls[0]?.[0] ?? '')).toMatchObject({ status: 500, path: '/boom', method: 'GET' })
+  })
+
+  it('omits error fields when next completes normally', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const middleware = auditLogger()
+    const c = createMockContext()
+
+    await middleware(c as never, async () => {})
+
+    const record = JSON.parse(logSpy.mock.calls[0]?.[0] ?? '')
+    expect(record).toMatchObject({ status: 200, path: '/test', method: 'GET' })
+    expect(record).not.toHaveProperty('errorClass')
+    expect(record).not.toHaveProperty('errorMessage')
+  })
+
+  it('emits scrubbed HTTPException details when next throws an HTTPException', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const middleware = auditLogger()
+    const c = createMockContext()
+
+    await expect(
+      middleware(c as never, async () => {
+        throw new HTTPException(400, { message: 'symbol must be a non-empty string' })
+      }),
+    ).rejects.toBeInstanceOf(HTTPException)
+
+    const record = JSON.parse(logSpy.mock.calls[0]?.[0] ?? '')
+    expect(record).toMatchObject({ status: 400, path: '/test', method: 'GET', errorClass: 'HTTPException' })
+    expect(record.errorMessage).toContain('symbol must')
+  })
+
+  it('redacts secrets from generic error messages when next throws', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const middleware = auditLogger()
+    const c = createMockContext()
+
+    await expect(
+      middleware(c as never, async () => {
+        throw new Error('bearer sk-abcdef1234567890ABCDEF failed')
+      }),
+    ).rejects.toBeInstanceOf(Error)
+
+    const record = JSON.parse(logSpy.mock.calls[0]?.[0] ?? '')
+    expect(record).toMatchObject({ status: 500, path: '/test', method: 'GET', errorClass: 'Error' })
+    expect(record.errorMessage).toContain('[redacted]')
+    expect(record.errorMessage).not.toContain('sk-abcdef1234567890ABCDEF')
   })
 })


### PR DESCRIPTION
> **Phase 5 (issue #6) の audit 構造化部分。** PR #12 で audit logger の status 誤記録を直したのに続き、error path の observability を追加。

## Changes

`AuditRecord` に populated-only な optional フィールド 2つ:

- `errorClass?: string` — catch 時に `err.constructor.name` をセット
- `errorMessage?: string` — `err.message` の先頭200文字 + secret-like トークンを `[redacted]` に置換

正常完了時は両フィールドとも undefined のまま → `JSON.stringify` の既定挙動で出力から落ちる (dead field にならない)。

Scrubber はモジュール内ローカル、以下をマスク:
- `bearer <token>` / `basic <token>`
- `sk_xxxxxxxxxx` 系
- 一般的な 32文字以上の連続英数字トークン

## Tests

`test/infrastructure/logger/auditLogger.test.ts` に追加:
1. 200 正常 → audit 行に `errorClass` / `errorMessage` キーが存在しない
2. `throw new HTTPException(400, {message: 'symbol must be...'})` → `errorClass: 'HTTPException'` + `errorMessage` に期待文字列
3. `throw new Error('bearer sk-abcdef1234567890ABCDEF failed')` → `errorClass: 'Error'` + `errorMessage` に `[redacted]` 含む / 生トークンは含まない

既存の 200/400/500 status テストは温存。

## Scope

- `src/infrastructure/logger/AuditLogger.ts` + 同 test のみ
- 並列 PR (5-webull / 5-risk) と無衝突

## Test plan

- [x] `pnpm run typecheck` pass
- [x] `pnpm test` pass (14 files / 56 tests)

Refs: #6 (Phase 5), #12 (audit logger status fix)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 監査ログにエラー種別とサニタイズされたエラーメッセージが記録されるようになりました（機密トークン等を自動で伏せ字化、出力長を制限）。

* **Tests**
  * エラー記録・機密情報の伏せ字処理を検証する包括的な単体テストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->