### PR TITLE
Phase 5: error taxonomy + app-level onError (issue #6)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono'
+import { HTTPException } from 'hono/http-exception'
 import type { Env } from './config/env'
 import { auditLogger } from './infrastructure/logger/AuditLogger'
 import { basicAuthMiddleware } from './middleware/basicAuth'
@@ -8,6 +9,7 @@ import { trade } from './routes/trade'
 import { events } from './routes/events'
 // Webull routes (Phase 2 append)
 import { webull } from './routes/webull'
+import { BrokerRequestError, TradingError, ValidationError } from './shared/errors'
 
 export type AppBindings = {
   Bindings: Env
@@ -34,6 +36,32 @@ export function createApp() {
   // Webull routes (Phase 2 append)
   app.use('/webull/*', basicAuthMiddleware())
   app.route('/webull', webull)
+  app.onError((err, c) => {
+    if (err instanceof BrokerRequestError) {
+      return c.json({ error: err.code, status: err.status }, err.status)
+    }
+
+    if (err instanceof ValidationError) {
+      return c.json(
+        {
+          error: err.code,
+          message: err.message,
+          ...(err.field ? { field: err.field } : {}),
+        },
+        err.status,
+      )
+    }
+
+    if (err instanceof TradingError) {
+      return c.json({ error: err.code, message: err.message }, err.status)
+    }
+
+    if (err instanceof HTTPException) {
+      return err.getResponse()
+    }
+
+    return c.json({ error: 'internal_error' }, 500)
+  })
   return app
 }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -10,10 +10,38 @@ import { events } from './routes/events'
 // Webull routes (Phase 2 append)
 import { webull } from './routes/webull'
 import { BrokerRequestError, TradingError, ValidationError } from './shared/errors'
+import type { ErrorHandler } from 'hono'
 
 export type AppBindings = {
   Bindings: Env
   Variables: { requestId: string }
+}
+
+export const errorHandler: ErrorHandler<AppBindings> = (err, c) => {
+  if (err instanceof BrokerRequestError) {
+    return c.json({ error: err.code, status: err.status }, err.status)
+  }
+
+  if (err instanceof ValidationError) {
+    return c.json(
+      {
+        error: err.code,
+        message: err.message,
+        ...(err.field ? { field: err.field } : {}),
+      },
+      err.status,
+    )
+  }
+
+  if (err instanceof TradingError) {
+    return c.json({ error: err.code, message: err.message }, err.status)
+  }
+
+  if (err instanceof HTTPException) {
+    return err.getResponse()
+  }
+
+  return c.json({ error: 'internal_error' }, 500)
 }
 
 export function createApp() {
@@ -36,32 +64,7 @@ export function createApp() {
   // Webull routes (Phase 2 append)
   app.use('/webull/*', basicAuthMiddleware())
   app.route('/webull', webull)
-  app.onError((err, c) => {
-    if (err instanceof BrokerRequestError) {
-      return c.json({ error: err.code, status: err.status }, err.status)
-    }
-
-    if (err instanceof ValidationError) {
-      return c.json(
-        {
-          error: err.code,
-          message: err.message,
-          ...(err.field ? { field: err.field } : {}),
-        },
-        err.status,
-      )
-    }
-
-    if (err instanceof TradingError) {
-      return c.json({ error: err.code, message: err.message }, err.status)
-    }
-
-    if (err instanceof HTTPException) {
-      return err.getResponse()
-    }
-
-    return c.json({ error: 'internal_error' }, 500)
-  })
+  app.onError(errorHandler)
   return app
 }
 

--- a/src/infrastructure/logger/AuditLogger.ts
+++ b/src/infrastructure/logger/AuditLogger.ts
@@ -1,5 +1,6 @@
 import type { MiddlewareHandler } from 'hono'
 import { HTTPException } from 'hono/http-exception'
+import { TradingError } from '../../shared/errors'
 
 export interface AuditRecord {
   requestId: string
@@ -33,7 +34,7 @@ export function auditLogger(): MiddlewareHandler<{ Variables: { requestId: strin
       await next()
       status = c.res.status
     } catch (err) {
-      status = err instanceof HTTPException ? err.status : 500
+      status = err instanceof TradingError ? err.status : err instanceof HTTPException ? err.status : 500
       if (err instanceof Error) {
         errorClass = err.constructor.name
         errorMessage = scrubSecret(err.message.split('\n')[0]?.trim() ?? '')

--- a/src/routes/events.ts
+++ b/src/routes/events.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import type { TradeEventIngestRequest } from '../infrastructure/webull/TradeEventBridge'
+import { ValidationError } from '../shared/errors'
 import { TradeEventService } from '../trading/application/TradeEventService'
 import { isTradeEventType, isTradeStatus, type TradeEvent } from '../trading/domain/TradeEvent'
 
@@ -9,7 +10,7 @@ export const events = new Hono().post('/trade', async (c) => {
   const payload = (await c.req.json().catch(() => null)) as unknown
 
   if (!isTradeEventIngestRequest(payload)) {
-    return c.json({ error: 'Bad Request' }, 400)
+    throw new ValidationError('event payload is invalid', { field: 'event' })
   }
 
   await tradeEventService.handle(payload.event)

--- a/src/routes/trade.ts
+++ b/src/routes/trade.ts
@@ -1,8 +1,8 @@
 import { Hono } from 'hono'
-import { HTTPException } from 'hono/http-exception'
 import type { AppBindings } from '../app'
 import { parseBooleanEnv, parseCsvEnv, parseNumberEnv, parseSymbolNotionalMap } from '../config/env'
 import { createWebullHttpClient, type WebullClientEnv } from '../infrastructure/webull/WebullHttpClient'
+import { ValidationError } from '../shared/errors'
 import { TradingService, type TradingConfig } from '../trading/application/TradingService'
 import { MockExecution } from '../trading/execution/MockExecution'
 import { WebullExecution } from '../trading/execution/WebullExecution'
@@ -36,7 +36,7 @@ async function parseTradeRequest(payload: Promise<unknown>): Promise<TradeReques
   const sellAbove = readFiniteNumber(body.sellAbove, 'sellAbove')
 
   if (buyBelow >= sellAbove) {
-    throw new HTTPException(400, { message: 'buyBelow must be less than sellAbove' })
+    throw new ValidationError('buyBelow must be less than sellAbove', { field: 'buyBelow' })
   }
 
   return {
@@ -101,7 +101,7 @@ function readSymbol(value: unknown): string {
   const symbol = readString(value).trim()
 
   if (symbol.length === 0) {
-    throw new HTTPException(400, { message: 'symbol must be a non-empty string' })
+    throw new ValidationError('symbol must be a non-empty string', { field: 'symbol' })
   }
 
   return symbol
@@ -112,7 +112,7 @@ function readPositiveNumber(value: unknown, field: 'price' | 'quantity'): number
     return value
   }
 
-  throw new HTTPException(400, { message: `${field} must be a finite number greater than 0` })
+  throw new ValidationError(`${field} must be a finite number greater than 0`, { field })
 }
 
 function readFiniteNumber(value: unknown, field: string): number {
@@ -120,5 +120,5 @@ function readFiniteNumber(value: unknown, field: string): number {
     return value
   }
 
-  throw new HTTPException(400, { message: `${field} must be a finite number` })
+  throw new ValidationError(`${field} must be a finite number`, { field })
 }

--- a/src/routes/webull.ts
+++ b/src/routes/webull.ts
@@ -1,9 +1,9 @@
 import { Hono } from 'hono'
-import { HTTPException } from 'hono/http-exception'
 import type { AppBindings } from '../app'
 import { parseBooleanEnv } from '../config/env'
 import { createWebullHttpClient } from '../infrastructure/webull/WebullHttpClient'
 import type { WebullPlaceOrderResponseDto } from '../infrastructure/webull/dto'
+import { ValidationError } from '../shared/errors'
 import type { OrderIntent, OrderSide } from '../trading/domain/OrderIntent'
 
 export const webull = new Hono<AppBindings>().post('/order/place', async (c) => {
@@ -55,7 +55,7 @@ function asRecord(value: unknown): Record<string, unknown> {
 
 function readSymbol(value: unknown): string {
   if (typeof value !== 'string' || value.trim().length === 0) {
-    throw new HTTPException(400, { message: 'symbol must be a non-empty string' })
+    throw new ValidationError('symbol must be a non-empty string', { field: 'symbol' })
   }
 
   return value.trim().toUpperCase()
@@ -66,7 +66,7 @@ function readSide(value: unknown): OrderSide {
     return value
   }
 
-  throw new HTTPException(400, { message: 'side must be BUY or SELL' })
+  throw new ValidationError('side must be BUY or SELL', { field: 'side' })
 }
 
 function readPositiveNumber(value: unknown, field: 'price' | 'quantity'): number {
@@ -74,5 +74,5 @@ function readPositiveNumber(value: unknown, field: 'price' | 'quantity'): number
     return value
   }
 
-  throw new HTTPException(400, { message: `${field} must be a finite number greater than 0` })
+  throw new ValidationError(`${field} must be a finite number greater than 0`, { field })
 }

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -1,4 +1,32 @@
-export class BrokerRequestError extends Error {
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
+
+export abstract class TradingError extends Error {
+  abstract readonly code: string
+  abstract readonly status: ContentfulStatusCode
+}
+
+export class ValidationError extends TradingError {
+  readonly code = 'validation_error'
+  readonly status = 400
+  override readonly cause?: unknown
+
+  constructor(
+    message: string,
+    readonly options?: { cause?: unknown; field?: string },
+  ) {
+    super(message)
+    this.name = 'ValidationError'
+    this.cause = options?.cause
+  }
+
+  get field(): string | undefined {
+    return this.options?.field
+  }
+}
+
+export class BrokerRequestError extends TradingError {
+  readonly code = 'broker_request_error'
+  readonly status = 502
   readonly broker = 'webull'
   override readonly cause?: unknown
 
@@ -12,3 +40,7 @@ export class BrokerRequestError extends Error {
     this.cause = options?.cause
   }
 }
+
+// Planned but deferred per issue #1 §13:
+// RiskRejectedError, BrokerResponseError, ConfigurationError,
+// TradeEventIngestError, BridgeConnectionError.

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import { Hono } from 'hono'
+import { HTTPException } from 'hono/http-exception'
+import { BrokerRequestError, TradingError, ValidationError } from '../src/shared/errors'
+
+describe('app-level onError', () => {
+  it('returns 500 for unknown errors', async () => {
+    const app = createErrorTestApp()
+    const response = await app.request('/boom')
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({ error: 'internal_error' })
+  })
+
+  it('returns 400 for ValidationError', async () => {
+    const app = createErrorTestApp()
+    const response = await app.request('/validation')
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: 'validation_error',
+      message: 'symbol must be a non-empty string',
+      field: 'symbol',
+    })
+  })
+})
+
+function createErrorTestApp() {
+  const app = new Hono()
+
+  app.get('/boom', () => {
+    throw new Error('unexpected')
+  })
+
+  app.get('/validation', () => {
+    throw new ValidationError('symbol must be a non-empty string', { field: 'symbol' })
+  })
+
+  app.get('/broker', () => {
+    throw new BrokerRequestError('Webull order placement failed', 'placeOrder')
+  })
+
+  app.onError((err, c) => {
+    if (err instanceof BrokerRequestError) {
+      return c.json({ error: err.code, status: err.status }, err.status)
+    }
+
+    if (err instanceof ValidationError) {
+      return c.json(
+        {
+          error: err.code,
+          message: err.message,
+          ...(err.field ? { field: err.field } : {}),
+        },
+        err.status,
+      )
+    }
+
+    if (err instanceof TradingError) {
+      return c.json({ error: err.code, message: err.message }, err.status)
+    }
+
+    if (err instanceof HTTPException) {
+      return err.getResponse()
+    }
+
+    return c.json({ error: 'internal_error' }, 500)
+  })
+
+  return app
+}

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { Hono } from 'hono'
 import { HTTPException } from 'hono/http-exception'
 import { BrokerRequestError, TradingError, ValidationError } from '../src/shared/errors'
+import { errorHandler, type AppBindings } from '../src/app'
 
 describe('app-level onError', () => {
   it('returns 500 for unknown errors', async () => {
@@ -26,7 +27,7 @@ describe('app-level onError', () => {
 })
 
 function createErrorTestApp() {
-  const app = new Hono()
+  const app = new Hono<AppBindings>()
 
   app.get('/boom', () => {
     throw new Error('unexpected')
@@ -40,32 +41,7 @@ function createErrorTestApp() {
     throw new BrokerRequestError('Webull order placement failed', 'placeOrder')
   })
 
-  app.onError((err, c) => {
-    if (err instanceof BrokerRequestError) {
-      return c.json({ error: err.code, status: err.status }, err.status)
-    }
-
-    if (err instanceof ValidationError) {
-      return c.json(
-        {
-          error: err.code,
-          message: err.message,
-          ...(err.field ? { field: err.field } : {}),
-        },
-        err.status,
-      )
-    }
-
-    if (err instanceof TradingError) {
-      return c.json({ error: err.code, message: err.message }, err.status)
-    }
-
-    if (err instanceof HTTPException) {
-      return err.getResponse()
-    }
-
-    return c.json({ error: 'internal_error' }, 500)
-  })
+  app.onError(errorHandler)
 
   return app
 }

--- a/test/routes/events.test.ts
+++ b/test/routes/events.test.ts
@@ -100,7 +100,11 @@ describe('POST /events/trade', () => {
     )
 
     expect(res.status).toBe(400)
-    await expect(res.json()).resolves.toEqual({ error: 'Bad Request' })
+    await expect(res.json()).resolves.toEqual({
+      error: 'validation_error',
+      message: 'event payload is invalid',
+      field: 'event',
+    })
   })
 
   it('returns 400 for a schema-invalid JSON body', async () => {
@@ -131,6 +135,10 @@ describe('POST /events/trade', () => {
     )
 
     expect(res.status).toBe(400)
-    await expect(res.json()).resolves.toEqual({ error: 'Bad Request' })
+    await expect(res.json()).resolves.toEqual({
+      error: 'validation_error',
+      message: 'event payload is invalid',
+      field: 'event',
+    })
   })
 })

--- a/test/routes/trade.test.ts
+++ b/test/routes/trade.test.ts
@@ -315,6 +315,10 @@ describe('trade routes', () => {
     )
 
     expect(response.status).toBe(400)
-    expect(await response.text()).toContain('symbol must be a non-empty string')
+    await expect(response.json()).resolves.toEqual({
+      error: 'validation_error',
+      message: 'symbol must be a non-empty string',
+      field: 'symbol',
+    })
   })
 })

--- a/test/shared/errors.test.ts
+++ b/test/shared/errors.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { BrokerRequestError, TradingError, ValidationError } from '../../src/shared/errors'
+
+describe('shared errors', () => {
+  it('ValidationError exposes trading error metadata', () => {
+    const error = new ValidationError('symbol must be a non-empty string', { field: 'symbol' })
+
+    expect(error).toBeInstanceOf(ValidationError)
+    expect(error).toBeInstanceOf(TradingError)
+    expect(error).toBeInstanceOf(Error)
+    expect(error).toMatchObject({
+      code: 'validation_error',
+      status: 400,
+      field: 'symbol',
+      message: 'symbol must be a non-empty string',
+    })
+  })
+
+  it('BrokerRequestError exposes trading error metadata', () => {
+    const cause = new Error('network down')
+    const error = new BrokerRequestError('Webull order placement failed', 'placeOrder', { cause })
+
+    expect(error).toBeInstanceOf(BrokerRequestError)
+    expect(error).toBeInstanceOf(TradingError)
+    expect(error).toBeInstanceOf(Error)
+    expect(error).toMatchObject({
+      code: 'broker_request_error',
+      status: 502,
+      operation: 'placeOrder',
+      cause,
+      message: 'Webull order placement failed',
+    })
+  })
+})


### PR DESCRIPTION
> **Phase 5 (issue #6) の error 分類部分。** Issue #1 §13 で列挙されたエラークラスのうち **本 PR で実際に使うものだけ** を追加。dead クラスは作らない。

## Changes

### `src/shared/errors.ts`
- 抽象基底 `TradingError extends Error` 追加 — `code: string` / `status: number` を強制
- `ValidationError extends TradingError` — `code='validation_error'`、`status=400`、`field?` オプション
- 既存 `BrokerRequestError` を `TradingError` 継承に書き換え — `code='broker_request_error'`、`status=502`
- ファイル末尾に **Issue #1 §13 の未実装クラス** をコメントとして列挙 (defer理由付き):
  - `RiskRejectedError` / `BrokerResponseError` / `ConfigurationError` / `TradeEventIngestError` / `BridgeConnectionError`
  - 必要になったら add する方針

### `src/app.ts` — 単一 `app.onError`
- `TradingError` → `c.json({ error: err.code, message?, field? }, err.status)`
  - `BrokerRequestError` は broker 由来の details leak 防止のため `message` を含めない
- `HTTPException` → Hono 既定 (`err.getResponse()`)
- それ以外 → 500 `{ error: 'internal_error' }`

### Route migration (HTTPException → ValidationError)
- `src/routes/trade.ts::parseTradeRequest` の 400 throw を `ValidationError` に置換 (`field` つき)
- `src/routes/webull.ts` の 400 throw も同様
- `src/routes/events.ts` は既存の `return c.json(..., 400)` (HTTPException ではなかった) を `throw new ValidationError(...)` に変更して、app レベルの整形統一に載せた (deviation: スコープでは "HTTPException 置換" としたが、events 側は既に return 方式だったため代替として一本化)

### auth 系の HTTPException は温存
- Hono の `basicAuth` が内部で `HTTPException(401)` を投げる部分は触らない (ミドルウェアの実装依存、Hono 既定レンダリングに任せる)

## Tests

- `test/shared/errors.test.ts` (新規): `ValidationError` / `BrokerRequestError` が `code` / `status` / instance chain を満たす
- `test/app.test.ts` (新規): 未知の Error → 500 `{error:'internal_error'}` / `ValidationError` → 400 `{error:'validation_error',...}`
- `test/routes/trade.test.ts` 更新: "empty symbol" の body shape を新形式 (`{error:'validation_error', message, field:'symbol'}`) で assert
- `test/routes/events.test.ts` も新 body 形式に合わせて更新

## Test plan

- [x] `pnpm run typecheck` pass
- [x] `pnpm test` pass (**16 files / 70 tests**)

## Scope

### Out of scope (deferred to future PRs)

| Class | 用途 |
|---|---|
| `RiskRejectedError` | Risk response は現状 200 + `allowed:false` で統一されており Error 化不要 |
| `BrokerResponseError` | Webull response の 2xx 非200 / malformed handling が必要になったら |
| `ConfigurationError` | env の parse-time failure 系が増えたら |
| `TradeEventIngestError` / `BridgeConnectionError` | bridge 経路のエラー分類が必要になったら |

## 並列 PR との関係

- [#18](https://github.com/ochanuco/webull-trading/pull/18) (Webull retry): `src/infrastructure/webull/WebullHttpClient.ts` のみ触るので無衝突。本 PR の `BrokerRequestError` extension とは instance shape を保っているため #18 側の throw 文は無変更で動く

Refs: #1 (design §13), #6 (Phase 5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * バリデーション失敗時にフィールド情報を含む構造化JSONで返すよう改善し、クライアントで原因が判別しやすく
  * 未知のエラーはHTTP 500の統一エラー応答に統一

* **新機能**
  * アプリケーション全体のエラーハンドリングを統一して一貫したHTTPステータスとJSONレスポンスを提供
  * 新しいエラー種別を導入して、エラーの種類とステータスを明示

* **テスト**
  * エラーハンドリング（検証エラー・外部ブローカーエラー・内部エラー）を検証する自動テストを追加

* **運用改善**
  * ログ収集でエラー種別に応じたHTTPステータスを正しく記録するよう改善
<!-- end of auto-generated comment: release notes by coderabbit.ai -->