### PR TITLE
feat(ops): move non-secret config to wrangler.jsonc env.vars (#24)

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,9 +1,13 @@
 # Local dev secrets for `wrangler dev`. Copy to `.dev.vars` and fill in.
-# Non-secret config (DRY_RUN / TRADING_ENABLED / ALLOWED_SYMBOLS / MAX_ORDER_NOTIONAL
-# / SYMBOL_MAX_NOTIONAL / MARKET_HOURS_CHECK / WEBULL_API_BASE) now lives in
-# wrangler.jsonc::env.<target>.vars and is loaded automatically by `wrangler dev`
-# from the default env (the "webull-trading" worker). Override any of them by
-# uncommenting below.
+#
+# Split:
+# - Operational flags (not sensitive): DRY_RUN / TRADING_ENABLED / MARKET_HOURS_CHECK
+#   → live in wrangler.jsonc::vars and wrangler.jsonc::env.<target>.vars.
+#   Override locally by uncommenting the block at the bottom.
+# - Sensitive (personal strategy / credentials / non-public endpoint):
+#   ALLOWED_SYMBOLS / MAX_ORDER_NOTIONAL / SYMBOL_MAX_NOTIONAL /
+#   WEBULL_API_BASE / BASIC_AUTH_* / EVENT_INGEST_SECRET / WEBULL_APP_* / WEBULL_ACCOUNT_ID
+#   → set below for local dev, use `wrangler secret put` for deployed envs.
 
 BASIC_AUTH_USER=<your-username>
 BASIC_AUTH_PASSWORD=<your-password>
@@ -11,12 +15,12 @@ EVENT_INGEST_SECRET=change-me
 WEBULL_APP_KEY=
 WEBULL_APP_SECRET=
 WEBULL_ACCOUNT_ID=
+WEBULL_API_BASE=https://openapi.webull.com
+ALLOWED_SYMBOLS=SOXL,SOXS
+MAX_ORDER_NOTIONAL=100
+SYMBOL_MAX_NOTIONAL={"SOXL":200,"SOXS":150}
 
-# Local overrides (optional — leave commented to use wrangler.jsonc defaults):
+# Local overrides for operational flags (optional):
 # DRY_RUN=true
 # TRADING_ENABLED=false
-# ALLOWED_SYMBOLS=SOXL,SOXS
-# MAX_ORDER_NOTIONAL=100
-# SYMBOL_MAX_NOTIONAL={"SOXL":200,"SOXS":150}
 # MARKET_HOURS_CHECK=false
-# WEBULL_API_BASE=https://openapi.webull.com

--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,13 +1,22 @@
+# Local dev secrets for `wrangler dev`. Copy to `.dev.vars` and fill in.
+# Non-secret config (DRY_RUN / TRADING_ENABLED / ALLOWED_SYMBOLS / MAX_ORDER_NOTIONAL
+# / SYMBOL_MAX_NOTIONAL / MARKET_HOURS_CHECK / WEBULL_API_BASE) now lives in
+# wrangler.jsonc::env.<target>.vars and is loaded automatically by `wrangler dev`
+# from the default env (the "webull-trading" worker). Override any of them by
+# uncommenting below.
+
 BASIC_AUTH_USER=<your-username>
 BASIC_AUTH_PASSWORD=<your-password>
-DRY_RUN=true
-TRADING_ENABLED=false
-ALLOWED_SYMBOLS=SOXL,SOXS
-MAX_ORDER_NOTIONAL=100
 EVENT_INGEST_SECRET=change-me
 WEBULL_APP_KEY=
 WEBULL_APP_SECRET=
 WEBULL_ACCOUNT_ID=
-WEBULL_API_BASE=https://openapi.webull.com
-SYMBOL_MAX_NOTIONAL={"SOXL":200,"SOXS":150}
-MARKET_HOURS_CHECK=false
+
+# Local overrides (optional — leave commented to use wrangler.jsonc defaults):
+# DRY_RUN=true
+# TRADING_ENABLED=false
+# ALLOWED_SYMBOLS=SOXL,SOXS
+# MAX_ORDER_NOTIONAL=100
+# SYMBOL_MAX_NOTIONAL={"SOXL":200,"SOXS":150}
+# MARKET_HOURS_CHECK=false
+# WEBULL_API_BASE=https://openapi.webull.com

--- a/README.md
+++ b/README.md
@@ -117,16 +117,25 @@ pnpm exec wrangler deploy --env production
 - `MAX_ORDER_NOTIONAL` — 1注文上限 (個人の資金規模)
 - `SYMBOL_MAX_NOTIONAL` — symbol 別上限 (同上)
 
+`wrangler secret put` は対話プロンプトで値を入力する。**1 件ずつ実行して、入力値と対象 env を都度目視確認する** ことを推奨 (ループ化すると誤 env 投入のリスクが高い)。
+
 ```bash
 # staging
-for key in BASIC_AUTH_USER BASIC_AUTH_PASSWORD EVENT_INGEST_SECRET \
-           WEBULL_APP_KEY WEBULL_APP_SECRET WEBULL_ACCOUNT_ID WEBULL_API_BASE \
-           ALLOWED_SYMBOLS MAX_ORDER_NOTIONAL SYMBOL_MAX_NOTIONAL; do
-  pnpm exec wrangler secret put "$key" --env staging
-done
+pnpm exec wrangler secret put BASIC_AUTH_USER --env staging
+pnpm exec wrangler secret put BASIC_AUTH_PASSWORD --env staging
+pnpm exec wrangler secret put EVENT_INGEST_SECRET --env staging
+pnpm exec wrangler secret put WEBULL_APP_KEY --env staging
+pnpm exec wrangler secret put WEBULL_APP_SECRET --env staging
+pnpm exec wrangler secret put WEBULL_ACCOUNT_ID --env staging
+pnpm exec wrangler secret put WEBULL_API_BASE --env staging
+pnpm exec wrangler secret put ALLOWED_SYMBOLS --env staging
+pnpm exec wrangler secret put MAX_ORDER_NOTIONAL --env staging
+pnpm exec wrangler secret put SYMBOL_MAX_NOTIONAL --env staging
 
-# production も同じ set
+# production は --env production で同じ 10 件
 ```
+
+投入後に `pnpm exec wrangler secret list --env staging` で 10 件揃ったことを確認。
 
 `wrangler secret put` は同名 var を上書きするので、一時的に `DRY_RUN` などを var と違う値にしたい場合のエスケープハッチにも使える (通常は wrangler.jsonc 編集が望ましい)。
 

--- a/README.md
+++ b/README.md
@@ -99,29 +99,29 @@ pnpm exec wrangler deploy --env staging
 pnpm exec wrangler deploy --env production
 ```
 
+### 非 secret 設定 (`wrangler.jsonc::env.<target>.vars`)
+
+`DRY_RUN` / `TRADING_ENABLED` / `ALLOWED_SYMBOLS` / `MAX_ORDER_NOTIONAL` / `SYMBOL_MAX_NOTIONAL` / `MARKET_HOURS_CHECK` / `WEBULL_API_BASE` は `wrangler.jsonc` に env ごとに記述済。変更は **ファイルを編集して再デプロイ** (git で差分が残る = 監査トレイル)。
+
+**fail-closed 前提で両 env とも初期値は `DRY_RUN=true` / `TRADING_ENABLED=false`。** 本番で LIVE 発注に切り替える時は wrangler.jsonc の `env.production.vars` を編集してコミット + `wrangler deploy --env production`。staging で十分疎通確認してから本番を触る。
+
 ### Secrets 投入 (`wrangler secret put`)
 
-`.dev.vars` の内容は **本番/staging に自動同期しない**。環境ごとに明示的に投入する:
+以下の **秘匿値のみ** secret として環境ごとに投入:
 
 ```bash
 # staging
 pnpm exec wrangler secret put BASIC_AUTH_USER --env staging
 pnpm exec wrangler secret put BASIC_AUTH_PASSWORD --env staging
 pnpm exec wrangler secret put EVENT_INGEST_SECRET --env staging
-pnpm exec wrangler secret put ALLOWED_SYMBOLS --env staging
-pnpm exec wrangler secret put MAX_ORDER_NOTIONAL --env staging
-pnpm exec wrangler secret put SYMBOL_MAX_NOTIONAL --env staging
-# Phase 3 Webull
 pnpm exec wrangler secret put WEBULL_APP_KEY --env staging
 pnpm exec wrangler secret put WEBULL_APP_SECRET --env staging
 pnpm exec wrangler secret put WEBULL_ACCOUNT_ID --env staging
 
-# production (同じ set を production に)
-pnpm exec wrangler secret put BASIC_AUTH_USER --env production
-# ... 以下同様
+# production も同じ set
 ```
 
-`DRY_RUN` / `TRADING_ENABLED` / `MARKET_HOURS_CHECK` / `WEBULL_API_BASE` は env var (非 secret) なので `wrangler.jsonc` の `env.<target>.vars` に平文で書くか、同じく `wrangler secret put` で投入可。**本番で DRY_RUN=false / TRADING_ENABLED=true にする場合は、先に staging で十分疎通確認してから**。
+`wrangler secret put` は同名 var を上書きするので、どうしても一時的に DRY_RUN などを var と違う値にしたい場合のエスケープハッチにも使える (通常は wrangler.jsonc 編集が望ましい)。
 
 ### デプロイ
 

--- a/README.md
+++ b/README.md
@@ -99,29 +99,36 @@ pnpm exec wrangler deploy --env staging
 pnpm exec wrangler deploy --env production
 ```
 
-### 非 secret 設定 (`wrangler.jsonc::env.<target>.vars`)
+### 運用フラグ (`wrangler.jsonc::env.<target>.vars`)
 
-`DRY_RUN` / `TRADING_ENABLED` / `ALLOWED_SYMBOLS` / `MAX_ORDER_NOTIONAL` / `SYMBOL_MAX_NOTIONAL` / `MARKET_HOURS_CHECK` / `WEBULL_API_BASE` は `wrangler.jsonc` に env ごとに記述済。変更は **ファイルを編集して再デプロイ** (git で差分が残る = 監査トレイル)。
+`DRY_RUN` / `TRADING_ENABLED` / `MARKET_HOURS_CHECK` の 3つは純粋な運用フラグとして wrangler.jsonc に env ごと記述済。変更は **ファイルを編集して再デプロイ** (git 差分 = 監査トレイル)。
 
 **fail-closed 前提で両 env とも初期値は `DRY_RUN=true` / `TRADING_ENABLED=false`。** 本番で LIVE 発注に切り替える時は wrangler.jsonc の `env.production.vars` を編集してコミット + `wrangler deploy --env production`。staging で十分疎通確認してから本番を触る。
 
 ### Secrets 投入 (`wrangler secret put`)
 
-以下の **秘匿値のみ** secret として環境ごとに投入:
+以下は個人戦略・認証情報・非公開 endpoint を含むので全て secret 扱い:
+
+- `BASIC_AUTH_USER` / `BASIC_AUTH_PASSWORD` — 管理 API の認証
+- `EVENT_INGEST_SECRET` — `/events/trade` の secret header
+- `WEBULL_APP_KEY` / `WEBULL_APP_SECRET` / `WEBULL_ACCOUNT_ID` — broker 認証
+- `WEBULL_API_BASE` — sandbox URL が非公開のため
+- `ALLOWED_SYMBOLS` — 取引対象銘柄 (個人戦略)
+- `MAX_ORDER_NOTIONAL` — 1注文上限 (個人の資金規模)
+- `SYMBOL_MAX_NOTIONAL` — symbol 別上限 (同上)
 
 ```bash
 # staging
-pnpm exec wrangler secret put BASIC_AUTH_USER --env staging
-pnpm exec wrangler secret put BASIC_AUTH_PASSWORD --env staging
-pnpm exec wrangler secret put EVENT_INGEST_SECRET --env staging
-pnpm exec wrangler secret put WEBULL_APP_KEY --env staging
-pnpm exec wrangler secret put WEBULL_APP_SECRET --env staging
-pnpm exec wrangler secret put WEBULL_ACCOUNT_ID --env staging
+for key in BASIC_AUTH_USER BASIC_AUTH_PASSWORD EVENT_INGEST_SECRET \
+           WEBULL_APP_KEY WEBULL_APP_SECRET WEBULL_ACCOUNT_ID WEBULL_API_BASE \
+           ALLOWED_SYMBOLS MAX_ORDER_NOTIONAL SYMBOL_MAX_NOTIONAL; do
+  pnpm exec wrangler secret put "$key" --env staging
+done
 
 # production も同じ set
 ```
 
-`wrangler secret put` は同名 var を上書きするので、どうしても一時的に DRY_RUN などを var と違う値にしたい場合のエスケープハッチにも使える (通常は wrangler.jsonc 編集が望ましい)。
+`wrangler secret put` は同名 var を上書きするので、一時的に `DRY_RUN` などを var と違う値にしたい場合のエスケープハッチにも使える (通常は wrangler.jsonc 編集が望ましい)。
 
 ### デプロイ
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -6,12 +6,39 @@
   "observability": {
     "enabled": true
   },
+  "vars": {
+    "DRY_RUN": "true",
+    "TRADING_ENABLED": "false",
+    "ALLOWED_SYMBOLS": "SOXL,SOXS",
+    "MAX_ORDER_NOTIONAL": "100",
+    "SYMBOL_MAX_NOTIONAL": "{\"SOXL\":200,\"SOXS\":150}",
+    "MARKET_HOURS_CHECK": "false",
+    "WEBULL_API_BASE": "https://openapi.webull.com"
+  },
   "env": {
     "staging": {
-      "name": "webull-trading-staging"
+      "name": "webull-trading-staging",
+      "vars": {
+        "DRY_RUN": "true",
+        "TRADING_ENABLED": "false",
+        "ALLOWED_SYMBOLS": "SOXL,SOXS",
+        "MAX_ORDER_NOTIONAL": "100",
+        "SYMBOL_MAX_NOTIONAL": "{\"SOXL\":200,\"SOXS\":150}",
+        "MARKET_HOURS_CHECK": "false",
+        "WEBULL_API_BASE": "https://openapi.webull.com"
+      }
     },
     "production": {
-      "name": "webull-trading-production"
+      "name": "webull-trading-production",
+      "vars": {
+        "DRY_RUN": "true",
+        "TRADING_ENABLED": "false",
+        "ALLOWED_SYMBOLS": "SOXL,SOXS",
+        "MAX_ORDER_NOTIONAL": "100",
+        "SYMBOL_MAX_NOTIONAL": "{\"SOXL\":200,\"SOXS\":150}",
+        "MARKET_HOURS_CHECK": "false",
+        "WEBULL_API_BASE": "https://openapi.webull.com"
+      }
     }
   }
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -9,11 +9,7 @@
   "vars": {
     "DRY_RUN": "true",
     "TRADING_ENABLED": "false",
-    "ALLOWED_SYMBOLS": "SOXL,SOXS",
-    "MAX_ORDER_NOTIONAL": "100",
-    "SYMBOL_MAX_NOTIONAL": "{\"SOXL\":200,\"SOXS\":150}",
-    "MARKET_HOURS_CHECK": "false",
-    "WEBULL_API_BASE": "https://openapi.webull.com"
+    "MARKET_HOURS_CHECK": "false"
   },
   "env": {
     "staging": {
@@ -21,11 +17,7 @@
       "vars": {
         "DRY_RUN": "true",
         "TRADING_ENABLED": "false",
-        "ALLOWED_SYMBOLS": "SOXL,SOXS",
-        "MAX_ORDER_NOTIONAL": "100",
-        "SYMBOL_MAX_NOTIONAL": "{\"SOXL\":200,\"SOXS\":150}",
-        "MARKET_HOURS_CHECK": "false",
-        "WEBULL_API_BASE": "https://openapi.webull.com"
+        "MARKET_HOURS_CHECK": "false"
       }
     },
     "production": {
@@ -33,11 +25,7 @@
       "vars": {
         "DRY_RUN": "true",
         "TRADING_ENABLED": "false",
-        "ALLOWED_SYMBOLS": "SOXL,SOXS",
-        "MAX_ORDER_NOTIONAL": "100",
-        "SYMBOL_MAX_NOTIONAL": "{\"SOXL\":200,\"SOXS\":150}",
-        "MARKET_HOURS_CHECK": "false",
-        "WEBULL_API_BASE": "https://openapi.webull.com"
+        "MARKET_HOURS_CHECK": "false"
       }
     }
   }


### PR DESCRIPTION
> **#24 (Production operational readiness) の続き。** 非 secret な運用 flag を git 管理下に移し、個人の取引戦略に関わる情報は secret 側に置く。

## 分類

| 区分 | 項目 | 格納先 |
|---|---|---|
| 運用フラグ (非秘匿) | `DRY_RUN` / `TRADING_ENABLED` / `MARKET_HOURS_CHECK` | `wrangler.jsonc::vars` + `env.<target>.vars` |
| 認証 / 秘密 | `BASIC_AUTH_USER` / `BASIC_AUTH_PASSWORD` / `EVENT_INGEST_SECRET` / `WEBULL_APP_KEY` / `WEBULL_APP_SECRET` / `WEBULL_ACCOUNT_ID` | `wrangler secret put` |
| 非公開 endpoint | `WEBULL_API_BASE` (sandbox URL 非公開) | `wrangler secret put` |
| 個人戦略 / 規模情報 | `ALLOWED_SYMBOLS` / `MAX_ORDER_NOTIONAL` / `SYMBOL_MAX_NOTIONAL` | `wrangler secret put` |

## Changes

### `wrangler.jsonc`
- `vars` (default env、`wrangler dev`用) と `env.staging.vars` / `env.production.vars` に**運用フラグ3つのみ**記述
- いずれも fail-closed: `DRY_RUN=true` / `TRADING_ENABLED=false` / `MARKET_HOURS_CHECK=false`
- LIVE 化は wrangler.jsonc を PR 経由で編集 → merge → deploy (git で監査可)

### `.dev.vars.example`
- 秘匿性の高さで2グループに分けて記載、冒頭に基準を明文化
- 運用フラグは commented override として末尾に

### `README.md` "Deploy / Secrets"
- 「運用フラグ」と「Secrets 投入」に節を分割
- secret 一覧を for-loop シェルスクリプトにして追加/削除が容易に

## Test plan
- [x] `pnpm exec wrangler deploy --dry-run` (default)
- [x] `pnpm exec wrangler deploy --dry-run --env staging` (vars は 3 flags のみ bundle 確認)
- [x] `pnpm exec wrangler deploy --dry-run --env production`
- [x] `pnpm test` 73/73 pass (test は Env を注入、コード変更なし)

## Refs
- #24 (parent)
- #27 (previous runbook — 今回の分類を改訂)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 展開ランブックを明確化：運用フラグ（DRY_RUN／TRADING_ENABLED／MARKET_HOURS_CHECK）が非機密の構成変数として管理され、ステージングは安全なデフォルト（DRY_RUN=true、TRADING_ENABLED=false）であることを記載。プロダクション切替手順も追記。

* **Chores**
  * 環境変数テンプレートと秘密情報の扱いを整理し、非機密フラグと機密シークレットの分離を強化。シークレット登録手順を簡素化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->