### PR TITLE
ci: GitHub Actions for typecheck + test (subset of #24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: ci
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  worker:
+    name: worker (typecheck + test)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install worker deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm run typecheck
+
+      - name: Test (worker + bridge via vitest glob)
+        run: pnpm test
+
+  bridge:
+    name: bridge (typecheck)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: bridge
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: bridge/pnpm-lock.yaml
+
+      - name: Install bridge deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm exec tsc --noEmit -p .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/bridge/tsconfig.json
+++ b/bridge/tsconfig.json
@@ -16,5 +16,6 @@
     "allowImportingTsExtensions": false,
     "noEmit": true
   },
-  "include": ["./**/*.ts"]
+  "include": ["./**/*.ts"],
+  "exclude": ["./**/*.test.ts"]
 }


### PR DESCRIPTION
> **#24 (Production operational readiness) の CI 部分だけ先行。**

他の #24 項目 (secrets / deploy strategy / observability / rate limit / エラー taxonomy 追加) は続きの PR で分割対応予定。

## Changes

`.github/workflows/ci.yml` 新規:

### Worker job
- `pnpm install --frozen-lockfile`
- `pnpm run typecheck` (`tsc --noEmit`)
- `pnpm test` (vitest — bridge test も vitest glob 経由で含む)

### Bridge job
- `bridge/` を working-directory に、独自 lockfile で `pnpm install --frozen-lockfile`
- `pnpm exec tsc --noEmit -p .`

### 共通
- Node 24 pin (`.tool-versions` / mise と整合)
- `pnpm/action-setup@v4` が `package.json::packageManager` を読むので version 指定は重複させない
- `concurrency` で PR 毎の in-flight run を cancel、main push は温存

## Trigger
- `pull_request` to `main`
- `push` to `main` (merge 後の確認ラン)

## 運用メモ

- Branch protection で本 workflow を **required check** に指定すると PR マージ前に typecheck / test 強制化できる → GitHub 側 settings 変更なので本 PR には含めない。マージ後に owner が手動設定
- bridge の lockfile キャッシュキーを分離しているので worker/bridge 片方の deps 更新で cache miss が相手に波及しない

## Test plan

- [x] workflow YAML 構文 OK (ローカル確認)
- [ ] PR 作成時に本 workflow が GitHub で起動するのを確認
- [ ] 両 job が green

Refs: #24 (parent)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CIワークフローを追加しました。mainブランチへのプッシュおよびプルリクエスト時に自動で型チェックとテストが実行され、並列実行とキャンセル制御が改善されました。
  * TypeScript設定を更新し、テストファイルをコンパイル対象から除外してビルドおよび型チェックの対象を明確化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->