### PR TITLE
feat(strategy): Pullback戦略 + 3x ETF guardrails + sizing (#39)

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -62,6 +62,11 @@ export interface Env {
   MARKET_HOURS_CHECK?: string
 }
 
+// Pullback strategy per-symbol rule overrides (Phase 2c append)
+export interface Env {
+  SYMBOL_RULES?: string
+}
+
 let didWarnInvalidSymbolNotionalMap = false
 
 export function parseSymbolNotionalMap(value: string | undefined): Record<string, number> {
@@ -94,4 +99,73 @@ export function parseSymbolNotionalMap(value: string | undefined): Record<string
 
     return {}
   }
+}
+
+let didWarnInvalidSymbolRules = false
+
+/**
+ * Parses SYMBOL_RULES JSON into a per-symbol PullbackUptrendStrategy rule map.
+ * Keys are symbols, values are partial overrides of SymbolRule. Missing fields
+ * fall through to DEFAULT_RULE at strategy level. Returns `{}` on any error so
+ * a typo in one env entry cannot wedge the whole symbol universe.
+ *
+ * Example: `{"SOXL":{"stopPct":-0.03,"timeStopDays":5}}`
+ */
+export function parseSymbolRulesMap(
+  value: string | undefined,
+): Record<string, Partial<SymbolRuleShape>> {
+  if (!value) return {}
+
+  try {
+    const parsed = JSON.parse(value) as unknown
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      throw new Error('value must be an object')
+    }
+
+    const result: Record<string, Partial<SymbolRuleShape>> = {}
+    for (const [symbol, rule] of Object.entries(parsed)) {
+      if (typeof rule !== 'object' || rule === null || Array.isArray(rule)) {
+        throw new Error(`rule for '${symbol}' must be an object`)
+      }
+      result[symbol.toUpperCase()] = coerceRule(rule as Record<string, unknown>, symbol)
+    }
+    return result
+  } catch (error) {
+    if (!didWarnInvalidSymbolRules) {
+      didWarnInvalidSymbolRules = true
+      console.warn(
+        `Invalid SYMBOL_RULES value; using empty rules: ${error instanceof Error ? error.message : String(error)}`,
+      )
+    }
+    return {}
+  }
+}
+
+interface SymbolRuleShape {
+  stopPct: number
+  takeProfitPct: number
+  timeStopDays: number
+  pullbackMax: number
+  pullbackMin: number
+}
+
+function coerceRule(raw: Record<string, unknown>, symbol: string): Partial<SymbolRuleShape> {
+  const out: Partial<SymbolRuleShape> = {}
+  const numberKeys: Array<keyof SymbolRuleShape> = [
+    'stopPct',
+    'takeProfitPct',
+    'timeStopDays',
+    'pullbackMax',
+    'pullbackMin',
+  ]
+  for (const key of numberKeys) {
+    if (raw[key] !== undefined) {
+      const value = raw[key]
+      if (typeof value !== 'number' || !Number.isFinite(value)) {
+        throw new Error(`'${symbol}.${key}' must be a finite number`)
+      }
+      out[key] = value
+    }
+  }
+  return out
 }

