### PR TITLE
feat(risk): inverse-pair correlation cap + stop-out cooldown (#38-A)

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -67,6 +67,11 @@ export interface Env {
   SYMBOL_RULES?: string
 }
 
+// Risk correlation config (Phase 2b append)
+export interface Env {
+  INVERSE_PAIRS?: string
+}
+
 let didWarnInvalidSymbolNotionalMap = false
 
 export function parseSymbolNotionalMap(value: string | undefined): Record<string, number> {
@@ -168,4 +173,52 @@ function coerceRule(raw: Record<string, unknown>, symbol: string): Partial<Symbo
     }
   }
   return out
+}
+
+let didWarnInvalidInversePairs = false
+
+/**
+ * Parses INVERSE_PAIRS JSON into a bidirectional pair lookup. An inverse pair
+ * is two symbols whose prices are structurally anti-correlated (e.g. SOXL/SOXS).
+ * Holding both at once is a P&L decay trap, not a hedge, so the correlation
+ * gate must reject BUY X while any position in its inverse exists.
+ *
+ * Accepts either a map `{"SOXL":"SOXS"}` (expanded to both directions) or an
+ * already-bidirectional map. Fails closed (empty result) on any malformed entry.
+ */
+export function parseInversePairs(value: string | undefined): Record<string, string> {
+  if (!value) return {}
+
+  try {
+    const parsed = JSON.parse(value) as unknown
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      throw new Error('value must be an object')
+    }
+
+    const result: Record<string, string> = {}
+    for (const [left, right] of Object.entries(parsed)) {
+      if (typeof right !== 'string' || right.trim().length === 0) {
+        throw new Error(`inverse pair for '${left}' must be a non-empty string`)
+      }
+      const leftKey = left.toUpperCase()
+      const rightKey = right.toUpperCase()
+      if (leftKey === rightKey) {
+        throw new Error(`inverse pair '${leftKey}' cannot reference itself`)
+      }
+      result[leftKey] = rightKey
+      // Expand to both directions so a caller only needs to write the map once.
+      if (result[rightKey] === undefined) {
+        result[rightKey] = leftKey
+      }
+    }
+    return result
+  } catch (error) {
+    if (!didWarnInvalidInversePairs) {
+      didWarnInvalidInversePairs = true
+      console.warn(
+        `Invalid INVERSE_PAIRS value; using empty pairs: ${error instanceof Error ? error.message : String(error)}`,
+      )
+    }
+    return {}
+  }
 }

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -67,11 +67,6 @@ export interface Env {
   SYMBOL_RULES?: string
 }
 
-// Risk correlation config (Phase 2b append)
-export interface Env {
-  INVERSE_PAIRS?: string
-}
-
 let didWarnInvalidSymbolNotionalMap = false
 
 export function parseSymbolNotionalMap(value: string | undefined): Record<string, number> {
@@ -221,4 +216,9 @@ export function parseInversePairs(value: string | undefined): Record<string, str
     }
     return {}
   }
+}
+
+// Risk correlation config (Phase 2b append)
+export interface Env {
+  INVERSE_PAIRS?: string
 }

--- a/src/routes/trade.ts
+++ b/src/routes/trade.ts
@@ -1,6 +1,12 @@
 import { Hono } from 'hono'
 import type { AppBindings } from '../app'
-import { parseBooleanEnv, parseCsvEnv, parseNumberEnv, parseSymbolNotionalMap } from '../config/env'
+import {
+  parseBooleanEnv,
+  parseCsvEnv,
+  parseInversePairs,
+  parseNumberEnv,
+  parseSymbolNotionalMap,
+} from '../config/env'
 import { createWebullHttpClient, type WebullClientEnv } from '../infrastructure/webull/WebullHttpClient'
 import { ValidationError } from '../shared/errors'
 import { TradingService, type TradingConfig } from '../trading/application/TradingService'
@@ -57,6 +63,7 @@ export function createTradingService(
   env: {
     DRY_RUN?: string
     SYMBOL_STATE?: DurableObjectNamespace<SymbolStateDO>
+    INVERSE_PAIRS?: string
   } & WebullClientEnv,
 ): TradingService {
   const execution = parseBooleanEnv(env.DRY_RUN, true)
@@ -69,6 +76,7 @@ export function createTradingService(
     execution,
     {
       positionStore: env.SYMBOL_STATE ? new SymbolStateClient(env.SYMBOL_STATE) : undefined,
+      inversePairs: parseInversePairs(env.INVERSE_PAIRS),
     },
   )
 }

