### PR TITLE
feat(trading): T+1 settled-cash guard (#37-D)

### DIFF
--- a/src/trading/application/TradingService.ts
+++ b/src/trading/application/TradingService.ts
@@ -168,6 +168,24 @@ export class TradingService {
       }
     }
 
+    // T+1 settled-cash guard: if settledCash has been seeded (> 0), a BUY whose
+    // notional exceeds it would be a good-faith violation on a JP CASH account.
+    // When settledCash is 0 we treat the symbol as unseeded and skip the check
+    // so existing tests and the legacy FixedRule path keep working unchanged.
+    if (
+      decision.orderIntent.side === 'BUY' &&
+      state.settledCash > 0 &&
+      decision.orderIntent.notional > state.settledCash
+    ) {
+      return {
+        allowed: false,
+        riskDecision: appendReason(
+          decision.riskDecision,
+          `insufficient settled cash: notional ${decision.orderIntent.notional} exceeds settledCash ${state.settledCash}`,
+        ),
+      }
+    }
+
     const lock = {
       clientOrderId: decision.orderIntent.clientOrderId,
       side: decision.orderIntent.side,

--- a/src/trading/events/TradeEventHandler.ts
+++ b/src/trading/events/TradeEventHandler.ts
@@ -121,20 +121,55 @@ export class TradeEventHandler {
       price: filledPrice,
     })
 
-    if (lock.side === 'SELL' && pre.position !== null && next.position === null) {
-      const realizedPnl = (filledPrice - pre.position.avgPrice) * event.filledQty
-      const holdMs = this.now().getTime() - new Date(pre.position.openedAt).getTime()
-      const holdDays = Math.max(0, Math.floor(holdMs / MS_PER_DAY))
-      logExit({
-        clientOrderId: clientOrderId ?? lock.clientOrderId,
-        orderId,
-        symbol,
-        realizedPnl,
-        holdDays,
-        exitReason: 'OTHER',
-      })
+    if (lock.side === 'SELL') {
+      // T+1: SELL proceeds are unsettled until the next business day.
+      const tradeDay = this.now()
+      await this.positionStore
+        .addPendingSettlement(symbol, {
+          tradeDate: toYmd(tradeDay),
+          settleDate: toYmd(nextBusinessDay(tradeDay)),
+          amount: filledPrice * event.filledQty,
+        })
+        .catch((error) => {
+          this.log(
+            JSON.stringify({
+              warning: 'pending-settlement-failed',
+              symbol,
+              message: error instanceof Error ? error.message : String(error),
+            }),
+          )
+        })
+
+      if (pre.position !== null && next.position === null) {
+        const realizedPnl = (filledPrice - pre.position.avgPrice) * event.filledQty
+        const holdMs = this.now().getTime() - new Date(pre.position.openedAt).getTime()
+        const holdDays = Math.max(0, Math.floor(holdMs / MS_PER_DAY))
+        logExit({
+          clientOrderId: clientOrderId ?? lock.clientOrderId,
+          orderId,
+          symbol,
+          realizedPnl,
+          holdDays,
+          exitReason: 'OTHER',
+        })
+      }
     }
   }