--- a/src/trading/strategy/pullbackSizing.ts
+++ b/src/trading/strategy/pullbackSizing.ts
@@ -1,0 +1,64 @@
+export interface PullbackSizingInput {
+  equity: number
+  entryPrice: number
+  /** Stop-loss fraction, negative (e.g. -0.04). */
+  stopPct: number
+  atr20: number
+  /** Longer-window baseline ATR(20) for the low-vol cap. */
+  baselineAtr20: number
+  /** Optional symbol-specific absolute notional cap. */
+  symbolCap?: number
+  /** Risk fraction of NAV per trade. Default 0.004 (0.4%). */
+  riskPerTradePct?: number
+  /** ATR floor ratio. If atr20 < baselineAtr20 * this, size is halved. Default 0.5. */
+  atrFloorRatio?: number
+}
+
+export interface PullbackSizingResult {
+  quantity: number
+  notional: number
+  capped: boolean
+  capReason?: 'atr-floor' | 'symbol-cap' | 'invalid-stop' | 'insufficient-risk-budget'
+}
+
+/**
+ * Fixed-% NAV risk sizing with ATR floor + absolute symbol cap.
+ *
+ * `qty = floor(equity * riskPct / (entry * |stopPct|))`. If current ATR has
+ * collapsed to less than `atrFloorRatio` of its baseline, the POC halves the
+ * size (vol expansion risk). A separate `symbolCap` hard-limits notional.
+ */
+export function computePullbackSizing(input: PullbackSizingInput): PullbackSizingResult {
+  const riskPct = input.riskPerTradePct ?? 0.004
+  const atrFloor = input.atrFloorRatio ?? 0.5
+  const stopDistance = Math.abs(input.entryPrice * input.stopPct)
+
+  if (!Number.isFinite(stopDistance) || stopDistance <= 0) {
+    return { quantity: 0, notional: 0, capped: true, capReason: 'invalid-stop' }
+  }
+
+  const riskBudget = input.equity * riskPct
+  if (!Number.isFinite(riskBudget) || riskBudget <= 0) {
+    return { quantity: 0, notional: 0, capped: true, capReason: 'insufficient-risk-budget' }
+  }
+
+  let quantity = Math.floor(riskBudget / stopDistance)
+  let capped = false
+  let capReason: PullbackSizingResult['capReason']
+
+  if (input.baselineAtr20 > 0 && input.atr20 < input.baselineAtr20 * atrFloor) {
+    quantity = Math.floor(quantity / 2)
+    capped = true
+    capReason = 'atr-floor'
+  }
+
+  let notional = quantity * input.entryPrice
+  if (input.symbolCap !== undefined && notional > input.symbolCap) {
+    quantity = Math.floor(input.symbolCap / input.entryPrice)
+    notional = quantity * input.entryPrice
+    capped = true
+    capReason = 'symbol-cap'
+  }
+
+  return { quantity, notional, capped, capReason }
+}