--- a/src/trading/application/TradingService.ts
+++ b/src/trading/application/TradingService.ts
@@ -41,6 +41,11 @@ export interface TradingServiceOptions {
   positionStore?: PositionStore
   /** How long a pending-order lock stays live before a new submit can replace it. */
   pendingLockTtlMs?: number
+  /**
+   * Bidirectional map of structurally anti-correlated symbols. If SYMBOL_STATE
+   * shows an open position for the inverse, BUY is rejected (P&L decay trap).
+   */
+  inversePairs?: Record<string, string>
   now?: () => Date
 }
 
@@ -49,6 +54,7 @@ const DEFAULT_PENDING_LOCK_TTL_MS = 60_000
 export class TradingService {
   private readonly positionStore?: PositionStore
   private readonly pendingLockTtlMs: number
+  private readonly inversePairs: Record<string, string>
   private readonly now: () => Date
 
   constructor(
@@ -64,6 +70,7 @@ export class TradingService {
       options.pendingLockTtlMs > 0
         ? options.pendingLockTtlMs
         : DEFAULT_PENDING_LOCK_TTL_MS
+    this.inversePairs = options.inversePairs ?? {}
     this.now = options.now ?? (() => new Date())
   }
 
@@ -183,6 +190,25 @@ export class TradingService {
           decision.riskDecision,
           `insufficient settled cash: notional ${decision.orderIntent.notional} exceeds settledCash ${state.settledCash}`,
         ),
+      }
+    }
+
+    // Inverse-pair correlation cap: holding SOXL and SOXS at once is a structural
+    // decay trap. Only gate BUY — a SELL that closes the existing leg must remain
+    // possible even while the inverse leg is open.
+    if (decision.orderIntent.side === 'BUY') {
+      const inverse = this.inversePairs[symbol.toUpperCase()]
+      if (inverse) {
+        const inverseState = await this.positionStore.getState(inverse)
+        if (inverseState.position !== null && inverseState.position.qty > 0) {
+          return {
+            allowed: false,
+            riskDecision: appendReason(
+              decision.riskDecision,
+              `inverse-pair exposure: ${inverse} position (qty ${inverseState.position.qty}) blocks BUY ${symbol}`,
+            ),
+          }
+        }
       }
     }
 

--- a/src/trading/events/TradeEventHandler.ts
+++ b/src/trading/events/TradeEventHandler.ts
@@ -152,6 +152,23 @@ export class TradeEventHandler {
           holdDays,
           exitReason: 'OTHER',
         })
+
+        // Stop-out cooldown: a losing exit parks the symbol until the next
+        // business day so a whipsaw re-entry cannot compound the loss.
+        if (realizedPnl < 0) {
+          const cooldownUntil = nextBusinessDay(this.now()).toISOString()
+          await this.positionStore
+            .setCooldown(symbol, cooldownUntil)
+            .catch((error) => {
+              this.log(
+                JSON.stringify({
+                  warning: 'stop-out-cooldown-failed',
+                  symbol,
+                  message: error instanceof Error ? error.message : String(error),
+                }),
+              )
+            })
+        }
       }
     }
   }

--- a/src/trading/state/PositionStore.ts
+++ b/src/trading/state/PositionStore.ts
@@ -17,4 +17,5 @@ export interface PositionStore {
     fill: { side: 'BUY' | 'SELL'; qty: number; price: number },
   ): Promise<SymbolState>
   addPendingSettlement(symbol: string, settlement: PendingSettlement): Promise<SymbolState>
+  setCooldown(symbol: string, untilIso: string): Promise<SymbolState>
 }

--- a/src/trading/state/SymbolStateClient.ts
+++ b/src/trading/state/SymbolStateClient.ts
@@ -39,4 +39,8 @@ export class SymbolStateClient implements PositionStore {
   addPendingSettlement(symbol: string, settlement: PendingSettlement): Promise<SymbolState> {
     return this.stub(symbol).addPendingSettlement(symbol, settlement)
   }
+
+  setCooldown(symbol: string, untilIso: string): Promise<SymbolState> {
+    return this.stub(symbol).setCooldown(symbol, untilIso)
+  }
 }

