### PR TITLE
feat(webull): canonical HMAC-SHA1 signing + sandbox endpoint alignment (issue #21)

### DIFF
--- a/src/infrastructure/webull/WebullAuth.ts
+++ b/src/infrastructure/webull/WebullAuth.ts
@@ -1,47 +1,344 @@
+const WEBULL_SIGNATURE_ALGORITHM = 'HMAC-SHA1'
+const WEBULL_SIGNATURE_VERSION = '1.0'
+
+type SignablePrimitive = string | number | boolean
+type SignableValue =
+  | SignablePrimitive
+  | readonly SignablePrimitive[]
+  | null
+  | undefined
+
 export interface WebullAuthConfig {
   appKey?: string
   appSecret?: string
-  accountId?: string
+  version?: string
+}
+
+export interface BuildSignedHeadersInput {
+  method: string
+  path: string
+  query?: Record<string, SignableValue>
+  body?: string
+  appKey: string
+  appSecret: string
+  host: string
+  nonce?: string
+  timestamp?: string
+  version?: string
+}
+
+interface CanonicalStringInput {
+  path: string
+  query?: Record<string, SignableValue>
+  headers: Record<string, string>
+  bodyMd5?: string
 }
 
 export class WebullAuth {
   constructor(private readonly config: WebullAuthConfig) {}
 
-  async createHeaders(method: string, path: string, body?: string): Promise<Record<string, string>> {
-    const { appKey, appSecret, accountId } = this.config
+  async createHeaders({
+    method,
+    path,
+    query,
+    body,
+    host,
+    nonce,
+    timestamp,
+    version,
+  }: Omit<BuildSignedHeadersInput, 'appKey' | 'appSecret'>): Promise<Record<string, string>> {
+    const { appKey, appSecret, version: configVersion } = this.config
 
-    if (!appKey || !appSecret || !accountId) {
+    if (!appKey || !appSecret) {
       throw new Error('Missing Webull credentials')
     }
 
-    const timestamp = new Date().toISOString()
-    const payload = [method.toUpperCase(), path, timestamp, body ?? ''].join('\n')
-
-    return {
-      Authorization: `HMAC ${appKey}:${await signPayload(appSecret, payload)}`,
-      'X-Webull-App-Key': appKey,
-      'X-Webull-Account-Id': accountId,
-      'X-Webull-Timestamp': timestamp,
-    }
+    return buildSignedHeaders({
+      method,
+      path,
+      query,
+      body,
+      appKey,
+      appSecret,
+      host,
+      nonce,
+      timestamp,
+      version: version ?? configVersion,
+    })
   }
 }
 
-/**
- * Placeholder for real Webull signing. Production Webull auth would derive the canonical string,
- * handle nonce/timestamp rules, and emit the broker-specific signature headers.
- */
-async function signPayload(secret: string, payload: string): Promise<string> {
+export async function buildSignedHeaders({
+  method,
+  path,
+  query,
+  body,
+  appKey,
+  appSecret,
+  host,
+  nonce = crypto.randomUUID(),
+  timestamp = new Date().toISOString(),
+  version,
+}: BuildSignedHeadersInput): Promise<Record<string, string>> {
+  const normalizedMethod = method.toUpperCase()
+  if (normalizedMethod !== 'GET' && normalizedMethod !== 'POST') {
+    throw new Error(`Unsupported Webull signing method: ${method}`)
+  }
+
+  const signingHeaders = {
+    host,
+    'x-app-key': appKey,
+    'x-signature-algorithm': WEBULL_SIGNATURE_ALGORITHM,
+    'x-signature-nonce': nonce,
+    'x-signature-version': WEBULL_SIGNATURE_VERSION,
+    'x-timestamp': timestamp,
+    ...(version === undefined ? {} : { 'x-version': version }),
+  }
+  const bodyMd5 = body === undefined || body.length === 0 ? undefined : await md5UpperHex(body)
+  const stringToSign = canonicalString({
+    path,
+    query,
+    headers: signingHeaders,
+    bodyMd5,
+  })
+  const encodedString = urlEncodeCanonical(stringToSign)
+  const signature = await hmacSha1Base64(appSecret, encodedString)
+
+  return {
+    ...signingHeaders,
+    'x-signature': signature,
+  }
+}
+
+export function canonicalString({
+  path,
+  query,
+  headers,
+  bodyMd5,
+}: CanonicalStringInput): string {
+  const merged = new Map<string, string>()
+
+  for (const [key, value] of Object.entries(headers)) {
+    merged.set(key.toLowerCase(), value)
+  }
+
+  if (query) {
+    for (const [key, value] of Object.entries(query)) {
+      const normalized = normalizeSignableValue(value)
+      if (normalized !== undefined) {
+        merged.set(key, normalized)
+      }
+    }
+  }
+
+  const sortedPairs = [...merged.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `${key}=${value}`)
+    .join('&')
+
+  return bodyMd5 ? `${path}&${sortedPairs}&${bodyMd5}` : `${path}&${sortedPairs}`
+}
+
+export function urlEncodeCanonical(value: string): string {
+  return encodeURIComponent(value).replace(/[!'()*]/g, (char) =>
+    `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+  )
+}
+
+export async function hmacSha1Base64(secret: string, value: string): Promise<string> {
   const key = await crypto.subtle.importKey(
     'raw',
-    new TextEncoder().encode(secret),
-    { name: 'HMAC', hash: 'SHA-256' },
+    new TextEncoder().encode(`${secret}&`),
+    { name: 'HMAC', hash: 'SHA-1' },
     false,
     ['sign'],
   )
-  const signature = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(payload))
-  return toHex(signature)
+  const signature = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(value))
+  return toBase64(signature)
+}
+
+export async function md5UpperHex(value: string): Promise<string> {
+  const input = new TextEncoder().encode(value)
+
+  try {
+    const digest = await crypto.subtle.digest('MD5', input)
+    return toHex(digest).toUpperCase()
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'NotSupportedError') {
+      return md5UpperHexFallback(input)
+    }
+    throw error
+  }
+}
+
+function normalizeSignableValue(value: SignableValue): string | undefined {
+  if (value === null || value === undefined) {
+    return undefined
+  }
+
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => String(entry))
+      .sort((left, right) => left.localeCompare(right))
+      .join('&')
+  }
+
+  return String(value)
 }
 
 function toHex(value: ArrayBuffer): string {
   return Array.from(new Uint8Array(value), (byte) => byte.toString(16).padStart(2, '0')).join('')
+}
+
+function toBase64(value: ArrayBuffer): string {
+  const bytes = new Uint8Array(value)
+  let binary = ''
+
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte)
+  }
+
+  return btoa(binary)
+}
+
+// Workers supports MD5 in WebCrypto, but Vitest's Node runtime does not.
+function md5UpperHexFallback(input: Uint8Array): string {
+  const words = md5Words(input)
+  return wordsToBytes(words)
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('')
+    .toUpperCase()
+}
+
+function md5Words(input: Uint8Array): number[] {
+  const blocks = new Array<number>(((input.length + 8) >> 6 << 4) + 16).fill(0)
+
+  for (let index = 0; index < input.length; index += 1) {
+    const blockIndex = index >> 2
+    blocks[blockIndex] = (blocks[blockIndex] ?? 0) | (input[index]! << ((index % 4) * 8))
+  }
+
+  const paddingIndex = input.length >> 2
+  blocks[paddingIndex] = (blocks[paddingIndex] ?? 0) | (0x80 << ((input.length % 4) * 8))
+  blocks[blocks.length - 2] = input.length * 8
+
+  let a = 0x67452301
+  let b = 0xefcdab89
+  let c = 0x98badcfe
+  let d = 0x10325476
+
+  for (let i = 0; i < blocks.length; i += 16) {
+    const prevA = a
+    const prevB = b
+    const prevC = c
+    const prevD = d
+
+    a = ff(a, b, c, d, blocks[i]!, 7, -680876936)
+    d = ff(d, a, b, c, blocks[i + 1]!, 12, -389564586)
+    c = ff(c, d, a, b, blocks[i + 2]!, 17, 606105819)
+    b = ff(b, c, d, a, blocks[i + 3]!, 22, -1044525330)
+    a = ff(a, b, c, d, blocks[i + 4]!, 7, -176418897)
+    d = ff(d, a, b, c, blocks[i + 5]!, 12, 1200080426)
+    c = ff(c, d, a, b, blocks[i + 6]!, 17, -1473231341)
+    b = ff(b, c, d, a, blocks[i + 7]!, 22, -45705983)
+    a = ff(a, b, c, d, blocks[i + 8]!, 7, 1770035416)
+    d = ff(d, a, b, c, blocks[i + 9]!, 12, -1958414417)
+    c = ff(c, d, a, b, blocks[i + 10]!, 17, -42063)
+    b = ff(b, c, d, a, blocks[i + 11]!, 22, -1990404162)
+    a = ff(a, b, c, d, blocks[i + 12]!, 7, 1804603682)
+    d = ff(d, a, b, c, blocks[i + 13]!, 12, -40341101)
+    c = ff(c, d, a, b, blocks[i + 14]!, 17, -1502002290)
+    b = ff(b, c, d, a, blocks[i + 15]!, 22, 1236535329)
+
+    a = gg(a, b, c, d, blocks[i + 1]!, 5, -165796510)
+    d = gg(d, a, b, c, blocks[i + 6]!, 9, -1069501632)
+    c = gg(c, d, a, b, blocks[i + 11]!, 14, 643717713)
+    b = gg(b, c, d, a, blocks[i]!, 20, -373897302)
+    a = gg(a, b, c, d, blocks[i + 5]!, 5, -701558691)
+    d = gg(d, a, b, c, blocks[i + 10]!, 9, 38016083)
+    c = gg(c, d, a, b, blocks[i + 15]!, 14, -660478335)
+    b = gg(b, c, d, a, blocks[i + 4]!, 20, -405537848)
+    a = gg(a, b, c, d, blocks[i + 9]!, 5, 568446438)
+    d = gg(d, a, b, c, blocks[i + 14]!, 9, -1019803690)
+    c = gg(c, d, a, b, blocks[i + 3]!, 14, -187363961)
+    b = gg(b, c, d, a, blocks[i + 8]!, 20, 1163531501)
+    a = gg(a, b, c, d, blocks[i + 13]!, 5, -1444681467)
+    d = gg(d, a, b, c, blocks[i + 2]!, 9, -51403784)
+    c = gg(c, d, a, b, blocks[i + 7]!, 14, 1735328473)
+    b = gg(b, c, d, a, blocks[i + 12]!, 20, -1926607734)
+
+    a = hh(a, b, c, d, blocks[i + 5]!, 4, -378558)
+    d = hh(d, a, b, c, blocks[i + 8]!, 11, -2022574463)
+    c = hh(c, d, a, b, blocks[i + 11]!, 16, 1839030562)
+    b = hh(b, c, d, a, blocks[i + 14]!, 23, -35309556)
+    a = hh(a, b, c, d, blocks[i + 1]!, 4, -1530992060)
+    d = hh(d, a, b, c, blocks[i + 4]!, 11, 1272893353)
+    c = hh(c, d, a, b, blocks[i + 7]!, 16, -155497632)
+    b = hh(b, c, d, a, blocks[i + 10]!, 23, -1094730640)
+    a = hh(a, b, c, d, blocks[i + 13]!, 4, 681279174)
+    d = hh(d, a, b, c, blocks[i]!, 11, -358537222)
+    c = hh(c, d, a, b, blocks[i + 3]!, 16, -722521979)
+    b = hh(b, c, d, a, blocks[i + 6]!, 23, 76029189)
+    a = hh(a, b, c, d, blocks[i + 9]!, 4, -640364487)
+    d = hh(d, a, b, c, blocks[i + 12]!, 11, -421815835)
+    c = hh(c, d, a, b, blocks[i + 15]!, 16, 530742520)
+    b = hh(b, c, d, a, blocks[i + 2]!, 23, -995338651)
+
+    a = ii(a, b, c, d, blocks[i]!, 6, -198630844)
+    d = ii(d, a, b, c, blocks[i + 7]!, 10, 1126891415)
+    c = ii(c, d, a, b, blocks[i + 14]!, 15, -1416354905)
+    b = ii(b, c, d, a, blocks[i + 5]!, 21, -57434055)
+    a = ii(a, b, c, d, blocks[i + 12]!, 6, 1700485571)
+    d = ii(d, a, b, c, blocks[i + 3]!, 10, -1894986606)
+    c = ii(c, d, a, b, blocks[i + 10]!, 15, -1051523)
+    b = ii(b, c, d, a, blocks[i + 1]!, 21, -2054922799)
+    a = ii(a, b, c, d, blocks[i + 8]!, 6, 1873313359)
+    d = ii(d, a, b, c, blocks[i + 15]!, 10, -30611744)
+    c = ii(c, d, a, b, blocks[i + 6]!, 15, -1560198380)
+    b = ii(b, c, d, a, blocks[i + 13]!, 21, 1309151649)
+    a = ii(a, b, c, d, blocks[i + 4]!, 6, -145523070)
+    d = ii(d, a, b, c, blocks[i + 11]!, 10, -1120210379)
+    c = ii(c, d, a, b, blocks[i + 2]!, 15, 718787259)
+    b = ii(b, c, d, a, blocks[i + 9]!, 21, -343485551)
+
+    a = addUnsigned(a, prevA)
+    b = addUnsigned(b, prevB)
+    c = addUnsigned(c, prevC)
+    d = addUnsigned(d, prevD)
+  }
+
+  return [a, b, c, d]
+}
+
+function wordsToBytes(words: number[]): number[] {
+  return words.flatMap((word) => [
+    word & 0xff,
+    (word >>> 8) & 0xff,
+    (word >>> 16) & 0xff,
+    (word >>> 24) & 0xff,
+  ])
+}
+
+function ff(a: number, b: number, c: number, d: number, x: number, s: number, t: number): number {
+  return rotateLeft(addUnsigned(a, addUnsigned(addUnsigned((b & c) | (~b & d), x), t)), s) + b
+}
+
+function gg(a: number, b: number, c: number, d: number, x: number, s: number, t: number): number {
+  return rotateLeft(addUnsigned(a, addUnsigned(addUnsigned((b & d) | (c & ~d), x), t)), s) + b
+}
+
+function hh(a: number, b: number, c: number, d: number, x: number, s: number, t: number): number {
+  return rotateLeft(addUnsigned(a, addUnsigned(addUnsigned(b ^ c ^ d, x), t)), s) + b
+}
+
+function ii(a: number, b: number, c: number, d: number, x: number, s: number, t: number): number {
+  return rotateLeft(addUnsigned(a, addUnsigned(addUnsigned(c ^ (b | ~d), x), t)), s) + b
+}
+
+function rotateLeft(value: number, bits: number): number {
+  return (value << bits) | (value >>> (32 - bits))
+}
+
+function addUnsigned(left: number, right: number): number {
+  return (((left >>> 0) + (right >>> 0)) & 0xffffffff) | 0
 }

--- a/src/infrastructure/webull/WebullHttpClient.ts
+++ b/src/infrastructure/webull/WebullHttpClient.ts
@@ -72,7 +72,7 @@ export class WebullHttpClient {
     } = {},
   ): Promise<T> {
     const payload = body === undefined ? undefined : JSON.stringify(body)
-    const url = buildRequestUrl(this.baseUrl, path, query)
+    const resolvedUrl = buildRequestUrl(this.baseUrl, path, query)
     let lastFailure: Error | undefined
     let lastStatus: number | undefined
 
@@ -80,10 +80,10 @@ export class WebullHttpClient {
     try {
       authHeaders = await this.options.auth.createHeaders({
         method,
-        path,
+        path: resolvedUrl.pathname + resolvedUrl.search,
         query,
         body: payload,
-        host: this.host,
+        host: resolvedUrl.host,
         // Webull SDK sets x-version=v1 for the documented trade/account routes.
         version: 'v1',
       })
@@ -109,7 +109,7 @@ export class WebullHttpClient {
 
         timeoutId = setTimeout(() => controller.abort(), this.timeoutMs)
 
-        response = await this.fetchFn(url, {
+        response = await this.fetchFn(resolvedUrl.href, {
           method,
           headers,
           body: payload,
@@ -250,7 +250,7 @@ function wait(delayMs: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, delayMs))
 }
 
-function buildRequestUrl(baseUrl: string, path: string, query?: Record<string, string>): string {
+function buildRequestUrl(baseUrl: string, path: string, query?: Record<string, string>): URL {
   const url = new URL(path, `${baseUrl}/`)
 
   if (query) {
@@ -259,5 +259,5 @@ function buildRequestUrl(baseUrl: string, path: string, query?: Record<string, s
     }
   }
 
-  return url.toString()
+  return url
 }

--- a/src/infrastructure/webull/WebullHttpClient.ts
+++ b/src/infrastructure/webull/WebullHttpClient.ts
@@ -20,6 +20,7 @@ interface WebullRetryOptions {
 
 interface WebullHttpClientOptions {
   auth: WebullAuth
+  accountId?: string
   baseUrl?: string
   timeoutMs?: number
   retry?: WebullRetryOptions
@@ -28,12 +29,14 @@ interface WebullHttpClientOptions {
 
 export class WebullHttpClient {
   private readonly baseUrl: string
+  private readonly host: string
   private readonly timeoutMs: number
   private readonly fetchFn: typeof fetch
   private readonly retry: Required<WebullRetryOptions>
 
   constructor(private readonly options: WebullHttpClientOptions) {
-    this.baseUrl = (options.baseUrl ?? 'https://openapi.webull.com').replace(/\/+$/, '')
+    this.baseUrl = (options.baseUrl ?? 'https://api.sandbox.webull.hk').replace(/\/+$/, '')
+    this.host = new URL(this.baseUrl).host
     this.timeoutMs = options.timeoutMs ?? 5000
     this.fetchFn = options.fetchFn ?? fetch
     this.retry = {
@@ -45,22 +48,45 @@ export class WebullHttpClient {
   }
 
   async getAccount(): Promise<WebullAccountDto> {
-    return this.request<WebullAccountDto>('GET', '/account')
+    return this.request<WebullAccountDto>('GET', '/account/profile', {
+      query: { account_id: this.requireAccountId() },
+    })
   }
 
   async placeOrder(intent: OrderIntent): Promise<WebullPlaceOrderResponseDto> {
-    return this.request<WebullPlaceOrderResponseDto>('POST', '/order/place', toWebullPlaceOrderRequest(intent))
+    return this.request<WebullPlaceOrderResponseDto>('POST', '/trade/order/place', {
+      query: { account_id: this.requireAccountId() },
+      body: toWebullPlaceOrderRequest(intent),
+    })
   }
 
-  private async request<T>(method: 'GET' | 'POST', path: string, body?: unknown): Promise<T> {
+  private async request<T>(
+    method: 'GET' | 'POST',
+    path: string,
+    {
+      query,
+      body,
+    }: {
+      query?: Record<string, string>
+      body?: unknown
+    } = {},
+  ): Promise<T> {
     const payload = body === undefined ? undefined : JSON.stringify(body)
+    const url = buildRequestUrl(this.baseUrl, path, query)
     let lastFailure: Error | undefined
     let lastStatus: number | undefined
 
-    // Create auth headers once, outside retry loop - auth errors should fail immediately
     let authHeaders: Record<string, string>
     try {
-      authHeaders = await this.options.auth.createHeaders(method, path, payload)
+      authHeaders = await this.options.auth.createHeaders({
+        method,
+        path,
+        query,
+        body: payload,
+        host: this.host,
+        // Webull SDK sets x-version=v1 for the documented trade/account routes.
+        version: 'v1',
+      })
     } catch (error) {
       throw new BrokerRequestError(
         `Webull authentication failed: ${error instanceof Error ? error.message : String(error)}`,
@@ -83,7 +109,7 @@ export class WebullHttpClient {
 
         timeoutId = setTimeout(() => controller.abort(), this.timeoutMs)
 
-        response = await this.fetchFn(`${this.baseUrl}${path}`, {
+        response = await this.fetchFn(url, {
           method,
           headers,
           body: payload,
@@ -169,6 +195,14 @@ export class WebullHttpClient {
       `${method} ${path}`,
     )
   }
+
+  private requireAccountId(): string {
+    if (!this.options.accountId) {
+      throw new BrokerRequestError('Missing Webull account ID', 'webullAccountId')
+    }
+
+    return this.options.accountId
+  }
 }
 
 export function createWebullHttpClient(
@@ -179,8 +213,8 @@ export function createWebullHttpClient(
     auth: new WebullAuth({
       appKey: env.WEBULL_APP_KEY,
       appSecret: env.WEBULL_APP_SECRET,
-      accountId: env.WEBULL_ACCOUNT_ID,
     }),
+    accountId: env.WEBULL_ACCOUNT_ID,
     baseUrl: env.WEBULL_API_BASE,
     timeoutMs: options?.timeoutMs,
     retry: options?.retry,
@@ -214,4 +248,16 @@ function getRetryDelayMs({
 
 function wait(delayMs: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, delayMs))
+}
+
+function buildRequestUrl(baseUrl: string, path: string, query?: Record<string, string>): string {
+  const url = new URL(path, `${baseUrl}/`)
+
+  if (query) {
+    for (const [key, value] of Object.entries(query)) {
+      url.searchParams.set(key, value)
+    }
+  }
+
+  return url.toString()
 }

--- a/src/infrastructure/webull/dto.ts
+++ b/src/infrastructure/webull/dto.ts
@@ -1,23 +1,35 @@
 export interface WebullAccountDto {
-  accountId: string
-  accountType: string
-  status: string
+  accountId?: string
+  accountType?: string
+  secAccountId?: string
+  accountNo?: string
+  status?: string
 }
 
 export interface WebullPlaceOrderRequestDto {
-  symbol: string
-  side: 'BUY' | 'SELL'
-  quantity: number
-  limitPrice: number
+  stock_order: {
+    client_order_id: string
+    symbol: string
+    side: 'BUY' | 'SELL'
+    tif: 'DAY'
+    order_type: 'LIMIT'
+    limit_price: string
+    qty: string
+    extended_hours_trading: boolean
+  }
 }
 
 export interface WebullPlaceOrderResponseDto {
-  orderId: string
-  status: string
-  symbol: string
-  side: 'BUY' | 'SELL'
-  quantity: number
-  limitPrice: number
+  orderId?: string
+  order_id?: string
+  client_order_id?: string
+  status?: string
+  symbol?: string
+  side?: 'BUY' | 'SELL'
+  quantity?: number
+  qty?: number | string
+  limitPrice?: number
+  limit_price?: string
   message?: string
   submittedAt?: string
 }

--- a/src/infrastructure/webull/mapper.ts
+++ b/src/infrastructure/webull/mapper.ts
@@ -18,7 +18,7 @@ export function toWebullPlaceOrderRequest(intent: OrderIntent): WebullPlaceOrder
 }
 
 export function toExecutionResult(dto: WebullPlaceOrderResponseDto): ExecutionResult {
-  const brokerOrderId = dto.orderId ?? dto.order_id ?? dto.client_order_id
+  const brokerOrderId = dto.orderId ?? dto.order_id
 
   return {
     mode: 'LIVE',

--- a/src/infrastructure/webull/mapper.ts
+++ b/src/infrastructure/webull/mapper.ts
@@ -4,18 +4,26 @@ import type { WebullPlaceOrderRequestDto, WebullPlaceOrderResponseDto } from './
 
 export function toWebullPlaceOrderRequest(intent: OrderIntent): WebullPlaceOrderRequestDto {
   return {
-    symbol: intent.symbol.toUpperCase(),
-    side: intent.side,
-    quantity: intent.quantity,
-    limitPrice: intent.price,
+    stock_order: {
+      client_order_id: crypto.randomUUID().replaceAll('-', ''),
+      symbol: intent.symbol.toUpperCase(),
+      side: intent.side,
+      tif: 'DAY',
+      order_type: 'LIMIT',
+      limit_price: intent.price.toFixed(3),
+      qty: String(intent.quantity),
+      extended_hours_trading: false,
+    },
   }
 }
 
 export function toExecutionResult(dto: WebullPlaceOrderResponseDto): ExecutionResult {
+  const brokerOrderId = dto.orderId ?? dto.order_id ?? dto.client_order_id
+
   return {
     mode: 'LIVE',
-    submitted: dto.orderId.trim().length > 0,
-    brokerOrderId: dto.orderId,
+    submitted: typeof brokerOrderId === 'string' && brokerOrderId.trim().length > 0,
+    brokerOrderId,
     errorReason: dto.message,
   }
 }

--- a/test/infrastructure/webull/webullAuth.test.ts
+++ b/test/infrastructure/webull/webullAuth.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import {
+  canonicalString,
+  hmacSha1Base64,
+  md5UpperHex,
+  urlEncodeCanonical,
+} from '../../../src/infrastructure/webull/WebullAuth'
+
+describe('WebullAuth helpers', () => {
+  it('builds the canonical string without a body hash when the body is empty', () => {
+    const result = canonicalString({
+      path: '/account/profile',
+      query: {
+        account_id: 'acct-123',
+      },
+      headers: {
+        host: 'api.sandbox.webull.hk',
+        'x-app-key': 'app-key',
+        'x-signature-algorithm': 'HMAC-SHA1',
+        'x-signature-nonce': 'nonce-1',
+        'x-signature-version': '1.0',
+        'x-timestamp': '2026-04-18T12:30:45Z',
+        'x-version': 'v1',
+      },
+    })
+
+    expect(result).toBe(
+      '/account/profile&account_id=acct-123&host=api.sandbox.webull.hk&x-app-key=app-key&x-signature-algorithm=HMAC-SHA1&x-signature-nonce=nonce-1&x-signature-version=1.0&x-timestamp=2026-04-18T12:30:45Z&x-version=v1',
+    )
+  })
+
+  it('builds the canonical string with a body hash when the body is present', () => {
+    const result = canonicalString({
+      path: '/trade/place_order',
+      query: {
+        q1: 'yyy',
+      },
+      headers: {
+        host: 'api.webull.com',
+        'x-app-key': '776da210ab4a452795d74e726ebd74b6',
+        'x-signature-algorithm': 'HMAC-SHA1',
+        'x-signature-nonce': '48ef5afed43d4d91ae514aaeafbc29ba',
+        'x-signature-version': '1.0',
+        'x-timestamp': '2022-01-04T03:55:31Z',
+      },
+      bodyMd5: 'E296C96787E1A309691CEF3692F5EEDD',
+    })
+
+    expect(result).toBe(
+      '/trade/place_order&host=api.webull.com&q1=yyy&x-app-key=776da210ab4a452795d74e726ebd74b6&x-signature-algorithm=HMAC-SHA1&x-signature-nonce=48ef5afed43d4d91ae514aaeafbc29ba&x-signature-version=1.0&x-timestamp=2022-01-04T03:55:31Z&E296C96787E1A309691CEF3692F5EEDD',
+    )
+  })
+
+  it('URL-encodes spaces as %20 and keeps unreserved characters unchanged', () => {
+    expect(urlEncodeCanonical('a b-_.~')).toBe('a%20b-_.~')
+  })
+
+  it('produces uppercase MD5 hex digests', async () => {
+    await expect(md5UpperHex('{"symbol":"AAPL"}')).resolves.toBe('0DAB09372CD53C138B7309FFAA8A5E68')
+  })
+
+  it('matches the HMAC-SHA1 worked example from Webull docs', async () => {
+    const encodedSignString =
+      '%2Ftrade%2Fplace_order%26a1%3Dwebull%26a2%3D123%26a3%3Dxxx%26host%3Dapi.webull.com%26q1%3Dyyy%26x-app-key%3D776da210ab4a452795d74e726ebd74b6%26x-signature-algorithm%3DHMAC-SHA1%26x-signature-nonce%3D48ef5afed43d4d91ae514aaeafbc29ba%26x-signature-version%3D1.0%26x-timestamp%3D2022-01-04T03%3A55%3A31Z%26E296C96787E1A309691CEF3692F5EEDD'
+
+    await expect(hmacSha1Base64('0f50a2e853334a9aae1a783bee120c1f', encodedSignString)).resolves.toBe(
+      'kvlS6opdZDhEBo5jq40nHYXaLvM=',
+    )
+  })
+})

--- a/test/infrastructure/webull/webullHttpClient.test.ts
+++ b/test/infrastructure/webull/webullHttpClient.test.ts
@@ -16,8 +16,8 @@ function createClient(fetchFn: typeof fetch, timeoutMs?: number): WebullHttpClie
     auth: new WebullAuth({
       appKey: 'app-key',
       appSecret: 'app-secret',
-      accountId: 'acct-1',
     }),
+    accountId: 'acct-1',
     baseUrl: 'https://broker.example.test',
     timeoutMs,
     retry: {
@@ -31,7 +31,7 @@ function createClient(fetchFn: typeof fetch, timeoutMs?: number): WebullHttpClie
 }
 
 describe('WebullHttpClient', () => {
-  it('places an order with the expected method, URL, body, and auth header', async () => {
+  it('places an order with the expected method, URL, body, and Webull auth headers', async () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -51,21 +51,58 @@ describe('WebullHttpClient', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
     const [url, init] = fetchMock.mock.calls[0]!
-    expect(url).toBe('https://broker.example.test/order/place')
+    expect(url).toBe('https://broker.example.test/trade/order/place?account_id=acct-1')
     expect(init?.method).toBe('POST')
-    expect(init?.body).toBe(JSON.stringify({
-      symbol: 'SOXL',
-      side: 'BUY',
-      quantity: 2,
-      limitPrice: 9.5,
-    }))
+    expect(JSON.parse(init?.body as string)).toMatchObject({
+      stock_order: {
+        client_order_id: expect.any(String),
+        symbol: 'SOXL',
+        side: 'BUY',
+        tif: 'DAY',
+        order_type: 'LIMIT',
+        limit_price: '9.500',
+        qty: '2',
+        extended_hours_trading: false,
+      },
+    })
     expect(init?.headers).toMatchObject({
       Accept: 'application/json',
       'Content-Type': 'application/json',
-      'X-Webull-App-Key': 'app-key',
-      'X-Webull-Account-Id': 'acct-1',
+      host: 'broker.example.test',
+      'x-app-key': 'app-key',
+      'x-signature-algorithm': 'HMAC-SHA1',
+      'x-signature-version': '1.0',
+      'x-signature-nonce': expect.any(String),
+      'x-timestamp': expect.any(String),
+      'x-version': 'v1',
+      'x-signature': expect.any(String),
     })
-    expect((init?.headers as Record<string, string>).Authorization).toMatch(/^HMAC app-key:/)
+  })
+
+  it('requests account details from the documented profile endpoint', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          accountId: 'acct-1',
+          status: 'OPEN',
+        }),
+        { status: 200 },
+      ),
+    )
+    const client = createClient(fetchMock)
+
+    await client.getAccount()
+
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(url).toBe('https://broker.example.test/account/profile?account_id=acct-1')
+    expect(init?.method).toBe('GET')
+    expect(init?.body).toBeUndefined()
+    expect(init?.headers).toMatchObject({
+      Accept: 'application/json',
+      host: 'broker.example.test',
+      'x-app-key': 'app-key',
+      'x-signature': expect.any(String),
+    })
   })
 
   it('retries a transient 500 response and succeeds on the next attempt', async () => {


### PR DESCRIPTION
> **issue #21** のサンドボックス疎通フォーカス版。canonical signing の本実装と endpoint 合わせ。gRPC は並列 PR #30。

## What was wrong

`src/infrastructure/webull/WebullAuth.ts` は **HMAC-SHA256 の placeholder**。Webull の実仕様は **HMAC-SHA1** なので sandbox に蹴られる状態だった。

## Canonical signing 実装 (`developer.webull.com/api-doc/develop/auth/` 準拠)

- canonical string: `uri & sorted(headers + query) & md5(body)` (body 空の場合は body 部を省略)
- URL encode: RFC-3986 (`encodeURIComponent` 相当、unreserved は `- _ .`、`%XX` は大文字)
- HMAC-SHA1、key = `appSecret + "&"`
- 結果は **base64** で `x-signature` header に
- Body MD5 は **uppercase hex**

### Pure helpers
- `canonicalString(...)` / `urlEncodeCanonical(...)` / `hmacSha1Base64(...)` / `md5UpperHex(...)` / `buildSignedHeaders(...)` として分離、単体テスト容易
- **Webull docs の worked example をロックインする regression test** 追加 (secret `0f50a2e853334a9aae1a783bee120c1f` → `kvlS6opdZDhEBo5jq40nHYXaLvM=`)

## Endpoint alignment

- `getAccount()` → `GET /account/profile?account_id=...` を新規追加 (疎通 smoke 用)
- `placeOrder(intent)` → `POST /trade/order/place?account_id=...` に更新 (従来 placeholder は `/trade/place_order`)。body は `stock_order` スキーマ
- 既存の timeout + retry (PR #18) はそのまま通す
- `host` header は `WEBULL_API_BASE` から自動派生

## DTOs / mapper

- `OrderIntent` / `ExecutionResult` で実際に使う field に絞った minimal 対応
- Webull の full schema 対応は後続 (POC 疎通では足りる)

## Verification

- [x] `pnpm run typecheck` ✅
- [x] `pnpm test` ✅ **17 files / 79 tests** (Webull docs の worked example も pass)
- [ ] sandbox 実疎通 (secrets 投入 + staging deploy)

## TODOs (code に残す)

- `placeOrder` path は官能 trade doc (`/trade/order/place`) に揃えたが、sandbox が別 alias を使う可能性あり (`/trade/place_order` が auth doc の例示だが trade doc の方が新しいと判断)
- Webull 固有 header `category` は未対応
- full response schema の網羅なし

## 並列 PR #30 (gRPC bridge) との関係

- 編集箇所が `src/infrastructure/webull/**` (HTTP signing) と `bridge/**` (gRPC) で **完全分離**、衝突なし
- 両 merge 後に bridge local + Worker staging で end-to-end サンドボックス疎通テスト可能に

Refs: #21 (parent), #30 (parallel gRPC PR), #18 (retry pattern)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * Webullの署名付き認証ヘッダー生成を全面刷新しました（署名方式・ヘッダー構成の変更、バージョン対応、ホスト/タイムスタンプ/ノンス含む）。
  * リクエストURL構築とクエリ引数処理を強化しました。

* **Bug Fixes**
  * 注文送信とアカウント取得でアカウントIDをクエリに渡すよう修正し、注文ペイロード形式を新仕様に合わせました。
  * レスポンス/DTOの柔軟性を向上させました。

* **Tests**
  * 認証ヘルパー関数の単体テストと、注文・アカウント周りのテストを追加／更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->