--- a/src/trading/strategy/strategies/PullbackUptrendStrategy.ts
+++ b/src/trading/strategy/strategies/PullbackUptrendStrategy.ts
@@ -1,0 +1,158 @@
+import type { Signal } from '../../domain/Signal'
+import type { PendingOrderLock, PositionState } from '../../state/types'
+
+export interface PullbackIndicators {
+  price: number
+  sma50: number
+  return50d: number
+  high20d: number
+  atr20: number
+  baselineAtr20: number
+}
+
+export interface SymbolRule {
+  /** Stop-loss as a fraction of avgPrice (negative). Default -0.04. */
+  stopPct: number
+  /** Take-profit as a fraction of avgPrice (positive). Default 0.07. */
+  takeProfitPct: number
+  /** Time stop in business days. Default 10. */
+  timeStopDays: number
+  /** Pullback range: closer to 0 bound. Default -0.03. */
+  pullbackMax: number
+  /** Pullback range: deeper bound. Default -0.06. */
+  pullbackMin: number
+}
+
+export const DEFAULT_RULE: SymbolRule = Object.freeze({
+  stopPct: -0.04,
+  takeProfitPct: 0.07,
+  timeStopDays: 10,
+  pullbackMax: -0.03,
+  pullbackMin: -0.06,
+})
+
+/**
+ * 3x leveraged ETFs (SOXL / SOXS / TQQQ / SQQQ ...): tighter stop, shorter
+ * time stop to avoid volatility-drag + path-dependency decay.
+ */
+export const LEVERAGED_RULE: SymbolRule = Object.freeze({
+  stopPct: -0.03,
+  takeProfitPct: 0.07,
+  timeStopDays: 5,
+  pullbackMax: -0.03,
+  pullbackMin: -0.06,
+})
+
+export interface PullbackInput {
+  symbol: string
+  indicators: PullbackIndicators
+  position: PositionState | null
+  pendingOrder: PendingOrderLock | null
+  cooldownUntil: string | null
+  /** Business days elapsed since position.openedAt. 0 when position is null. */
+  holdBusinessDays: number
+  now: Date
+}
+
+export class PullbackUptrendStrategy {
+  readonly name = 'PullbackUptrendStrategy'
+
+  constructor(private readonly rules: Record<string, SymbolRule> = {}) {}
+
+  resolveRule(symbol: string): SymbolRule {
+    const override = this.rules[symbol.toUpperCase()]
+    return override ?? DEFAULT_RULE
+  }
+
+  decide(input: PullbackInput): Signal {
+    const rule = this.resolveRule(input.symbol)
+    const now = input.now
+
+    if (input.pendingOrder !== null) {
+      return hold(input, 'pending order in flight')
+    }
+    if (input.cooldownUntil && new Date(input.cooldownUntil).getTime() > now.getTime()) {
+      return hold(input, `cooldown active until ${input.cooldownUntil}`)
+    }
+
+    if (input.position !== null) {
+      return this.exitDecision(input, input.position, rule)
+    }
+    return this.entryDecision(input, rule)
+  }
+
+  private exitDecision(input: PullbackInput, position: PositionState, rule: SymbolRule): Signal {
+    const pnlPct = (input.indicators.price - position.avgPrice) / position.avgPrice
+
+    if (pnlPct >= rule.takeProfitPct) {
+      return sell(input, position, `take-profit hit: pnl ${pnlPct.toFixed(4)} >= ${rule.takeProfitPct}`)
+    }
+    if (pnlPct <= rule.stopPct) {
+      return sell(input, position, `stop-loss hit: pnl ${pnlPct.toFixed(4)} <= ${rule.stopPct}`)
+    }
+    if (input.holdBusinessDays >= rule.timeStopDays) {
+      return sell(
+        input,
+        position,
+        `time-stop hit: held ${input.holdBusinessDays}d >= ${rule.timeStopDays}d`,
+      )
+    }
+    return hold(input, `holding: pnl ${pnlPct.toFixed(4)} within (${rule.stopPct}, ${rule.takeProfitPct})`)
+  }
+
+  private entryDecision(input: PullbackInput, rule: SymbolRule): Signal {
+    const ind = input.indicators
+    if (ind.return50d <= 0.08) {
+      return hold(input, `50d return ${ind.return50d.toFixed(4)} <= 0.08 trend threshold`)
+    }
+    if (ind.price <= ind.sma50) {
+      return hold(input, `price ${ind.price} <= sma50 ${ind.sma50}`)
+    }
+    if (ind.high20d <= 0) {
+      return hold(input, 'invalid 20d high')
+    }
+    const pullback = (ind.price - ind.high20d) / ind.high20d
+    if (pullback > rule.pullbackMax) {
+      return hold(input, `pullback ${pullback.toFixed(4)} > ${rule.pullbackMax} (not deep enough)`)
+    }
+    if (pullback < rule.pullbackMin) {
+      return hold(input, `pullback ${pullback.toFixed(4)} < ${rule.pullbackMin} (too deep)`)
+    }
+    return buy(input, `pullback ${pullback.toFixed(4)} in uptrend (50d return ${ind.return50d.toFixed(4)})`)
+  }
+}
+
+function hold(input: PullbackInput, reason: string): Signal {
+  return {
+    action: 'HOLD',
+    symbol: input.symbol,
+    quantity: 0,
+    price: input.indicators.price,
+    reason,
+    generatedAtIso: input.now.toISOString(),
+  }
+}
+
+function buy(input: PullbackInput, reason: string): Signal {
+  // Quantity is resolved by the sizing module (pullbackSizing.ts); signal
+  // carries 0 here so downstream code knows to compute it.
+  return {
+    action: 'BUY',
+    symbol: input.symbol,
+    quantity: 0,
+    price: input.indicators.price,
+    reason,
+    generatedAtIso: input.now.toISOString(),
+  }
+}
+
+function sell(input: PullbackInput, position: PositionState, reason: string): Signal {
+  return {
+    action: 'SELL',
+    symbol: input.symbol,
+    quantity: position.qty,
+    price: input.indicators.price,
+    reason,
+    generatedAtIso: input.now.toISOString(),
+  }
+}