--- a/test/config/inversePairs.test.ts
+++ b/test/config/inversePairs.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { parseInversePairs } from '../../src/config/env'
+
+describe('parseInversePairs', () => {
+  it('returns empty for undefined', () => {
+    expect(parseInversePairs(undefined)).toEqual({})
+  })
+
+  it('expands a one-sided map to both directions', () => {
+    expect(parseInversePairs('{"SOXL":"SOXS"}')).toEqual({ SOXL: 'SOXS', SOXS: 'SOXL' })
+  })
+
+  it('uppercases both sides', () => {
+    expect(parseInversePairs('{"soxl":"soxs"}')).toEqual({ SOXL: 'SOXS', SOXS: 'SOXL' })
+  })
+
+  it('returns {} on malformed JSON', () => {
+    expect(parseInversePairs('not-json')).toEqual({})
+  })
+
+  it('rejects a self-pair', () => {
+    expect(parseInversePairs('{"SOXL":"SOXL"}')).toEqual({})
+  })
+
+  it('rejects a non-string value', () => {
+    expect(parseInversePairs('{"SOXL":1}')).toEqual({})
+  })
+})

--- a/test/events/tradeEventHandlerCooldown.test.ts
+++ b/test/events/tradeEventHandlerCooldown.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+import { TradeEventHandler } from '../../src/trading/events/TradeEventHandler'
+import type { PositionStore } from '../../src/trading/state/PositionStore'
+import { emptySymbolState, type PendingOrderLock, type SymbolState } from '../../src/trading/state/types'
+
+const tuesday = new Date('2026-04-21T14:30:00.000Z')
+
+const sellLock: PendingOrderLock = {
+  clientOrderId: 'coid-sell',
+  side: 'SELL',
+  submittedAt: tuesday.toISOString(),
+  expiresAt: new Date(tuesday.getTime() + 60_000).toISOString(),
+}
+
+function makeStore(pre: SymbolState, post: SymbolState) {
+  const cooldownCalls: Array<{ symbol: string; untilIso: string }> = []
+  let state = pre
+  const store: PositionStore = {
+    async getState() {
+      return state
+    },
+    async lockPendingOrder() {
+      return { ok: true, state }
+    },
+    async clearPendingOrder() {
+      return state
+    },
+    async recordFill() {
+      state = post
+      return state
+    },
+    async addPendingSettlement() {
+      return state
+    },
+    async setCooldown(symbol, untilIso) {
+      cooldownCalls.push({ symbol, untilIso })
+      return state
+    },
+  }
+  return { store, cooldownCalls }
+}
+
+describe('TradeEventHandler stop-out cooldown', () => {
+  it('sets cooldownUntil = next business day when SELL closes at a loss', async () => {
+    const pre: SymbolState = {
+      ...emptySymbolState('SOXL', () => tuesday),
+      pendingOrder: sellLock,
+      position: { qty: 2, avgPrice: 10, openedAt: '2026-04-18T14:30:00.000Z' },
+    }
+    const post: SymbolState = { ...pre, position: null, pendingOrder: null }
+    const { store, cooldownCalls } = makeStore(pre, post)
+
+    const handler = new TradeEventHandler(() => {}, { positionStore: store, now: () => tuesday })
+    await handler.handle({
+      eventType: 'ORDER_FILLED',
+      orderId: 'ord-sell',
+      symbol: 'SOXL',
+      status: 'FILLED',
+      filledQty: 2,
+      rawPayload: { client_order_id: 'coid-sell', filled_price: 9 }, // loss
+      receivedAt: tuesday.toISOString(),
+    })
+
+    expect(cooldownCalls).toEqual([
+      { symbol: 'SOXL', untilIso: '2026-04-22T14:30:00.000Z' },
+    ])
+  })
+
+  it('does NOT set a cooldown on a profitable exit', async () => {
+    const pre: SymbolState = {
+      ...emptySymbolState('SOXL', () => tuesday),
+      pendingOrder: sellLock,
+      position: { qty: 2, avgPrice: 10, openedAt: '2026-04-18T14:30:00.000Z' },
+    }
+    const post: SymbolState = { ...pre, position: null, pendingOrder: null }
+    const { store, cooldownCalls } = makeStore(pre, post)
+
+    const handler = new TradeEventHandler(() => {}, { positionStore: store, now: () => tuesday })
+    await handler.handle({
+      eventType: 'ORDER_FILLED',
+      orderId: 'ord-sell',
+      symbol: 'SOXL',
+      status: 'FILLED',
+      filledQty: 2,
+      rawPayload: { client_order_id: 'coid-sell', filled_price: 12 }, // gain
+      receivedAt: tuesday.toISOString(),
+    })
+
+    expect(cooldownCalls).toEqual([])
+  })
+})

