### PR TITLE
feat(quotes): cron-driven quote feed + staleness guard (#37-B)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,12 +9,14 @@ const app = createApp()
 export default {
   fetch: app.fetch,
   async scheduled(_event: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void> {
+    const requestId = crypto.randomUUID()
     ctx.waitUntil(
       runQuoteFeed({ env }).then(
         (summary) => {
           console.log(
             JSON.stringify({
               event: 'quote_feed_run',
+              requestId,
               fetched: summary.fetched,
               persisted: summary.persisted,
               skipped: summary.skipped,
@@ -26,6 +28,7 @@ export default {
           console.error(
             JSON.stringify({
               event: 'quote_feed_error',
+              requestId,
               message: error instanceof Error ? error.message : String(error),
             }),
           )

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,36 @@
 import { createApp } from './app'
+import type { Env } from './config/env'
+import { runQuoteFeed } from './trading/quotes/quoteScheduler'
 
 export { SymbolStateDO } from './trading/state/SymbolStateDO'
 
-export default createApp()
+const app = createApp()
+
+export default {
+  fetch: app.fetch,
+  async scheduled(_event: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void> {
+    ctx.waitUntil(
+      runQuoteFeed({ env }).then(
+        (summary) => {
+          console.log(
+            JSON.stringify({
+              event: 'quote_feed_run',
+              fetched: summary.fetched,
+              persisted: summary.persisted,
+              skipped: summary.skipped,
+              errors: summary.errors,
+            }),
+          )
+        },
+        (error) => {
+          console.error(
+            JSON.stringify({
+              event: 'quote_feed_error',
+              message: error instanceof Error ? error.message : String(error),
+            }),
+          )
+        },
+      ),
+    )
+  },
+}

--- a/src/infrastructure/quotes/WebullQuoteClient.ts
+++ b/src/infrastructure/quotes/WebullQuoteClient.ts
@@ -106,8 +106,16 @@ export class WebullQuoteClient {
       )
     }
 
-    const json = (await response.json()) as unknown
-    return normalizeSnapshots(json, this.now().toISOString())
+    try {
+      const json = (await response.json()) as unknown
+      return normalizeSnapshots(json, this.now().toISOString())
+    } catch (error) {
+      throw new BrokerRequestError(
+        `Webull quote response parse failed: ${error instanceof Error ? error.message : String(error)}`,
+        `GET ${QUOTE_PATH}`,
+        { cause: error instanceof Error ? error : undefined },
+      )
+    }
   }
 }
 
@@ -164,7 +172,7 @@ function coerceNumber(value: number | string | undefined): number | null {
 }
 
 function coerceAsOf(raw: RawSnapshotEntry, fallback: string): string {
-  if (typeof raw.trade_time === 'string' && raw.trade_time.length > 0) return raw.trade_time
+  if (typeof raw.trade_time === 'string' && raw.trade_time.trim().length > 0) return raw.trade_time.trim()
   if (raw.timestamp !== undefined) {
     const ms = typeof raw.timestamp === 'number' ? raw.timestamp : Number(raw.timestamp)
     if (Number.isFinite(ms)) {

--- a/src/infrastructure/quotes/WebullQuoteClient.ts
+++ b/src/infrastructure/quotes/WebullQuoteClient.ts
@@ -1,0 +1,176 @@
+import { BrokerRequestError } from '../../shared/errors'
+import { WebullAuth } from '../webull/WebullAuth'
+import { inferWebullMarket } from '../webull/mapper'
+
+export type WebullQuoteCategory = 'US_STOCK' | 'JP_STOCK'
+
+export interface QuoteResult {
+  symbol: string
+  price: number
+  asOf: string
+}
+
+export interface WebullQuoteClientEnv {
+  WEBULL_APP_KEY?: string
+  WEBULL_APP_SECRET?: string
+  WEBULL_API_BASE?: string
+}
+
+interface WebullQuoteClientOptions {
+  auth: WebullAuth
+  baseUrl?: string
+  timeoutMs?: number
+  fetchFn?: typeof fetch
+  now?: () => Date
+}
+
+interface RawSnapshotEntry {
+  symbol?: string
+  last_price?: number | string
+  last?: number | string
+  price?: number | string
+  trade_time?: string
+  timestamp?: number | string
+}
+
+const QUOTE_PATH = '/market-data/snapshot'
+
+/**
+ * Minimal Webull market-data snapshot client. Signs requests with the same
+ * HMAC-SHA1 canonical signing used by {@link WebullHttpClient}. Scope for #37-B
+ * is read-only last-price + asOf so the cron handler can land a
+ * {@link QuoteSnapshot} into each symbol's Durable Object.
+ */
+export class WebullQuoteClient {
+  private readonly baseUrl: string
+  private readonly timeoutMs: number
+  private readonly fetchFn: typeof fetch
+  private readonly now: () => Date
+
+  constructor(private readonly options: WebullQuoteClientOptions) {
+    this.baseUrl = (options.baseUrl ?? 'https://api.sandbox.webull.hk').replace(/\/+$/, '')
+    this.timeoutMs = options.timeoutMs ?? 5000
+    this.fetchFn = options.fetchFn ?? fetch
+    this.now = options.now ?? (() => new Date())
+  }
+
+  async getSnapshots(symbols: string[], category: WebullQuoteCategory): Promise<QuoteResult[]> {
+    if (symbols.length === 0) return []
+
+    const query = { symbols: symbols.join(','), category }
+    const url = new URL(QUOTE_PATH, `${this.baseUrl}/`)
+    for (const [key, value] of Object.entries(query)) {
+      url.searchParams.set(key, value)
+    }
+
+    let authHeaders: Record<string, string>
+    try {
+      authHeaders = await this.options.auth.createHeaders({
+        method: 'GET',
+        path: url.pathname + url.search,
+        query,
+        host: url.host,
+        version: 'v1',
+      })
+    } catch (error) {
+      throw new BrokerRequestError(
+        `Webull quote auth failed: ${error instanceof Error ? error.message : String(error)}`,
+        `GET ${QUOTE_PATH}`,
+        { cause: error instanceof Error ? error : undefined },
+      )
+    }
+
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs)
+    let response: Response
+    try {
+      response = await this.fetchFn(url.href, {
+        method: 'GET',
+        headers: { Accept: 'application/json', ...authHeaders },
+        signal: controller.signal,
+      })
+    } catch (error) {
+      throw new BrokerRequestError(
+        `Webull quote fetch failed: ${error instanceof Error ? error.message : String(error)}`,
+        `GET ${QUOTE_PATH}`,
+        { cause: error instanceof Error ? error : undefined },
+      )
+    } finally {
+      clearTimeout(timeoutId)
+    }
+
+    if (!response.ok) {
+      throw new BrokerRequestError(
+        `Webull quote request failed with status ${response.status}`,
+        `GET ${QUOTE_PATH}`,
+      )
+    }
+
+    const json = (await response.json()) as unknown
+    return normalizeSnapshots(json, this.now().toISOString())
+  }
+}
+
+export function createWebullQuoteClient(
+  env: WebullQuoteClientEnv,
+  options?: { fetchFn?: typeof fetch; timeoutMs?: number; now?: () => Date },
+): WebullQuoteClient {
+  return new WebullQuoteClient({
+    auth: new WebullAuth({
+      appKey: env.WEBULL_APP_KEY,
+      appSecret: env.WEBULL_APP_SECRET,
+    }),
+    baseUrl: env.WEBULL_API_BASE,
+    timeoutMs: options?.timeoutMs,
+    fetchFn: options?.fetchFn,
+    now: options?.now,
+  })
+}
+
+export function groupSymbolsByCategory(symbols: string[]): Record<WebullQuoteCategory, string[]> {
+  const grouped: Record<WebullQuoteCategory, string[]> = { US_STOCK: [], JP_STOCK: [] }
+  for (const symbol of symbols) {
+    const category: WebullQuoteCategory = inferWebullMarket(symbol) === 'JP' ? 'JP_STOCK' : 'US_STOCK'
+    grouped[category].push(symbol)
+  }
+  return grouped
+}
+
+function normalizeSnapshots(json: unknown, fallbackAsOf: string): QuoteResult[] {
+  const rawList = extractList(json)
+  const results: QuoteResult[] = []
+  for (const raw of rawList) {
+    const symbol = typeof raw.symbol === 'string' ? raw.symbol.trim() : ''
+    const price = coerceNumber(raw.last_price ?? raw.last ?? raw.price)
+    if (!symbol || price === null) continue
+    results.push({ symbol, price, asOf: coerceAsOf(raw, fallbackAsOf) })
+  }
+  return results
+}
+
+function extractList(json: unknown): RawSnapshotEntry[] {
+  if (Array.isArray(json)) return json as RawSnapshotEntry[]
+  if (json && typeof json === 'object') {
+    const data = (json as { data?: unknown }).data
+    if (Array.isArray(data)) return data as RawSnapshotEntry[]
+  }
+  return []
+}
+
+function coerceNumber(value: number | string | undefined): number | null {
+  if (value === undefined || value === null) return null
+  const num = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(num) && num > 0 ? num : null
+}
+
+function coerceAsOf(raw: RawSnapshotEntry, fallback: string): string {
+  if (typeof raw.trade_time === 'string' && raw.trade_time.length > 0) return raw.trade_time
+  if (raw.timestamp !== undefined) {
+    const ms = typeof raw.timestamp === 'number' ? raw.timestamp : Number(raw.timestamp)
+    if (Number.isFinite(ms)) {
+      const millis = ms > 1e12 ? ms : ms * 1000
+      return new Date(millis).toISOString()
+    }
+  }
+  return fallback
+}

--- a/src/trading/quotes/quoteScheduler.ts
+++ b/src/trading/quotes/quoteScheduler.ts
@@ -70,9 +70,20 @@ export async function runQuoteFeed(options: RunQuoteFeedOptions): Promise<QuoteR
         fetchedAt,
         source: QUOTE_SOURCE,
       }
-      const stub = env.SYMBOL_STATE.get(env.SYMBOL_STATE.idFromName(symbol))
-      await stub.setQuote(symbol, quote)
-      summary.persisted += 1
+      try {
+        const stub = env.SYMBOL_STATE.get(env.SYMBOL_STATE.idFromName(symbol))
+        if (!stub) {
+          summary.errors.push({ category, message: `Failed to get DO stub for ${symbol}` })
+          continue
+        }
+        await stub.setQuote(symbol, quote)
+        summary.persisted += 1
+      } catch (error) {
+        summary.errors.push({
+          category,
+          message: `Failed to persist ${symbol}: ${error instanceof Error ? error.message : String(error)}`,
+        })
+      }
     }
   }
 

--- a/src/trading/quotes/quoteScheduler.ts
+++ b/src/trading/quotes/quoteScheduler.ts
@@ -1,0 +1,80 @@
+import type { Env } from '../../config/env'
+import { parseCsvEnv } from '../../config/env'
+import {
+  groupSymbolsByCategory,
+  WebullQuoteClient,
+  createWebullQuoteClient,
+  type QuoteResult,
+  type WebullQuoteCategory,
+} from '../../infrastructure/quotes/WebullQuoteClient'
+import type { QuoteSnapshot } from '../state/types'
+
+const QUOTE_SOURCE = 'webull-snapshot'
+
+export interface QuoteRunSummary {
+  fetched: number
+  persisted: number
+  skipped: string[]
+  errors: Array<{ category: WebullQuoteCategory; message: string }>
+}
+
+interface RunQuoteFeedOptions {
+  env: Env
+  client?: WebullQuoteClient
+  now?: () => Date
+}
+
+/**
+ * Fetches latest snapshots for every symbol in ALLOWED_SYMBOLS and writes the
+ * result into each symbol's Durable Object. Called from the Workers cron
+ * handler so strategy logic can read {@link QuoteSnapshot} with an `asOf` <
+ * maxAgeMs freshness guard.
+ */
+export async function runQuoteFeed(options: RunQuoteFeedOptions): Promise<QuoteRunSummary> {
+  const { env } = options
+  const now = options.now ?? (() => new Date())
+  const symbols = parseCsvEnv(env.ALLOWED_SYMBOLS)
+
+  const summary: QuoteRunSummary = { fetched: 0, persisted: 0, skipped: [], errors: [] }
+  if (symbols.length === 0) return summary
+
+  const client = options.client ?? createWebullQuoteClient(env, { now })
+  const groups = groupSymbolsByCategory(symbols)
+  const fetchedAt = now().toISOString()
+
+  for (const [category, group] of Object.entries(groups) as Array<[WebullQuoteCategory, string[]]>) {
+    if (group.length === 0) continue
+    let results: QuoteResult[]
+    try {
+      results = await client.getSnapshots(group, category)
+    } catch (error) {
+      summary.errors.push({
+        category,
+        message: error instanceof Error ? error.message : String(error),
+      })
+      continue
+    }
+
+    const bySymbol = new Map(results.map((r) => [r.symbol, r]))
+    summary.fetched += results.length
+
+    for (const symbol of group) {
+      const result = bySymbol.get(symbol)
+      if (!result) {
+        summary.skipped.push(symbol)
+        continue
+      }
+      const quote: QuoteSnapshot = {
+        price: result.price,
+        asOf: result.asOf,
+        fetchedAt,
+        source: QUOTE_SOURCE,
+      }
+      const stub = env.SYMBOL_STATE.get(env.SYMBOL_STATE.idFromName(symbol))
+      await stub.setQuote(symbol, quote)
+      summary.persisted += 1
+    }
+  }
+
+  return summary
+}

--- a/src/trading/state/SymbolStateDO.ts
+++ b/src/trading/state/SymbolStateDO.ts
@@ -7,9 +7,16 @@ import {
   recordSignal,
   rollSettlements,
   setCooldown,
+  setQuote,
   type TransitionContext,
 } from './stateTransitions'
-import { emptySymbolState, type PendingOrderLock, type PendingSettlement, type SymbolState } from './types'
+import {
+  emptySymbolState,
+  type PendingOrderLock,
+  type PendingSettlement,
+  type QuoteSnapshot,
+  type SymbolState,
+} from './types'
 
 const STATE_KEY = 'state'
 
@@ -69,6 +76,13 @@ export class SymbolStateDO extends DurableObject<object> {
   async recordSignal(symbol: string): Promise<SymbolState> {
     const state = await this.load(symbol)
     const next = recordSignal(state, this.transitionCtx)
+    await this.save(next)
+    return next
+  }
+
+  async setQuote(symbol: string, quote: QuoteSnapshot): Promise<SymbolState> {
+    const state = await this.load(symbol)
+    const next = setQuote(state, quote, this.transitionCtx)
     await this.save(next)
     return next
   }

--- a/src/trading/state/stateTransitions.ts
+++ b/src/trading/state/stateTransitions.ts
@@ -2,6 +2,7 @@ import type {
   PendingOrderLock,
   PendingSettlement,
   PositionState,
+  QuoteSnapshot,
   SymbolState,
 } from './types'
 
@@ -82,6 +83,24 @@ export function recordSignal(
 ): SymbolState {
   const iso = ctx.now().toISOString()
   return { ...state, lastSignalAt: iso, updatedAt: iso }
+}
+
+export function setQuote(
+  state: SymbolState,
+  quote: QuoteSnapshot,
+  ctx: TransitionContext = defaultCtx,
+): SymbolState {
+  return { ...state, lastQuote: quote, updatedAt: ctx.now().toISOString() }
+}
+
+export function isQuoteStale(
+  quote: QuoteSnapshot | null,
+  asOfIso: string,
+  maxAgeMs: number,
+): boolean {
+  if (!quote) return true
+  const diffMs = new Date(asOfIso).getTime() - new Date(quote.fetchedAt).getTime()
+  return !Number.isFinite(diffMs) || diffMs > maxAgeMs
 }
 
 export function addPendingSettlement(

--- a/src/trading/state/stateTransitions.ts
+++ b/src/trading/state/stateTransitions.ts
@@ -90,6 +90,10 @@ export function setQuote(
   quote: QuoteSnapshot,
   ctx: TransitionContext = defaultCtx,
 ): SymbolState {
+  // Validate quote.price before accepting it (fail-closed)
+  if (!Number.isFinite(quote.price) || quote.price <= 0) {
+    throw new Error(`Invalid quote.price: ${quote.price} (must be a finite number > 0)`)
+  }
   return { ...state, lastQuote: quote, updatedAt: ctx.now().toISOString() }
 }
 
@@ -100,7 +104,7 @@ export function isQuoteStale(
 ): boolean {
   if (!quote) return true
   const diffMs = new Date(asOfIso).getTime() - new Date(quote.fetchedAt).getTime()
-  return !Number.isFinite(diffMs) || diffMs > maxAgeMs
+  return !Number.isFinite(diffMs) || diffMs <= 0 || diffMs > maxAgeMs
 }
 
 export function addPendingSettlement(

--- a/src/trading/state/types.ts
+++ b/src/trading/state/types.ts
@@ -17,6 +17,13 @@ export interface PendingSettlement {
   amount: number
 }
 
+export interface QuoteSnapshot {
+  price: number
+  asOf: string
+  fetchedAt: string
+  source: string
+}
+
 export interface SymbolState {
   symbol: string
   position: PositionState | null
@@ -26,6 +33,7 @@ export interface SymbolState {
   settledCash: number
   pendingSettlement: PendingSettlement[]
   lastExecutedPrice: number | null
+  lastQuote: QuoteSnapshot | null
   updatedAt: string
 }
 
@@ -39,6 +47,7 @@ export function emptySymbolState(symbol: string, now: () => Date = () => new Dat
     settledCash: 0,
     pendingSettlement: [],
     lastExecutedPrice: null,
+    lastQuote: null,
     updatedAt: now().toISOString(),
   }
 }

--- a/test/infrastructure/quotes/webullQuoteClient.test.ts
+++ b/test/infrastructure/quotes/webullQuoteClient.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  WebullQuoteClient,
+  groupSymbolsByCategory,
+} from '../../../src/infrastructure/quotes/WebullQuoteClient'
+import { WebullAuth } from '../../../src/infrastructure/webull/WebullAuth'
+
+const baseAuth = new WebullAuth({ appKey: 'ak', appSecret: 'sk' })
+
+function mockFetch(responseBody: unknown, init: ResponseInit = { status: 200 }): typeof fetch {
+  const json = JSON.stringify(responseBody)
+  return vi.fn(
+    async () => new Response(json, { status: 200, headers: { 'Content-Type': 'application/json' }, ...init }),
+  ) as unknown as typeof fetch
+}
+
+describe('groupSymbolsByCategory', () => {
+  it('routes 4-digit codes to JP_STOCK and others to US_STOCK', () => {
+    const grouped = groupSymbolsByCategory(['SOXL', '7203', 'AAPL', '9984'])
+    expect(grouped.US_STOCK).toEqual(['SOXL', 'AAPL'])
+    expect(grouped.JP_STOCK).toEqual(['7203', '9984'])
+  })
+})
+
+describe('WebullQuoteClient.getSnapshots', () => {
+  it('returns an empty array when no symbols are requested', async () => {
+    const fetchFn = vi.fn() as unknown as typeof fetch
+    const client = new WebullQuoteClient({ auth: baseAuth, fetchFn })
+    const result = await client.getSnapshots([], 'US_STOCK')
+    expect(result).toEqual([])
+    expect(fetchFn).not.toHaveBeenCalled()
+  })
+
+  it('parses `data[]` envelope with last_price and trade_time', async () => {
+    const fetchFn = mockFetch({
+      data: [
+        { symbol: 'SOXL', last_price: '10.25', trade_time: '2026-04-18T10:00:00.000Z' },
+        { symbol: 'AAPL', last_price: 200 },
+      ],
+    })
+    const client = new WebullQuoteClient({
+      auth: baseAuth,
+      fetchFn,
+      now: () => new Date('2026-04-18T10:00:05.000Z'),
+    })
+    const result = await client.getSnapshots(['SOXL', 'AAPL'], 'US_STOCK')
+    expect(result).toEqual([
+      { symbol: 'SOXL', price: 10.25, asOf: '2026-04-18T10:00:00.000Z' },
+      { symbol: 'AAPL', price: 200, asOf: '2026-04-18T10:00:05.000Z' },
+    ])
+  })
+
+  it('drops entries with non-positive or non-finite price', async () => {
+    const fetchFn = mockFetch({
+      data: [
+        { symbol: 'GOOD', last_price: 5 },
+        { symbol: 'ZERO', last_price: 0 },
+        { symbol: 'NAN', last_price: 'abc' },
+        { symbol: '', last_price: 1 },
+      ],
+    })
+    const client = new WebullQuoteClient({
+      auth: baseAuth,
+      fetchFn,
+      now: () => new Date('2026-04-18T10:00:05.000Z'),
+    })
+    const result = await client.getSnapshots(['GOOD', 'ZERO', 'NAN', ''], 'US_STOCK')
+    expect(result.map((r) => r.symbol)).toEqual(['GOOD'])
+  })
+
+  it('throws BrokerRequestError on non-2xx response', async () => {
+    const fetchFn = mockFetch({ error: 'bad' }, { status: 500 })
+    const client = new WebullQuoteClient({ auth: baseAuth, fetchFn })
+    await expect(client.getSnapshots(['AAPL'], 'US_STOCK')).rejects.toThrow(/status 500/)
+  })
+})

--- a/test/trading/state/quoteTransitions.test.ts
+++ b/test/trading/state/quoteTransitions.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { isQuoteStale, setQuote } from '../../../src/trading/state/stateTransitions'
+import { emptySymbolState, type QuoteSnapshot } from '../../../src/trading/state/types'
+
+const fixedNow = (iso: string) => () => new Date(iso)
+
+const quote: QuoteSnapshot = {
+  price: 10,
+  asOf: '2026-04-18T10:00:00.000Z',
+  fetchedAt: '2026-04-18T10:00:01.000Z',
+  source: 'webull-snapshot',
+}
+
+describe('setQuote', () => {
+  it('stores the latest quote on state', () => {
+    const state = emptySymbolState('SOXL', fixedNow('2026-04-18T09:00:00.000Z'))
+    const next = setQuote(state, quote, { now: fixedNow('2026-04-18T10:00:02.000Z') })
+    expect(next.lastQuote).toEqual(quote)
+    expect(next.updatedAt).toBe('2026-04-18T10:00:02.000Z')
+  })
+
+  it('replaces an older quote when called twice', () => {
+    let state = emptySymbolState('SOXL', fixedNow('2026-04-18T09:00:00.000Z'))
+    state = setQuote(state, quote, { now: fixedNow('2026-04-18T10:00:02.000Z') })
+    const newer: QuoteSnapshot = { ...quote, price: 11, asOf: '2026-04-18T10:05:00.000Z' }
+    const next = setQuote(state, newer, { now: fixedNow('2026-04-18T10:05:01.000Z') })
+    expect(next.lastQuote?.price).toBe(11)
+  })
+})
+
+describe('isQuoteStale', () => {
+  it('returns true when no quote is present', () => {
+    expect(isQuoteStale(null, '2026-04-18T10:00:00.000Z', 60_000)).toBe(true)
+  })
+
+  it('returns false when quote is within maxAgeMs', () => {
+    expect(isQuoteStale(quote, '2026-04-18T10:00:30.000Z', 60_000)).toBe(false)
+  })
+
+  it('returns true when quote is older than maxAgeMs', () => {
+    expect(isQuoteStale(quote, '2026-04-18T10:05:00.000Z', 60_000)).toBe(true)
+  })
+
+  it('returns true when asOfIso is unparseable', () => {
+    expect(isQuoteStale(quote, 'not-a-date', 60_000)).toBe(true)
+  })
+})

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -19,6 +19,9 @@
   "migrations": [
     { "tag": "v1", "new_sqlite_classes": ["SymbolStateDO"] }
   ],
+  "triggers": {
+    "crons": ["*/5 * * * *"]
+  },
   "env": {
     "staging": {
       "name": "webull-trading-staging",


### PR DESCRIPTION
## 概要

#37 のうち quote 取得側 (Part B)。Strategy が Durable Object から鮮度保証付きの last-price を読めるようにする。

- `WebullQuoteClient` — `GET /market-data/snapshot` を発注クライアントと同じ canonical HMAC-SHA1 で署名 (`WebullAuth` 再利用)。4桁数字コードは `JP_STOCK`、それ以外は `US_STOCK` にルーティング。
- `quoteScheduler.runQuoteFeed` — category 単位で snapshot を取得し、`setQuote` で `SYMBOL_STATE` DO に書き込む。
- `src/index.ts` — Workers の `scheduled` ハンドラを `*/5 * * * *` cron に接続 (`wrangler.jsonc` にトリガー追加)。
- `stateTransitions.setQuote` / `isQuoteStale` — Strategy 側で DO ランタイム無しに鮮度判定できるよう純関数で公開。

POC 方針: category 単位で fail-closed (片側のフェッチ失敗が他方を巻き込まない)。レスポンスに含まれなかった symbol は `skipped` に積んで次 tick でリトライするだけ。

## 今回の scope 外 (明示)

- TradingService と DO の統合 (pending-order lock / recordFill / cooldown) → #37-C
- T+1 settled-cash ガード → #37-D
- 長期運用向けのフォールバック feed — POC では Webull のみに留める

## 動作確認

- [x] `pnpm run typecheck`
- [x] `pnpm test` (120 件 pass、追加: `quoteTransitions` / `webullQuoteClient`)
- [x] `pnpm exec wrangler deploy --dry-run` (新しい `triggers.crons` を受理)
- [ ] Live: staging デプロイ後に `quote_feed_run` ログが流れることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 市場データの定期的な自動取得機能を追加しました。設定されたシンボルの相場情報を5分ごとに自動で取得・保存します。
  * 取得した相場データには価格とタイムスタンプが含まれ、システムで利用可能になります。

* **テスト**
  * 新しい機能に対する包括的なテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->