--- a/test/config/symbolRules.test.ts
+++ b/test/config/symbolRules.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { parseSymbolRulesMap } from '../../src/config/env'
+
+describe('parseSymbolRulesMap', () => {
+  it('returns empty on undefined', () => {
+    expect(parseSymbolRulesMap(undefined)).toEqual({})
+  })
+
+  it('parses valid JSON and uppercases keys', () => {
+    const out = parseSymbolRulesMap('{"soxl":{"stopPct":-0.03,"timeStopDays":5}}')
+    expect(out).toEqual({ SOXL: { stopPct: -0.03, timeStopDays: 5 } })
+  })
+
+  it('returns {} on malformed JSON', () => {
+    expect(parseSymbolRulesMap('not-json')).toEqual({})
+  })
+
+  it('returns {} when a field value is non-numeric', () => {
+    expect(parseSymbolRulesMap('{"SOXL":{"stopPct":"tight"}}')).toEqual({})
+  })
+
+  it('silently drops unknown keys', () => {
+    const out = parseSymbolRulesMap('{"SOXL":{"stopPct":-0.03,"foo":"bar"}}')
+    expect(out).toEqual({ SOXL: { stopPct: -0.03 } })
+  })
+})

--- a/test/strategy/pullbackSizing.test.ts
+++ b/test/strategy/pullbackSizing.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import { computePullbackSizing } from '../../src/trading/strategy/pullbackSizing'
+
+describe('computePullbackSizing', () => {
+  it('sizes to 0.4% NAV risk divided by stop distance', () => {
+    // $100k equity, 0.4% risk = $400 budget. Entry $100, stop -4% = $4 risk/share.
+    // qty = floor(400 / 4) = 100. notional = 100 * 100 = 10_000.
+    const result = computePullbackSizing({
+      equity: 100_000,
+      entryPrice: 100,
+      stopPct: -0.04,
+      atr20: 2,
+      baselineAtr20: 2,
+    })
+    expect(result.quantity).toBe(100)
+    expect(result.notional).toBe(10_000)
+    expect(result.capped).toBe(false)
+  })
+
+  it('implied $ risk never exceeds equity * riskPerTradePct', () => {
+    const equity = 50_000
+    const result = computePullbackSizing({
+      equity,
+      entryPrice: 55,
+      stopPct: -0.05,
+      atr20: 1,
+      baselineAtr20: 1,
+      riskPerTradePct: 0.004,
+    })
+    const maxRisk = equity * 0.004
+    const realizedRisk = result.quantity * Math.abs(55 * -0.05)
+    expect(realizedRisk).toBeLessThanOrEqual(maxRisk)
+  })
+
+  it('halves the size when ATR(20) collapses below half the baseline', () => {
+    const base = computePullbackSizing({
+      equity: 100_000,
+      entryPrice: 100,
+      stopPct: -0.04,
+      atr20: 2,
+      baselineAtr20: 2,
+    })
+    const floored = computePullbackSizing({
+      equity: 100_000,
+      entryPrice: 100,
+      stopPct: -0.04,
+      atr20: 0.5,
+      baselineAtr20: 2,
+    })
+    expect(floored.quantity).toBe(Math.floor(base.quantity / 2))
+    expect(floored.capped).toBe(true)
+    expect(floored.capReason).toBe('atr-floor')
+  })
+
+  it('clamps to symbolCap when unrestricted notional would exceed it', () => {
+    const result = computePullbackSizing({
+      equity: 1_000_000,
+      entryPrice: 100,
+      stopPct: -0.04,
+      atr20: 2,
+      baselineAtr20: 2,
+      symbolCap: 5_000,
+    })
+    expect(result.notional).toBeLessThanOrEqual(5_000)
+    expect(result.capped).toBe(true)
+    expect(result.capReason).toBe('symbol-cap')
+  })
+
+  it('rejects a non-positive stop distance', () => {
+    expect(
+      computePullbackSizing({ equity: 100_000, entryPrice: 100, stopPct: 0, atr20: 2, baselineAtr20: 2 }),
+    ).toMatchObject({ quantity: 0, capReason: 'invalid-stop' })
+  })
+})

