### PR TITLE
feat(state): Durable Object scaffold for per-symbol trading state (#37-A)

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,3 +1,5 @@
+import type { SymbolStateDO } from '../trading/state/SymbolStateDO'
+
 export interface Env {
   BASIC_AUTH_USER: string
   BASIC_AUTH_PASSWORD: string
@@ -6,6 +8,7 @@ export interface Env {
   ALLOWED_SYMBOLS: string
   MAX_ORDER_NOTIONAL: string
   EVENT_INGEST_SECRET: string
+  SYMBOL_STATE: DurableObjectNamespace<SymbolStateDO>
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
 import { createApp } from './app'
 
+export { SymbolStateDO } from './trading/state/SymbolStateDO'
+
 export default createApp()

--- a/src/trading/state/SymbolStateDO.ts
+++ b/src/trading/state/SymbolStateDO.ts
@@ -1,0 +1,94 @@
+import { DurableObject } from 'cloudflare:workers'
+import {
+  addPendingSettlement,
+  clearPendingOrder,
+  lockPendingOrder,
+  recordFill,
+  recordSignal,
+  rollSettlements,
+  setCooldown,
+  type TransitionContext,
+} from './stateTransitions'
+import { emptySymbolState, type PendingOrderLock, type PendingSettlement, type SymbolState } from './types'
+
+const STATE_KEY = 'state'
+
+/**
+ * Per-symbol state held in a Durable Object. Instance id must be derived from
+ * the symbol (e.g. `SYMBOL_STATE.idFromName(symbol)`) so all reads/writes for
+ * the same ticker land on the same object.
+ */
+export class SymbolStateDO extends DurableObject<object> {
+  private readonly transitionCtx: TransitionContext = { now: () => new Date() }
+
+  async getState(symbol: string): Promise<SymbolState> {
+    const state = await this.load(symbol)
+    // Defensive roll-forward: if asOf day is past any pending settleDate,
+    // move those amounts into settledCash immediately.
+    const rolled = rollSettlements(state, this.transitionCtx.now().toISOString(), this.transitionCtx)
+    if (rolled !== state) {
+      await this.save(rolled)
+    }
+    return rolled
+  }
+
+  async lockPendingOrder(
+    symbol: string,
+    lock: PendingOrderLock,
+  ): Promise<{ ok: boolean; state: SymbolState }> {
+    const state = await this.load(symbol)
+    const result = lockPendingOrder(state, lock, this.transitionCtx)
+    if (result.ok) await this.save(result.state)
+    return result
+  }
+
+  async clearPendingOrder(symbol: string): Promise<SymbolState> {
+    const state = await this.load(symbol)
+    const next = clearPendingOrder(state, this.transitionCtx)
+    await this.save(next)
+    return next
+  }
+
+  async recordFill(
+    symbol: string,
+    fill: { side: 'BUY' | 'SELL'; qty: number; price: number },
+  ): Promise<SymbolState> {
+    const state = await this.load(symbol)
+    const next = recordFill(state, fill, this.transitionCtx)
+    await this.save(next)
+    return next
+  }
+
+  async setCooldown(symbol: string, untilIso: string): Promise<SymbolState> {
+    const state = await this.load(symbol)
+    const next = setCooldown(state, untilIso, this.transitionCtx)
+    await this.save(next)
+    return next
+  }
+
+  async recordSignal(symbol: string): Promise<SymbolState> {
+    const state = await this.load(symbol)
+    const next = recordSignal(state, this.transitionCtx)
+    await this.save(next)
+    return next
+  }
+
+  async addPendingSettlement(
+    symbol: string,
+    settlement: PendingSettlement,
+  ): Promise<SymbolState> {
+    const state = await this.load(symbol)
+    const next = addPendingSettlement(state, settlement, this.transitionCtx)
+    await this.save(next)
+    return next
+  }
+
+  private async load(symbol: string): Promise<SymbolState> {
+    const stored = await this.ctx.storage.get<SymbolState>(STATE_KEY)
+    return stored ?? emptySymbolState(symbol, this.transitionCtx.now)
+  }
+
+  private async save(state: SymbolState): Promise<void> {
+    await this.ctx.storage.put(STATE_KEY, state)
+  }
+}

--- a/src/trading/state/SymbolStateDO.ts
+++ b/src/trading/state/SymbolStateDO.ts
@@ -85,7 +85,17 @@ export class SymbolStateDO extends DurableObject<object> {
 
   private async load(symbol: string): Promise<SymbolState> {
     const stored = await this.ctx.storage.get<SymbolState>(STATE_KEY)
-    return stored ?? emptySymbolState(symbol, this.transitionCtx.now)
+    // Check symbol matches; if mismatch, overwrite with correct empty state
+    if (stored !== undefined && stored.symbol === symbol) {
+      return stored
+    }
+    // Mismatched or missing: return empty and clear storage
+    const empty = emptySymbolState(symbol, this.transitionCtx.now)
+    if (stored !== undefined) {
+      // Clear mismatched state
+      await this.ctx.storage.put(STATE_KEY, empty)
+    }
+    return empty
   }
 
   private async save(state: SymbolState): Promise<void> {

--- a/src/trading/state/stateTransitions.ts
+++ b/src/trading/state/stateTransitions.ts
@@ -22,6 +22,13 @@ export function lockPendingOrder(
   lock: PendingOrderLock,
   ctx: TransitionContext = defaultCtx,
 ): { ok: boolean; state: SymbolState } {
+  // Validate lock.expiresAt before accepting the lock (fail-closed)
+  const lockExpiresAtMs = new Date(lock.expiresAt).getTime()
+  if (!Number.isFinite(lockExpiresAtMs)) {
+    // Invalid expiresAt (NaN) - reject the lock
+    return { ok: false, state }
+  }
+
   if (state.pendingOrder !== null && !isExpired(state.pendingOrder.expiresAt, ctx.now)) {
     return { ok: false, state }
   }

--- a/src/trading/state/stateTransitions.ts
+++ b/src/trading/state/stateTransitions.ts
@@ -1,0 +1,141 @@
+import type {
+  PendingOrderLock,
+  PendingSettlement,
+  PositionState,
+  SymbolState,
+} from './types'
+
+/**
+ * Pure state transitions applied by {@link SymbolStateDO}. Exposed separately
+ * so they are testable without a Durable Object runtime. Every function takes
+ * the current state and returns a new state — no mutation, no I/O.
+ */
+
+export interface TransitionContext {
+  now: () => Date
+}
+
+const defaultCtx: TransitionContext = { now: () => new Date() }
+
+export function lockPendingOrder(
+  state: SymbolState,
+  lock: PendingOrderLock,
+  ctx: TransitionContext = defaultCtx,
+): { ok: boolean; state: SymbolState } {
+  if (state.pendingOrder !== null && !isExpired(state.pendingOrder.expiresAt, ctx.now)) {
+    return { ok: false, state }
+  }
+  return {
+    ok: true,
+    state: { ...state, pendingOrder: lock, updatedAt: ctx.now().toISOString() },
+  }
+}
+
+export function clearPendingOrder(
+  state: SymbolState,
+  ctx: TransitionContext = defaultCtx,
+): SymbolState {
+  return { ...state, pendingOrder: null, updatedAt: ctx.now().toISOString() }
+}
+
+export function recordFill(
+  state: SymbolState,
+  fill: { side: 'BUY' | 'SELL'; qty: number; price: number },
+  ctx: TransitionContext = defaultCtx,
+): SymbolState {
+  const position = applyFillToPosition(state.position, fill, ctx.now)
+  return {
+    ...state,
+    position,
+    pendingOrder: null,
+    lastExecutedPrice: fill.price,
+    updatedAt: ctx.now().toISOString(),
+  }
+}
+
+export function setCooldown(
+  state: SymbolState,
+  untilIso: string,
+  ctx: TransitionContext = defaultCtx,
+): SymbolState {
+  return { ...state, cooldownUntil: untilIso, updatedAt: ctx.now().toISOString() }
+}
+
+export function recordSignal(
+  state: SymbolState,
+  ctx: TransitionContext = defaultCtx,
+): SymbolState {
+  const iso = ctx.now().toISOString()
+  return { ...state, lastSignalAt: iso, updatedAt: iso }
+}
+
+export function addPendingSettlement(
+  state: SymbolState,
+  settlement: PendingSettlement,
+  ctx: TransitionContext = defaultCtx,
+): SymbolState {
+  return {
+    ...state,
+    pendingSettlement: [...state.pendingSettlement, settlement],
+    updatedAt: ctx.now().toISOString(),
+  }
+}
+
+/**
+ * Any pendingSettlement whose settleDate is on or before `asOf` moves its
+ * amount into `settledCash` and is removed from the queue. Used both
+ * proactively (T+1 EOD roll) and defensively on read.
+ */
+export function rollSettlements(
+  state: SymbolState,
+  asOfIso: string,
+  ctx: TransitionContext = defaultCtx,
+): SymbolState {
+  const asOfDay = asOfIso.slice(0, 10)
+  let settledCash = state.settledCash
+  const remaining: PendingSettlement[] = []
+  for (const s of state.pendingSettlement) {
+    if (s.settleDate <= asOfDay) {
+      settledCash += s.amount
+    } else {
+      remaining.push(s)
+    }
+  }
+  if (remaining.length === state.pendingSettlement.length) {
+    return state
+  }
+  return {
+    ...state,
+    settledCash,
+    pendingSettlement: remaining,
+    updatedAt: ctx.now().toISOString(),
+  }
+}
+
+function applyFillToPosition(
+  position: PositionState | null,
+  fill: { side: 'BUY' | 'SELL'; qty: number; price: number },
+  now: () => Date,
+): PositionState | null {
+  if (fill.side === 'BUY') {
+    if (position === null) {
+      return { qty: fill.qty, avgPrice: fill.price, openedAt: now().toISOString() }
+    }
+    const totalQty = position.qty + fill.qty
+    if (totalQty <= 0) return null
+    const avgPrice = (position.qty * position.avgPrice + fill.qty * fill.price) / totalQty
+    return { qty: totalQty, avgPrice, openedAt: position.openedAt }
+  }
+  // SELL
+  if (position === null) {
+    // Short not supported in POC; treat as flat with no position adjustment.
+    return null
+  }
+  const remaining = position.qty - fill.qty
+  if (remaining <= 0) return null
+  return { ...position, qty: remaining }
+}
+
+function isExpired(expiresAtIso: string, now: () => Date): boolean {
+  return new Date(expiresAtIso).getTime() <= now().getTime()
+}

--- a/src/trading/state/stateTransitions.ts
+++ b/src/trading/state/stateTransitions.ts
@@ -82,6 +82,13 @@ export function addPendingSettlement(
   settlement: PendingSettlement,
   ctx: TransitionContext = defaultCtx,
 ): SymbolState {
+  // Validate settlement inputs before adding
+  if (!Number.isFinite(settlement.amount) || settlement.amount <= 0) {
+    throw new Error(`Invalid settlement.amount: ${settlement.amount} (must be a finite number > 0)`)
+  }
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(settlement.settleDate)) {
+    throw new Error(`Invalid settlement.settleDate: ${settlement.settleDate} (must match YYYY-MM-DD pattern)`)
+  }
   return {
     ...state,
     pendingSettlement: [...state.pendingSettlement, settlement],
@@ -136,11 +143,13 @@ function applyFillToPosition(
   }
   // SELL
   if (position === null) {
-    // Short not supported in POC; treat as flat with no position adjustment.
-    return null
+    throw new Error('Cannot SELL without an open position (short not supported)')
   }
   const remaining = position.qty - fill.qty
-  if (remaining <= 0) return null
+  if (remaining < 0) {
+    throw new Error(`SELL overfill: position.qty=${position.qty}, fill.qty=${fill.qty}`)
+  }
+  if (remaining === 0) return null
   return { ...position, qty: remaining }
 }
 

--- a/src/trading/state/stateTransitions.ts
+++ b/src/trading/state/stateTransitions.ts
@@ -43,6 +43,14 @@ export function recordFill(
   fill: { side: 'BUY' | 'SELL'; qty: number; price: number },
   ctx: TransitionContext = defaultCtx,
 ): SymbolState {
+  // Validate fill inputs before applying
+  if (!Number.isFinite(fill.qty) || fill.qty <= 0) {
+    throw new Error(`Invalid fill.qty: ${fill.qty} (must be a finite number > 0)`)
+  }
+  if (!Number.isFinite(fill.price) || fill.price <= 0) {
+    throw new Error(`Invalid fill.price: ${fill.price} (must be a finite number > 0)`)
+  }
+
   const position = applyFillToPosition(state.position, fill, ctx.now)
   return {
     ...state,

--- a/src/trading/state/types.ts
+++ b/src/trading/state/types.ts
@@ -1,0 +1,44 @@
+export interface PositionState {
+  qty: number
+  avgPrice: number
+  openedAt: string
+}
+
+export interface PendingOrderLock {
+  clientOrderId: string
+  side: 'BUY' | 'SELL'
+  submittedAt: string
+  expiresAt: string
+}
+
+export interface PendingSettlement {
+  tradeDate: string
+  settleDate: string
+  amount: number
+}
+
+export interface SymbolState {
+  symbol: string
+  position: PositionState | null
+  pendingOrder: PendingOrderLock | null
+  lastSignalAt: string | null
+  cooldownUntil: string | null
+  settledCash: number
+  pendingSettlement: PendingSettlement[]
+  lastExecutedPrice: number | null
+  updatedAt: string
+}
+
+export function emptySymbolState(symbol: string, now: () => Date = () => new Date()): SymbolState {
+  return {
+    symbol,
+    position: null,
+    pendingOrder: null,
+    lastSignalAt: null,
+    cooldownUntil: null,
+    settledCash: 0,
+    pendingSettlement: [],
+    lastExecutedPrice: null,
+    updatedAt: now().toISOString(),
+  }
+}

--- a/test/trading/state/stateTransitions.test.ts
+++ b/test/trading/state/stateTransitions.test.ts
@@ -55,6 +55,24 @@ describe('lockPendingOrder', () => {
     expect(res.ok).toBe(true)
     expect(res.state.pendingOrder?.clientOrderId).toBe('coid-next')
   })
+
+  it('rejects lock with invalid expiresAt (fail-closed)', () => {
+    const state = emptySymbolState('SOXL', fixedNow('2026-04-18T10:00:00.000Z'))
+    const invalidLock = { ...lock, expiresAt: 'invalid-date' }
+    const res = lockPendingOrder(state, invalidLock, { now: fixedNow('2026-04-18T10:00:00.000Z') })
+
+    expect(res.ok).toBe(false)
+    expect(res.state.pendingOrder).toBeNull()
+  })
+
+  it('rejects lock with empty expiresAt', () => {
+    const state = emptySymbolState('SOXL', fixedNow('2026-04-18T10:00:00.000Z'))
+    const invalidLock = { ...lock, expiresAt: '' }
+    const res = lockPendingOrder(state, invalidLock, { now: fixedNow('2026-04-18T10:00:00.000Z') })
+
+    expect(res.ok).toBe(false)
+    expect(res.state.pendingOrder).toBeNull()
+  })
 })
 
 describe('recordFill', () => {
@@ -99,6 +117,48 @@ describe('recordFill', () => {
     state = recordFill(state, { side: 'BUY', qty: 1, price: 10 }, { now: fixedNow('2026-04-18T12:00:00.000Z') })
 
     expect(state.position?.openedAt).toBe('2026-04-18T10:05:00.000Z')
+  })
+
+  it('rejects fill with invalid qty (NaN)', () => {
+    const state = emptySymbolState('SOXL', fixedNow('2026-04-18T10:00:00.000Z'))
+    expect(() => {
+      recordFill(state, { side: 'BUY', qty: NaN, price: 9 }, { now: fixedNow('2026-04-18T10:05:00.000Z') })
+    }).toThrow('Invalid fill.qty')
+  })
+
+  it('rejects fill with zero qty', () => {
+    const state = emptySymbolState('SOXL', fixedNow('2026-04-18T10:00:00.000Z'))
+    expect(() => {
+      recordFill(state, { side: 'BUY', qty: 0, price: 9 }, { now: fixedNow('2026-04-18T10:05:00.000Z') })
+    }).toThrow('Invalid fill.qty')
+  })
+
+  it('rejects fill with negative qty', () => {
+    const state = emptySymbolState('SOXL', fixedNow('2026-04-18T10:00:00.000Z'))
+    expect(() => {
+      recordFill(state, { side: 'BUY', qty: -1, price: 9 }, { now: fixedNow('2026-04-18T10:05:00.000Z') })
+    }).toThrow('Invalid fill.qty')
+  })
+
+  it('rejects fill with invalid price (NaN)', () => {
+    const state = emptySymbolState('SOXL', fixedNow('2026-04-18T10:00:00.000Z'))
+    expect(() => {
+      recordFill(state, { side: 'BUY', qty: 2, price: NaN }, { now: fixedNow('2026-04-18T10:05:00.000Z') })
+    }).toThrow('Invalid fill.price')
+  })
+
+  it('rejects fill with zero price', () => {
+    const state = emptySymbolState('SOXL', fixedNow('2026-04-18T10:00:00.000Z'))
+    expect(() => {
+      recordFill(state, { side: 'BUY', qty: 2, price: 0 }, { now: fixedNow('2026-04-18T10:05:00.000Z') })
+    }).toThrow('Invalid fill.price')
+  })
+
+  it('rejects fill with negative price', () => {
+    const state = emptySymbolState('SOXL', fixedNow('2026-04-18T10:00:00.000Z'))
+    expect(() => {
+      recordFill(state, { side: 'BUY', qty: 2, price: -9 }, { now: fixedNow('2026-04-18T10:05:00.000Z') })
+    }).toThrow('Invalid fill.price')
   })
 })
 
@@ -168,10 +228,77 @@ describe('misc transitions', () => {
     )
     state = addPendingSettlement(
       state,
-      { tradeDate: '2026-04-18', settleDate: '2026-04-19', amount: -5 },
+      { tradeDate: '2026-04-18', settleDate: '2026-04-19', amount: 5 },
       { now: fixedNow('2026-04-18T10:00:01.000Z') },
     )
     expect(state.pendingSettlement).toHaveLength(2)
-    expect(state.pendingSettlement[1]?.amount).toBe(-5)
+    expect(state.pendingSettlement[0]?.amount).toBe(10)
+    expect(state.pendingSettlement[1]?.amount).toBe(5)
+  })
+
+  it('addPendingSettlement rejects invalid amount (NaN)', () => {
+    const state = emptySymbolState('SOXL', fixedNow('2026-04-18T10:00:00.000Z'))
+    expect(() => {
+      addPendingSettlement(
+        state,
+        { tradeDate: '2026-04-18', settleDate: '2026-04-19', amount: NaN },
+        { now: fixedNow('2026-04-18T10:00:00.000Z') },
+      )
+    }).toThrow('Invalid settlement.amount')
+  })
+
+  it('addPendingSettlement rejects zero amount', () => {
+    const state = emptySymbolState('SOXL', fixedNow('2026-04-18T10:00:00.000Z'))
+    expect(() => {
+      addPendingSettlement(
+        state,
+        { tradeDate: '2026-04-18', settleDate: '2026-04-19', amount: 0 },
+        { now: fixedNow('2026-04-18T10:00:00.000Z') },
+      )
+    }).toThrow('Invalid settlement.amount')
+  })
+
+  it('addPendingSettlement rejects negative amount', () => {
+    const state = emptySymbolState('SOXL', fixedNow('2026-04-18T10:00:00.000Z'))
+    expect(() => {
+      addPendingSettlement(
+        state,
+        { tradeDate: '2026-04-18', settleDate: '2026-04-19', amount: -5 },
+        { now: fixedNow('2026-04-18T10:00:00.000Z') },
+      )
+    }).toThrow('Invalid settlement.amount')
+  })
+
+  it('addPendingSettlement rejects invalid settleDate format', () => {
+    const state = emptySymbolState('SOXL', fixedNow('2026-04-18T10:00:00.000Z'))
+    expect(() => {
+      addPendingSettlement(
+        state,
+        { tradeDate: '2026-04-18', settleDate: 'invalid-date', amount: 10 },
+        { now: fixedNow('2026-04-18T10:00:00.000Z') },
+      )
+    }).toThrow('Invalid settlement.settleDate')
+  })
+
+  it('addPendingSettlement rejects settleDate with wrong format (ISO timestamp)', () => {
+    const state = emptySymbolState('SOXL', fixedNow('2026-04-18T10:00:00.000Z'))
+    expect(() => {
+      addPendingSettlement(
+        state,
+        { tradeDate: '2026-04-18', settleDate: '2026-04-19T10:00:00.000Z', amount: 10 },
+        { now: fixedNow('2026-04-18T10:00:00.000Z') },
+      )
+    }).toThrow('Invalid settlement.settleDate')
+  })
+
+  it('addPendingSettlement rejects empty settleDate', () => {
+    const state = emptySymbolState('SOXL', fixedNow('2026-04-18T10:00:00.000Z'))
+    expect(() => {
+      addPendingSettlement(
+        state,
+        { tradeDate: '2026-04-18', settleDate: '', amount: 10 },
+        { now: fixedNow('2026-04-18T10:00:00.000Z') },
+      )
+    }).toThrow('Invalid settlement.settleDate')
   })
 })

--- a/test/trading/state/stateTransitions.test.ts
+++ b/test/trading/state/stateTransitions.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest'
+import {
+  addPendingSettlement,
+  clearPendingOrder,
+  lockPendingOrder,
+  recordFill,
+  recordSignal,
+  rollSettlements,
+  setCooldown,
+} from '../../../src/trading/state/stateTransitions'
+import { emptySymbolState, type PendingOrderLock } from '../../../src/trading/state/types'
+
+const fixedNow = (iso: string) => () => new Date(iso)
+
+const lock: PendingOrderLock = {
+  clientOrderId: 'coid-1',
+  side: 'BUY',
+  submittedAt: '2026-04-18T10:00:00.000Z',
+  expiresAt: '2026-04-18T10:05:00.000Z',
+}
+
+describe('lockPendingOrder', () => {
+  it('accepts a fresh lock when no pending order exists', () => {
+    const state = emptySymbolState('SOXL', fixedNow('2026-04-18T09:59:59.000Z'))
+    const res = lockPendingOrder(state, lock, { now: fixedNow('2026-04-18T10:00:00.000Z') })
+
+    expect(res.ok).toBe(true)
+    expect(res.state.pendingOrder).toEqual(lock)
+  })
+
+  it('rejects a second lock while the first has not expired', () => {
+    let state = emptySymbolState('SOXL', fixedNow('2026-04-18T10:00:00.000Z'))
+    state = lockPendingOrder(state, lock, { now: fixedNow('2026-04-18T10:00:00.000Z') }).state
+
+    const res = lockPendingOrder(
+      state,
+      { ...lock, clientOrderId: 'coid-2' },
+      { now: fixedNow('2026-04-18T10:02:00.000Z') },
+    )
+
+    expect(res.ok).toBe(false)
+    expect(res.state.pendingOrder?.clientOrderId).toBe('coid-1')
+  })
+
+  it('accepts a new lock after the previous one has expired', () => {
+    let state = emptySymbolState('SOXL', fixedNow('2026-04-18T10:00:00.000Z'))
+    state = lockPendingOrder(state, lock, { now: fixedNow('2026-04-18T10:00:00.000Z') }).state
+
+    const res = lockPendingOrder(
+      state,
+      { ...lock, clientOrderId: 'coid-next' },
+      { now: fixedNow('2026-04-18T10:10:00.000Z') },
+    )
+
+    expect(res.ok).toBe(true)
+    expect(res.state.pendingOrder?.clientOrderId).toBe('coid-next')
+  })
+})
+
+describe('recordFill', () => {
+  it('opens a long position from flat on BUY', () => {
+    const state = emptySymbolState('SOXL', fixedNow('2026-04-18T10:00:00.000Z'))
+    const next = recordFill(
+      state,
+      { side: 'BUY', qty: 2, price: 9 },
+      { now: fixedNow('2026-04-18T10:05:00.000Z') },
+    )
+
+    expect(next.position).toEqual({
+      qty: 2,
+      avgPrice: 9,
+      openedAt: '2026-04-18T10:05:00.000Z',
+    })
+    expect(next.pendingOrder).toBeNull()
+    expect(next.lastExecutedPrice).toBe(9)
+  })
+
+  it('averages the fill price on a subsequent BUY', () => {
+    let state = emptySymbolState('SOXL', fixedNow('2026-04-18T10:00:00.000Z'))
+    state = recordFill(state, { side: 'BUY', qty: 2, price: 9 }, { now: fixedNow('2026-04-18T10:05:00.000Z') })
+    state = recordFill(state, { side: 'BUY', qty: 2, price: 11 }, { now: fixedNow('2026-04-18T11:00:00.000Z') })
+
+    expect(state.position?.qty).toBe(4)
+    expect(state.position?.avgPrice).toBe(10)
+  })
+
+  it('closes the position on a SELL that matches the qty', () => {
+    let state = emptySymbolState('SOXL', fixedNow('2026-04-18T10:00:00.000Z'))
+    state = recordFill(state, { side: 'BUY', qty: 2, price: 9 }, { now: fixedNow('2026-04-18T10:05:00.000Z') })
+    state = recordFill(state, { side: 'SELL', qty: 2, price: 12 }, { now: fixedNow('2026-04-18T11:00:00.000Z') })
+
+    expect(state.position).toBeNull()
+    expect(state.lastExecutedPrice).toBe(12)
+  })
+
+  it('keeps the opened_at timestamp when scaling in', () => {
+    let state = emptySymbolState('SOXL', fixedNow('2026-04-18T10:00:00.000Z'))
+    state = recordFill(state, { side: 'BUY', qty: 2, price: 9 }, { now: fixedNow('2026-04-18T10:05:00.000Z') })
+    state = recordFill(state, { side: 'BUY', qty: 1, price: 10 }, { now: fixedNow('2026-04-18T12:00:00.000Z') })
+
+    expect(state.position?.openedAt).toBe('2026-04-18T10:05:00.000Z')
+  })
+})
+
+describe('rollSettlements', () => {
+  it('moves matured settlements into settledCash', () => {
+    const state = {
+      ...emptySymbolState('SOXL', fixedNow('2026-04-17T00:00:00.000Z')),
+      settledCash: 100,
+      pendingSettlement: [
+        { tradeDate: '2026-04-17', settleDate: '2026-04-18', amount: 50 },
+        { tradeDate: '2026-04-18', settleDate: '2026-04-19', amount: 80 },
+      ],
+    }
+
+    const next = rollSettlements(state, '2026-04-18T23:59:59.000Z', {
+      now: fixedNow('2026-04-18T23:59:59.000Z'),
+    })
+
+    expect(next.settledCash).toBe(150)
+    expect(next.pendingSettlement).toEqual([
+      { tradeDate: '2026-04-18', settleDate: '2026-04-19', amount: 80 },
+    ])
+  })
+
+  it('is a no-op when nothing has matured yet', () => {
+    const state = {
+      ...emptySymbolState('SOXL', fixedNow('2026-04-18T00:00:00.000Z')),
+      settledCash: 100,
+      pendingSettlement: [{ tradeDate: '2026-04-18', settleDate: '2026-04-19', amount: 80 }],
+    }
+
+    const next = rollSettlements(state, '2026-04-18T23:59:59.000Z', {
+      now: fixedNow('2026-04-18T23:59:59.000Z'),
+    })
+
+    expect(next).toBe(state)
+  })
+})
+
+describe('misc transitions', () => {
+  it('setCooldown stores the ISO timestamp', () => {
+    const state = emptySymbolState('SOXL', fixedNow('2026-04-18T10:00:00.000Z'))
+    const next = setCooldown(state, '2026-04-19T10:00:00.000Z', { now: fixedNow('2026-04-18T10:00:00.000Z') })
+    expect(next.cooldownUntil).toBe('2026-04-19T10:00:00.000Z')
+  })
+
+  it('recordSignal updates lastSignalAt and updatedAt', () => {
+    const state = emptySymbolState('SOXL', fixedNow('2026-04-18T00:00:00.000Z'))
+    const next = recordSignal(state, { now: fixedNow('2026-04-18T10:00:00.000Z') })
+    expect(next.lastSignalAt).toBe('2026-04-18T10:00:00.000Z')
+    expect(next.updatedAt).toBe('2026-04-18T10:00:00.000Z')
+  })
+
+  it('clearPendingOrder removes the lock regardless of expiry', () => {
+    let state = emptySymbolState('SOXL', fixedNow('2026-04-18T10:00:00.000Z'))
+    state = lockPendingOrder(state, lock, { now: fixedNow('2026-04-18T10:00:00.000Z') }).state
+    state = clearPendingOrder(state, { now: fixedNow('2026-04-18T10:00:10.000Z') })
+    expect(state.pendingOrder).toBeNull()
+  })
+
+  it('addPendingSettlement appends new entries without reordering', () => {
+    let state = emptySymbolState('SOXL', fixedNow('2026-04-18T10:00:00.000Z'))
+    state = addPendingSettlement(
+      state,
+      { tradeDate: '2026-04-18', settleDate: '2026-04-19', amount: 10 },
+      { now: fixedNow('2026-04-18T10:00:00.000Z') },
+    )
+    state = addPendingSettlement(
+      state,
+      { tradeDate: '2026-04-18', settleDate: '2026-04-19', amount: -5 },
+      { now: fixedNow('2026-04-18T10:00:01.000Z') },
+    )
+    expect(state.pendingSettlement).toHaveLength(2)
+    expect(state.pendingSettlement[1]?.amount).toBe(-5)
+  })
+})

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -11,6 +11,14 @@
     "TRADING_ENABLED": "false",
     "MARKET_HOURS_CHECK": "false"
   },
+  "durable_objects": {
+    "bindings": [
+      { "name": "SYMBOL_STATE", "class_name": "SymbolStateDO" }
+    ]
+  },
+  "migrations": [
+    { "tag": "v1", "new_sqlite_classes": ["SymbolStateDO"] }
+  ],
   "env": {
     "staging": {
       "name": "webull-trading-staging",
@@ -18,6 +26,11 @@
         "DRY_RUN": "true",
         "TRADING_ENABLED": "false",
         "MARKET_HOURS_CHECK": "false"
+      },
+      "durable_objects": {
+        "bindings": [
+          { "name": "SYMBOL_STATE", "class_name": "SymbolStateDO" }
+        ]
       }
     },
     "production": {
@@ -26,6 +39,11 @@
         "DRY_RUN": "true",
         "TRADING_ENABLED": "false",
         "MARKET_HOURS_CHECK": "false"
+      },
+      "durable_objects": {
+        "bindings": [
+          { "name": "SYMBOL_STATE", "class_name": "SymbolStateDO" }
+        ]
       }
     }
   }


