### PR TITLE
fix(webull): exclude x-version from canonical signing (401 UNAUTHORIZED)

### DIFF
--- a/src/infrastructure/webull/WebullAuth.ts
+++ b/src/infrastructure/webull/WebullAuth.ts
@@ -77,7 +77,7 @@ export async function buildSignedHeaders({
   appSecret,
   host,
   nonce = crypto.randomUUID(),
-  timestamp = new Date().toISOString(),
+  timestamp = isoTimestampNoMillis(),
   version,
 }: BuildSignedHeadersInput): Promise<Record<string, string>> {
   const normalizedMethod = method.toUpperCase()
@@ -85,6 +85,10 @@ export async function buildSignedHeaders({
     throw new Error(`Unsupported Webull signing method: ${method}`)
   }
 
+  // The Python SDK (webullsdkcore.auth.composer.default_signature_composer) signs
+  // exactly these six headers + optional query/body, regardless of whether the
+  // request carries an x-version header. Including x-version in the canonical
+  // string makes Webull reject the signature as UNAUTHORIZED.
   const signingHeaders = {
     host,
     'x-app-key': appKey,
@@ -92,7 +96,6 @@ export async function buildSignedHeaders({
     'x-signature-nonce': nonce,
     'x-signature-version': WEBULL_SIGNATURE_VERSION,
     'x-timestamp': timestamp,
-    ...(version === undefined ? {} : { 'x-version': version }),
   }
   const bodyMd5 = body === undefined || body.length === 0 ? undefined : await md5UpperHex(body)
   const stringToSign = canonicalString({
@@ -106,8 +109,13 @@ export async function buildSignedHeaders({
 
   return {
     ...signingHeaders,
+    ...(version === undefined ? {} : { 'x-version': version }),
     'x-signature': signature,
   }
+}
+
+function isoTimestampNoMillis(): string {
+  return new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')
 }
 
 export function canonicalString({

--- a/test/infrastructure/webull/webullAuth.test.ts
+++ b/test/infrastructure/webull/webullAuth.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  buildSignedHeaders,
   canonicalString,
   hmacSha1Base64,
   md5UpperHex,
@@ -57,6 +58,25 @@ describe('WebullAuth helpers', () => {
 
   it('produces uppercase MD5 hex digests', async () => {
     await expect(md5UpperHex('{"symbol":"AAPL"}')).resolves.toBe('0DAB09372CD53C138B7309FFAA8A5E68')
+  })
+
+  it('omits x-version from the canonical signing even when sent as a request header', async () => {
+    const common = {
+      method: 'GET' as const,
+      path: '/app/subscriptions/list',
+      appKey: 'app-key',
+      appSecret: 'app-secret',
+      host: 'api.sandbox.webull.hk',
+      nonce: 'nonce-1',
+      timestamp: '2026-04-18T12:30:45Z',
+    }
+
+    const withVersion = await buildSignedHeaders({ ...common, version: 'v1' })
+    const withoutVersion = await buildSignedHeaders({ ...common })
+
+    expect(withVersion['x-version']).toBe('v1')
+    expect(withoutVersion['x-version']).toBeUndefined()
+    expect(withVersion['x-signature']).toBe(withoutVersion['x-signature'])
   })
 
   it('matches the HMAC-SHA1 worked example from Webull docs', async () => {


### PR DESCRIPTION
## Problem

\`pnpm run accounts\` に Webull sandbox (JP UAT) credentials を渡すと 401:

\`\`\`
Body: {"error_code":"UNAUTHORIZED"}
\`\`\`

## Root cause

Webull の [Python SDK](https://github.com/webull-inc/openapi-python-sdk/blob/main/webull-python-sdk-core/webullsdkcore/auth/composer/default_signature_composer.py#L54-L65) の \`_refresh_sign_headers\` は **6 header のみ**を canonical signing に含める:

- \`host\` / \`x-app-key\` / \`x-signature-algorithm\` / \`x-signature-nonce\` / \`x-signature-version\` / \`x-timestamp\`

\`x-version\` はエンドポイント version 識別子として request header に **送るが**、サーバー側の canonical 再構築では**除外される**。我々の \`buildSignedHeaders\` は version option が渡された時に \`x-version\` を canonical に混ぜていたので署名がズレて 401。

## Fix

- \`buildSignedHeaders\` の \`signingHeaders\` から \`x-version\` を除外。signing 後に response headers に追加
- timestamp 既定を SDK と揃えて ms なし (\`%Y-%m-%dT%H:%M:%SZ\`) に

## 検証

JP UAT 実 endpoint で \`/app/subscriptions/list\` が成功 (account_id 2件返却確認)。

### Regression test 追加

\`buildSignedHeaders\` に version=\"v1\" を付けた場合/付けない場合で **同一の x-signature が得られる** ことを assert。将来 canonical 署名対象の header set が変わった時に気付ける。

- [x] \`pnpm run typecheck\` pass
- [x] \`pnpm test\` pass (**77 tests**, +1 regression)
- [x] 実 JP UAT への疎通で account_id 取得確認

## Refs
- #32 (live 疎通)、#21 closed parent (canonical signing PR #31 の follow-up fix)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 認証ヘッダー生成時のタイムスタンプ形式を調整しました。
  * APIリクエストの署名計算からバージョン情報を除外しました。

* **テスト**
  * 認証ヘッダーの署名動作に関する検証テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->