### PR TITLE
feat(strategy): Pullback scheduler + indicators + bar client scaffold

### DIFF
--- a/src/infrastructure/quotes/BarClient.ts
+++ b/src/infrastructure/quotes/BarClient.ts
@@ -1,0 +1,156 @@
+import type { DailyBar } from '../../trading/strategy/indicators'
+import { BrokerRequestError } from '../../shared/errors'
+import { WebullAuth } from '../webull/WebullAuth'
+import { inferWebullMarket } from '../webull/mapper'
+
+export type BarCategory = 'US_STOCK' | 'JP_STOCK'
+
+export interface BarClient {
+  getDailyBars(symbol: string, lookback: number): Promise<DailyBar[]>
+}
+
+export interface WebullBarClientEnv {
+  WEBULL_APP_KEY?: string
+  WEBULL_APP_SECRET?: string
+  WEBULL_API_BASE?: string
+  WEBULL_BARS_PATH?: string
+}
+
+interface WebullBarClientOptions {
+  auth: WebullAuth
+  baseUrl?: string
+  barsPath?: string
+  timeoutMs?: number
+  fetchFn?: typeof fetch
+}
+
+/**
+ * Minimal daily-bar client. The Webull JP UAT bar endpoint is not yet verified
+ * from this POC, so the path is overridable via env (`WEBULL_BARS_PATH`) and
+ * the response mapper is forgiving — any bar missing a usable close is
+ * filtered out instead of throwing. Once the production path is known, this
+ * client can be locked down.
+ */
+export class WebullBarClient implements BarClient {
+  private readonly baseUrl: string
+  private readonly barsPath: string
+  private readonly timeoutMs: number
+  private readonly fetchFn: typeof fetch
+
+  constructor(private readonly options: WebullBarClientOptions) {
+    this.baseUrl = (options.baseUrl ?? 'https://api.sandbox.webull.hk').replace(/\/+$/, '')
+    this.barsPath = options.barsPath ?? '/market-data/candles'
+    this.timeoutMs = options.timeoutMs ?? 5_000
+    this.fetchFn = options.fetchFn ?? fetch
+  }
+
+  async getDailyBars(symbol: string, lookback: number): Promise<DailyBar[]> {
+    const category: BarCategory = inferWebullMarket(symbol) === 'JP' ? 'JP_STOCK' : 'US_STOCK'
+    const query = { symbol, category, period: '1d', limit: String(lookback) }
+
+    const url = new URL(this.barsPath, `${this.baseUrl}/`)
+    for (const [k, v] of Object.entries(query)) url.searchParams.set(k, v)
+
+    let headers: Record<string, string>
+    try {
+      headers = await this.options.auth.createHeaders({
+        method: 'GET',
+        path: url.pathname + url.search,
+        query,
+        host: url.host,
+        version: 'v1',
+      })
+    } catch (error) {
+      throw new BrokerRequestError(
+        `Webull bar auth failed: ${error instanceof Error ? error.message : String(error)}`,
+        `GET ${this.barsPath}`,
+        { cause: error instanceof Error ? error : undefined },
+      )
+    }
+
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs)
+    let response: Response
+    try {
+      response = await this.fetchFn(url.href, {
+        method: 'GET',
+        headers: { Accept: 'application/json', ...headers },
+        signal: controller.signal,
+      })
+    } catch (error) {
+      throw new BrokerRequestError(
+        `Webull bar fetch failed: ${error instanceof Error ? error.message : String(error)}`,
+        `GET ${this.barsPath}`,
+        { cause: error instanceof Error ? error : undefined },
+      )
+    } finally {
+      clearTimeout(timeoutId)
+    }
+
+    if (!response.ok) {
+      throw new BrokerRequestError(
+        `Webull bar request failed with status ${response.status}`,
+        `GET ${this.barsPath}`,
+      )
+    }
+
+    return normalizeBars((await response.json()) as unknown)
+  }
+}
+
+export function createWebullBarClient(
+  env: WebullBarClientEnv,
+  options?: { fetchFn?: typeof fetch; timeoutMs?: number },
+): WebullBarClient {
+  return new WebullBarClient({
+    auth: new WebullAuth({
+      appKey: env.WEBULL_APP_KEY,
+      appSecret: env.WEBULL_APP_SECRET,
+    }),
+    baseUrl: env.WEBULL_API_BASE,
+    barsPath: env.WEBULL_BARS_PATH,
+    fetchFn: options?.fetchFn,
+    timeoutMs: options?.timeoutMs,
+  })
+}
+
+interface RawBar {
+  date?: string
+  trade_time?: string
+  open?: number | string
+  high?: number | string
+  low?: number | string
+  close?: number | string
+}
+
+function normalizeBars(json: unknown): DailyBar[] {
+  const rawList = extractList(json)
+  const bars: DailyBar[] = []
+  for (const raw of rawList) {
+    const date = typeof raw.date === 'string' ? raw.date : typeof raw.trade_time === 'string' ? raw.trade_time.slice(0, 10) : ''
+    const open = toNumber(raw.open)
+    const high = toNumber(raw.high)
+    const low = toNumber(raw.low)
+    const close = toNumber(raw.close)
+    if (!date || open === null || high === null || low === null || close === null) continue
+    bars.push({ date, open, high, low, close })
+  }
+  // Ensure oldest-first for downstream indicators.
+  bars.sort((a, b) => a.date.localeCompare(b.date))
+  return bars
+}
+
+function extractList(json: unknown): RawBar[] {
+  if (Array.isArray(json)) return json as RawBar[]
+  if (json && typeof json === 'object') {
+    const data = (json as { data?: unknown }).data
+    if (Array.isArray(data)) return data as RawBar[]
+  }
+  return []
+}
+
+function toNumber(value: number | string | undefined): number | null {
+  if (value === undefined || value === null) return null
+  const num = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(num) ? num : null
+}

