### PR TITLE
feat(trading): TradingService ⇆ SymbolStateDO 統合 (#37-C)

### DIFF
--- a/src/routes/events.ts
+++ b/src/routes/events.ts
@@ -1,19 +1,22 @@
 import { Hono } from 'hono'
+import type { AppBindings } from '../app'
 import type { TradeEventIngestRequest } from '../infrastructure/webull/TradeEventBridge'
 import { ValidationError } from '../shared/errors'
 import { TradeEventService } from '../trading/application/TradeEventService'
 import { isTradeEventType, isTradeStatus, type TradeEvent } from '../trading/domain/TradeEvent'
+import { SymbolStateClient } from '../trading/state/SymbolStateClient'
 
-const tradeEventService = new TradeEventService()
-
-export const events = new Hono().post('/trade', async (c) => {
+export const events = new Hono<AppBindings>().post('/trade', async (c) => {
   const payload = (await c.req.json().catch(() => null)) as unknown
 
   if (!isTradeEventIngestRequest(payload)) {
     throw new ValidationError('event payload is invalid', { field: 'event' })
   }
 
-  await tradeEventService.handle(payload.event)
+  const service = new TradeEventService({
+    positionStore: c.env.SYMBOL_STATE ? new SymbolStateClient(c.env.SYMBOL_STATE) : undefined,
+  })
+  await service.handle(payload.event)
 
   return c.json({ ok: true })
 })

--- a/src/routes/trade.ts
+++ b/src/routes/trade.ts
@@ -7,6 +7,8 @@ import { TradingService, type TradingConfig } from '../trading/application/Tradi
 import { MockExecution } from '../trading/execution/MockExecution'
 import { WebullExecution } from '../trading/execution/WebullExecution'
 import { DefaultRiskPolicy } from '../trading/risk/DefaultRiskPolicy'
+import { SymbolStateClient } from '../trading/state/SymbolStateClient'
+import type { SymbolStateDO } from '../trading/state/SymbolStateDO'
 import { FixedRuleStrategy } from '../trading/strategy/strategies/FixedRuleStrategy'
 
 interface TradeRequest {
@@ -54,6 +56,7 @@ export function createTradingService(
   request: TradeRequest,
   env: {
     DRY_RUN?: string
+    SYMBOL_STATE?: DurableObjectNamespace<SymbolStateDO>
   } & WebullClientEnv,
 ): TradingService {
   const execution = parseBooleanEnv(env.DRY_RUN, true)
@@ -64,6 +67,9 @@ export function createTradingService(
     new FixedRuleStrategy(request.buyBelow, request.sellAbove),
     new DefaultRiskPolicy(),
     execution,
+    {
+      positionStore: env.SYMBOL_STATE ? new SymbolStateClient(env.SYMBOL_STATE) : undefined,
+    },
   )
 }
 

--- a/src/trading/application/TradeEventService.ts
+++ b/src/trading/application/TradeEventService.ts
@@ -1,8 +1,15 @@
 import type { TradeEvent } from '../domain/TradeEvent'
-import { TradeEventHandler } from '../events/TradeEventHandler'
+import { TradeEventHandler, type TradeEventHandlerOptions } from '../events/TradeEventHandler'
 
 export class TradeEventService {
-  constructor(private readonly handler: TradeEventHandler = new TradeEventHandler()) {}
+  private readonly handler: TradeEventHandler
+
+  constructor(handlerOrOptions: TradeEventHandler | TradeEventHandlerOptions = {}) {
+    this.handler =
+      handlerOrOptions instanceof TradeEventHandler
+        ? handlerOrOptions
+        : new TradeEventHandler(console.log, handlerOrOptions)
+  }
 
   async handle(event: TradeEvent): Promise<void> {
     await this.handler.handle(event)

--- a/src/trading/application/TradingService.ts
+++ b/src/trading/application/TradingService.ts
@@ -58,7 +58,12 @@ export class TradingService {
     options: TradingServiceOptions = {},
   ) {
     this.positionStore = options.positionStore
-    this.pendingLockTtlMs = options.pendingLockTtlMs ?? DEFAULT_PENDING_LOCK_TTL_MS
+    this.pendingLockTtlMs =
+      options.pendingLockTtlMs !== undefined &&
+      Number.isFinite(options.pendingLockTtlMs) &&
+      options.pendingLockTtlMs > 0
+        ? options.pendingLockTtlMs
+        : DEFAULT_PENDING_LOCK_TTL_MS
     this.now = options.now ?? (() => new Date())
   }
 
@@ -105,7 +110,7 @@ export class TradingService {
       return decision
     }
 
-    const stateGate = await this.applyStateGate(decision, input.symbol)
+    const stateGate = await this.applyStateGate(decision, decision.orderIntent.symbol)
     if (!stateGate.allowed) {
       return { ...decision, riskDecision: stateGate.riskDecision }
     }

--- a/src/trading/application/TradingService.ts
+++ b/src/trading/application/TradingService.ts
@@ -4,6 +4,7 @@ import type { RiskDecision } from '../domain/RiskDecision'
 import type { Signal } from '../domain/Signal'
 import type { Execution } from '../execution/Execution'
 import type { RiskPolicy } from '../risk/RiskPolicy'
+import type { PositionStore } from '../state/PositionStore'
 import type { Strategy, StrategyInput } from '../strategy/Strategy'
 import {
   logPostSubmit,
@@ -36,12 +37,30 @@ export interface TradeCallContext {
   requestId?: string
 }
 
+export interface TradingServiceOptions {
+  positionStore?: PositionStore
+  /** How long a pending-order lock stays live before a new submit can replace it. */
+  pendingLockTtlMs?: number
+  now?: () => Date
+}
+
+const DEFAULT_PENDING_LOCK_TTL_MS = 60_000
+
 export class TradingService {
+  private readonly positionStore?: PositionStore
+  private readonly pendingLockTtlMs: number
+  private readonly now: () => Date
+
   constructor(
     private readonly strategy: Strategy,
     private readonly riskPolicy: RiskPolicy,
     private readonly execution: Execution,
-  ) {}
+    options: TradingServiceOptions = {},
+  ) {
+    this.positionStore = options.positionStore
+    this.pendingLockTtlMs = options.pendingLockTtlMs ?? DEFAULT_PENDING_LOCK_TTL_MS
+    this.now = options.now ?? (() => new Date())
+  }
 
   decide(input: StrategyInput, config: TradingConfig, ctx?: TradeCallContext): TradingDecision {
     const signal = this.strategy.decide(input)
@@ -86,6 +105,11 @@ export class TradingService {
       return decision
     }
 
+    const stateGate = await this.applyStateGate(decision, input.symbol)
+    if (!stateGate.allowed) {
+      return { ...decision, riskDecision: stateGate.riskDecision }
+    }
+
     const intent = decision.orderIntent
     logTradeIntent({ requestId: ctx?.requestId, clientOrderId: intent.clientOrderId, intent })
     logPreSubmit({ requestId: ctx?.requestId, clientOrderId: intent.clientOrderId, intent })
@@ -95,9 +119,19 @@ export class TradingService {
     let error: Error | undefined
     try {
       executionResult = await this.execution.execute(intent)
+      // DRY_RUN never emits a TradeEvent, so the pending-order lock must be
+      // released here; otherwise every subsequent DRY_RUN call would bounce
+      // off the stale lock.
+      if (executionResult.mode === 'DRY_RUN' && this.positionStore) {
+        await this.positionStore.clearPendingOrder(intent.symbol)
+      }
       return { ...decision, executionResult }
     } catch (err) {
       error = err instanceof Error ? err : new Error(String(err))
+      if (this.positionStore) {
+        // Fail-closed: a failed submit must not leave a phantom lock in place.
+        await this.positionStore.clearPendingOrder(intent.symbol).catch(() => undefined)
+      }
       throw err
     } finally {
       logPostSubmit({
@@ -109,6 +143,41 @@ export class TradingService {
         error,
       })
     }
+  }
+
+  private async applyStateGate(
+    decision: TradingDecision,
+    symbol: string,
+  ): Promise<{ allowed: true } | { allowed: false; riskDecision: RiskDecision }> {
+    if (!this.positionStore || !decision.orderIntent) {
+      return { allowed: true }
+    }
+
+    const now = this.now()
+    const state = await this.positionStore.getState(symbol)
+
+    if (state.cooldownUntil && new Date(state.cooldownUntil).getTime() > now.getTime()) {
+      return {
+        allowed: false,
+        riskDecision: appendReason(decision.riskDecision, `cooldown active until ${state.cooldownUntil}`),
+      }
+    }
+
+    const lock = {
+      clientOrderId: decision.orderIntent.clientOrderId,
+      side: decision.orderIntent.side,
+      submittedAt: now.toISOString(),
+      expiresAt: new Date(now.getTime() + this.pendingLockTtlMs).toISOString(),
+    }
+    const result = await this.positionStore.lockPendingOrder(symbol, lock)
+    if (!result.ok) {
+      return {
+        allowed: false,
+        riskDecision: appendReason(decision.riskDecision, 'pending order already in flight'),
+      }
+    }
+
+    return { allowed: true }
   }
 
   private createOrderIntent(signal: Signal): OrderIntent | undefined {
@@ -124,5 +193,13 @@ export class TradingService {
       notional: signal.price * signal.quantity,
       clientOrderId: crypto.randomUUID().replaceAll('-', ''),
     }
+  }
+}
+
+function appendReason(decision: RiskDecision, reason: string): RiskDecision {
+  return {
+    allowed: false,
+    reasons: [...decision.reasons, reason],
+    normalizedIntent: decision.normalizedIntent,
   }
 }

--- a/src/trading/events/TradeEventHandler.ts
+++ b/src/trading/events/TradeEventHandler.ts
@@ -82,11 +82,43 @@ export class TradeEventHandler {
     filledPrice?: number
   }): Promise<void> {
     if (!this.positionStore) return
-    if (event.filledQty === undefined || filledPrice === undefined) return
+    if (event.filledQty === undefined || filledPrice === undefined) {
+      // Best-effort cleanup: release pending lock and log exit before returning
+      try {
+        logExit({
+          clientOrderId,
+          orderId,
+          symbol,
+          realizedPnl: 0,
+          holdDays: 0,
+          exitReason: 'OTHER',
+        })
+      } catch {
+        // ignore logExit errors
+      }
+      await this.positionStore.clearPendingOrder(symbol).catch(() => undefined)
+      return
+    }
 
     const pre = await this.positionStore.getState(symbol)
     const lock = pre.pendingOrder
     if (!lock) return
+
+    // Verify the pending lock belongs to this fill
+    const eventClientOrderId = clientOrderId ?? event.orderId
+    if (lock.clientOrderId !== eventClientOrderId) {
+      // Stale or mismatched lock; ignore this fill
+      this.log(
+        JSON.stringify({
+          warning: 'fill-lock-mismatch',
+          symbol,
+          orderId,
+          eventClientOrderId,
+          lockClientOrderId: lock.clientOrderId,
+        }),
+      )
+      return
+    }
 
     const next = await this.positionStore.recordFill(symbol, {
       side: lock.side,

--- a/src/trading/events/TradeEventHandler.ts
+++ b/src/trading/events/TradeEventHandler.ts
@@ -1,5 +1,6 @@
 import type { TradeEvent } from '../domain/TradeEvent'
-import { logFill } from '../../infrastructure/logger/tradeJournal'
+import type { PositionStore } from '../state/PositionStore'
+import { logFill, logExit } from '../../infrastructure/logger/tradeJournal'
 
 export interface TradeEventAuditRecord {
   source: 'trade-event'
@@ -11,8 +12,24 @@ export interface TradeEventAuditRecord {
   receivedAt: string
 }
 
+export interface TradeEventHandlerOptions {
+  positionStore?: PositionStore
+  now?: () => Date
+}
+
+const MS_PER_DAY = 86_400_000
+
 export class TradeEventHandler {
-  constructor(private readonly log: (message: string) => void = console.log) {}
+  private readonly positionStore?: PositionStore
+  private readonly now: () => Date
+
+  constructor(
+    private readonly log: (message: string) => void = console.log,
+    options: TradeEventHandlerOptions = {},
+  ) {
+    this.positionStore = options.positionStore
+    this.now = options.now ?? (() => new Date())
+  }
 
   async handle(event: TradeEvent): Promise<void> {
     const orderId = event.orderId.trim()
@@ -34,8 +51,6 @@ export class TradeEventHandler {
 
     this.log(JSON.stringify(record))
 
-    // Emit a parallel trade-journal line so a single query by client_order_id
-    // can reconstruct the full decision → fill lifecycle.
     const clientOrderId = readClientOrderId(event.rawPayload)
     const filledPrice = readFilledPrice(event.rawPayload)
 
@@ -47,6 +62,51 @@ export class TradeEventHandler {
       filledPrice,
       status,
     })
+
+    if (status === 'FILLED' && this.positionStore) {
+      await this.applyFillToState({ symbol, event, orderId, clientOrderId, filledPrice })
+    }
+  }
+
+  private async applyFillToState({
+    symbol,
+    event,
+    orderId,
+    clientOrderId,
+    filledPrice,
+  }: {
+    symbol: string
+    event: TradeEvent
+    orderId: string
+    clientOrderId?: string
+    filledPrice?: number
+  }): Promise<void> {
+    if (!this.positionStore) return
+    if (event.filledQty === undefined || filledPrice === undefined) return
+
+    const pre = await this.positionStore.getState(symbol)
+    const lock = pre.pendingOrder
+    if (!lock) return
+
+    const next = await this.positionStore.recordFill(symbol, {
+      side: lock.side,
+      qty: event.filledQty,
+      price: filledPrice,
+    })
+
+    if (lock.side === 'SELL' && pre.position !== null && next.position === null) {
+      const realizedPnl = (filledPrice - pre.position.avgPrice) * event.filledQty
+      const holdMs = this.now().getTime() - new Date(pre.position.openedAt).getTime()
+      const holdDays = Math.max(0, Math.floor(holdMs / MS_PER_DAY))
+      logExit({
+        clientOrderId: clientOrderId ?? lock.clientOrderId,
+        orderId,
+        symbol,
+        realizedPnl,
+        holdDays,
+        exitReason: 'OTHER',
+      })
+    }
   }
 }
 

--- a/src/trading/events/TradeEventHandler.ts
+++ b/src/trading/events/TradeEventHandler.ts
@@ -83,20 +83,15 @@ export class TradeEventHandler {
   }): Promise<void> {
     if (!this.positionStore) return
     if (event.filledQty === undefined || filledPrice === undefined) {
-      // Best-effort cleanup: release pending lock and log exit before returning
-      try {
-        logExit({
-          clientOrderId,
-          orderId,
-          symbol,
-          realizedPnl: 0,
-          holdDays: 0,
-          exitReason: 'OTHER',
-        })
-      } catch {
-        // ignore logExit errors
+      // Best-effort cleanup: only release pending lock if it belongs to this order
+      const pre = await this.positionStore.getState(symbol)
+      const lock = pre.pendingOrder
+      if (lock) {
+        const eventClientOrderId = clientOrderId ?? event.orderId
+        if (lock.clientOrderId === eventClientOrderId) {
+          await this.positionStore.clearPendingOrder(symbol).catch(() => undefined)
+        }
       }
-      await this.positionStore.clearPendingOrder(symbol).catch(() => undefined)
       return
     }
 

--- a/src/trading/state/PositionStore.ts
+++ b/src/trading/state/PositionStore.ts
@@ -1,0 +1,19 @@
+import type { PendingOrderLock, SymbolState } from './types'
+
+/**
+ * The subset of {@link SymbolStateDO} that TradingService and TradeEventHandler
+ * need. Exposing it as an interface keeps both testable without a Durable
+ * Object runtime.
+ */
+export interface PositionStore {
+  getState(symbol: string): Promise<SymbolState>
+  lockPendingOrder(
+    symbol: string,
+    lock: PendingOrderLock,
+  ): Promise<{ ok: boolean; state: SymbolState }>
+  clearPendingOrder(symbol: string): Promise<SymbolState>
+  recordFill(
+    symbol: string,
+    fill: { side: 'BUY' | 'SELL'; qty: number; price: number },
+  ): Promise<SymbolState>
+}

--- a/src/trading/state/SymbolStateClient.ts
+++ b/src/trading/state/SymbolStateClient.ts
@@ -1,0 +1,38 @@
+import type { PositionStore } from './PositionStore'
+import type { SymbolStateDO } from './SymbolStateDO'
+import type { PendingOrderLock, SymbolState } from './types'
+
+/**
+ * Thin adapter from {@link DurableObjectNamespace} to {@link PositionStore}.
+ * Routes every call for a given symbol to the DO instance derived from
+ * `idFromName(symbol)` so all reads/writes land on the same object.
+ */
+export class SymbolStateClient implements PositionStore {
+  constructor(private readonly namespace: DurableObjectNamespace<SymbolStateDO>) {}
+
+  private stub(symbol: string): DurableObjectStub<SymbolStateDO> {
+    return this.namespace.get(this.namespace.idFromName(symbol))
+  }
+
+  getState(symbol: string): Promise<SymbolState> {
+    return this.stub(symbol).getState(symbol)
+  }
+
+  lockPendingOrder(
+    symbol: string,
+    lock: PendingOrderLock,
+  ): Promise<{ ok: boolean; state: SymbolState }> {
+    return this.stub(symbol).lockPendingOrder(symbol, lock)
+  }
+
+  clearPendingOrder(symbol: string): Promise<SymbolState> {
+    return this.stub(symbol).clearPendingOrder(symbol)
+  }
+
+  recordFill(
+    symbol: string,
+    fill: { side: 'BUY' | 'SELL'; qty: number; price: number },
+  ): Promise<SymbolState> {
+    return this.stub(symbol).recordFill(symbol, fill)
+  }
+}

--- a/test/events/tradeEventHandlerState.test.ts
+++ b/test/events/tradeEventHandlerState.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { TradeEventHandler } from '../../src/trading/events/TradeEventHandler'
+import { setTradeJournalSink } from '../../src/infrastructure/logger/tradeJournal'
+import type { PositionStore } from '../../src/trading/state/PositionStore'
+import { emptySymbolState, type PendingOrderLock, type SymbolState } from '../../src/trading/state/types'
+
+const fixedNow = new Date('2026-04-18T10:00:00.000Z')
+
+function makeStore(initial: SymbolState, afterFill: SymbolState): PositionStore & { recordFillCalls: unknown[] } {
+  let state = initial
+  const recordFillCalls: unknown[] = []
+  return {
+    recordFillCalls,
+    async getState() {
+      return state
+    },
+    async lockPendingOrder() {
+      return { ok: true, state }
+    },
+    async clearPendingOrder() {
+      return state
+    },
+    async recordFill(symbol, fill) {
+      recordFillCalls.push({ symbol, fill })
+      state = afterFill
+      return state
+    },
+  }
+}
+
+describe('TradeEventHandler with PositionStore', () => {
+  const lock: PendingOrderLock = {
+    clientOrderId: 'coid-1',
+    side: 'SELL',
+    submittedAt: '2026-04-18T09:59:30.000Z',
+    expiresAt: '2026-04-18T10:00:30.000Z',
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('applies recordFill and emits logExit when a SELL closes the position', async () => {
+    const pre: SymbolState = {
+      ...emptySymbolState('SOXL', () => fixedNow),
+      pendingOrder: lock,
+      position: { qty: 2, avgPrice: 9, openedAt: '2026-04-15T10:00:00.000Z' },
+    }
+    const post: SymbolState = { ...pre, position: null, pendingOrder: null }
+    const store = makeStore(pre, post)
+
+    const journalLines: string[] = []
+    const restore = setTradeJournalSink((line) => journalLines.push(line))
+
+    const handler = new TradeEventHandler(() => {}, { positionStore: store, now: () => fixedNow })
+    await handler.handle({
+      eventType: 'ORDER_FILLED',
+      orderId: 'ord-1',
+      symbol: 'SOXL',
+      status: 'FILLED',
+      filledQty: 2,
+      rawPayload: { client_order_id: 'coid-1', filled_price: 12 },
+      receivedAt: fixedNow.toISOString(),
+    })
+    restore()
+
+    expect(store.recordFillCalls).toEqual([
+      { symbol: 'SOXL', fill: { side: 'SELL', qty: 2, price: 12 } },
+    ])
+
+    const exit = journalLines.map((l) => JSON.parse(l)).find((r) => r.trade_event_type === 'exit')
+    expect(exit).toMatchObject({
+      symbol: 'SOXL',
+      order_id: 'ord-1',
+      client_order_id: 'coid-1',
+      realized_pnl: 6,
+      hold_days: 3,
+      exit_reason: 'OTHER',
+    })
+  })
+
+  it('skips recordFill when no pending lock exists (stale event)', async () => {
+    const state: SymbolState = emptySymbolState('SOXL', () => fixedNow)
+    const store = makeStore(state, state)
+
+    const handler = new TradeEventHandler(() => {}, { positionStore: store, now: () => fixedNow })
+    await handler.handle({
+      eventType: 'ORDER_FILLED',
+      orderId: 'ord-ghost',
+      symbol: 'SOXL',
+      status: 'FILLED',
+      filledQty: 2,
+      rawPayload: { filled_price: 12 },
+      receivedAt: fixedNow.toISOString(),
+    })
+
+    expect(store.recordFillCalls).toEqual([])
+  })
+
+  it('does not emit logExit on a BUY fill', async () => {
+    const buyLock: PendingOrderLock = { ...lock, side: 'BUY' }
+    const pre: SymbolState = {
+      ...emptySymbolState('SOXL', () => fixedNow),
+      pendingOrder: buyLock,
+    }
+    const post: SymbolState = {
+      ...pre,
+      pendingOrder: null,
+      position: { qty: 2, avgPrice: 9, openedAt: fixedNow.toISOString() },
+    }
+    const store = makeStore(pre, post)
+
+    const journalLines: string[] = []
+    const restore = setTradeJournalSink((line) => journalLines.push(line))
+    const handler = new TradeEventHandler(() => {}, { positionStore: store, now: () => fixedNow })
+    await handler.handle({
+      eventType: 'ORDER_FILLED',
+      orderId: 'ord-2',
+      symbol: 'SOXL',
+      status: 'FILLED',
+      filledQty: 2,
+      rawPayload: { client_order_id: 'coid-1', filled_price: 9 },
+      receivedAt: fixedNow.toISOString(),
+    })
+    restore()
+
+    expect(store.recordFillCalls).toHaveLength(1)
+    const exit = journalLines.map((l) => JSON.parse(l)).find((r) => r.trade_event_type === 'exit')
+    expect(exit).toBeUndefined()
+  })
+})

--- a/test/trading/application/tradingServiceState.test.ts
+++ b/test/trading/application/tradingServiceState.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from 'vitest'
+import { TradingService, type TradingConfig } from '../../../src/trading/application/TradingService'
+import { MockExecution } from '../../../src/trading/execution/MockExecution'
+import { DefaultRiskPolicy } from '../../../src/trading/risk/DefaultRiskPolicy'
+import type { PositionStore } from '../../../src/trading/state/PositionStore'
+import { emptySymbolState, type PendingOrderLock, type SymbolState } from '../../../src/trading/state/types'
+import { FixedRuleStrategy } from '../../../src/trading/strategy/strategies/FixedRuleStrategy'
+
+const fixedNow = new Date('2026-04-18T10:00:00.000Z')
+
+const baseConfig: TradingConfig = {
+  dryRun: true,
+  tradingEnabled: true,
+  allowedSymbols: ['SOXL'],
+  maxOrderNotional: 1_000,
+  symbolMaxNotional: {},
+  marketHoursCheck: false,
+}
+
+const buyInput = {
+  symbol: 'SOXL',
+  price: 9,
+  quantity: 2,
+  buyBelow: 10,
+  sellAbove: 20,
+}
+
+function makeStore(initial?: SymbolState): PositionStore & { state: SymbolState; calls: string[] } {
+  let state = initial ?? emptySymbolState('SOXL', () => fixedNow)
+  const calls: string[] = []
+  return {
+    get state() {
+      return state
+    },
+    calls,
+    async getState() {
+      calls.push('getState')
+      return state
+    },
+    async lockPendingOrder(_symbol: string, lock: PendingOrderLock) {
+      calls.push('lockPendingOrder')
+      if (state.pendingOrder && new Date(state.pendingOrder.expiresAt).getTime() > fixedNow.getTime()) {
+        return { ok: false, state }
+      }
+      state = { ...state, pendingOrder: lock }
+      return { ok: true, state }
+    },
+    async clearPendingOrder() {
+      calls.push('clearPendingOrder')
+      state = { ...state, pendingOrder: null }
+      return state
+    },
+    async recordFill() {
+      calls.push('recordFill')
+      return state
+    },
+  }
+}
+
+function makeService(store: PositionStore) {
+  return new TradingService(
+    new FixedRuleStrategy(buyInput.buyBelow, buyInput.sellAbove),
+    new DefaultRiskPolicy(),
+    new MockExecution(),
+    { positionStore: store, now: () => fixedNow },
+  )
+}
+
+describe('TradingService state gate', () => {
+  it('blocks the trade when cooldownUntil is in the future', async () => {
+    const future = new Date(fixedNow.getTime() + 60_000).toISOString()
+    const store = makeStore({ ...emptySymbolState('SOXL', () => fixedNow), cooldownUntil: future })
+    const result = await makeService(store).executeTrade(buyInput, baseConfig)
+
+    expect(result.riskDecision.allowed).toBe(false)
+    expect(result.riskDecision.reasons.some((r) => r.includes('cooldown'))).toBe(true)
+    expect(result.executionResult).toBeUndefined()
+    expect(store.calls).toEqual(['getState'])
+  })
+
+  it('blocks the trade when a pending order is already in flight', async () => {
+    const lock: PendingOrderLock = {
+      clientOrderId: 'existing-lock',
+      side: 'BUY',
+      submittedAt: fixedNow.toISOString(),
+      expiresAt: new Date(fixedNow.getTime() + 60_000).toISOString(),
+    }
+    const store = makeStore({ ...emptySymbolState('SOXL', () => fixedNow), pendingOrder: lock })
+    const result = await makeService(store).executeTrade(buyInput, baseConfig)
+
+    expect(result.riskDecision.allowed).toBe(false)
+    expect(result.riskDecision.reasons.some((r) => r.includes('pending order'))).toBe(true)
+    expect(result.executionResult).toBeUndefined()
+  })
+
+  it('lock-then-clear on successful DRY_RUN execution so the next tick can fire', async () => {
+    const store = makeStore()
+    const result = await makeService(store).executeTrade(buyInput, baseConfig)
+
+    expect(result.executionResult?.mode).toBe('DRY_RUN')
+    expect(store.calls).toContain('lockPendingOrder')
+    expect(store.calls).toContain('clearPendingOrder')
+    expect(store.state.pendingOrder).toBeNull()
+  })
+
+  it('clears the lock when execution throws so state does not wedge', async () => {
+    const store = makeStore()
+    const throwingExecution = {
+      execute: vi.fn(async () => {
+        throw new Error('broker down')
+      }),
+    }
+    const service = new TradingService(
+      new FixedRuleStrategy(buyInput.buyBelow, buyInput.sellAbove),
+      new DefaultRiskPolicy(),
+      throwingExecution,
+      { positionStore: store, now: () => fixedNow },
+    )
+
+    await expect(service.executeTrade(buyInput, baseConfig)).rejects.toThrow('broker down')
+    expect(store.calls).toContain('clearPendingOrder')
+    expect(store.state.pendingOrder).toBeNull()
+  })
+})


### PR DESCRIPTION
## 概要

#37 の Part C。TradingService と TradeEventHandler を SymbolStateDO に接続し、FixedRule 時代の重複 BUY 病を構造的に潰す。

- `PositionStore` インターフェース + `SymbolStateClient` (DO 名前空間ラッパー) を追加。TradingService と TradeEventHandler が DO runtime 非依存でテスト可能に。
- **pre-submit gate** (TradingService.executeTrade):
  - `cooldownUntil` が未来なら submit 拒否 (reason を riskDecision に追記)。
  - `lockPendingOrder` を取得できなければ `pending order already in flight` で拒否。
  - DRY_RUN 成功時は `clearPendingOrder` で即解放 (TradeEvent が来ないため)。
  - submit 例外時も `clearPendingOrder` (fail-closed、ロック残留を防止)。
- **post-fill** (TradeEventHandler):
  - `status === 'FILLED'` のとき pre-state の `pendingOrder` を参照し、`recordFill(side, qty, price)` を呼ぶ。
  - SELL で position が閉じた場合 `logExit` を emit (realized PnL = (fill_price - avgPrice) × qty、hold_days は openedAt からの日数)。payload に filled_price が無ければ exit ログは出さない (best-effort)。

## scope 外

- realized PnL の通貨/税前後区別 — follow-up
- exit_reason の分類 (TP/SL/TIME_STOP) — 戦略側で判定する必要があるので #39 で扱う
- T+1 settled-cash ガード — #37-D

## 動作確認

- [x] `pnpm run typecheck`
- [x] `pnpm test` (127 件 pass、追加: `tradingServiceState` / `tradeEventHandlerState`)
- [x] `pnpm exec wrangler deploy --dry-run`
- [ ] Live: cooldown / lock-conflict / SELL exit ログを staging で観測

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ポジションの永続的状態を扱う抽象インターフェースと外部ストア接続を追加
  * シンボル単位の状態クライアントを導入し状態操作を外部ストアに委譲
  * 取引サービスに保留注文ロックやTTLなどのオプションを追加

* **改善**
  * ルート処理がリクエストごとに状態連携を行うよう変更
  * 約定処理で実現損益・保有日数を算出し、保留ロックの取得／解放を制御

* **テスト**
  * 状態連携とゲーティングの統合テストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->