--- a/test/strategy/pullbackUptrendStrategy.test.ts
+++ b/test/strategy/pullbackUptrendStrategy.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_RULE,
+  LEVERAGED_RULE,
+  PullbackUptrendStrategy,
+  type PullbackInput,
+} from '../../src/trading/strategy/strategies/PullbackUptrendStrategy'
+import type { PendingOrderLock, PositionState } from '../../src/trading/state/types'
+
+const now = new Date('2026-04-20T14:30:00.000Z')
+
+/** Build a valid BUY-triggering input; individual tests mutate one field. */
+function goodEntryInput(): PullbackInput {
+  return {
+    symbol: 'AAPL',
+    indicators: {
+      price: 96, // 4% pullback from high20d=100
+      sma50: 90,
+      return50d: 0.12,
+      high20d: 100,
+      atr20: 1.5,
+      baselineAtr20: 1.5,
+    },
+    position: null,
+    pendingOrder: null,
+    cooldownUntil: null,
+    holdBusinessDays: 0,
+    now,
+  }
+}
+
+const openPosition: PositionState = {
+  qty: 10,
+  avgPrice: 100,
+  openedAt: '2026-04-15T14:30:00.000Z',
+}
+
+describe('PullbackUptrendStrategy entry', () => {
+  const strategy = new PullbackUptrendStrategy()
+
+  it('BUYs when all four entry conditions hold', () => {
+    const signal = strategy.decide(goodEntryInput())
+    expect(signal.action).toBe('BUY')
+    expect(signal.quantity).toBe(0) // sizing resolves this downstream
+  })
+
+  it('HOLDs when 50d return is below the +8% trend threshold', () => {
+    const input = goodEntryInput()
+    input.indicators.return50d = 0.05
+    expect(strategy.decide(input).action).toBe('HOLD')
+  })
+
+  it('HOLDs when price is at or below sma50', () => {
+    const input = goodEntryInput()
+    input.indicators.price = 89
+    input.indicators.high20d = 100
+    expect(strategy.decide(input).action).toBe('HOLD')
+  })
+
+  it('HOLDs when pullback is shallower than -3%', () => {
+    const input = goodEntryInput()
+    input.indicators.price = 99 // -1%
+    expect(strategy.decide(input).action).toBe('HOLD')
+  })
+
+  it('HOLDs when pullback is deeper than -6%', () => {
+    const input = goodEntryInput()
+    input.indicators.price = 93 // -7%
+    expect(strategy.decide(input).action).toBe('HOLD')
+  })
+
+  it('HOLDs when a pending order is in flight', () => {
+    const input = goodEntryInput()
+    input.pendingOrder = {
+      clientOrderId: 'x',
+      side: 'BUY',
+      submittedAt: now.toISOString(),
+      expiresAt: new Date(now.getTime() + 60_000).toISOString(),
+    } satisfies PendingOrderLock
+    expect(strategy.decide(input).reason).toMatch(/pending order/)
+  })
+
+  it('HOLDs while cooldownUntil is in the future', () => {
+    const input = goodEntryInput()
+    input.cooldownUntil = new Date(now.getTime() + 60_000).toISOString()
+    expect(strategy.decide(input).reason).toMatch(/cooldown/)
+  })
+})
+
+describe('PullbackUptrendStrategy exit priority', () => {
+  const strategy = new PullbackUptrendStrategy()
+
+  function withPosition(price: number, holdBusinessDays = 0): PullbackInput {
+    return {
+      symbol: 'AAPL',
+      indicators: { price, sma50: 0, return50d: 0, high20d: 0, atr20: 0, baselineAtr20: 0 },
+      position: openPosition,
+      pendingOrder: null,
+      cooldownUntil: null,
+      holdBusinessDays,
+      now,
+    }
+  }
+
+  it('SELLs on take-profit before time-stop', () => {
+    const signal = strategy.decide(withPosition(108, 20))
+    expect(signal.action).toBe('SELL')
+    expect(signal.reason).toMatch(/take-profit/)
+  })
+
+  it('SELLs on stop-loss before time-stop', () => {
+    const signal = strategy.decide(withPosition(95, 20))
+    expect(signal.action).toBe('SELL')
+    expect(signal.reason).toMatch(/stop-loss/)
+  })
+
+  it('SELLs on time-stop once hold reaches timeStopDays', () => {
+    const signal = strategy.decide(withPosition(101, DEFAULT_RULE.timeStopDays))
+    expect(signal.action).toBe('SELL')
+    expect(signal.reason).toMatch(/time-stop/)
+  })
+
+  it('HOLDs while pnl and hold are inside the rule envelope', () => {
+    expect(strategy.decide(withPosition(101, 3)).action).toBe('HOLD')
+  })
+})
+
+describe('PullbackUptrendStrategy 3x ETF guardrail', () => {
+  const strategy = new PullbackUptrendStrategy({ SOXL: LEVERAGED_RULE })
+
+  it('applies LEVERAGED_RULE for SOXL', () => {
+    expect(strategy.resolveRule('SOXL').timeStopDays).toBe(5)
+    expect(strategy.resolveRule('SOXL').stopPct).toBe(-0.03)
+  })
+
+  it('falls back to DEFAULT_RULE for non-listed symbols', () => {
+    expect(strategy.resolveRule('AAPL')).toEqual(DEFAULT_RULE)
+  })
+
+  it('SELLs SOXL at hold=5 days where DEFAULT_RULE would still hold', () => {
+    const signal = strategy.decide({
+      symbol: 'SOXL',
+      indicators: { price: 101, sma50: 0, return50d: 0, high20d: 0, atr20: 0, baselineAtr20: 0 },
+      position: openPosition,
+      pendingOrder: null,
+      cooldownUntil: null,
+      holdBusinessDays: 5,
+      now,
+    })
+    expect(signal.action).toBe('SELL')
+    expect(signal.reason).toMatch(/time-stop/)
+  })
+
+  it('SELLs SOXL on the tighter -3% stop', () => {
+    const signal = strategy.decide({
+      symbol: 'SOXL',
+      indicators: { price: 96.5, sma50: 0, return50d: 0, high20d: 0, atr20: 0, baselineAtr20: 0 },
+      position: openPosition,
+      pendingOrder: null,
+      cooldownUntil: null,
+      holdBusinessDays: 1,
+      now,
+    })
+    expect(signal.action).toBe('SELL')
+    expect(signal.reason).toMatch(/stop-loss/)
+  })
+})