--- a/src/trading/strategy/indicators.ts
+++ b/src/trading/strategy/indicators.ts
@@ -1,0 +1,87 @@
+/**
+ * Daily OHLC bar. Field names match Webull's camel-cased data API payloads
+ * (close / high / low / open) to keep the mapper on the client side trivial.
+ */
+export interface DailyBar {
+  date: string
+  open: number
+  high: number
+  low: number
+  close: number
+}
+
+export interface PullbackIndicatorSnapshot {
+  price: number
+  sma50: number
+  return50d: number
+  high20d: number
+  atr20: number
+  baselineAtr20: number
+}
+
+/**
+ * Computes the inputs PullbackUptrendStrategy needs from the last ~60 daily
+ * bars. `bars` must be oldest-first. Returns `null` when the window is too
+ * short — strategy stays HOLD rather than fire on half-initialized data.
+ */
+export function computePullbackIndicators(bars: DailyBar[]): PullbackIndicatorSnapshot | null {
+  if (bars.length < 50) return null
+
+  const closes = bars.map((b) => b.close)
+  const highs = bars.map((b) => b.high)
+  const last = closes[closes.length - 1]!
+  const baseline = closes[closes.length - 50]!
+  if (baseline <= 0) return null
+
+  const sma50 = average(closes.slice(-50))
+  const high20d = Math.max(...highs.slice(-20))
+  const return50d = (last - baseline) / baseline
+
+  const trueRanges = computeTrueRanges(bars)
+  if (trueRanges.length < 20) return null
+  const atr20 = average(trueRanges.slice(-20))
+  // Baseline ATR = longer-window average that `computePullbackSizing` compares
+  // against to decide whether to floor the size. 60 bars ≈ ~3 months daily.
+  const baselineAtr20 = average(trueRanges.slice(-Math.min(trueRanges.length, 60)))
+
+  return { price: last, sma50, return50d, high20d, atr20, baselineAtr20 }
+}
+
+export function computeHoldBusinessDays(openedAtIso: string, now: Date): number {
+  const opened = new Date(openedAtIso)
+  if (!Number.isFinite(opened.getTime())) return 0
+  let count = 0
+  const cursor = new Date(opened.getTime())
+  // Count each subsequent weekday up to `now` (half-open). Weekends skipped.
+  const end = now.getTime()
+  while (true) {
+    cursor.setUTCDate(cursor.getUTCDate() + 1)
+    if (cursor.getTime() > end) break
+    const dow = cursor.getUTCDay()
+    if (dow !== 0 && dow !== 6) count += 1
+  }
+  return count
+}
+
+function computeTrueRanges(bars: DailyBar[]): number[] {
+  const tr: number[] = []
+  for (let i = 1; i < bars.length; i += 1) {
+    const curr = bars[i]!
+    const prev = bars[i - 1]!
+    tr.push(
+      Math.max(
+        curr.high - curr.low,
+        Math.abs(curr.high - prev.close),
+        Math.abs(curr.low - prev.close),
+      ),
+    )
+  }
+  return tr
+}
+
+function average(values: number[]): number {
+  if (values.length === 0) return 0
+  let sum = 0
+  for (const v of values) sum += v
+  return sum / values.length
+}

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -56,6 +56,9 @@ export async function runPullbackScheduler(
   const strategy =
     options.strategy ?? new PullbackUptrendStrategy(options.rulesMap ?? {})
   const pendingLockTtlMs = options.pendingLockTtlMs ?? 60_000
+  if (typeof pendingLockTtlMs !== 'number' || !Number.isFinite(pendingLockTtlMs) || pendingLockTtlMs <= 0) {
+    throw new Error(`pendingLockTtlMs must be a finite positive number, got: ${pendingLockTtlMs}`)
+  }
 
   const summary: PullbackRunSummary = {
     evaluated: 0,
@@ -121,6 +124,15 @@ export async function runPullbackScheduler(
         })
         continue
       }