--- a/test/events/tradeEventHandlerSettlement.test.ts
+++ b/test/events/tradeEventHandlerSettlement.test.ts
@@ -41,6 +41,9 @@ function makeStore(pre: SymbolState, post: SymbolState) {
       settlements.push({ symbol, settlement })
       return state
     },
+    async setCooldown() {
+      return state
+    },
   }
   return { store, settlements }
 }

--- a/test/events/tradeEventHandlerState.test.ts
+++ b/test/events/tradeEventHandlerState.test.ts
@@ -34,6 +34,9 @@ function makeStore(
       settlementCalls.push({ symbol, settlement })
       return state
     },
+    async setCooldown() {
+      return state
+    },
   }
 }
 

--- a/test/trading/application/tradingServiceCorrelation.test.ts
+++ b/test/trading/application/tradingServiceCorrelation.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+import { TradingService, type TradingConfig } from '../../../src/trading/application/TradingService'
+import { MockExecution } from '../../../src/trading/execution/MockExecution'
+import { DefaultRiskPolicy } from '../../../src/trading/risk/DefaultRiskPolicy'
+import type { PositionStore } from '../../../src/trading/state/PositionStore'
+import { emptySymbolState, type SymbolState } from '../../../src/trading/state/types'
+import { FixedRuleStrategy } from '../../../src/trading/strategy/strategies/FixedRuleStrategy'
+
+const now = new Date('2026-04-21T14:30:00.000Z')
+
+const config: TradingConfig = {
+  dryRun: true,
+  tradingEnabled: true,
+  allowedSymbols: ['SOXL', 'SOXS'],
+  maxOrderNotional: 10_000,
+  symbolMaxNotional: {},
+  marketHoursCheck: false,
+}
+
+const buySoxl = { symbol: 'SOXL', price: 9, quantity: 2, buyBelow: 10, sellAbove: 20 }
+
+function makeStore(statesBySymbol: Record<string, SymbolState>): PositionStore {
+  return {
+    async getState(symbol) {
+      return statesBySymbol[symbol.toUpperCase()] ?? emptySymbolState(symbol, () => now)
+    },
+    async lockPendingOrder(_symbol, _lock) {
+      return { ok: true, state: emptySymbolState('_', () => now) }
+    },
+    async clearPendingOrder(symbol) {
+      return emptySymbolState(symbol, () => now)
+    },
+    async recordFill(symbol) {
+      return emptySymbolState(symbol, () => now)
+    },
+    async addPendingSettlement(symbol) {
+      return emptySymbolState(symbol, () => now)
+    },
+    async setCooldown(symbol) {
+      return emptySymbolState(symbol, () => now)
+    },
+  }
+}
+
+function service(store: PositionStore, inversePairs: Record<string, string>) {
+  return new TradingService(
+    new FixedRuleStrategy(buySoxl.buyBelow, buySoxl.sellAbove),
+    new DefaultRiskPolicy(),
+    new MockExecution(),
+    { positionStore: store, inversePairs, now: () => now },
+  )
+}
+
+describe('TradingService inverse-pair correlation cap', () => {
+  it('rejects BUY SOXL when SOXS has an open position', async () => {
+    const store = makeStore({
+      SOXS: {
+        ...emptySymbolState('SOXS', () => now),
+        position: { qty: 5, avgPrice: 10, openedAt: now.toISOString() },
+      },
+    })
+    const result = await service(store, { SOXL: 'SOXS', SOXS: 'SOXL' }).executeTrade(buySoxl, config)
+
+    expect(result.riskDecision.allowed).toBe(false)
+    expect(result.riskDecision.reasons.some((r) => r.includes('inverse-pair'))).toBe(true)
+    expect(result.executionResult).toBeUndefined()
+  })
+
+  it('allows BUY SOXL when SOXS is flat', async () => {
+    const store = makeStore({})
+    const result = await service(store, { SOXL: 'SOXS', SOXS: 'SOXL' }).executeTrade(buySoxl, config)
+    expect(result.riskDecision.allowed).toBe(true)
+  })
+
+  it('allows BUY SOXL when no inverse-pair map is configured', async () => {
+    const store = makeStore({
+      SOXS: {
+        ...emptySymbolState('SOXS', () => now),
+        position: { qty: 5, avgPrice: 10, openedAt: now.toISOString() },
+      },
+    })
+    const result = await service(store, {}).executeTrade(buySoxl, config)
+    expect(result.riskDecision.allowed).toBe(true)
+  })
+
+  it('does not gate a SELL against the inverse leg', async () => {
+    const sellInput = { symbol: 'SOXL', price: 25, quantity: 2, buyBelow: 10, sellAbove: 20 }
+    const store = makeStore({
+      SOXS: {
+        ...emptySymbolState('SOXS', () => now),
+        position: { qty: 5, avgPrice: 10, openedAt: now.toISOString() },
+      },
+    })
+    const result = await service(store, { SOXL: 'SOXS', SOXS: 'SOXL' }).executeTrade(sellInput, config)
+    // SELL signals with no position still fail at RiskPolicy for DefaultRiskPolicy,
+    // but the reason must NOT be the inverse-pair correlation reason.
+    expect(result.riskDecision.reasons.some((r) => r.includes('inverse-pair'))).toBe(false)
+  })
+})