### PR DESCRIPTION
**Issue #37 の A スライス。** DO state layer の scaffold のみ、TradingService 統合は後続 PR で。

## Why A だけ先行

Codex / trading-strategist 両者一致で「戦略より state 優先」。ただし一気に整合統合すると大 PR になるので、**スキーマ・基底クラス・マイグレーション** を先に固めて回して、strategy/ route の統合は別レビューサイクルに逃がす。

## Changes

### `src/trading/state/`
- `types.ts` — `SymbolState` / `PositionState` / `PendingOrderLock` / `PendingSettlement` shape + `emptySymbolState()`
- `stateTransitions.ts` — 純粋関数だけ。DurableObject runtime 不要で unit test できる:
  - `lockPendingOrder` (expiry 付きの二重発注ガード)
  - `clearPendingOrder`
  - `recordFill` (BUY / SELL / scale-in / flat-close、avg price 計算)
  - `recordSignal` / `setCooldown` / `addPendingSettlement`
  - **`rollSettlements`** (settleDate ≤ asOf を `settledCash` に移動 = T+1 ロールフォワード)
- `SymbolStateDO.ts` — `DurableObject` 基底を extend、RPC スタイルの method 群。`getState()` は読み取り時に `rollSettlements` を defensive 実行 (cron 経由の batch roll 不要)。