+      if (!Number.isFinite(indicators.price) || indicators.price <= 0) {
+        summary.rejected.push({ symbol: upper, reason: `invalid price: ${indicators.price}` })
+        continue
+      }
+      const notional = sizing.quantity * indicators.price
+      if (!Number.isFinite(notional) || notional <= 0) {
+        summary.rejected.push({ symbol: upper, reason: `invalid notional: ${notional} (qty=${sizing.quantity}, price=${indicators.price})` })
+        continue
+      }
       intent = buildIntent(upper, 'BUY', sizing.quantity, indicators.price)
     } else {
       // SELL: close the full open position.
@@ -128,14 +140,32 @@ export async function runPullbackScheduler(
         summary.rejected.push({ symbol: upper, reason: 'SELL without position' })
         continue
       }
+      if (!Number.isFinite(state.position.qty) || state.position.qty <= 0) {
+        summary.rejected.push({ symbol: upper, reason: `invalid position qty: ${state.position.qty}` })
+        continue
+      }
+      if (!Number.isFinite(indicators.price) || indicators.price <= 0) {
+        summary.rejected.push({ symbol: upper, reason: `invalid price: ${indicators.price}` })
+        continue
+      }
+      const notional = state.position.qty * indicators.price
+      if (!Number.isFinite(notional) || notional <= 0) {
+        summary.rejected.push({ symbol: upper, reason: `invalid notional: ${notional} (qty=${state.position.qty}, price=${indicators.price})` })
+        continue
+      }
       intent = buildIntent(upper, 'SELL', state.position.qty, indicators.price)
     }
 
