### PR TITLE
feat(webull): pnpm run accounts (list Webull account_ids)

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -14,8 +14,10 @@ BASIC_AUTH_PASSWORD=<your-password>
 EVENT_INGEST_SECRET=change-me
 WEBULL_APP_KEY=
 WEBULL_APP_SECRET=
+# Run `pnpm run accounts` after setting the two above to fetch account_id.
 WEBULL_ACCOUNT_ID=
-WEBULL_API_BASE=https://openapi.webull.com
+# Sandbox default. Use https://openapi.webull.com for production.
+WEBULL_API_BASE=https://api.sandbox.webull.hk
 ALLOWED_SYMBOLS=SOXL,SOXS
 MAX_ORDER_NOTIONAL=100
 SYMBOL_MAX_NOTIONAL={"SOXL":200,"SOXS":150}

--- a/README.md
+++ b/README.md
@@ -75,8 +75,21 @@ cd bridge && pnpm install && pnpm exec tsc --noEmit -p .
 | `SYMBOL_MAX_NOTIONAL` | `{}` | JSON inline で symbol 別上書き |
 | `MARKET_HOURS_CHECK` | `false` | UTC 13:30-20:00 Mon-Fri チェック |
 | `EVENT_INGEST_SECRET` | — | `/events/trade` の secret header 値 |
-| `WEBULL_APP_KEY` / `WEBULL_APP_SECRET` / `WEBULL_ACCOUNT_ID` | — | Webull 認証 (placeholder signing) |
+| `WEBULL_APP_KEY` / `WEBULL_APP_SECRET` / `WEBULL_ACCOUNT_ID` | — | Webull 認証 |
 | `WEBULL_API_BASE` | `https://openapi.webull.com` | Webull HTTP base |
+
+### Webull account_id を取得する
+
+Webull sandbox は公開 dashboard で account_id を表示しないので、app_key + app_secret だけで API を叩いて取得する:
+
+```bash
+WEBULL_APP_KEY="$(op read 'op://Personal/WEBULL_APP_KEY/credential')" \
+WEBULL_APP_SECRET="$(op read 'op://Personal/WEBULL_APP_SECRET/credential')" \
+WEBULL_API_BASE=https://api.sandbox.webull.hk \
+  pnpm run accounts
+```
+
+返ってきた JSON の `account_id` を `.dev.vars` の `WEBULL_ACCOUNT_ID` に、deploy 時は `wrangler secret put WEBULL_ACCOUNT_ID --env staging` に投入。
 
 ## Deploy / Secrets (Cloudflare Workers)
 

--- a/package.json
+++ b/package.json
@@ -8,13 +8,15 @@
     "deploy": "wrangler deploy",
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "accounts": "tsx scripts/list-webull-accounts.ts"
   },
   "dependencies": {
     "hono": "^4.12.14"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260417.1",
+    "tsx": "^4.20.6",
     "typescript": "^5.6.3",
     "vitest": "^2.1.9",
     "wrangler": "^4.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20260417.1
         version: 4.20260417.1
+      tsx:
+        specifier: ^4.20.6
+        version: 4.21.0
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
@@ -791,6 +794,9 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
   hono@4.12.14:
     resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
     engines: {node: '>=16.9.0'}
@@ -837,6 +843,9 @@ packages:
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
   rollup@4.60.1:
     resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
@@ -889,6 +898,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -1516,6 +1530,10 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   hono@4.12.14: {}
 
   kleur@4.1.5: {}
@@ -1557,6 +1575,8 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  resolve-pkg-maps@1.0.0: {}
 
   rollup@4.60.1:
     dependencies:
@@ -1644,6 +1664,13 @@ snapshots:
 
   tslib@2.8.1:
     optional: true
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.3
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   typescript@5.9.3: {}
 

--- a/scripts/list-webull-accounts.ts
+++ b/scripts/list-webull-accounts.ts
@@ -1,0 +1,40 @@
+/**
+ * One-off helper: fetch Webull subscriptions (account_id list) for your app.
+ *
+ * Usage:
+ *   WEBULL_APP_KEY=... WEBULL_APP_SECRET=... WEBULL_API_BASE=https://api.sandbox.webull.hk \
+ *     pnpm run accounts
+ *
+ * Copy the account_id into `.dev.vars` as WEBULL_ACCOUNT_ID.
+ */
+
+import { createWebullHttpClient } from '../src/infrastructure/webull/WebullHttpClient'
+
+const appKey = process.env.WEBULL_APP_KEY
+const appSecret = process.env.WEBULL_APP_SECRET
+const apiBase = process.env.WEBULL_API_BASE
+
+if (!appKey || !appSecret) {
+  console.error('Set WEBULL_APP_KEY and WEBULL_APP_SECRET in the environment first.')
+  process.exit(1)
+}
+
+if (!apiBase) {
+  console.error('Set WEBULL_API_BASE (e.g. https://api.sandbox.webull.hk).')
+  process.exit(1)
+}
+
+const client = createWebullHttpClient({
+  WEBULL_APP_KEY: appKey,
+  WEBULL_APP_SECRET: appSecret,
+  WEBULL_API_BASE: apiBase,
+})
+
+const subscriptions = await client.listSubscriptions()
+
+if (subscriptions.length === 0) {
+  console.error('No subscriptions returned. Confirm the app has any subscribed accounts in the Webull developer dashboard.')
+  process.exit(2)
+}
+
+console.log(JSON.stringify(subscriptions, null, 2))

--- a/scripts/list-webull-accounts.ts
+++ b/scripts/list-webull-accounts.ts
@@ -37,4 +37,6 @@ if (subscriptions.length === 0) {
   process.exit(2)
 }
 
-console.log(JSON.stringify(subscriptions, null, 2))
+// Extract and deduplicate account_id values only (avoid logging sensitive fields)
+const accountIds = Array.from(new Set(subscriptions.map((sub) => sub.account_id)))
+console.log(JSON.stringify(accountIds, null, 2))

--- a/src/infrastructure/webull/WebullHttpClient.ts
+++ b/src/infrastructure/webull/WebullHttpClient.ts
@@ -1,6 +1,6 @@
 import type { OrderIntent } from '../../trading/domain/OrderIntent'
 import { BrokerRequestError } from '../../shared/errors'
-import type { WebullAccountDto, WebullPlaceOrderResponseDto } from './dto'
+import type { WebullAccountDto, WebullPlaceOrderResponseDto, WebullSubscriptionDto } from './dto'
 import { toWebullPlaceOrderRequest } from './mapper'
 import { WebullAuth } from './WebullAuth'
 
@@ -45,6 +45,10 @@ export class WebullHttpClient {
       multiplier: options.retry?.multiplier ?? 2,
       jitter: options.retry?.jitter ?? 0.25,
     }
+  }
+
+  async listSubscriptions(): Promise<WebullSubscriptionDto[]> {
+    return this.request<WebullSubscriptionDto[]>('GET', '/app/subscriptions/list')
   }
 
   async getAccount(): Promise<WebullAccountDto> {

--- a/src/infrastructure/webull/dto.ts
+++ b/src/infrastructure/webull/dto.ts
@@ -6,6 +6,13 @@ export interface WebullAccountDto {
   status?: string
 }
 
+export interface WebullSubscriptionDto {
+  subscription_id?: string
+  user_id?: string
+  account_id?: string
+  account_number?: string
+}
+
 export interface WebullPlaceOrderRequestDto {
   stock_order: {
     client_order_id: string

--- a/test/infrastructure/webull/webullHttpClient.test.ts
+++ b/test/infrastructure/webull/webullHttpClient.test.ts
@@ -180,4 +180,22 @@ describe('WebullHttpClient', () => {
     })
     expect(fetchMock).toHaveBeenCalledTimes(2)
   })
+
+  it('listSubscriptions hits /app/subscriptions/list and returns the array', async () => {
+    const subscriptions = [
+      { subscription_id: 'sub-1', user_id: 'u-1', account_id: 'acct-abc', account_number: '123' },
+    ]
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(JSON.stringify(subscriptions), { status: 200 }))
+    const client = createClient(fetchMock)
+
+    const result = await client.listSubscriptions()
+
+    expect(result).toEqual(subscriptions)
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(String(url)).toContain('/app/subscriptions/list')
+    expect(init?.method).toBe('GET')
+    expect(init?.body).toBeUndefined()
+  })
 })