+}
+
+function toYmd(date: Date): string {
+  return date.toISOString().slice(0, 10)
+}
+
+/**
+ * Next business day (skips Sat/Sun). POC scope — does not honour JP/US holidays.
+ */
+export function nextBusinessDay(date: Date): Date {
+  const next = new Date(date.getTime() + MS_PER_DAY)
+  const dow = next.getUTCDay()
+  if (dow === 6) return new Date(next.getTime() + 2 * MS_PER_DAY) // Sat → Mon
+  if (dow === 0) return new Date(next.getTime() + MS_PER_DAY) // Sun → Mon
+  return next
 }
 
 function readClientOrderId(payload: unknown): string | undefined {

--- a/src/trading/state/PositionStore.ts
+++ b/src/trading/state/PositionStore.ts
@@ -1,4 +1,4 @@
-import type { PendingOrderLock, SymbolState } from './types'
+import type { PendingOrderLock, PendingSettlement, SymbolState } from './types'
 
 /**
  * The subset of {@link SymbolStateDO} that TradingService and TradeEventHandler
@@ -16,4 +16,5 @@ export interface PositionStore {
     symbol: string,
     fill: { side: 'BUY' | 'SELL'; qty: number; price: number },
   ): Promise<SymbolState>
+  addPendingSettlement(symbol: string, settlement: PendingSettlement): Promise<SymbolState>
 }

--- a/src/trading/state/SymbolStateClient.ts
+++ b/src/trading/state/SymbolStateClient.ts
@@ -1,6 +1,6 @@
 import type { PositionStore } from './PositionStore'
 import type { SymbolStateDO } from './SymbolStateDO'
-import type { PendingOrderLock, SymbolState } from './types'
+import type { PendingOrderLock, PendingSettlement, SymbolState } from './types'
 
 /**
  * Thin adapter from {@link DurableObjectNamespace} to {@link PositionStore}.
@@ -34,5 +34,9 @@ export class SymbolStateClient implements PositionStore {
     fill: { side: 'BUY' | 'SELL'; qty: number; price: number },
   ): Promise<SymbolState> {
     return this.stub(symbol).recordFill(symbol, fill)
+  }
+
+  addPendingSettlement(symbol: string, settlement: PendingSettlement): Promise<SymbolState> {
+    return this.stub(symbol).addPendingSettlement(symbol, settlement)
   }
 }

--- a/test/events/tradeEventHandlerSettlement.test.ts
+++ b/test/events/tradeEventHandlerSettlement.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+import { TradeEventHandler, nextBusinessDay } from '../../src/trading/events/TradeEventHandler'
+import type { PositionStore } from '../../src/trading/state/PositionStore'
+import {
+  emptySymbolState,
+  type PendingOrderLock,
+  type PendingSettlement,
+  type SymbolState,
+} from '../../src/trading/state/types'
+
+const friday = new Date('2026-04-17T10:00:00.000Z') // Fri
+const tuesday = new Date('2026-04-21T10:00:00.000Z') // Tue
+
+const sellLock: PendingOrderLock = {
+  clientOrderId: 'coid-sell',
+  side: 'SELL',
+  submittedAt: tuesday.toISOString(),
+  expiresAt: new Date(tuesday.getTime() + 60_000).toISOString(),
+}
+
+const buyLock: PendingOrderLock = { ...sellLock, side: 'BUY', clientOrderId: 'coid-buy' }
+
+function makeStore(pre: SymbolState, post: SymbolState) {
+  const settlements: Array<{ symbol: string; settlement: PendingSettlement }> = []
+  let state = pre
+  const store: PositionStore = {
+    async getState() {
+      return state
+    },
+    async lockPendingOrder() {
+      return { ok: true, state }
+    },
+    async clearPendingOrder() {
+      return state
+    },
+    async recordFill() {
+      state = post
+      return state
+    },
+    async addPendingSettlement(symbol, settlement) {
+      settlements.push({ symbol, settlement })
+      return state
+    },
+  }
+  return { store, settlements }
+}
+
+describe('nextBusinessDay', () => {
+  it('rolls Fri → Mon', () => {
+    expect(nextBusinessDay(friday).toISOString().slice(0, 10)).toBe('2026-04-20')
+  })
+  it('rolls Sat → Mon', () => {
+    const sat = new Date('2026-04-18T10:00:00.000Z')
+    expect(nextBusinessDay(sat).toISOString().slice(0, 10)).toBe('2026-04-20')
+  })
+  it('rolls Tue → Wed', () => {
+    expect(nextBusinessDay(tuesday).toISOString().slice(0, 10)).toBe('2026-04-22')
+  })
+})
+
+describe('TradeEventHandler SELL → addPendingSettlement', () => {
+  it('pushes a T+1 settlement row for a SELL fill', async () => {
+    const pre: SymbolState = {
+      ...emptySymbolState('SOXL', () => tuesday),
+      pendingOrder: sellLock,
+      position: { qty: 3, avgPrice: 8, openedAt: '2026-04-15T10:00:00.000Z' },
+    }
+    const post: SymbolState = { ...pre, position: null, pendingOrder: null }
+    const { store, settlements } = makeStore(pre, post)
+
+    const handler = new TradeEventHandler(() => {}, { positionStore: store, now: () => tuesday })
+    await handler.handle({
+      eventType: 'ORDER_FILLED',
+      orderId: 'ord-sell',
+      symbol: 'SOXL',
+      status: 'FILLED',
+      filledQty: 3,
+      rawPayload: { client_order_id: 'coid-sell', filled_price: 12 },
+      receivedAt: tuesday.toISOString(),
+    })
+
+    expect(settlements).toEqual([
+      {
+        symbol: 'SOXL',
+        settlement: { tradeDate: '2026-04-21', settleDate: '2026-04-22', amount: 36 },
+      },
+    ])
+  })
+
+  it('does not add a settlement row on a BUY fill', async () => {
+    const pre: SymbolState = {
+      ...emptySymbolState('SOXL', () => tuesday),
+      pendingOrder: buyLock,
+    }
+    const post: SymbolState = {
+      ...pre,
+      position: { qty: 3, avgPrice: 9, openedAt: tuesday.toISOString() },
+      pendingOrder: null,
+    }
+    const { store, settlements } = makeStore(pre, post)
+
+    const handler = new TradeEventHandler(() => {}, { positionStore: store, now: () => tuesday })
+    await handler.handle({
+      eventType: 'ORDER_FILLED',
+      orderId: 'ord-buy',
+      symbol: 'SOXL',
+      status: 'FILLED',
+      filledQty: 3,
+      rawPayload: { client_order_id: 'coid-buy', filled_price: 9 },
+      receivedAt: tuesday.toISOString(),
+    })
+
+    expect(settlements).toEqual([])
+  })
+})

--- a/test/events/tradeEventHandlerState.test.ts
+++ b/test/events/tradeEventHandlerState.test.ts
@@ -6,11 +6,16 @@ import { emptySymbolState, type PendingOrderLock, type SymbolState } from '../..
 
 const fixedNow = new Date('2026-04-18T10:00:00.000Z')
 
-function makeStore(initial: SymbolState, afterFill: SymbolState): PositionStore & { recordFillCalls: unknown[] } {
+function makeStore(
+  initial: SymbolState,
+  afterFill: SymbolState,
+): PositionStore & { recordFillCalls: unknown[]; settlementCalls: unknown[] } {
   let state = initial
   const recordFillCalls: unknown[] = []
+  const settlementCalls: unknown[] = []
   return {
     recordFillCalls,
+    settlementCalls,
     async getState() {
       return state
     },
@@ -23,6 +28,10 @@ function makeStore(initial: SymbolState, afterFill: SymbolState): PositionStore 
     async recordFill(symbol, fill) {
       recordFillCalls.push({ symbol, fill })
       state = afterFill
+      return state
+    },
+    async addPendingSettlement(symbol, settlement) {
+      settlementCalls.push({ symbol, settlement })
       return state
     },
   }

--- a/test/trading/application/tradingServiceSettlement.test.ts
+++ b/test/trading/application/tradingServiceSettlement.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import { TradingService, type TradingConfig } from '../../../src/trading/application/TradingService'
+import { MockExecution } from '../../../src/trading/execution/MockExecution'
+import { DefaultRiskPolicy } from '../../../src/trading/risk/DefaultRiskPolicy'
+import type { PositionStore } from '../../../src/trading/state/PositionStore'
+import { emptySymbolState, type SymbolState } from '../../../src/trading/state/types'
+import { FixedRuleStrategy } from '../../../src/trading/strategy/strategies/FixedRuleStrategy'
+
+const fixedNow = new Date('2026-04-20T10:00:00.000Z')
+
+const config: TradingConfig = {
+  dryRun: true,
+  tradingEnabled: true,
+  allowedSymbols: ['SOXL'],
+  maxOrderNotional: 1_000,
+  symbolMaxNotional: {},
+  marketHoursCheck: false,
+}
+
+const buyInput = {
+  symbol: 'SOXL',
+  price: 9,
+  quantity: 3,
+  buyBelow: 10,
+  sellAbove: 20,
+}
+
+function makeStore(state: SymbolState): PositionStore {
+  return {
+    async getState() {
+      return state
+    },
+    async lockPendingOrder() {
+      return { ok: true, state }
+    },
+    async clearPendingOrder() {
+      return state
+    },
+    async recordFill() {
+      return state
+    },
+    async addPendingSettlement() {
+      return state
+    },
+  }
+}
+
+function makeService(store: PositionStore) {
+  return new TradingService(
+    new FixedRuleStrategy(buyInput.buyBelow, buyInput.sellAbove),
+    new DefaultRiskPolicy(),
+    new MockExecution(),
+    { positionStore: store, now: () => fixedNow },
+  )
+}
+
+describe('TradingService settled-cash guard', () => {
+  it('rejects a BUY when notional exceeds seeded settledCash', async () => {
+    const state: SymbolState = { ...emptySymbolState('SOXL', () => fixedNow), settledCash: 20 }
+    const result = await makeService(makeStore(state)).executeTrade(buyInput, config)
+
+    expect(result.riskDecision.allowed).toBe(false)
+    expect(result.riskDecision.reasons.some((r) => r.includes('insufficient settled cash'))).toBe(true)
+    expect(result.executionResult).toBeUndefined()
+  })
+
+  it('allows the BUY when settledCash is zero (unseeded / ungated)', async () => {
+    const state: SymbolState = emptySymbolState('SOXL', () => fixedNow)
+    const result = await makeService(makeStore(state)).executeTrade(buyInput, config)
+
+    expect(result.riskDecision.allowed).toBe(true)
+    expect(result.executionResult?.mode).toBe('DRY_RUN')
+  })
+
+  it('allows the BUY when settledCash >= notional', async () => {
+    const state: SymbolState = { ...emptySymbolState('SOXL', () => fixedNow), settledCash: 100 }
+    const result = await makeService(makeStore(state)).executeTrade(buyInput, config)
+
+    expect(result.riskDecision.allowed).toBe(true)
+  })
+})

--- a/test/trading/application/tradingServiceState.test.ts
+++ b/test/trading/application/tradingServiceState.test.ts
@@ -54,6 +54,10 @@ function makeStore(initial?: SymbolState): PositionStore & { state: SymbolState;
       calls.push('recordFill')
       return state
     },
+    async addPendingSettlement() {
+      calls.push('addPendingSettlement')
+      return state
+    },
   }
 }
 


### PR DESCRIPTION
## 概要

#37 の Part D。JP CASH account の good-faith violation を構造的に防ぐ。

- **Pre-submit BUY**: \`state.settledCash > 0\` かつ \`notional > settledCash\` → reject。\`settledCash === 0\` は unseeded / POC ungated として素通り (既存 FixedRule テスト互換)。
- **Post-fill SELL**: \`addPendingSettlement({ tradeDate, settleDate: 次営業日, amount: qty*price })\` を push。既存の \`rollSettlements\` が settleDate ≤ today で \`settledCash\` に加算する。
- **nextBusinessDay**: 土日のみスキップ。JP/US 祝日カレンダーは POC scope 外 (#38 で取引所カレンダーと合わせて扱う)。

## scope 外
- settledCash の初期シード手段 (admin endpoint / reconcile job) — 実運用時に別 issue
- JP/US 祝日カレンダー — #38
- BUY fill 時の settledCash 減算 — broker 側で debit される前提、state は eventual に追従

## 動作確認
- [x] \`pnpm run typecheck\`
- [x] \`pnpm test\` (135 件 pass、追加: \`tradingServiceSettlement\` / \`tradeEventHandlerSettlement\`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 売却取引の決済記録を自動作成
  * 営業日ベースの決済日計算を追加

* **バグ修正**
  * 確定現金が不足している場合、買付注文をブロック

* **テスト**
  * 決済処理および取引サービスのテストスイートを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->