+    const expiresAtMs = now().getTime() + pendingLockTtlMs
+    if (!Number.isFinite(expiresAtMs) || expiresAtMs <= now().getTime()) {
+      summary.rejected.push({ symbol: upper, reason: `invalid expiresAt computed from pendingLockTtlMs: ${pendingLockTtlMs}` })
+      continue
+    }
     const lockResult = await options.positionStore.lockPendingOrder(upper, {
       clientOrderId: intent.clientOrderId,
       side: intent.side,
       submittedAt: now().toISOString(),
-      expiresAt: new Date(now().getTime() + pendingLockTtlMs).toISOString(),
+      expiresAt: new Date(expiresAtMs).toISOString(),
     })
     if (!lockResult.ok) {
       summary.rejected.push({ symbol: upper, reason: 'pending order already in flight' })
@@ -168,12 +198,22 @@ export async function runPullbackScheduler(
 }
 
 function buildIntent(symbol: string, side: 'BUY' | 'SELL', qty: number, price: number): OrderIntent {
+  if (!Number.isFinite(qty) || qty <= 0) {
+    throw new Error(`buildIntent: invalid qty=${qty} for ${symbol}`)
+  }
+  if (!Number.isFinite(price) || price <= 0) {
+    throw new Error(`buildIntent: invalid price=${price} for ${symbol}`)
+  }
+  const notional = qty * price
+  if (!Number.isFinite(notional) || notional <= 0) {
+    throw new Error(`buildIntent: invalid notional=${notional} for ${symbol} (qty=${qty}, price=${price})`)
+  }
   return {
     symbol,
     side,
     quantity: qty,
     price,
-    notional: qty * price,
+    notional,
     clientOrderId: crypto.randomUUID().replaceAll('-', ''),
   }
 }

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -1,0 +1,181 @@
+import type { BarClient } from '../../infrastructure/quotes/BarClient'
+import type { Execution } from '../execution/Execution'
+import type { PositionStore } from '../state/PositionStore'
+import {
+  computeHoldBusinessDays,
+  computePullbackIndicators,
+  type DailyBar,
+} from './indicators'
+import { computePullbackSizing } from './pullbackSizing'
+import type { ExecutionResult } from '../domain/ExecutionResult'
+import type { OrderIntent } from '../domain/OrderIntent'
+import {
+  DEFAULT_RULE,
+  PullbackUptrendStrategy,
+  type SymbolRule,
+} from './strategies/PullbackUptrendStrategy'
+
+const DEFAULT_BAR_LOOKBACK = 60
+
+export interface PullbackSchedulerOptions {
+  symbols: string[]
+  equity: number
+  barClient: BarClient
+  positionStore: PositionStore
+  execution: Execution
+  strategy?: PullbackUptrendStrategy
+  rulesMap?: Record<string, SymbolRule>
+  symbolCapMap?: Record<string, number>
+  barLookback?: number
+  riskPerTradePct?: number
+  pendingLockTtlMs?: number
+  now?: () => Date
+}
+
+export interface PullbackRunSummary {
+  evaluated: number
+  buys: number
+  sells: number
+  holds: number
+  rejected: Array<{ symbol: string; reason: string }>
+  errors: Array<{ symbol: string; message: string }>
+}
+
+/**
+ * Drives PullbackUptrendStrategy across the ALLOWED_SYMBOLS universe on a
+ * daily cadence: pulls daily bars, computes indicators, reads DO state,
+ * resolves quantity via `computePullbackSizing`, then submits through the
+ * provided {@link Execution}. The scheduler itself is transport-agnostic —
+ * {@link src/index.ts} wires it to a Workers cron trigger.
+ */
+export async function runPullbackScheduler(
+  options: PullbackSchedulerOptions,
+): Promise<PullbackRunSummary> {
+  const now = options.now ?? (() => new Date())
+  const lookback = options.barLookback ?? DEFAULT_BAR_LOOKBACK
+  const strategy =
+    options.strategy ?? new PullbackUptrendStrategy(options.rulesMap ?? {})
+  const pendingLockTtlMs = options.pendingLockTtlMs ?? 60_000
+
+  const summary: PullbackRunSummary = {
+    evaluated: 0,
+    buys: 0,
+    sells: 0,
+    holds: 0,
+    rejected: [],
+    errors: [],
+  }
+
+  for (const symbol of options.symbols) {
+    summary.evaluated += 1
+    const upper = symbol.toUpperCase()
+    let bars: DailyBar[]
+    try {
+      bars = await options.barClient.getDailyBars(symbol, lookback)
+    } catch (error) {
+      summary.errors.push({ symbol: upper, message: messageOf(error) })
+      continue
+    }
+
+    const indicators = computePullbackIndicators(bars)
+    if (!indicators) {
+      summary.rejected.push({ symbol: upper, reason: 'insufficient bars for indicators' })
+      continue
+    }
+
+    const state = await options.positionStore.getState(upper)
+    const holdBusinessDays =
+      state.position !== null ? computeHoldBusinessDays(state.position.openedAt, now()) : 0
+
+    const signal = strategy.decide({
+      symbol: upper,
+      indicators,
+      position: state.position,
+      pendingOrder: state.pendingOrder,
+      cooldownUntil: state.cooldownUntil,
+      holdBusinessDays,
+      now: now(),
+    })
+
+    if (signal.action === 'HOLD') {
+      summary.holds += 1
+      continue
+    }
+
+    let intent: OrderIntent
+    if (signal.action === 'BUY') {
+      const rule = strategy.resolveRule(upper)
+      const sizing = computePullbackSizing({
+        equity: options.equity,
+        entryPrice: indicators.price,
+        stopPct: rule.stopPct,
+        atr20: indicators.atr20,
+        baselineAtr20: indicators.baselineAtr20,
+        symbolCap: options.symbolCapMap?.[upper],
+        riskPerTradePct: options.riskPerTradePct,
+      })
+      if (sizing.quantity <= 0) {
+        summary.rejected.push({
+          symbol: upper,
+          reason: `sizing rejected: ${sizing.capReason ?? 'zero qty'}`,
+        })
+        continue
+      }
+      intent = buildIntent(upper, 'BUY', sizing.quantity, indicators.price)
+      summary.buys += 1
+    } else {
+      // SELL: close the full open position.
+      if (state.position === null) {
+        summary.rejected.push({ symbol: upper, reason: 'SELL without position' })
+        continue
+      }
+      intent = buildIntent(upper, 'SELL', state.position.qty, indicators.price)
+      summary.sells += 1
+    }
+
+    const lockResult = await options.positionStore.lockPendingOrder(upper, {
+      clientOrderId: intent.clientOrderId,
+      side: intent.side,
+      submittedAt: now().toISOString(),
+      expiresAt: new Date(now().getTime() + pendingLockTtlMs).toISOString(),
+    })
+    if (!lockResult.ok) {
+      summary.rejected.push({ symbol: upper, reason: 'pending order already in flight' })
+      continue
+    }
+
+    let result: ExecutionResult | undefined
+    try {
+      result = await options.execution.execute(intent)
+    } catch (error) {
+      await options.positionStore.clearPendingOrder(upper).catch(() => undefined)
+      summary.errors.push({ symbol: upper, message: messageOf(error) })
+      continue
+    }
+
+    if (result.mode === 'DRY_RUN') {
+      // No broker event will clear the lock; release it eagerly.
+      await options.positionStore.clearPendingOrder(upper).catch(() => undefined)
+    }
+  }
+
+  return summary
+}
+
+function buildIntent(symbol: string, side: 'BUY' | 'SELL', qty: number, price: number): OrderIntent {
+  return {
+    symbol,
+    side,
+    quantity: qty,
+    price,
+    notional: qty * price,
+    clientOrderId: crypto.randomUUID().replaceAll('-', ''),
+  }
+}
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+// Re-export DEFAULT_RULE so callers can seed options without another import.
+export { DEFAULT_RULE }

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -122,7 +122,6 @@ export async function runPullbackScheduler(
         continue
       }
       intent = buildIntent(upper, 'BUY', sizing.quantity, indicators.price)
-      summary.buys += 1
     } else {
       // SELL: close the full open position.
       if (state.position === null) {
@@ -130,7 +129,6 @@ export async function runPullbackScheduler(
         continue
       }
       intent = buildIntent(upper, 'SELL', state.position.qty, indicators.price)
-      summary.sells += 1
     }
 
     const lockResult = await options.positionStore.lockPendingOrder(upper, {
@@ -151,6 +149,13 @@ export async function runPullbackScheduler(
       await options.positionStore.clearPendingOrder(upper).catch(() => undefined)
       summary.errors.push({ symbol: upper, message: messageOf(error) })
       continue
+    }
+
+    // Increment counters only after successful execution.
+    if (intent.side === 'BUY') {
+      summary.buys += 1
+    } else {
+      summary.sells += 1
     }
 
     if (result.mode === 'DRY_RUN') {

--- a/test/trading/strategy/indicators.test.ts
+++ b/test/trading/strategy/indicators.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import {
+  computeHoldBusinessDays,
+  computePullbackIndicators,
+  type DailyBar,
+} from '../../../src/trading/strategy/indicators'
+
+function makeBars(closes: number[]): DailyBar[] {
+  return closes.map((close, i) => {
+    const iso = new Date(Date.UTC(2026, 0, 1 + i)).toISOString().slice(0, 10)
+    return { date: iso, open: close, high: close * 1.01, low: close * 0.99, close }
+  })
+}
+
+describe('computePullbackIndicators', () => {
+  it('returns null when fewer than 50 bars are provided', () => {
+    expect(computePullbackIndicators(makeBars([1, 2, 3]))).toBeNull()
+  })
+
+  it('computes sma50 / return50d / high20d from the tail window', () => {
+    const closes = Array.from({ length: 60 }, (_, i) => 100 + i)
+    const result = computePullbackIndicators(makeBars(closes))
+    expect(result).not.toBeNull()
+    const r = result!
+    expect(r.price).toBe(159)
+    // sma50 = average of closes 110..159 = (110+159)/2 = 134.5
+    expect(r.sma50).toBeCloseTo(134.5, 4)
+    // 50d return: last vs closes[-50] = closes[10] = 110 → (159 - 110)/110
+    expect(r.return50d).toBeCloseTo((159 - 110) / 110, 4)
+    // high20d = max of highs for last 20 bars. highs are close*1.01.
+    expect(r.high20d).toBeCloseTo(159 * 1.01, 4)
+  })
+})
+
+describe('computeHoldBusinessDays', () => {
+  it('counts weekday-only days between open and now', () => {
+    // Mon 2026-04-13 open, Fri 2026-04-17 now → 4 business days
+    expect(
+      computeHoldBusinessDays('2026-04-13T10:00:00.000Z', new Date('2026-04-17T10:00:00.000Z')),
+    ).toBe(4)
+  })
+
+  it('skips weekends', () => {
+    // Fri open, next Mon now → 1 business day (weekend does not count)
+    expect(
+      computeHoldBusinessDays('2026-04-17T10:00:00.000Z', new Date('2026-04-20T10:00:00.000Z')),
+    ).toBe(1)
+  })
+
+  it('returns 0 for an invalid ISO', () => {
+    expect(computeHoldBusinessDays('not-a-date', new Date())).toBe(0)
+  })
+})

--- a/test/trading/strategy/pullbackScheduler.test.ts
+++ b/test/trading/strategy/pullbackScheduler.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { BarClient } from '../../../src/infrastructure/quotes/BarClient'
+import type { Execution } from '../../../src/trading/execution/Execution'
+import type { PositionStore } from '../../../src/trading/state/PositionStore'
+import { emptySymbolState, type SymbolState } from '../../../src/trading/state/types'
+import { runPullbackScheduler } from '../../../src/trading/strategy/pullbackScheduler'
+import type { DailyBar } from '../../../src/trading/strategy/indicators'
+
+const now = new Date('2026-04-20T14:30:00.000Z')
+
+function uptrendBars(): DailyBar[] {
+  // 60 bars, uptrend ~+15% over 50d, ending with a mild -4% pullback from high.
+  const bars: DailyBar[] = []
+  for (let i = 0; i < 55; i += 1) {
+    const close = 100 + i * 0.4 // slow uptrend, ends at ~121.6
+    bars.push(synth(i, close))
+  }
+  // The 20d high hit at bar 55
+  bars.push(synth(55, 122))
+  bars.push(synth(56, 121))
+  bars.push(synth(57, 120))
+  bars.push(synth(58, 118))
+  // pullback: -4% from high 122 = 117.12 → put close at ~117.5
+  bars.push(synth(59, 117.5))
+  return bars
+}
+
+function synth(i: number, close: number): DailyBar {
+  const date = new Date(Date.UTC(2026, 0, 1 + i)).toISOString().slice(0, 10)
+  return { date, open: close, high: close * 1.005, low: close * 0.995, close }
+}
+
+function makeStore(states: Record<string, SymbolState>) {
+  return {
+    async getState(symbol: string) {
+      return states[symbol.toUpperCase()] ?? emptySymbolState(symbol, () => now)
+    },
+    async lockPendingOrder() {
+      return { ok: true, state: emptySymbolState('_', () => now) }
+    },
+    async clearPendingOrder(symbol: string) {
+      return emptySymbolState(symbol, () => now)
+    },
+    async recordFill(symbol: string) {
+      return emptySymbolState(symbol, () => now)
+    },
+    async addPendingSettlement(symbol: string) {
+      return emptySymbolState(symbol, () => now)
+    },
+    async setCooldown(symbol: string) {
+      return emptySymbolState(symbol, () => now)
+    },
+  } satisfies PositionStore
+}
+
+function mockBarClient(bars: DailyBar[]): BarClient {
+  return { getDailyBars: vi.fn(async () => bars) }
+}
+
+function mockExecution(): Execution & { calls: unknown[] } {
+  const calls: unknown[] = []
+  return {
+    calls,
+    async execute(intent) {
+      calls.push(intent)
+      return {
+        mode: 'DRY_RUN',
+        submitted: true,
+        brokerOrderId: 'dry-run-1',
+      }
+    },
+  }
+}
+
+describe('runPullbackScheduler', () => {
+  it('places a BUY when the Pullback entry conditions fire', async () => {
+    const store = makeStore({})
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: store,
+      execution,
+      now: () => now,
+    })
+
+    expect(summary.buys).toBe(1)
+    expect(execution.calls).toHaveLength(1)
+    const intent = execution.calls[0] as { side: string; quantity: number }
+    expect(intent.side).toBe('BUY')
+    expect(intent.quantity).toBeGreaterThan(0)
+  })
+
+  it('HOLDs (and does not submit) when bars are too short for indicators', async () => {
+    const store = makeStore({})
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient([synth(0, 100), synth(1, 101)]),
+      positionStore: store,
+      execution,
+      now: () => now,
+    })
+
+    expect(summary.buys).toBe(0)
+    expect(summary.rejected).toEqual([
+      { symbol: 'AAPL', reason: 'insufficient bars for indicators' },
+    ])
+    expect(execution.calls).toHaveLength(0)
+  })
+
+  it('records bar-client errors without halting the rest of the universe', async () => {
+    const store = makeStore({})
+    const execution = mockExecution()
+    const crashingClient: BarClient = {
+      async getDailyBars(symbol) {
+        if (symbol === 'BROKEN') throw new Error('upstream 500')
+        return uptrendBars()
+      },
+    }
+    const summary = await runPullbackScheduler({
+      symbols: ['BROKEN', 'AAPL'],
+      equity: 100_000,
+      barClient: crashingClient,
+      positionStore: store,
+      execution,
+      now: () => now,
+    })
+
+    expect(summary.errors).toEqual([{ symbol: 'BROKEN', message: 'upstream 500' }])
+    expect(summary.buys).toBe(1)
+  })
+})