### PR DESCRIPTION
## 概要

Phase 2c の第一戦略。Codex × trading-strategist の 2 ラウンド議論で **3x ETF を universe に残すなら Pullback** に収束 → 採用。

### `PullbackUptrendStrategy`
- **Entry (AND)**: 50日 return > +8% / price > SMA50 / 20日高の -3% 〜 -6% の位置 / pending_order 無 / cooldown clear
- **Exit (priority)**: TP +7% → SL -4% → time-stop 10BD
- signal.quantity=0 で返し、size は `computePullbackSizing` に委譲

### `LEVERAGED_RULE` (SOXL / SOXS 等 3x ETF)
- stopPct: -3% (厳格化)
- timeStopDays: 5 (vol drag + path decay 対策で短縮)

### `computePullbackSizing`
- `qty = floor(equity * 0.4% / |entry * stopPct|)`
- `atr20 < baselineAtr20 * 0.5` なら half-size (ATR floor)
- `symbolCap` で絶対上限 (既存 `SYMBOL_MAX_NOTIONAL` と整合)

### `parseSymbolRulesMap`
- `SYMBOL_RULES` env を per-symbol 部分上書きとして解釈 (`{"SOXL":{"stopPct":-0.03}}`)
- 不正値は一件でも混ざれば `{}` に落として fail-closed

## scope 外 (別 PR)

- Route / cron 配線: indicator (SMA50 / ATR20) の計算元 (Webull historical bar or pre-computed store) が未決。先に本 PR で戦略だけ確定し、scheduled handler は follow-up。
- Donchian / Mean-reversion 比較実装 — #39 の次候補として保留

## 動作確認

- [x] `pnpm run typecheck`
- [x] `pnpm test` (160 件 pass、追加: `pullbackUptrendStrategy` / `pullbackSizing` / `symbolRules`)