### PR TITLE
feat(quotes): QuoteSnapshot に bid/ask を optional で追加 (#51)

### DIFF
--- a/src/infrastructure/quotes/WebullQuoteClient.ts
+++ b/src/infrastructure/quotes/WebullQuoteClient.ts
@@ -8,6 +8,8 @@ export interface QuoteResult {
   symbol: string
   price: number
   asOf: string
+  bid?: number
+  ask?: number
 }
 
 export interface WebullQuoteClientEnv {
@@ -31,6 +33,12 @@ interface RawSnapshotEntry {
   price?: number | string
   trade_time?: string
   timestamp?: number | string
+  bid?: number | string
+  ask?: number | string
+  bid_price?: number | string
+  ask_price?: number | string
+  bp?: number | string
+  ap?: number | string
 }
 
 const QUOTE_PATH = '/market-data/snapshot'
@@ -151,7 +159,12 @@ function normalizeSnapshots(json: unknown, fallbackAsOf: string): QuoteResult[] 
     const symbol = typeof raw.symbol === 'string' ? raw.symbol.trim() : ''
     const price = coerceNumber(raw.last_price ?? raw.last ?? raw.price)
     if (!symbol || price === null) continue
-    results.push({ symbol, price, asOf: coerceAsOf(raw, fallbackAsOf) })
+    const bid = coerceNumber(raw.bid ?? raw.bid_price ?? raw.bp)
+    const ask = coerceNumber(raw.ask ?? raw.ask_price ?? raw.ap)
+    const entry: QuoteResult = { symbol, price, asOf: coerceAsOf(raw, fallbackAsOf) }
+    if (bid !== null) entry.bid = bid
+    if (ask !== null) entry.ask = ask
+    results.push(entry)
   }
   return results
 }

--- a/src/infrastructure/quotes/WebullQuoteClient.ts
+++ b/src/infrastructure/quotes/WebullQuoteClient.ts
@@ -159,8 +159,8 @@ function normalizeSnapshots(json: unknown, fallbackAsOf: string): QuoteResult[] 
     const symbol = typeof raw.symbol === 'string' ? raw.symbol.trim() : ''
     const price = coerceNumber(raw.last_price ?? raw.last ?? raw.price)
     if (!symbol || price === null) continue
-    const bid = coerceNumber(raw.bid ?? raw.bid_price ?? raw.bp)
-    const ask = coerceNumber(raw.ask ?? raw.ask_price ?? raw.ap)
+    const bid = coerceFirstValidNumber(raw.bid, raw.bid_price, raw.bp)
+    const ask = coerceFirstValidNumber(raw.ask, raw.ask_price, raw.ap)
     const entry: QuoteResult = { symbol, price, asOf: coerceAsOf(raw, fallbackAsOf) }
     if (bid !== null) entry.bid = bid
     if (ask !== null) entry.ask = ask
@@ -182,6 +182,14 @@ function coerceNumber(value: number | string | undefined): number | null {
   if (value === undefined || value === null) return null
   const num = typeof value === 'number' ? value : Number(value)
   return Number.isFinite(num) && num > 0 ? num : null
+}
+
+function coerceFirstValidNumber(...values: unknown[]): number | null {
+  for (const value of values) {
+    const result = coerceNumber(value as number | string | undefined)
+    if (result !== null) return result
+  }
+  return null
 }
 
 function coerceAsOf(raw: RawSnapshotEntry, fallback: string): string {

--- a/src/trading/quotes/quoteScheduler.ts
+++ b/src/trading/quotes/quoteScheduler.ts
@@ -70,6 +70,8 @@ export async function runQuoteFeed(options: RunQuoteFeedOptions): Promise<QuoteR
         fetchedAt,
         source: QUOTE_SOURCE,
       }