### PR DESCRIPTION
> **#32 の前提道具**。sandbox の `WEBULL_ACCOUNT_ID` を取得するヘルパー。

## Why

Webull sandbox には公開 dashboard が無く、sandbox 口座の `account_id` を目視で確認できない。正規の取得方法は `GET /app/subscriptions/list` を app_key + app_secret だけで叩くこと ([Webull docs: Account List](https://developer.webull.com/api-doc/trade/account/app_subscription/))。このエンドポイントを呼ぶためのタイピング + one-off script を追加する。

## Changes

### `src/infrastructure/webull/WebullHttpClient.ts`
- `listSubscriptions(): Promise<WebullSubscriptionDto[]>` を追加。既存の canonical signing + timeout + retry パスをそのまま使うので account_id 不要の GET として素直に飛ぶ。

### `src/infrastructure/webull/dto.ts`
- `WebullSubscriptionDto` (`subscription_id` / `user_id` / `account_id` / `account_number`) を追加。

### `scripts/list-webull-accounts.ts` (新規)
- tsx で動く one-off CLI。env から 3 つの変数を読んで `listSubscriptions()` を叩き、JSON を stdout に吐く。
- 秘匿値はあくまで env 渡し、ファイル書き込みしない。

### `package.json`
- `tsx` を devDep に追加 (Node CLI 実行用、Workers runtime には影響なし)
- `"accounts": "tsx scripts/list-webull-accounts.ts"` script

### `README.md`
- Env 節の直下に **"Webull account_id を取得する"** を追加、`op read` で app_key/secret を渡す使用例

### Tests
- `test/infrastructure/webull/webullHttpClient.test.ts` に 1件 (`listSubscriptions` の path / method / body 無し) の unit test

## 使い方

```bash
WEBULL_APP_KEY="$(op read 'op://Personal/WEBULL_APP_KEY/credential')" \
WEBULL_APP_SECRET="$(op read 'op://Personal/WEBULL_APP_SECRET/credential')" \
WEBULL_API_BASE=https://api.sandbox.webull.hk \
  pnpm run accounts
```

出力の `account_id` を `.dev.vars` の `WEBULL_ACCOUNT_ID` に貼る。deploy 時は `wrangler secret put WEBULL_ACCOUNT_ID --env staging`。

## Test plan
- [x] `pnpm run typecheck` pass
- [x] `pnpm test` pass (15 files / 76 tests)
- [ ] 実 sandbox で `pnpm run accounts` を実行して account_id が取れるか (本 PR merge 後に手元で確認)

Refs: #32 (live 疎通)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Webull 認証済みアカウント一覧を取得するローカル実行コマンドを追加しました。

* **ドキュメント**
  * Webull 認証手順を拡充し、account_id の取得方法と展開時の設定手順（ローカル保存とクラウド環境への登録）を明記しました。
  * 開発用APIエンドポイント例をサンドボックスURLに更新しました。

* **テスト**
  * 新コマンドに対応するユニットテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->