### wrangler / binding
- `durable_objects.bindings: [{ name: SYMBOL_STATE, class_name: SymbolStateDO }]`
- `migrations: [{ tag: v1, new_sqlite_classes: [SymbolStateDO] }]` (SQLite-backed DO)
- staging / production env それぞれにも binding 追加
- `src/index.ts` で `SymbolStateDO` を re-export (wrangler discovery 用)
- `Env` に `SYMBOL_STATE: DurableObjectNamespace<SymbolStateDO>` 追加

## 意図的に含めていないもの → follow-up

- **`#37-B`**: cron quote feed + staleness guard (`*/5 * * * *`、`quote_age > 15min` で strategy HOLD 強制)
- **`#37-C`**: TradingService 統合 (pending-order lock check、recordFill on TradeEvent、recordSignal on decide、cooldown チェック)。PR #41 で定義したのに呼ばれていない `logExit` の最初のコールサイトもここで入る
- **`#37-D`**: buy-side settled-cash guard、good-faith violation 防止 (T+1 完全整合)

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm test` 17 files / **95 tests** (stateTransitions 13 new)
- [x] `pnpm exec wrangler deploy --dry-run` で `env.SYMBOL_STATE (SymbolStateDO)` の binding を確認
- [ ] SymbolStateDO 自体の integration test は `@cloudflare/vitest-pool-workers` 導入時に追加 (scope 外、転換コストが大きいので pure function で代替カバー)

Refs: #37 (parent), #40 (closed、exit hook は #37-C で)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 各シンボルの取引状態を永続化・管理する機能を追加（注文ロック、約定記録、クールダウン、シグナル記録、清算のロールフォワードを含む）。
  * 環境設定に永続ストレージのバインディングを追加。

* **テスト**
  * 時刻依存の挙動を含む状態遷移ロジックの包括的なテストスイートを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->