### PR TITLE
feat(ops): wrangler staging/production environments + secrets runbook (#24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,77 @@ cd bridge && pnpm install && pnpm exec tsc --noEmit -p .
 | `WEBULL_APP_KEY` / `WEBULL_APP_SECRET` / `WEBULL_ACCOUNT_ID` | — | Webull 認証 (placeholder signing) |
 | `WEBULL_API_BASE` | `https://openapi.webull.com` | Webull HTTP base |
 
+## Deploy / Secrets (Cloudflare Workers)
+
+`wrangler.jsonc` に **staging / production** 2つの environments を定義してある。既定環境 (env 指定なし) はローカル dev 用、デプロイは必ず `--env` 付きで。
+
+| env | worker name | 用途 |
+|---|---|---|
+| default (no `--env`) | `webull-trading` | `wrangler dev` ローカル実行専用 |
+| `staging` | `webull-trading-staging` | 検証環境 |
+| `production` | `webull-trading-production` | 本番 |
+
+### 初回セットアップ
+
+```bash
+# 1. Cloudflare へログイン (ブラウザが開く)
+pnpm exec wrangler login
+
+# 2. Worker を空で作成して secrets 枠を用意
+pnpm exec wrangler deploy --env staging
+pnpm exec wrangler deploy --env production
+```
+
+### Secrets 投入 (`wrangler secret put`)
+
+`.dev.vars` の内容は **本番/staging に自動同期しない**。環境ごとに明示的に投入する:
+
+```bash
+# staging
+pnpm exec wrangler secret put BASIC_AUTH_USER --env staging
+pnpm exec wrangler secret put BASIC_AUTH_PASSWORD --env staging
+pnpm exec wrangler secret put EVENT_INGEST_SECRET --env staging
+pnpm exec wrangler secret put ALLOWED_SYMBOLS --env staging
+pnpm exec wrangler secret put MAX_ORDER_NOTIONAL --env staging
+pnpm exec wrangler secret put SYMBOL_MAX_NOTIONAL --env staging
+# Phase 3 Webull
+pnpm exec wrangler secret put WEBULL_APP_KEY --env staging
+pnpm exec wrangler secret put WEBULL_APP_SECRET --env staging
+pnpm exec wrangler secret put WEBULL_ACCOUNT_ID --env staging
+
+# production (同じ set を production に)
+pnpm exec wrangler secret put BASIC_AUTH_USER --env production
+# ... 以下同様
+```
+
+`DRY_RUN` / `TRADING_ENABLED` / `MARKET_HOURS_CHECK` / `WEBULL_API_BASE` は env var (非 secret) なので `wrangler.jsonc` の `env.<target>.vars` に平文で書くか、同じく `wrangler secret put` で投入可。**本番で DRY_RUN=false / TRADING_ENABLED=true にする場合は、先に staging で十分疎通確認してから**。
+
+### デプロイ
+
+```bash
+pnpm exec wrangler deploy --env staging       # staging に反映
+pnpm exec wrangler deploy --env production    # production に反映
+```
+
+### Secrets のローテーション
+
+```bash
+pnpm exec wrangler secret put WEBULL_APP_SECRET --env production  # 上書き投入
+pnpm exec wrangler secret list --env production                   # 現在の secrets (値は出ない)
+pnpm exec wrangler secret delete WEBULL_APP_SECRET --env staging  # 削除
+```
+
+### 1Password 連携 (推奨、dotfile 手元運用)
+
+\\`~/.coderabbit` の OAuth トークンと同じく、発行した credential を 1Password に保管して `op read` で解決する流れが安全:
+
+```bash
+export CLOUDFLARE_API_TOKEN="$(op read 'op://Personal/CLOUDFLARE_API_TOKEN/credential')"
+pnpm exec wrangler deploy --env staging
+```
+
+GitHub Actions での自動デプロイは **別 PR 予定** (CI/CD 拡張時、follow-up [#24](https://github.com/ochanuco/webull-trading/issues/24))。本 PR は手動デプロイ前提の runbook のみ。
+
 ## AI エージェント / レビュー設定
 
 このリポジトリは AI (Claude Code / Codex / CodeRabbit) で作業することを前提に設定ファイルを整備している:

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ pnpm exec wrangler secret delete WEBULL_APP_SECRET --env staging  # 削除
 
 ### 1Password 連携 (推奨、dotfile 手元運用)
 
-\\`~/.coderabbit` の OAuth トークンと同じく、発行した credential を 1Password に保管して `op read` で解決する流れが安全:
+`~/.coderabbit` の OAuth トークンと同じく、発行した credential を 1Password に保管して `op read` で解決する流れが安全:
 
 ```bash
 export CLOUDFLARE_API_TOKEN="$(op read 'op://Personal/CLOUDFLARE_API_TOKEN/credential')"

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -5,5 +5,13 @@
   "compatibility_date": "2025-10-01",
   "observability": {
     "enabled": true
+  },
+  "env": {
+    "staging": {
+      "name": "webull-trading-staging"
+    },
+    "production": {
+      "name": "webull-trading-production"
+    }
   }
 }


### PR DESCRIPTION
> **#24 (Production operational readiness) の次のサブ。** 前 PR #26 で CI を入れたので、次はデプロイターゲットを切る。

## Changes

### `wrangler.jsonc`
2つの environments を追加:

```jsonc
"env": {
  "staging":    { "name": "webull-trading-staging" },
  "production": { "name": "webull-trading-production" }
}
```

`wrangler deploy --dry-run --env staging` / `--env production` が通ることを確認 (bundle サイズは 94.48 KiB / gzip 23.05 KiB、default 環境と同一)。default env (no `--env`) は `wrangler dev` ローカル実行用に残す。

### `README.md` — **Deploy / Secrets** セクション追加
- env 3種の worker name 対応表
- 初回セットアップ (`wrangler login` → 空デプロイ)
- `wrangler secret put` コマンド例 (全 sensitive env var を env ごとに手動投入)
- デプロイ / ローテーション / list / delete
- 1Password の `op read` で `CLOUDFLARE_API_TOKEN` を渡すパターン (既存の coderabbit と同じ流儀)

### 意図的に含めないもの
- GitHub Actions auto-deploy — **別 PR 予定**。`CLOUDFLARE_API_TOKEN` の GitHub Secret 登録が前提なので、repo owner の設定作業と抱き合わせになる
- `DRY_RUN` / `TRADING_ENABLED` 等の **非** secret env を wrangler.jsonc の `env.<target>.vars` に平文で書く対応 — 初期値をどう置くか (staging は DRY_RUN=true 固定? それとも secret 経由?) の意思決定が要るので後続で

## Test plan
- [x] `pnpm exec wrangler deploy --dry-run` (default)
- [x] `pnpm exec wrangler deploy --dry-run --env staging`
- [x] `pnpm exec wrangler deploy --dry-run --env production`
- [ ] README の secret 手順を 1 passes 実際に実行して動作確認 (実口座アカウント必要)

Refs: #24 (parent), #26 (previous CI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * Cloudflare Workersのデプロイ手順を追記：Wranglerの初回セットアップ、ローカルdevとステージング／本番向けの環境定義、環境別のデプロイコマンドを追加。
  * 秘密管理とローテーション手順（wrangler secret put/list/delete）および1Passwordを使ったAPIトークン供給ワークフローを記載。
  * GitHub Actionsによる自動デプロイは別PRで対応する旨を明記。

* **その他**
  * wrangler.jsoncにステージング／本番のenv設定を追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->