--- a/test/trading/application/tradingServiceSettlement.test.ts
+++ b/test/trading/application/tradingServiceSettlement.test.ts
@@ -42,6 +42,9 @@ function makeStore(state: SymbolState): PositionStore {
     async addPendingSettlement() {
       return state
     },
+    async setCooldown() {
+      return state
+    },
   }
 }
 

--- a/test/trading/application/tradingServiceState.test.ts
+++ b/test/trading/application/tradingServiceState.test.ts
@@ -58,6 +58,10 @@ function makeStore(initial?: SymbolState): PositionStore & { state: SymbolState;
       calls.push('addPendingSettlement')
       return state
     },
+    async setCooldown() {
+      calls.push('setCooldown')
+      return state
+    },
   }
 }
 


### PR DESCRIPTION
## 概要

#38 Risk hardening の第一弾。残りの drawdown kill / halt / JP 値幅 / spread guard は別 PR。

### Inverse-pair correlation cap
- BUY 時、`INVERSE_PAIRS` で指定された逆相関 ETF が position を持っている場合 reject。
- SOXL/SOXS 同時保有は hedge ではなく構造的な P&L decay trap なので gate。
- SELL は gate しない (既存保有の清算は阻害しない)。

### Stop-out cooldown
- SELL fill で `realizedPnl < 0` のとき `setCooldown(symbol, nextBusinessDay(now))`。
- 次 tick の BUY は既存の cooldown ゲートで弾かれる (whipsaw re-entry 防止)。

### `parseInversePairs`
- `INVERSE_PAIRS` env: `{"SOXL":"SOXS"}` を双方向マップに自動展開。
- self-pair / 非文字列値 / JSON 不正は fail-closed で空マップに落とす。

## scope 外 (follow-up)
- Daily drawdown kill switch (新規 PortfolioStateDO が必要)
- Halt 検知 / JP 値幅制限 / 寄り付きギャップ
- Spread guard (bid/ask データ源が必要、quote feed は last price のみ)

## 動作確認
- [x] `pnpm run typecheck`
- [x] `pnpm test` (172 件 pass、追加: `tradingServiceCorrelation` / `tradeEventHandlerCooldown` / `inversePairs`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * インバースペア相関制限：設定した逆相関ペアに基づき、相関する銘柄への買い注文を自動で制限しリスクを低減
  * 自動クールダウン：損失で決済された銘柄に対し、次の営業日までのクールダウンを自動適用

* **設定**
  * 環境変数でインバースペアを指定可能（入力検証・正規化を実施）

* **テスト**
  * 上記挙動を検証するユニットテストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->