### PR TITLE
feat(logger): trade journal logging for review & improvement (issue #40)

### DIFF
--- a/bridge/grpc/client.test.ts
+++ b/bridge/grpc/client.test.ts
@@ -49,7 +49,8 @@ describe('createWebullGrpcTradeEventClient', () => {
     })
 
     const port = await bindServer(server)
-    server.start()
+
+    await new Promise((resolve) => setTimeout(resolve, 100))
 
     const onEvent = vi.fn()
     const client = createWebullGrpcTradeEventClient({
@@ -92,6 +93,7 @@ async function bindServer(server: grpc.Server): Promise<number> {
         return
       }
 
+      server.start()
       resolve(port)
     })
   })

--- a/docs/review-queries.md
+++ b/docs/review-queries.md
@@ -28,7 +28,9 @@ trade_event_type = "exit"
 ### Win rate by strategy
 
 ```
-trade_event_type = "exit"
+(join) exit records (trade_event_type = "exit")
+       -> decision records (trade_event_type = "decision")
+       on client_order_id
 (group by) strategy_name, exit_reason
 ```
 

--- a/docs/review-queries.md
+++ b/docs/review-queries.md
@@ -1,0 +1,69 @@
+# Trade journal review queries
+
+All trade-journal records are emitted to `console.log` as NDJSON (one JSON object per line) from the Worker and end up in Cloudflare Workers Logs. The audit middleware (`src/infrastructure/logger/AuditLogger.ts`) records HTTP request lifecycle; the trade-journal module (`src/infrastructure/logger/tradeJournal.ts`) records trade lifecycle. Both share the same sink so queries below match against Workers Logs output.
+
+## Record shapes
+
+Every trade-journal line has:
+
+- `timestamp` — ISO 8601 (UTC)
+- `trade_event_type` — one of `decision`, `intent`, `pre_submit`, `post_submit`, `fill`, `exit`
+- `symbol` — upper-case ticker (when applicable)
+- `request_id` — correlates to a single HTTP call; joins with `AuditLogger` records
+- `client_order_id` — correlates a trade across `intent → pre_submit → post_submit → fill → exit`
+- other fields depend on the event type; see `TradeJournalRecord` for the full set
+
+## Cloudflare Workers Logs filters
+
+Workers Logs supports JSON path filters. Examples:
+
+### Daily P&L
+
+```
+trade_event_type = "exit"
+(group by) date(timestamp)
+(sum) realized_pnl
+```
+
+### Win rate by strategy
+
+```
+trade_event_type = "exit"
+(group by) strategy_name, exit_reason
+```
+
+Join `exit` back to the original `decision` with matching `client_order_id` to recover `strategy_name`.
+
+### Risk-reject breakdown
+
+```
+trade_event_type = "decision" AND risk_allowed = false
+(group by) risk_reasons[0]
+(count) *
+```
+
+### Broker latency
+
+```
+trade_event_type = "post_submit"
+(avg, p95) latency_ms
+```
+
+### Quote staleness fall-through
+
+Look for `decision` records where `signal_action = "HOLD"` and (future) a reason tag like `quote_stale`. Issue #37 will wire the staleness guard to emit that reason; this section will be finalized when it lands.
+
+## Local grep cheatsheet (development)
+
+```
+wrangler tail --format=json | jq 'select(.trade_event_type=="exit")'
+wrangler tail --format=json | jq 'select(.client_order_id=="<id>")'
+```
+
+`wrangler tail` streams NDJSON from the Worker; pipe through `jq` to filter by trade event type or correlate by `client_order_id`.
+
+## Caveats
+
+- Logs older than the Workers Logs retention window (default 3 days unless you have Logpush) are gone. For longer retention, enable Logpush to R2 or an external sink (tracked separately in POC follow-ups).
+- `exit` events are only emitted once position tracking lands (issue #37). Until then, use `fill` as the latest trade-lifecycle record.
+- `realized_pnl` is emitted by the caller of `logExit` — correctness depends on whoever closes the position computing it against the right base currency.

--- a/src/infrastructure/logger/tradeJournal.ts
+++ b/src/infrastructure/logger/tradeJournal.ts
@@ -1,0 +1,187 @@
+import type { ExecutionResult } from '../../trading/domain/ExecutionResult'
+import type { OrderIntent } from '../../trading/domain/OrderIntent'
+import type { RiskDecision } from '../../trading/domain/RiskDecision'
+import type { Signal } from '../../trading/domain/Signal'
+
+export type TradeEventType =
+  | 'decision'
+  | 'intent'
+  | 'pre_submit'
+  | 'post_submit'
+  | 'fill'
+  | 'exit'
+
+export interface TradeJournalRecord {
+  timestamp: string
+  trade_event_type: TradeEventType
+  request_id?: string
+  client_order_id?: string
+  order_id?: string
+  symbol?: string
+  strategy_name?: string
+  signal_action?: Signal['action']
+  signal_reason?: string
+  risk_allowed?: boolean
+  risk_reasons?: string[]
+  side?: OrderIntent['side']
+  quantity?: number
+  limit_price?: number
+  notional?: number
+  latency_ms?: number
+  broker_status?: string
+  mode?: ExecutionResult['mode']
+  submitted?: boolean
+  filled_qty?: number
+  filled_price?: number
+  realized_pnl?: number
+  hold_days?: number
+  exit_reason?: 'TP' | 'SL' | 'TIME_STOP' | 'OTHER'
+  error_class?: string
+  error_message?: string
+}
+
+type LogSink = (line: string) => void
+
+let sink: LogSink = (line) => {
+  console.log(line)
+}
+
+/**
+ * For tests only: redirect trade-journal output to a custom sink.
+ * Returns a restore function that puts the previous sink back.
+ */
+export function setTradeJournalSink(next: LogSink): () => void {
+  const previous = sink
+  sink = next
+  return () => {
+    sink = previous
+  }
+}
+
+function emit(record: TradeJournalRecord): void {
+  sink(JSON.stringify(record))
+}
+
+export function logTradeDecision(input: {
+  requestId?: string
+  symbol: string
+  strategyName: string
+  signal: Signal
+  riskDecision: RiskDecision
+}): void {
+  emit({
+    timestamp: new Date().toISOString(),
+    trade_event_type: 'decision',
+    request_id: input.requestId,
+    symbol: input.symbol,
+    strategy_name: input.strategyName,
+    signal_action: input.signal.action,
+    signal_reason: input.signal.reason,
+    risk_allowed: input.riskDecision.allowed,
+    risk_reasons: input.riskDecision.reasons,
+  })
+}
+
+export function logTradeIntent(input: {
+  requestId?: string
+  clientOrderId: string
+  intent: OrderIntent
+}): void {
+  emit({
+    timestamp: new Date().toISOString(),
+    trade_event_type: 'intent',
+    request_id: input.requestId,
+    client_order_id: input.clientOrderId,
+    symbol: input.intent.symbol,
+    side: input.intent.side,
+    quantity: input.intent.quantity,
+    limit_price: input.intent.price,
+    notional: input.intent.notional,
+  })
+}
+
+export function logPreSubmit(input: {
+  requestId?: string
+  clientOrderId: string
+  intent: OrderIntent
+}): void {
+  emit({
+    timestamp: new Date().toISOString(),
+    trade_event_type: 'pre_submit',
+    request_id: input.requestId,
+    client_order_id: input.clientOrderId,
+    symbol: input.intent.symbol,
+    side: input.intent.side,
+    quantity: input.intent.quantity,
+    limit_price: input.intent.price,
+    notional: input.intent.notional,
+  })
+}
+
+export function logPostSubmit(input: {
+  requestId?: string
+  clientOrderId: string
+  symbol: string
+  result?: ExecutionResult
+  latencyMs?: number
+  error?: Error
+}): void {
+  emit({
+    timestamp: new Date().toISOString(),
+    trade_event_type: 'post_submit',
+    request_id: input.requestId,
+    client_order_id: input.clientOrderId,
+    symbol: input.symbol,
+    order_id: input.result?.brokerOrderId,
+    mode: input.result?.mode,
+    submitted: input.result?.submitted,
+    latency_ms: input.latencyMs,
+    broker_status: input.result?.errorReason,
+    error_class: input.error?.constructor.name,
+    error_message: input.error?.message ? truncate(input.error.message, 200) : undefined,
+  })
+}
+
+export function logFill(input: {
+  clientOrderId?: string
+  orderId?: string
+  symbol: string
+  filledQty?: number
+  filledPrice?: number
+  status?: string
+}): void {
+  emit({
+    timestamp: new Date().toISOString(),
+    trade_event_type: 'fill',
+    client_order_id: input.clientOrderId,
+    order_id: input.orderId,
+    symbol: input.symbol,
+    filled_qty: input.filledQty,
+    filled_price: input.filledPrice,
+    broker_status: input.status,
+  })
+}
+
+export function logExit(input: {
+  clientOrderId?: string
+  orderId?: string
+  symbol: string
+  realizedPnl: number
+  holdDays: number
+  exitReason: NonNullable<TradeJournalRecord['exit_reason']>
+}): void {
+  emit({
+    timestamp: new Date().toISOString(),
+    trade_event_type: 'exit',
+    client_order_id: input.clientOrderId,
+    order_id: input.orderId,
+    symbol: input.symbol,
+    realized_pnl: input.realizedPnl,
+    hold_days: input.holdDays,
+    exit_reason: input.exitReason,
+  })
+}
+
+function truncate(value: string, max: number): string {
+  return value.length <= max ? value : value.slice(0, max)
+}

--- a/src/infrastructure/webull/mapper.ts
+++ b/src/infrastructure/webull/mapper.ts
@@ -7,7 +7,7 @@ export function toWebullPlaceOrderRequest(intent: OrderIntent): WebullPlaceOrder
   return {
     new_orders: [
       {
-        client_order_id: crypto.randomUUID().replaceAll('-', ''),
+        client_order_id: intent.clientOrderId,
         symbol,
         instrument_type: 'EQUITY',
         market: inferWebullMarket(symbol),

--- a/src/routes/trade.ts
+++ b/src/routes/trade.ts
@@ -20,11 +20,13 @@ interface TradeRequest {
 export const trade = new Hono<AppBindings>().post('/decide', async (c) => {
   const request = await parseTradeRequest(c.req.json())
   const service = createTradingService(request, c.env)
-  return c.json(service.decide(request, readTradingConfig(c.env)))
+  return c.json(service.decide(request, readTradingConfig(c.env), { requestId: c.get('requestId') }))
 }).post('/execute', async (c) => {
   const request = await parseTradeRequest(c.req.json())
   const service = createTradingService(request, c.env)
-  return c.json(await service.executeTrade(request, readTradingConfig(c.env)))
+  return c.json(
+    await service.executeTrade(request, readTradingConfig(c.env), { requestId: c.get('requestId') }),
+  )
 })
 
 async function parseTradeRequest(payload: Promise<unknown>): Promise<TradeRequest> {

--- a/src/routes/webull.ts
+++ b/src/routes/webull.ts
@@ -3,18 +3,50 @@ import type { AppBindings } from '../app'
 import { parseBooleanEnv } from '../config/env'
 import { createWebullHttpClient } from '../infrastructure/webull/WebullHttpClient'
 import type { WebullPlaceOrderResponseDto } from '../infrastructure/webull/dto'
+import { logPostSubmit, logPreSubmit } from '../infrastructure/logger/tradeJournal'
 import { ValidationError } from '../shared/errors'
 import type { OrderIntent, OrderSide } from '../trading/domain/OrderIntent'
 
 export const webull = new Hono<AppBindings>().post('/order/place', async (c) => {
   const intent = await parseOrderIntent(c.req.json())
+  const requestId = c.get('requestId')
+
+  logPreSubmit({ requestId, clientOrderId: intent.clientOrderId, intent })
 
   if (parseBooleanEnv(c.env.DRY_RUN, true)) {
-    return c.json(createDryRunResponse(intent))
+    const dto = createDryRunResponse(intent)
+    logPostSubmit({
+      requestId,
+      clientOrderId: intent.clientOrderId,
+      symbol: intent.symbol,
+      result: { mode: 'DRY_RUN', submitted: true, brokerOrderId: dto.order_id },
+      latencyMs: 0,
+    })
+    return c.json(dto)
   }
 
   const client = createWebullHttpClient(c.env)
-  return c.json(await client.placeOrder(intent))
+  const startedAt = Date.now()
+  let dto: WebullPlaceOrderResponseDto | undefined
+  let error: Error | undefined
+  try {
+    dto = await client.placeOrder(intent)
+    return c.json(dto)
+  } catch (err) {
+    error = err instanceof Error ? err : new Error(String(err))
+    throw err
+  } finally {
+    logPostSubmit({
+      requestId,
+      clientOrderId: intent.clientOrderId,
+      symbol: intent.symbol,
+      result: dto
+        ? { mode: 'LIVE', submitted: !!dto.order_id, brokerOrderId: dto.order_id, errorReason: dto.message }
+        : undefined,
+      latencyMs: Date.now() - startedAt,
+      error,
+    })
+  }
 })
 
 async function parseOrderIntent(payload: Promise<unknown>): Promise<OrderIntent> {
@@ -30,12 +62,13 @@ async function parseOrderIntent(payload: Promise<unknown>): Promise<OrderIntent>
     quantity,
     price,
     notional: quantity * price,
+    clientOrderId: crypto.randomUUID().replaceAll('-', ''),
   }
 }
 
-function createDryRunResponse(_intent: OrderIntent): WebullPlaceOrderResponseDto {
+function createDryRunResponse(intent: OrderIntent): WebullPlaceOrderResponseDto {
   return {
-    client_order_id: crypto.randomUUID().replaceAll('-', ''),
+    client_order_id: intent.clientOrderId,
     order_id: `dry-run-${crypto.randomUUID()}`,
     message: 'DRY_RUN=true, broker request skipped',
   }

--- a/src/trading/application/TradingService.ts
+++ b/src/trading/application/TradingService.ts
@@ -5,6 +5,12 @@ import type { Signal } from '../domain/Signal'
 import type { Execution } from '../execution/Execution'
 import type { RiskPolicy } from '../risk/RiskPolicy'
 import type { Strategy, StrategyInput } from '../strategy/Strategy'
+import {
+  logPostSubmit,
+  logPreSubmit,
+  logTradeDecision,
+  logTradeIntent,
+} from '../../infrastructure/logger/tradeJournal'
 
 export interface TradingConfig {
   dryRun: boolean
@@ -26,6 +32,10 @@ export interface TradingExecution extends TradingDecision {
   executionResult?: ExecutionResult
 }
 
+export interface TradeCallContext {
+  requestId?: string
+}
+
 export class TradingService {
   constructor(
     private readonly strategy: Strategy,
@@ -33,7 +43,7 @@ export class TradingService {
     private readonly execution: Execution,
   ) {}
 
-  decide(input: StrategyInput, config: TradingConfig): TradingDecision {
+  decide(input: StrategyInput, config: TradingConfig, ctx?: TradeCallContext): TradingDecision {
     const signal = this.strategy.decide(input)
     const orderIntent = this.createOrderIntent(signal)
     const riskDecision = this.riskPolicy.evaluate({
@@ -47,25 +57,57 @@ export class TradingService {
       now: config.now,
     })
 
+    const resolvedIntent =
+      riskDecision.normalizedIntent !== undefined ? riskDecision.normalizedIntent : orderIntent
+
+    logTradeDecision({
+      requestId: ctx?.requestId,
+      symbol: input.symbol,
+      strategyName: this.strategy.name,
+      signal,
+      riskDecision,
+    })
+
     return {
       signal,
-      orderIntent: riskDecision.normalizedIntent !== undefined ? riskDecision.normalizedIntent : orderIntent,
+      orderIntent: resolvedIntent,
       riskDecision,
     }
   }
 
-  async executeTrade(input: StrategyInput, config: TradingConfig): Promise<TradingExecution> {
-    const decision = this.decide(input, config)
+  async executeTrade(
+    input: StrategyInput,
+    config: TradingConfig,
+    ctx?: TradeCallContext,
+  ): Promise<TradingExecution> {
+    const decision = this.decide(input, config, ctx)
 
     if (!decision.riskDecision.allowed || !decision.orderIntent) {
       return decision
     }
 
-    const executionResult = await this.execution.execute(decision.orderIntent)
+    const intent = decision.orderIntent
+    logTradeIntent({ requestId: ctx?.requestId, clientOrderId: intent.clientOrderId, intent })
+    logPreSubmit({ requestId: ctx?.requestId, clientOrderId: intent.clientOrderId, intent })
 
-    return {
-      ...decision,
-      executionResult,
+    const startedAt = Date.now()
+    let executionResult: ExecutionResult | undefined
+    let error: Error | undefined
+    try {
+      executionResult = await this.execution.execute(intent)
+      return { ...decision, executionResult }
+    } catch (err) {
+      error = err instanceof Error ? err : new Error(String(err))
+      throw err
+    } finally {
+      logPostSubmit({
+        requestId: ctx?.requestId,
+        clientOrderId: intent.clientOrderId,
+        symbol: intent.symbol,
+        result: executionResult,
+        latencyMs: Date.now() - startedAt,
+        error,
+      })
     }
   }
 
@@ -80,6 +122,7 @@ export class TradingService {
       quantity: signal.quantity,
       price: signal.price,
       notional: signal.price * signal.quantity,
+      clientOrderId: crypto.randomUUID().replaceAll('-', ''),
     }
   }
 }

--- a/src/trading/domain/OrderIntent.ts
+++ b/src/trading/domain/OrderIntent.ts
@@ -6,4 +6,10 @@ export interface OrderIntent {
   quantity: number
   price: number
   notional: number
+  /**
+   * Broker-facing idempotency key. Generated once when the intent is
+   * constructed so the same id flows through decision → submit → fill
+   * for audit correlation.
+   */
+  clientOrderId: string
 }

--- a/src/trading/events/TradeEventHandler.ts
+++ b/src/trading/events/TradeEventHandler.ts
@@ -1,4 +1,5 @@
 import type { TradeEvent } from '../domain/TradeEvent'
+import { logFill } from '../../infrastructure/logger/tradeJournal'
 
 export interface TradeEventAuditRecord {
   source: 'trade-event'
@@ -14,12 +15,16 @@ export class TradeEventHandler {
   constructor(private readonly log: (message: string) => void = console.log) {}
 
   async handle(event: TradeEvent): Promise<void> {
+    const orderId = event.orderId.trim()
+    const symbol = event.symbol.trim().toUpperCase()
+    const status = event.status.trim()
+
     const record: TradeEventAuditRecord = {
       source: 'trade-event',
       eventType: event.eventType.trim(),
-      orderId: event.orderId.trim(),
-      symbol: event.symbol.trim().toUpperCase(),
-      status: event.status.trim(),
+      orderId,
+      symbol,
+      status,
       receivedAt: event.receivedAt,
     }
 
@@ -28,5 +33,40 @@ export class TradeEventHandler {
     }
 
     this.log(JSON.stringify(record))
+
+    // Emit a parallel trade-journal line so a single query by client_order_id
+    // can reconstruct the full decision → fill lifecycle.
+    const clientOrderId = readClientOrderId(event.rawPayload)
+    const filledPrice = readFilledPrice(event.rawPayload)
+
+    logFill({
+      clientOrderId,
+      orderId,
+      symbol,
+      filledQty: event.filledQty,
+      filledPrice,
+      status,
+    })
   }
+}
+
+function readClientOrderId(payload: unknown): string | undefined {
+  if (!isRecord(payload)) return undefined
+  const value = payload.client_order_id ?? payload.clientOrderId
+  return typeof value === 'string' ? value : undefined
+}
+
+function readFilledPrice(payload: unknown): number | undefined {
+  if (!isRecord(payload)) return undefined
+  const value = payload.filled_price ?? payload.filledPrice ?? payload.price
+  if (typeof value === 'number') return value
+  if (typeof value === 'string') {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : undefined
+  }
+  return undefined
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }

--- a/src/trading/strategy/Strategy.ts
+++ b/src/trading/strategy/Strategy.ts
@@ -7,5 +7,6 @@ export interface StrategyInput {
 }
 
 export interface Strategy {
+  readonly name: string
   decide(input: StrategyInput): Signal
 }

--- a/src/trading/strategy/strategies/FixedRuleStrategy.ts
+++ b/src/trading/strategy/strategies/FixedRuleStrategy.ts
@@ -2,6 +2,8 @@ import type { Signal } from '../../domain/Signal'
 import type { Strategy, StrategyInput } from '../Strategy'
 
 export class FixedRuleStrategy implements Strategy {
+  readonly name = 'FixedRuleStrategy'
+
   constructor(
     private readonly buyBelow: number,
     private readonly sellAbove: number,

--- a/test/execution/mockExecution.test.ts
+++ b/test/execution/mockExecution.test.ts
@@ -11,6 +11,7 @@ describe('MockExecution', () => {
       quantity: 2,
       price: 10,
       notional: 20,
+      clientOrderId: 'test-coid',
     })
 
     expect(result.mode).toBe('DRY_RUN')

--- a/test/infrastructure/logger/tradeJournal.test.ts
+++ b/test/infrastructure/logger/tradeJournal.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest'
+import {
+  logExit,
+  logFill,
+  logPostSubmit,
+  logPreSubmit,
+  logTradeDecision,
+  logTradeIntent,
+  setTradeJournalSink,
+  type TradeJournalRecord,
+} from '../../../src/infrastructure/logger/tradeJournal'
+import type { OrderIntent } from '../../../src/trading/domain/OrderIntent'
+
+const intent: OrderIntent = {
+  symbol: 'SOXL',
+  side: 'BUY',
+  quantity: 2,
+  price: 9,
+  notional: 18,
+  clientOrderId: 'coid-1',
+}
+
+function captureLines(): { lines: TradeJournalRecord[]; restore: () => void } {
+  const lines: TradeJournalRecord[] = []
+  const restore = setTradeJournalSink((line) => {
+    lines.push(JSON.parse(line))
+  })
+  return { lines, restore }
+}
+
+describe('tradeJournal', () => {
+  it('decision carries strategy name, signal, and risk fields', () => {
+    const { lines, restore } = captureLines()
+    try {
+      logTradeDecision({
+        requestId: 'req-1',
+        symbol: 'SOXL',
+        strategyName: 'FixedRuleStrategy',
+        signal: {
+          action: 'BUY',
+          symbol: 'SOXL',
+          quantity: 2,
+          price: 9,
+          reason: 'under threshold',
+          generatedAtIso: '2026-04-18T07:00:00Z',
+        },
+        riskDecision: { allowed: true, reasons: [] },
+      })
+    } finally {
+      restore()
+    }
+
+    expect(lines).toHaveLength(1)
+    expect(lines[0]).toMatchObject({
+      trade_event_type: 'decision',
+      request_id: 'req-1',
+      symbol: 'SOXL',
+      strategy_name: 'FixedRuleStrategy',
+      signal_action: 'BUY',
+      risk_allowed: true,
+    })
+  })
+
+  it('intent / pre_submit / post_submit share the same client_order_id', () => {
+    const { lines, restore } = captureLines()
+    try {
+      logTradeIntent({ requestId: 'req-1', clientOrderId: intent.clientOrderId, intent })
+      logPreSubmit({ requestId: 'req-1', clientOrderId: intent.clientOrderId, intent })
+      logPostSubmit({
+        requestId: 'req-1',
+        clientOrderId: intent.clientOrderId,
+        symbol: intent.symbol,
+        result: { mode: 'LIVE', submitted: true, brokerOrderId: 'ord-1' },
+        latencyMs: 123,
+      })
+    } finally {
+      restore()
+    }
+
+    const ids = new Set(lines.map((l) => l.client_order_id))
+    expect(ids).toEqual(new Set(['coid-1']))
+    const types = lines.map((l) => l.trade_event_type)
+    expect(types).toEqual(['intent', 'pre_submit', 'post_submit'])
+    expect(lines[2]).toMatchObject({ order_id: 'ord-1', mode: 'LIVE', submitted: true, latency_ms: 123 })
+  })
+
+  it('post_submit captures error class and truncates message', () => {
+    const { lines, restore } = captureLines()
+    const long = 'x'.repeat(300)
+    try {
+      logPostSubmit({
+        requestId: 'req-2',
+        clientOrderId: intent.clientOrderId,
+        symbol: intent.symbol,
+        error: new Error(long),
+      })
+    } finally {
+      restore()
+    }
+
+    expect(lines[0]?.error_class).toBe('Error')
+    expect(lines[0]?.error_message?.length).toBe(200)
+  })
+
+  it('fill + exit correlate via client_order_id', () => {
+    const { lines, restore } = captureLines()
+    try {
+      logFill({
+        clientOrderId: 'coid-1',
+        orderId: 'ord-1',
+        symbol: 'SOXL',
+        filledQty: 2,
+        filledPrice: 9.01,
+        status: 'FILLED',
+      })
+      logExit({
+        clientOrderId: 'coid-1',
+        orderId: 'ord-1',
+        symbol: 'SOXL',
+        realizedPnl: 1.02,
+        holdDays: 3,
+        exitReason: 'TP',
+      })
+    } finally {
+      restore()
+    }
+
+    expect(lines[0]).toMatchObject({
+      trade_event_type: 'fill',
+      client_order_id: 'coid-1',
+      filled_qty: 2,
+      filled_price: 9.01,
+    })
+    expect(lines[1]).toMatchObject({
+      trade_event_type: 'exit',
+      client_order_id: 'coid-1',
+      realized_pnl: 1.02,
+      hold_days: 3,
+      exit_reason: 'TP',
+    })
+  })
+})

--- a/test/infrastructure/webull/webullHttpClient.test.ts
+++ b/test/infrastructure/webull/webullHttpClient.test.ts
@@ -9,6 +9,7 @@ const intent: OrderIntent = {
   quantity: 2,
   price: 9.5,
   notional: 19,
+  clientOrderId: 'test-coid',
 }
 
 function createClient(fetchFn: typeof fetch, timeoutMs?: number): WebullHttpClient {
@@ -87,7 +88,14 @@ describe('WebullHttpClient', () => {
     )
     const client = createClient(fetchMock)
 
-    await client.placeOrder({ symbol: '1570', side: 'BUY', quantity: 1, price: 25000, notional: 25000 })
+    await client.placeOrder({
+      symbol: '1570',
+      side: 'BUY',
+      quantity: 1,
+      price: 25000,
+      notional: 25000,
+      clientOrderId: 'test-coid-jp',
+    })
 
     const body = JSON.parse(fetchMock.mock.calls[0]![1]!.body as string)
     expect(body.new_orders[0].market).toBe('JP')

--- a/test/risk/defaultRiskPolicy.test.ts
+++ b/test/risk/defaultRiskPolicy.test.ts
@@ -30,6 +30,7 @@ describe('DefaultRiskPolicy', () => {
         quantity: 2,
         price: 10,
         notional: 20,
+        clientOrderId: 'test-coid',
       },
     })
 
@@ -50,6 +51,7 @@ describe('DefaultRiskPolicy', () => {
         quantity: 2,
         price: 10,
         notional: 20,
+        clientOrderId: 'test-coid',
       },
     })
 
@@ -66,6 +68,7 @@ describe('DefaultRiskPolicy', () => {
         quantity: 2,
         price: 10,
         notional: 20,
+        clientOrderId: 'test-coid',
       },
     })
 
@@ -82,6 +85,7 @@ describe('DefaultRiskPolicy', () => {
         quantity: 20,
         price: 10,
         notional: 200,
+        clientOrderId: 'test-coid',
       },
       tradingEnabled: false,
     })
@@ -110,6 +114,7 @@ describe('DefaultRiskPolicy', () => {
         quantity: 4,
         price: 10,
         notional: 40,
+        clientOrderId: 'test-coid',
       },
       symbolMaxNotional: { SOXL: 50 },
     })
@@ -121,6 +126,7 @@ describe('DefaultRiskPolicy', () => {
         quantity: 6,
         price: 10,
         notional: 60,
+        clientOrderId: 'test-coid',
       },
       symbolMaxNotional: { SOXL: 50 },
     })
@@ -139,6 +145,7 @@ describe('DefaultRiskPolicy', () => {
         quantity: 11,
         price: 10,
         notional: 110,
+        clientOrderId: 'test-coid',
       },
       symbolMaxNotional: { SOXL: 50 },
     })
@@ -156,6 +163,7 @@ describe('DefaultRiskPolicy', () => {
         quantity: 2,
         price: 10,
         notional: 20,
+        clientOrderId: 'test-coid',
       },
       marketHoursCheck: true,
       now: () => new Date('2026-04-20T12:00:00.000Z'),
@@ -174,6 +182,7 @@ describe('DefaultRiskPolicy', () => {
         quantity: 2,
         price: 10,
         notional: 20,
+        clientOrderId: 'test-coid',
       },
       marketHoursCheck: true,
       now: () => new Date('2026-04-20T15:00:00.000Z'),
@@ -191,6 +200,7 @@ describe('DefaultRiskPolicy', () => {
         quantity: 2,
         price: 10,
         notional: 20,
+        clientOrderId: 'test-coid',
       },
       marketHoursCheck: false,
       now: () => new Date('2026-04-20T12:00:00.000Z'),

--- a/test/trading/execution/webullExecution.test.ts
+++ b/test/trading/execution/webullExecution.test.ts
@@ -9,6 +9,7 @@ const intent: OrderIntent = {
   quantity: 2,
   price: 9,
   notional: 18,
+  clientOrderId: 'test-coid',
 }
 
 describe('WebullExecution', () => {


### PR DESCRIPTION
Issue #40 実装。振り返り/改善用の構造化ログを既存 `AuditLogger` と並走させる。

## 何を出すか

`src/infrastructure/logger/tradeJournal.ts` に 6 つの lifecycle ヘルパ:

| helper | trade_event_type | 主な field |
|---|---|---|
| `logTradeDecision` | `decision` | `strategy_name`, `signal_action`, `signal_reason`, `risk_allowed`, `risk_reasons` |
| `logTradeIntent` | `intent` | `client_order_id`, `side`, `quantity`, `limit_price`, `notional` |
| `logPreSubmit` | `pre_submit` | 同上 (発注直前) |
| `logPostSubmit` | `post_submit` | `order_id`, `mode`, `submitted`, `latency_ms`, `broker_status`, `error_class` |
| `logFill` | `fill` | `client_order_id`, `order_id`, `filled_qty`, `filled_price` |
| `logExit` | `exit` | `realized_pnl`, `hold_days`, `exit_reason` |

全 NDJSON、`console.log` sink 共有 → Cloudflare Workers Logs にそのまま流れる。

## 相関キー設計

- **`request_id`**: HTTP call 単位 (既存 `AuditLogger` と join 可能)
- **`client_order_id`**: 1 trade を `decision → intent → pre_submit → post_submit → fill → exit` で貫通

`OrderIntent` に `clientOrderId: string` を **必須**で追加。`TradingService.createOrderIntent` で生成 → Webull mapper はこれを転写 (以前は mapper が独自に UUID 生成していたため fill event と intent が紐付かなかった)。

## Wiring

- `Strategy` interface に `readonly name: string` 追加、`FixedRuleStrategy` が `"FixedRuleStrategy"` を公開
- `TradingService.decide/executeTrade` が optional `TradeCallContext({requestId})` を受け取り各 lifecycle 点で自動 emit (`post_submit` は try/finally で latency + error まで必ず残す)
- `/trade/*` / `/webull/order/place` route が `c.get('requestId')` を service に渡して join key 確保
- `TradeEventHandler` が fill event 受信時に `client_order_id` と `filled_price` を raw payload から抽出して `logFill` も発行

## このPRのスコープ外

**`exit` 出力は helper 定義のみ、呼び出し箇所は未設置**。position tracker が無いと `realized_pnl` / `hold_days` を計算できないため、issue #37 (DO state layer) で position close の経路に組み込む。定義だけ置いておくことで、schema が先行して安定する (後から log field 増やすより schema 契約を固定する方が後段集計が楽)。

## Docs

`docs/review-queries.md` に:
- record shape 一覧
- Workers Logs フィルタ例 (daily P&L / 戦略別勝率 / Risk reject 率 / broker latency)
- `wrangler tail | jq` ローカル grep cheatsheet
- Logpush 未設定時のログ retention 注意

## Test plan
- [x] `pnpm run typecheck` pass
- [x] `pnpm test` pass (**16 files / 82 tests** — tradeJournal 用 4ケース追加)
- [x] OrderIntent の clientOrderId 必須化で既存 test fixture を更新 (bulk sed + 手修正1件)
- [x] `client_order_id` が intent/pre_submit/post_submit で一致することを test で assert
- [x] post_submit が error 捕捉 + message truncate 200 文字

Refs: #40 (parent), #37 (exit hook prerequisite), #12 #16 (AuditLogger origin)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * トレード・ジャーナルの出力を追加し、意思決定から約定・終了までの各イベントを追跡可能にしました。
* **ドキュメント**
  * Workers Logsでのトレード・ジャーナルの検索・集計例をまとめた参照ガイドを追加しました。
* **改善**
  * クライアント側の注文IDを全工程で伝搬して監査相関を強化。意思決定／送信時にリクエストIDを含めてログ出力します。
* **テスト**
  * ロギングや注文ID伝搬を検証する単体テストを追加・更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->