### PR TITLE
feat(webull): v2 /openapi/account/orders/place + market inference (issue #32)

### DIFF
--- a/src/infrastructure/webull/WebullHttpClient.ts
+++ b/src/infrastructure/webull/WebullHttpClient.ts
@@ -58,7 +58,9 @@ export class WebullHttpClient {
   }
 
   async placeOrder(intent: OrderIntent): Promise<WebullPlaceOrderResponseDto> {
-    return this.request<WebullPlaceOrderResponseDto>('POST', '/trade/order/place', {
+    // v2 endpoint. JP UAT / newer Webull deployments reject the v1
+    // `/trade/order/place` + `stock_order` body with ILLEGAL_PARAMETER.
+    return this.request<WebullPlaceOrderResponseDto>('POST', '/openapi/account/orders/place', {
       query: { account_id: this.requireAccountId() },
       body: toWebullPlaceOrderRequest(intent),
     })

--- a/src/infrastructure/webull/dto.ts
+++ b/src/infrastructure/webull/dto.ts
@@ -13,30 +13,29 @@ export interface WebullSubscriptionDto {
   account_number?: string
 }
 
+export type WebullMarket = 'US' | 'JP'
+
+export interface WebullV2OrderEntry {
+  client_order_id: string
+  symbol: string
+  instrument_type: 'EQUITY'
+  market: WebullMarket
+  order_type: 'LIMIT'
+  limit_price: string
+  quantity: string
+  support_trading_session: 'N'
+  side: 'BUY' | 'SELL'
+  time_in_force: 'DAY'
+  entrust_type: 'QTY'
+  account_tax_type: 'GENERAL'
+}
+
 export interface WebullPlaceOrderRequestDto {
-  stock_order: {
-    client_order_id: string
-    symbol: string
-    side: 'BUY' | 'SELL'
-    tif: 'DAY'
-    order_type: 'LIMIT'
-    limit_price: string
-    qty: string
-    extended_hours_trading: boolean
-  }
+  new_orders: [WebullV2OrderEntry]
 }
 
 export interface WebullPlaceOrderResponseDto {
-  orderId?: string
-  order_id?: string
   client_order_id?: string
-  status?: string
-  symbol?: string
-  side?: 'BUY' | 'SELL'
-  quantity?: number
-  qty?: number | string
-  limitPrice?: number
-  limit_price?: string
+  order_id?: string
   message?: string
-  submittedAt?: string
 }

--- a/src/infrastructure/webull/mapper.ts
+++ b/src/infrastructure/webull/mapper.ts
@@ -1,24 +1,31 @@
 import type { ExecutionResult } from '../../trading/domain/ExecutionResult'
 import type { OrderIntent } from '../../trading/domain/OrderIntent'
-import type { WebullPlaceOrderRequestDto, WebullPlaceOrderResponseDto } from './dto'
+import type { WebullMarket, WebullPlaceOrderRequestDto, WebullPlaceOrderResponseDto } from './dto'
 
 export function toWebullPlaceOrderRequest(intent: OrderIntent): WebullPlaceOrderRequestDto {
+  const symbol = intent.symbol.toUpperCase()
   return {
-    stock_order: {
-      client_order_id: crypto.randomUUID().replaceAll('-', ''),
-      symbol: intent.symbol.toUpperCase(),
-      side: intent.side,
-      tif: 'DAY',
-      order_type: 'LIMIT',
-      limit_price: intent.price.toFixed(3),
-      qty: String(intent.quantity),
-      extended_hours_trading: false,
-    },
+    new_orders: [
+      {
+        client_order_id: crypto.randomUUID().replaceAll('-', ''),
+        symbol,
+        instrument_type: 'EQUITY',
+        market: inferWebullMarket(symbol),
+        order_type: 'LIMIT',
+        limit_price: intent.price.toFixed(3),
+        quantity: String(intent.quantity),
+        support_trading_session: 'N',
+        side: intent.side,
+        time_in_force: 'DAY',
+        entrust_type: 'QTY',
+        account_tax_type: 'GENERAL',
+      },
+    ],
   }
 }
 
 export function toExecutionResult(dto: WebullPlaceOrderResponseDto): ExecutionResult {
-  const brokerOrderId = dto.orderId ?? dto.order_id
+  const brokerOrderId = dto.order_id
 
   return {
     mode: 'LIVE',
@@ -26,4 +33,10 @@ export function toExecutionResult(dto: WebullPlaceOrderResponseDto): ExecutionRe
     brokerOrderId,
     errorReason: dto.message,
   }
+}
+
+// 4-digit numeric codes are Japanese exchange tickers (TYO / TSE). Anything else
+// is treated as US by default. Extend this when adding other markets.
+export function inferWebullMarket(symbol: string): WebullMarket {
+  return /^\d{4}$/.test(symbol) ? 'JP' : 'US'
 }

--- a/src/routes/webull.ts
+++ b/src/routes/webull.ts
@@ -33,16 +33,11 @@ async function parseOrderIntent(payload: Promise<unknown>): Promise<OrderIntent>
   }
 }
 
-function createDryRunResponse(intent: OrderIntent): WebullPlaceOrderResponseDto {
+function createDryRunResponse(_intent: OrderIntent): WebullPlaceOrderResponseDto {
   return {
-    orderId: `dry-run-${crypto.randomUUID()}`,
-    status: 'DRY_RUN',
-    symbol: intent.symbol,
-    side: intent.side,
-    quantity: intent.quantity,
-    limitPrice: intent.price,
+    client_order_id: crypto.randomUUID().replaceAll('-', ''),
+    order_id: `dry-run-${crypto.randomUUID()}`,
     message: 'DRY_RUN=true, broker request skipped',
-    submittedAt: new Date().toISOString(),
   }
 }
 

--- a/test/infrastructure/webull/webullHttpClient.test.ts
+++ b/test/infrastructure/webull/webullHttpClient.test.ts
@@ -31,16 +31,12 @@ function createClient(fetchFn: typeof fetch, timeoutMs?: number): WebullHttpClie
 }
 
 describe('WebullHttpClient', () => {
-  it('places an order with the expected method, URL, body, and Webull auth headers', async () => {
+  it('places an order via the v2 endpoint with the expected body and auth headers', async () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(
         JSON.stringify({
-          orderId: 'ord-123',
-          status: 'SUBMITTED',
-          symbol: 'SOXL',
-          side: 'BUY',
-          quantity: 2,
-          limitPrice: 9.5,
+          client_order_id: 'cli-123',
+          order_id: 'ord-123',
         }),
         { status: 200 },
       ),
@@ -51,19 +47,25 @@ describe('WebullHttpClient', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
     const [url, init] = fetchMock.mock.calls[0]!
-    expect(url).toBe('https://broker.example.test/trade/order/place?account_id=acct-1')
+    expect(url).toBe('https://broker.example.test/openapi/account/orders/place?account_id=acct-1')
     expect(init?.method).toBe('POST')
     expect(JSON.parse(init?.body as string)).toMatchObject({
-      stock_order: {
-        client_order_id: expect.any(String),
-        symbol: 'SOXL',
-        side: 'BUY',
-        tif: 'DAY',
-        order_type: 'LIMIT',
-        limit_price: '9.500',
-        qty: '2',
-        extended_hours_trading: false,
-      },
+      new_orders: [
+        {
+          client_order_id: expect.any(String),
+          symbol: 'SOXL',
+          instrument_type: 'EQUITY',
+          market: 'US',
+          order_type: 'LIMIT',
+          limit_price: '9.500',
+          quantity: '2',
+          support_trading_session: 'N',
+          side: 'BUY',
+          time_in_force: 'DAY',
+          entrust_type: 'QTY',
+          account_tax_type: 'GENERAL',
+        },
+      ],
     })
     expect(init?.headers).toMatchObject({
       Accept: 'application/json',
@@ -77,6 +79,19 @@ describe('WebullHttpClient', () => {
       'x-version': 'v1',
       'x-signature': expect.any(String),
     })
+  })
+
+  it('infers JP market for 4-digit numeric tickers', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ client_order_id: 'cli', order_id: 'ord' }), { status: 200 }),
+    )
+    const client = createClient(fetchMock)
+
+    await client.placeOrder({ symbol: '1570', side: 'BUY', quantity: 1, price: 25000, notional: 25000 })
+
+    const body = JSON.parse(fetchMock.mock.calls[0]![1]!.body as string)
+    expect(body.new_orders[0].market).toBe('JP')
+    expect(body.new_orders[0].symbol).toBe('1570')
   })
 
   it('requests account details from the documented profile endpoint', async () => {

--- a/test/routes/trade.test.ts
+++ b/test/routes/trade.test.ts
@@ -127,12 +127,8 @@ describe('trade routes', () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(
         JSON.stringify({
-          orderId: 'ord-live-1',
-          status: 'SUBMITTED',
-          symbol: 'SOXL',
-          side: 'BUY',
-          quantity: 2,
-          limitPrice: 9,
+          client_order_id: 'cli-live-1',
+          order_id: 'ord-live-1',
         }),
         { status: 200 },
       ),

--- a/test/routes/webull.test.ts
+++ b/test/routes/webull.test.ts
@@ -68,13 +68,13 @@ describe('webull routes', () => {
 
     expect(response.status).toBe(200)
     const body = (await response.json()) as {
-      status: string
-      orderId: string
-      symbol: string
+      order_id: string
+      client_order_id: string
+      message?: string
     }
-    expect(body.status).toBe('DRY_RUN')
-    expect(body.orderId).toMatch(/^dry-run-/)
-    expect(body.symbol).toBe('SOXL')
+    expect(body.order_id).toMatch(/^dry-run-/)
+    expect(body.client_order_id).toMatch(/^[0-9a-f]{32}$/)
+    expect(body.message).toMatch(/DRY_RUN=true/)
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
@@ -82,12 +82,8 @@ describe('webull routes', () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(
         JSON.stringify({
-          orderId: 'ord-123',
-          status: 'SUBMITTED',
-          symbol: 'SOXL',
-          side: 'BUY',
-          quantity: 2,
-          limitPrice: 9,
+          client_order_id: 'cli-123',
+          order_id: 'ord-123',
         }),
         { status: 200 },
       ),
@@ -121,12 +117,8 @@ describe('webull routes', () => {
 
     expect(response.status).toBe(200)
     expect(await response.json()).toEqual({
-      orderId: 'ord-123',
-      status: 'SUBMITTED',
-      symbol: 'SOXL',
-      side: 'BUY',
-      quantity: 2,
-      limitPrice: 9,
+      client_order_id: 'cli-123',
+      order_id: 'ord-123',
     })
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })

--- a/test/trading/execution/webullExecution.test.ts
+++ b/test/trading/execution/webullExecution.test.ts
@@ -15,12 +15,8 @@ describe('WebullExecution', () => {
   it('maps the Webull response into an ExecutionResult', async () => {
     const client = {
       placeOrder: vi.fn().mockResolvedValue({
-        orderId: 'ord-123',
-        status: 'SUBMITTED',
-        symbol: 'SOXL',
-        side: 'BUY',
-        quantity: 2,
-        limitPrice: 9,
+        client_order_id: 'cli-123',
+        order_id: 'ord-123',
       }),
     }
     const execution = new WebullExecution(client)


### PR DESCRIPTION
JP UAT 向け発注を通すため Webull v2 API に切替。コアは `placeOrder` 実装のみ、listSubscriptions / getAccount は v1 で引き続き動く。

## 判明した事実 (#32 live 疎通で)

JP UAT (`jp-openapi-alb.uat.webullbroker.com`) は v1 の `/trade/order/place` + `stock_order` body を **一切受け付けない**:

| 試行 | Webull 返答 |
|---|---|
| v1 path, account_id in query | `account_id value:null is blank` / `ILLEGAL_PARAMETER` |
| v1 path, account_id in body | `trade_currency value is null` |
| v1 path, instrument_id in body | 同上 |
| v2 path, new_orders + account_tax_type | **200 + 実 order_id** |

[Python SDK v2 `PlaceOrderRequest`](https://github.com/webull-inc/openapi-python-sdk/blob/main/webull-python-sdk-trade/webullsdktrade/request/v2/palce_order_request.py) と同じ `/openapi/account/orders/place` を採用、body も同じ shape に揃える。

## Changes

### `src/infrastructure/webull/dto.ts`
- `WebullV2OrderEntry` 新設 (symbol + market + instrument_type + time_in_force + entrust_type + support_trading_session + account_tax_type)
- Request DTO は `new_orders: [entry]` array
- Response DTO は `client_order_id` / `order_id` / `message` のみに絞る

### `src/infrastructure/webull/mapper.ts`
- `toWebullPlaceOrderRequest` を v2 形状に
- `toExecutionResult` は `order_id` 読み取り
- **`inferWebullMarket(symbol)`** 新規ヘルパ: 4桁数字 → "JP"、その他 → "US"

### `src/infrastructure/webull/WebullHttpClient.ts`
- `placeOrder` path を `/openapi/account/orders/place` に

### `src/routes/webull.ts`
- dry-run レスポンスを v2 shape に更新 (旧: `orderId`/`status:'DRY_RUN'` → 新: `order_id`/`client_order_id`/`message`)

## Tests
- 78 tests passing (既存テストを v2 mock 応答に更新 + JP market inference の 1 ケース追加)

## 範囲外 / 後続

- `WEBULL_APP_KEY` / `WEBULL_APP_SECRET` は v1 テナントでも v2 テナントでも共通 (`x-version` header は SDK v2 コードでも `v1` のまま)
- `getAccount` / `listSubscriptions` は v1 の `/account/profile` / `/app/subscriptions/list` が JP UAT でも通るので据え置き
- `account_tax_type` は `GENERAL` 固定 (NISA / iDeCo 等の別 tax type が必要になったら拡張)
- `market` は symbol 推論 (`/^\d{4}$/` → JP)。ADR / option / 他市場を扱う時は OrderIntent に market を明示したほうが安全

## 検証
- [x] `pnpm run typecheck` pass
- [x] `pnpm test` pass (78/78)
- [x] JP UAT で AAPL limit order が実 `order_id` 返却確認

Refs: #32 (live 疎通), #21 closed parent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * Webull取引プラットフォームとの統合を最新APIバージョンに更新しました。
  * 注文応答の形式を簡潔に改善しました。ドライラン注文のID生成フォーマットも変更されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->