### PR TITLE
Phase 5: Webull retry + timeout (issue #6)

### DIFF
--- a/src/infrastructure/webull/WebullHttpClient.ts
+++ b/src/infrastructure/webull/WebullHttpClient.ts
@@ -57,6 +57,18 @@ export class WebullHttpClient {
     let lastFailure: Error | undefined
     let lastStatus: number | undefined
 
+    // Create auth headers once, outside retry loop - auth errors should fail immediately
+    let authHeaders: Record<string, string>
+    try {
+      authHeaders = await this.options.auth.createHeaders(method, path, payload)
+    } catch (error) {
+      throw new BrokerRequestError(
+        `Webull authentication failed: ${error instanceof Error ? error.message : String(error)}`,
+        `${method} ${path}`,
+        { cause: error instanceof Error ? error : undefined },
+      )
+    }
+
     for (let attempt = 1; attempt <= this.retry.maxAttempts; attempt += 1) {
       const controller = new AbortController()
       let timeoutId: ReturnType<typeof setTimeout> | undefined
@@ -66,7 +78,7 @@ export class WebullHttpClient {
         const headers = {
           Accept: 'application/json',
           ...(payload === undefined ? {} : { 'Content-Type': 'application/json' }),
-          ...(await this.options.auth.createHeaders(method, path, payload)),
+          ...authHeaders,
         }
 
         timeoutId = setTimeout(() => controller.abort(), this.timeoutMs)
@@ -80,6 +92,7 @@ export class WebullHttpClient {
       } catch (error) {
         const normalizedError = normalizeFetchError(error, this.timeoutMs)
         lastFailure = normalizedError ?? undefined
+        lastStatus = undefined // Clear stale status when no response is received
 
         if (normalizedError === null) {
           throw error

--- a/src/infrastructure/webull/WebullHttpClient.ts
+++ b/src/infrastructure/webull/WebullHttpClient.ts
@@ -1,4 +1,5 @@
 import type { OrderIntent } from '../../trading/domain/OrderIntent'
+import { BrokerRequestError } from '../../shared/errors'
 import type { WebullAccountDto, WebullPlaceOrderResponseDto } from './dto'
 import { toWebullPlaceOrderRequest } from './mapper'
 import { WebullAuth } from './WebullAuth'
@@ -10,10 +11,18 @@ export interface WebullClientEnv {
   WEBULL_API_BASE?: string
 }
 
+interface WebullRetryOptions {
+  maxAttempts?: number
+  baseDelayMs?: number
+  multiplier?: number
+  jitter?: number
+}
+
 interface WebullHttpClientOptions {
   auth: WebullAuth
   baseUrl?: string
   timeoutMs?: number
+  retry?: WebullRetryOptions
   fetchFn?: typeof fetch
 }
 
@@ -21,11 +30,18 @@ export class WebullHttpClient {
   private readonly baseUrl: string
   private readonly timeoutMs: number
   private readonly fetchFn: typeof fetch
+  private readonly retry: Required<WebullRetryOptions>
 
   constructor(private readonly options: WebullHttpClientOptions) {
     this.baseUrl = (options.baseUrl ?? 'https://openapi.webull.com').replace(/\/+$/, '')
     this.timeoutMs = options.timeoutMs ?? 5000
     this.fetchFn = options.fetchFn ?? fetch
+    this.retry = {
+      maxAttempts: options.retry?.maxAttempts ?? 3,
+      baseDelayMs: options.retry?.baseDelayMs ?? 200,
+      multiplier: options.retry?.multiplier ?? 2,
+      jitter: options.retry?.jitter ?? 0.25,
+    }
   }
 
   async getAccount(): Promise<WebullAccountDto> {
@@ -37,41 +53,109 @@ export class WebullHttpClient {
   }
 
   private async request<T>(method: 'GET' | 'POST', path: string, body?: unknown): Promise<T> {
-    const controller = new AbortController()
     const payload = body === undefined ? undefined : JSON.stringify(body)
-    const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs)
+    let lastFailure: Error | undefined
+    let lastStatus: number | undefined
 
-    try {
-      const response = await this.fetchFn(`${this.baseUrl}${path}`, {
-        method,
-        headers: {
-          Accept: 'application/json',
-          ...(payload === undefined ? {} : { 'Content-Type': 'application/json' }),
-          ...(await this.options.auth.createHeaders(method, path, payload)),
-        },
-        body: payload,
-        signal: controller.signal,
-      })
+    for (let attempt = 1; attempt <= this.retry.maxAttempts; attempt += 1) {
+      const controller = new AbortController()
+      const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs)
+      const headers = {
+        Accept: 'application/json',
+        ...(payload === undefined ? {} : { 'Content-Type': 'application/json' }),
+        ...(await this.options.auth.createHeaders(method, path, payload)),
+      }
+      let response: Response | undefined
 
-      if (!response.ok) {
-        throw new Error(`Webull request failed with status ${response.status}`)
+      try {
+        response = await this.fetchFn(`${this.baseUrl}${path}`, {
+          method,
+          headers,
+          body: payload,
+          signal: controller.signal,
+        })
+      } catch (error) {
+        const normalizedError = normalizeFetchError(error, this.timeoutMs)
+        lastFailure = normalizedError ?? undefined
+
+        if (normalizedError === null) {
+          throw error
+        }
+      } finally {
+        clearTimeout(timeoutId)
       }
 
-      return (await response.json()) as T
-    } catch (error) {
-      if (error instanceof Error && error.name === 'AbortError') {
-        throw new Error(`Webull request timed out after ${this.timeoutMs}ms`)
+      if (response === undefined) {
+        if (attempt < this.retry.maxAttempts) {
+          const delayMs = getRetryDelayMs({
+            attempt,
+            baseDelayMs: this.retry.baseDelayMs,
+            multiplier: this.retry.multiplier,
+            jitter: this.retry.jitter,
+          })
+          if (delayMs > 0) {
+            await wait(delayMs)
+          }
+          continue
+        }
+
+        break
       }
-      throw error
-    } finally {
-      clearTimeout(timeoutId)
+
+      if (response.ok) {
+        return (await response.json()) as T
+      }
+
+      lastStatus = response.status
+      lastFailure = new Error(`Webull request failed with status ${response.status}`)
+
+      if (response.status >= 400 && response.status < 500) {
+        throw new BrokerRequestError(
+          `Webull request failed permanently with status ${response.status}`,
+          `${method} ${path}`,
+          { cause: lastFailure },
+        )
+      }
+
+      if (attempt < this.retry.maxAttempts) {
+        const delayMs = getRetryDelayMs({
+          attempt,
+          baseDelayMs: this.retry.baseDelayMs,
+          multiplier: this.retry.multiplier,
+          jitter: this.retry.jitter,
+        })
+        if (delayMs > 0) {
+          await wait(delayMs)
+        }
+      }
     }
+
+    if (lastStatus !== undefined) {
+      throw new BrokerRequestError(
+        `Webull request failed after ${this.retry.maxAttempts} attempts with last status ${lastStatus}`,
+        `${method} ${path}`,
+        { cause: lastFailure },
+      )
+    }
+
+    if (lastFailure) {
+      throw new BrokerRequestError(
+        `Webull request failed after ${this.retry.maxAttempts} attempts: ${lastFailure.message}`,
+        `${method} ${path}`,
+        { cause: lastFailure },
+      )
+    }
+
+    throw new BrokerRequestError(
+      `Webull request failed after ${this.retry.maxAttempts} attempts`,
+      `${method} ${path}`,
+    )
   }
 }
 
 export function createWebullHttpClient(
   env: WebullClientEnv,
-  options?: { fetchFn?: typeof fetch; timeoutMs?: number },
+  options?: { fetchFn?: typeof fetch; timeoutMs?: number; retry?: WebullRetryOptions },
 ): WebullHttpClient {
   return new WebullHttpClient({
     auth: new WebullAuth({
@@ -81,6 +165,35 @@ export function createWebullHttpClient(
     }),
     baseUrl: env.WEBULL_API_BASE,
     timeoutMs: options?.timeoutMs,
+    retry: options?.retry,
     fetchFn: options?.fetchFn,
   })
+}
+
+function normalizeFetchError(error: unknown, timeoutMs: number): Error | null {
+  if (error instanceof Error && error.name === 'AbortError') {
+    return new Error(`Webull request timed out after ${timeoutMs}ms`)
+  }
+
+  return error instanceof Error ? error : null
+}
+
+function getRetryDelayMs({
+  attempt,
+  baseDelayMs,
+  multiplier,
+  jitter,
+}: {
+  attempt: number
+  baseDelayMs: number
+  multiplier: number
+  jitter: number
+}): number {
+  const exponentialDelay = baseDelayMs * multiplier ** (attempt - 1)
+  const jitterFactor = jitter <= 0 ? 1 : 1 + (Math.random() * 2 - 1) * jitter
+  return Math.max(0, Math.round(exponentialDelay * jitterFactor))
+}
+
+function wait(delayMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, delayMs))
 }

--- a/src/infrastructure/webull/WebullHttpClient.ts
+++ b/src/infrastructure/webull/WebullHttpClient.ts
@@ -59,15 +59,18 @@ export class WebullHttpClient {
 
     for (let attempt = 1; attempt <= this.retry.maxAttempts; attempt += 1) {
       const controller = new AbortController()
-      const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs)
-      const headers = {
-        Accept: 'application/json',
-        ...(payload === undefined ? {} : { 'Content-Type': 'application/json' }),
-        ...(await this.options.auth.createHeaders(method, path, payload)),
-      }
+      let timeoutId: ReturnType<typeof setTimeout> | undefined
       let response: Response | undefined
 
       try {
+        const headers = {
+          Accept: 'application/json',
+          ...(payload === undefined ? {} : { 'Content-Type': 'application/json' }),
+          ...(await this.options.auth.createHeaders(method, path, payload)),
+        }
+
+        timeoutId = setTimeout(() => controller.abort(), this.timeoutMs)
+
         response = await this.fetchFn(`${this.baseUrl}${path}`, {
           method,
           headers,
@@ -82,7 +85,9 @@ export class WebullHttpClient {
           throw error
         }
       } finally {
-        clearTimeout(timeoutId)
+        if (timeoutId !== undefined) {
+          clearTimeout(timeoutId)
+        }
       }
 
       if (response === undefined) {

--- a/test/infrastructure/webull/webullHttpClient.test.ts
+++ b/test/infrastructure/webull/webullHttpClient.test.ts
@@ -11,6 +11,25 @@ const intent: OrderIntent = {
   notional: 19,
 }
 
+function createClient(fetchFn: typeof fetch, timeoutMs?: number): WebullHttpClient {
+  return new WebullHttpClient({
+    auth: new WebullAuth({
+      appKey: 'app-key',
+      appSecret: 'app-secret',
+      accountId: 'acct-1',
+    }),
+    baseUrl: 'https://broker.example.test',
+    timeoutMs,
+    retry: {
+      maxAttempts: 3,
+      baseDelayMs: 0,
+      multiplier: 2,
+      jitter: 0,
+    },
+    fetchFn,
+  })
+}
+
 describe('WebullHttpClient', () => {
   it('places an order with the expected method, URL, body, and auth header', async () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
@@ -26,15 +45,7 @@ describe('WebullHttpClient', () => {
         { status: 200 },
       ),
     )
-    const client = new WebullHttpClient({
-      auth: new WebullAuth({
-        appKey: 'app-key',
-        appSecret: 'app-secret',
-        accountId: 'acct-1',
-      }),
-      baseUrl: 'https://broker.example.test',
-      fetchFn: fetchMock,
-    })
+    const client = createClient(fetchMock)
 
     await client.placeOrder(intent)
 
@@ -57,24 +68,79 @@ describe('WebullHttpClient', () => {
     expect((init?.headers as Record<string, string>).Authorization).toMatch(/^HMAC app-key:/)
   })
 
-  it('times out when fetch does not complete before the deadline', async () => {
-    const fetchMock = vi.fn<typeof fetch>((_url, init) => {
-      return new Promise<Response>((_resolve, reject) => {
-        init?.signal?.addEventListener('abort', () => {
-          reject(new DOMException('Aborted', 'AbortError'))
-        })
-      })
-    })
-    const client = new WebullHttpClient({
-      auth: new WebullAuth({
-        appKey: 'app-key',
-        appSecret: 'app-secret',
-        accountId: 'acct-1',
-      }),
-      timeoutMs: 20,
-      fetchFn: fetchMock,
-    })
+  it('retries a transient 500 response and succeeds on the next attempt', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response('server error', { status: 500 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            orderId: 'ord-123',
+            status: 'SUBMITTED',
+            symbol: 'SOXL',
+            side: 'BUY',
+            quantity: 2,
+            limitPrice: 9.5,
+          }),
+          { status: 200 },
+        ),
+      )
+    const client = createClient(fetchMock)
 
-    await expect(client.placeOrder(intent)).rejects.toThrow('Webull request timed out after 20ms')
+    await expect(client.placeOrder(intent)).resolves.toMatchObject({
+      orderId: 'ord-123',
+      status: 'SUBMITTED',
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('throws BrokerRequestError with the last status after exhausting retries on 500 responses', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response('server error', { status: 500 }))
+    const client = createClient(fetchMock)
+
+    await expect(client.placeOrder(intent)).rejects.toThrow(
+      'Webull request failed after 3 attempts with last status 500',
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('fails fast on 4xx responses without retrying', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response('bad request', { status: 400 }))
+    const client = createClient(fetchMock)
+
+    await expect(client.placeOrder(intent)).rejects.toThrow(
+      'Webull request failed permanently with status 400',
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries AbortError failures', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockRejectedValueOnce(new DOMException('Aborted', 'AbortError'))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            orderId: 'ord-456',
+            status: 'SUBMITTED',
+            symbol: 'SOXL',
+            side: 'BUY',
+            quantity: 2,
+            limitPrice: 9.5,
+          }),
+          { status: 200 },
+        ),
+      )
+    const client = createClient(fetchMock, 20)
+
+    await expect(client.placeOrder(intent)).resolves.toMatchObject({
+      orderId: 'ord-456',
+      status: 'SUBMITTED',
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 })


### PR DESCRIPTION
> **Phase 5 (issue #6) の Webull 側 retry 部分。** Bridge 側は PR #13 で先行済。今回は WebullHttpClient に同パターンを適用。

## Changes

### `src/infrastructure/webull/WebullHttpClient.ts`

- コンストラクタで `retry` / `timeoutMs` / `baseUrl` を受け取る options 方式に
- 既定: `maxAttempts=3`, `baseDelayMs=200`, `multiplier=2`, `jitter=0.25`, `timeoutMs=5000`
- **Retryable**: fetch rejection / AbortError (timeout) / 5xx
- **Non-retryable**: 4xx (permanent、即座に `BrokerRequestError`)
- 枯渇時は last status / cause を含む `BrokerRequestError` throw
- retry lib は導入しない (patternは bridge と同じ inline helper)

## Tests

`test/infrastructure/webull/webullHttpClient.test.ts` 拡張:
1. 500 → 200 (2 calls)
2. 3×500 → `BrokerRequestError` throw、last status メッセージ
3. 4xx → no retry (1 call)
4. AbortError (timeout) → retried

`baseDelayMs: 0`, `jitter: 0` で deterministic。

## Test plan

- [x] `pnpm run typecheck` pass
- [x] `pnpm test` pass (56 tests)

## Scope

### Out of scope
- symbol config / market hours → 並列 PR #17
- audit 構造化 → 並列 PR #16
- Bridge retry → PR #13 (merged)

## Known deviations

- codex は commit を 1本にまとめた (sandbox 制限で index rewrite が不安定だったため)。code と tests は同一の review 単位なので実質影響なし。

Refs: #6 (Phase 5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * クライアント生成時に再試行設定を追加し、リトライ挙動をカスタマイズ可能に。
  * 再試行時の指数バックオフ＋ジッターを導入。

* **不具合修正**
  * タイムアウト・中断・HTTPステータス別の扱いを改善。4xxは即時失敗、その他は再試行後に最終失敗情報を返す。

* **テスト**
  * 再試行の成功・失敗・中断挙動を検証するテストを追加・更新。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->