+      if (result.bid !== undefined) quote.bid = result.bid
+      if (result.ask !== undefined) quote.ask = result.ask
       try {
         const stub = env.SYMBOL_STATE.get(env.SYMBOL_STATE.idFromName(symbol))
         if (!stub) {

--- a/src/trading/state/types.ts
+++ b/src/trading/state/types.ts
@@ -22,6 +22,8 @@ export interface QuoteSnapshot {
   asOf: string
   fetchedAt: string
   source: string
+  bid?: number
+  ask?: number
 }
 
 export interface SymbolState {

--- a/test/infrastructure/quotes/webullQuoteClient.bidAsk.test.ts
+++ b/test/infrastructure/quotes/webullQuoteClient.bidAsk.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest'
+import { WebullQuoteClient } from '../../../src/infrastructure/quotes/WebullQuoteClient'
+import { WebullAuth } from '../../../src/infrastructure/webull/WebullAuth'
+
+const baseAuth = new WebullAuth({ appKey: 'ak', appSecret: 'sk' })
+
+function mockFetch(responseBody: unknown, init: ResponseInit = { status: 200 }): typeof fetch {
+  const json = JSON.stringify(responseBody)
+  return vi.fn(
+    async () => new Response(json, { status: 200, headers: { 'Content-Type': 'application/json' }, ...init }),
+  ) as unknown as typeof fetch
+}
+
+/**
+ * Bid/ask are blockers for spread guard (#38-D / #53). These tests pin the
+ * tolerant parsing of bid/ask fields regardless of the upstream UAT key
+ * naming, while keeping them strictly optional so existing quote feed paths
+ * keep working when the broker does not return them.
+ */
+describe('WebullQuoteClient.getSnapshots bid/ask', () => {
+  it('includes bid and ask when both are positive', async () => {
+    const fetchFn = mockFetch({
+      data: [{ symbol: 'SOXL', last_price: 10.25, bid: '10.24', ask: 10.26 }],
+    })
+    const client = new WebullQuoteClient({
+      auth: baseAuth,
+      fetchFn,
+      now: () => new Date('2026-04-18T10:00:05.000Z'),
+    })
+    const result = await client.getSnapshots(['SOXL'], 'US_STOCK')
+    expect(result).toEqual([
+      { symbol: 'SOXL', price: 10.25, asOf: '2026-04-18T10:00:05.000Z', bid: 10.24, ask: 10.26 },
+    ])
+  })
+
+  it('includes only bid when ask is missing', async () => {
+    const fetchFn = mockFetch({
+      data: [{ symbol: 'SOXL', last_price: 10.25, bid_price: 10.2 }],
+    })
+    const client = new WebullQuoteClient({
+      auth: baseAuth,
+      fetchFn,
+      now: () => new Date('2026-04-18T10:00:05.000Z'),
+    })
+    const [entry] = await client.getSnapshots(['SOXL'], 'US_STOCK')
+    expect(entry).toBeDefined()
+    expect(entry?.bid).toBe(10.2)
+    expect(entry?.ask).toBeUndefined()
+  })
+
+  it('accepts bp/ap fallback keys', async () => {
+    const fetchFn = mockFetch({
+      data: [{ symbol: 'SOXL', last_price: 10.25, bp: '10.1', ap: '10.3' }],
+    })
+    const client = new WebullQuoteClient({
+      auth: baseAuth,
+      fetchFn,
+      now: () => new Date('2026-04-18T10:00:05.000Z'),
+    })
+    const [entry] = await client.getSnapshots(['SOXL'], 'US_STOCK')
+    expect(entry?.bid).toBe(10.1)
+    expect(entry?.ask).toBe(10.3)
+  })
+
+  it('omits bid/ask when both are undefined (back-compat)', async () => {
+    const fetchFn = mockFetch({
+      data: [{ symbol: 'SOXL', last_price: 10.25 }],
+    })
+    const client = new WebullQuoteClient({
+      auth: baseAuth,
+      fetchFn,
+      now: () => new Date('2026-04-18T10:00:05.000Z'),
+    })
+    const result = await client.getSnapshots(['SOXL'], 'US_STOCK')
+    expect(result).toEqual([
+      { symbol: 'SOXL', price: 10.25, asOf: '2026-04-18T10:00:05.000Z' },
+    ])
+    expect('bid' in result[0]!).toBe(false)
+    expect('ask' in result[0]!).toBe(false)
+  })
+
+  it('drops bid/ask when non-positive or non-finite', async () => {
+    const fetchFn = mockFetch({
+      data: [
+        { symbol: 'A', last_price: 10, bid: 0, ask: -1 },
+        { symbol: 'B', last_price: 10, bid: 'abc', ask: 'def' },
+      ],
+    })
+    const client = new WebullQuoteClient({
+      auth: baseAuth,
+      fetchFn,
+      now: () => new Date('2026-04-18T10:00:05.000Z'),
+    })
+    const result = await client.getSnapshots(['A', 'B'], 'US_STOCK')
+    expect(result.map((r) => r.symbol)).toEqual(['A', 'B'])
+    for (const entry of result) {
+      expect(entry.bid).toBeUndefined()
+      expect(entry.ask).toBeUndefined()
+    }
+  })
+})


### PR DESCRIPTION
closes #51

## Summary

- `QuoteSnapshot` / `QuoteResult` に `bid?: number` / `ask?: number` を optional で追加。既存コード非破壊。
- `WebullQuoteClient.normalizeSnapshots` で bid/ask を寛容に抽出 (`bid` / `bid_price` / `bp`、`ask` / `ask_price` / `ap`)、`> 0` の finite 値のときだけ結果に含める。
- `runQuoteFeed` が Durable Object に書き込む `QuoteSnapshot` に bid/ask を伝搬 (取れたときのみ)。
- 新規テスト `test/infrastructure/quotes/webullQuoteClient.bidAsk.test.ts` を追加 (bid+ask / bid のみ / fallback キー / 両方欠落 / 非正値除外)。

## 背景

本 PR は spread guard (#38-D, #53) の blocker 前提。Webull UAT のレスポンス形式が未確定なので fallback key を広めに取りつつ、欠損時は従来通り `price` + `asOf` のみで書き込む fail-closed 方針。

## 動作確認

- [x] `pnpm run typecheck` pass
- [x] `pnpm test` で 185 tests 全 pass (既存テスト退行無し、追加 5 cases 含む)
- [ ] UAT レスポンスの bid/ask 実在確認は spread guard PR (#53) 側で実施予定

## Out of scope

- spread guard 本体 (#53 / #38-D)
- halt flag (#52 / #38-C)
- quote scheduler の cron / 頻度変更

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Webull相場データに任意のビッド/アスク価格を追加しました。
  * 異なるフィールド名や形式からビッド/アスクを自動判別して取り込めます。
  * 取得したビッド/アスクが相場スナップショットに永続化されます。

* **テスト**
  * ビッド/アスクの多様な入力形式・欠損・無効値を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->