### PR DESCRIPTION
## 概要

#39 で作った PullbackUptrendStrategy を実際に走らせるための配線。cron への接続自体は `WEBULL_BARS_PATH` が UAT で確定した後の follow-up にし、本 PR は scheduler / indicators / BarClient 骨子までに留める。

### `indicators.ts`
- `computePullbackIndicators(bars)` — SMA50 / 20d high / 50d return / ATR20 / baselineAtr20 を純関数で算出。bars < 50 本なら `null`、strategy 側で HOLD に落とす前提。
- `computeHoldBusinessDays(openedAt, now)` — 土日のみスキップ。JP/US 祝日カレンダーは #38 follow-up の対象。

### `WebullBarClient` (`src/infrastructure/quotes/BarClient.ts`)
- `GET /market-data/candles` 相当 (path は `WEBULL_BARS_PATH` で差し替え可)。
- UAT のレスポンス形式が未確定なので mapper は寛容 — close/open/high/low のいずれかが欠けた bar は silent drop し oldest-first にソート。
- `BarClient` インターフェースでテスト時は任意の bar を注入可能。

### `runPullbackScheduler`
- symbols を回し、indicators → state read → `PullbackUptrendStrategy.decide` → `computePullbackSizing` → `executeTrade` の一本道。
- DRY_RUN は lock を即解放 (TradeEvent が来ないため)。
- bar fetch 失敗は `summary.errors` に積んで universe 全体を止めない。

## scope 外 (follow-up)

- cron への接続 (`src/index.ts` の `scheduled` 第二 trigger) — UAT bar endpoint 確定後
- equity 取得 (現状は option 経由で注入、実運用では account balance API 呼び出しが必要)
- 取引所カレンダー (土日以外の祝日)

## 動作確認
- [x] `pnpm run typecheck`
- [x] `pnpm test` (180 件 pass、追加: `indicators` / `pullbackScheduler`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Webullから日足を取得する新しいバークライアントを追加。取得時の認証・タイムアウト対応、応答の正規化・日付/価格検証、古い順ソートで安定化しました。
  * プルバック指標算出ユーティリティを追加（SMA/ATR/20日高値/50日リターン等）と保有営業日計算を実装。
  * 日次でシンボルを評価するプルバックスケジューラーを追加し、BUY/SELL/HOLD判定・注文ロック・実行フローを備えました。

* **テスト**
  * 指標計算と保有営業日、及びスケジューラーの主要フローを検証する新規テストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->