### PR TITLE
feat(domain): 取引所カレンダー (JP/US 祝日) (#38-E)

### DIFF
--- a/src/trading/domain/tradingCalendar.ts
+++ b/src/trading/domain/tradingCalendar.ts
@@ -129,6 +129,9 @@ export function countTradingDaysBetween(
   const from = new Date(fromIso)
   if (!Number.isFinite(from.getTime())) return 0
   const end = to.getTime()
+  if (!Number.isFinite(end)) {
+    throw new Error('Invalid "to" date')
+  }
   let count = 0
   const cursor = new Date(from.getTime())
   while (true) {

--- a/src/trading/domain/tradingCalendar.ts
+++ b/src/trading/domain/tradingCalendar.ts
@@ -1,0 +1,149 @@
+/**
+ * 取引所カレンダー (JP 東証 / US NYSE)。
+ *
+ * 現状は 2026 / 2027 分だけ static テーブルで持つ。POC 運用に入る前に
+ * **2028 以降を追記する** こと (下の HOLIDAYS テーブル参照)。米国の
+ * early close (感謝祭翌日 13:00 close 等) は POC では扱わない。
+ *
+ * 祝日判定は UTC で比較する。Date 引数は UTC 日付として扱われ、
+ * getUTCFullYear / getUTCMonth / getUTCDate の組で YYYY-MM-DD に丸めて
+ * set と突き合わせる。時刻成分は無視する。
+ */
+
+export type TradingMarket = 'JP' | 'US'
+
+const MS_PER_DAY = 86_400_000
+
+// TODO: 2028 以降の祝日を運用入り前に追記する。
+// JP: 東証休業日 (国民の祝日 + 振替休日 + 年始 1/1–1/3 + 大晦日 12/31)
+// US NYSE: 9 祝日 + Good Friday。土日と重なる祝日は observed day (振替) を入れる。
+const HOLIDAYS: Record<TradingMarket, ReadonlySet<string>> = {
+  JP: new Set<string>([
+    // 2026
+    '2026-01-01', // 元日 (exchange closed)
+    '2026-01-02', // 年始休業
+    '2026-01-12', // 成人の日
+    '2026-02-11', // 建国記念の日
+    '2026-02-23', // 天皇誕生日
+    '2026-03-20', // 春分の日
+    '2026-04-29', // 昭和の日
+    '2026-05-04', // みどりの日
+    '2026-05-05', // こどもの日
+    '2026-05-06', // 振替休日 (憲法記念日 5/3 が日曜)
+    '2026-07-20', // 海の日
+    '2026-08-11', // 山の日
+    '2026-09-21', // 敬老の日
+    '2026-09-22', // 国民の休日
+    '2026-09-23', // 秋分の日
+    '2026-10-12', // スポーツの日
+    '2026-11-03', // 文化の日
+    '2026-11-23', // 勤労感謝の日
+    '2026-12-31', // 大納会翌営業日休 (TSE closed)
+    // 2027
+    '2027-01-01', // 元日
+    '2027-01-11', // 成人の日
+    '2027-02-11', // 建国記念の日
+    '2027-02-23', // 天皇誕生日
+    '2027-03-22', // 振替休日 (春分の日 3/21 が日曜)
+    '2027-04-29', // 昭和の日
+    '2027-05-03', // 憲法記念日
+    '2027-05-04', // みどりの日
+    '2027-05-05', // こどもの日
+    '2027-07-19', // 海の日
+    '2027-08-11', // 山の日
+    '2027-09-20', // 敬老の日
+    '2027-09-23', // 秋分の日
+    '2027-10-11', // スポーツの日
+    '2027-11-03', // 文化の日
+    '2027-11-23', // 勤労感謝の日
+    '2027-12-31', // TSE closed
+  ]),
+  US: new Set<string>([
+    // 2026
+    '2026-01-01', // New Year's Day
+    '2026-01-19', // MLK Day (3rd Mon Jan)
+    '2026-02-16', // Presidents' Day (3rd Mon Feb)
+    '2026-04-03', // Good Friday
+    '2026-05-25', // Memorial Day
+    '2026-06-19', // Juneteenth
+    '2026-07-03', // Independence Day observed (Jul 4 is Sat)
+    '2026-09-07', // Labor Day
+    '2026-11-26', // Thanksgiving
+    '2026-12-25', // Christmas
+    // 2027
+    '2027-01-01', // New Year's Day
+    '2027-01-18', // MLK Day
+    '2027-02-15', // Presidents' Day
+    '2027-03-26', // Good Friday
+    '2027-05-31', // Memorial Day
+    '2027-06-18', // Juneteenth observed (Jun 19 is Sat)
+    '2027-07-05', // Independence Day observed (Jul 4 is Sun)
+    '2027-09-06', // Labor Day
+    '2027-11-25', // Thanksgiving
+    '2027-12-24', // Christmas observed (Dec 25 is Sat)
+  ]),
+}
+
+function toYmdUtc(date: Date): string {
+  return date.toISOString().slice(0, 10)
+}
+
+function isWeekend(date: Date): boolean {
+  const dow = date.getUTCDay()
+  return dow === 0 || dow === 6
+}
+
+/**
+ * 指定 market の営業日なら true。土日 + 祝日で false。
+ */
+export function isTradingDay(date: Date, market: TradingMarket): boolean {
+  if (isWeekend(date)) return false
+  const ymd = toYmdUtc(date)
+  return !HOLIDAYS[market].has(ymd)
+}
+
+/**
+ * 指定日の**翌**営業日を返す。土日・祝日を連続してスキップする。
+ * 祝日テーブルが尽きた年を跨ぐ場合も、土日判定だけはそのまま動く。
+ */
+export function nextTradingDay(date: Date, market: TradingMarket): Date {
+  let cursor = new Date(date.getTime() + MS_PER_DAY)
+  // 祝日テーブル不足 / 連休で無限ループしないよう上限を設ける (31 日分)。
+  for (let i = 0; i < 31; i += 1) {
+    if (isTradingDay(cursor, market)) return cursor
+    cursor = new Date(cursor.getTime() + MS_PER_DAY)
+  }
+  return cursor
+}
+
+/**
+ * `fromIso` の翌日から `to` (両端含む / half-open: to まで) までを走査し、
+ * 営業日の数を返す。`fromIso` が invalid なら 0。祝日・土日は除外。
+ * `openedAt` がいつで `now` が現在時刻、という保有日数計算に使う。
+ */
+export function countTradingDaysBetween(
+  fromIso: string,
+  to: Date,
+  market: TradingMarket,
+): number {
+  const from = new Date(fromIso)
+  if (!Number.isFinite(from.getTime())) return 0
+  const end = to.getTime()
+  let count = 0
+  const cursor = new Date(from.getTime())
+  while (true) {
+    cursor.setUTCDate(cursor.getUTCDate() + 1)
+    if (cursor.getTime() > end) break
+    if (isTradingDay(cursor, market)) count += 1
+  }
+  return count
+}
+
+/**
+ * symbol から market を推定する軽量版。infrastructure 層の
+ * `inferWebullMarket` と同じ規則 (4 桁数字は JP / それ以外は US)。
+ * domain が infrastructure に依存しないよう独立に持つ。
+ */
+export function inferTradingMarket(symbol: string): TradingMarket {
+  return /^\d{4}$/.test(symbol) ? 'JP' : 'US'
+}

--- a/src/trading/domain/tradingCalendar.ts
+++ b/src/trading/domain/tradingCalendar.ts
@@ -81,6 +81,7 @@ const HOLIDAYS: Record<TradingMarket, ReadonlySet<string>> = {
     '2027-09-06', // Labor Day
     '2027-11-25', // Thanksgiving
     '2027-12-24', // Christmas observed (Dec 25 is Sat)
+    '2027-12-31', // New Year's Day observed (Jan 1 2028 is Sat)
   ]),
 }
 

--- a/src/trading/events/TradeEventHandler.ts
+++ b/src/trading/events/TradeEventHandler.ts
@@ -1,4 +1,5 @@
 import type { TradeEvent } from '../domain/TradeEvent'
+import { inferTradingMarket, nextTradingDay } from '../domain/tradingCalendar'
 import type { PositionStore } from '../state/PositionStore'
 import { logFill, logExit } from '../../infrastructure/logger/tradeJournal'
 
@@ -124,10 +125,11 @@ export class TradeEventHandler {
     if (lock.side === 'SELL') {
       // T+1: SELL proceeds are unsettled until the next business day.
       const tradeDay = this.now()
+      const market = inferTradingMarket(symbol)
       await this.positionStore
         .addPendingSettlement(symbol, {
           tradeDate: toYmd(tradeDay),
-          settleDate: toYmd(nextBusinessDay(tradeDay)),
+          settleDate: toYmd(nextTradingDay(tradeDay, market)),
           amount: filledPrice * event.filledQty,
         })
         .catch((error) => {
@@ -156,7 +158,7 @@ export class TradeEventHandler {
         // Stop-out cooldown: a losing exit parks the symbol until the next
         // business day so a whipsaw re-entry cannot compound the loss.
         if (realizedPnl < 0) {
-          const cooldownUntil = nextBusinessDay(this.now()).toISOString()
+          const cooldownUntil = nextTradingDay(this.now(), market).toISOString()
           await this.positionStore
             .setCooldown(symbol, cooldownUntil)
             .catch((error) => {
@@ -176,17 +178,6 @@ export class TradeEventHandler {
 
 function toYmd(date: Date): string {
   return date.toISOString().slice(0, 10)
-}
-
-/**
- * Next business day (skips Sat/Sun). POC scope — does not honour JP/US holidays.
- */
-export function nextBusinessDay(date: Date): Date {
-  const next = new Date(date.getTime() + MS_PER_DAY)
-  const dow = next.getUTCDay()
-  if (dow === 6) return new Date(next.getTime() + 2 * MS_PER_DAY) // Sat → Mon
-  if (dow === 0) return new Date(next.getTime() + MS_PER_DAY) // Sun → Mon
-  return next
 }
 
 function readClientOrderId(payload: unknown): string | undefined {

--- a/src/trading/strategy/indicators.ts
+++ b/src/trading/strategy/indicators.ts
@@ -1,3 +1,5 @@
+import { countTradingDaysBetween, type TradingMarket } from '../domain/tradingCalendar'
+
 /**
  * Daily OHLC bar. Field names match Webull's camel-cased data API payloads
  * (close / high / low / open) to keep the mapper on the client side trivial.
@@ -47,20 +49,12 @@ export function computePullbackIndicators(bars: DailyBar[]): PullbackIndicatorSn
   return { price: last, sma50, return50d, high20d, atr20, baselineAtr20 }
 }
 
-export function computeHoldBusinessDays(openedAtIso: string, now: Date): number {
-  const opened = new Date(openedAtIso)
-  if (!Number.isFinite(opened.getTime())) return 0
-  let count = 0
-  const cursor = new Date(opened.getTime())
-  // Count each subsequent weekday up to `now` (half-open). Weekends skipped.
-  const end = now.getTime()
-  while (true) {
-    cursor.setUTCDate(cursor.getUTCDate() + 1)
-    if (cursor.getTime() > end) break
-    const dow = cursor.getUTCDay()
-    if (dow !== 0 && dow !== 6) count += 1
-  }
-  return count
+export function computeHoldBusinessDays(
+  openedAtIso: string,
+  now: Date,
+  market: TradingMarket,
+): number {
+  return countTradingDaysBetween(openedAtIso, now, market)
 }
 
 function computeTrueRanges(bars: DailyBar[]): number[] {

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -1,4 +1,5 @@
 import type { BarClient } from '../../infrastructure/quotes/BarClient'
+import { inferTradingMarket } from '../domain/tradingCalendar'
 import type { Execution } from '../execution/Execution'
 import type { PositionStore } from '../state/PositionStore'
 import {
@@ -87,8 +88,11 @@ export async function runPullbackScheduler(
     }
 
     const state = await options.positionStore.getState(upper)
+    const market = inferTradingMarket(upper)
     const holdBusinessDays =
-      state.position !== null ? computeHoldBusinessDays(state.position.openedAt, now()) : 0
+      state.position !== null
+        ? computeHoldBusinessDays(state.position.openedAt, now(), market)
+        : 0
 
     const signal = strategy.decide({
       symbol: upper,

--- a/test/events/tradeEventHandlerSettlement.test.ts
+++ b/test/events/tradeEventHandlerSettlement.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { TradeEventHandler, nextBusinessDay } from '../../src/trading/events/TradeEventHandler'
+import { TradeEventHandler } from '../../src/trading/events/TradeEventHandler'
+import { nextTradingDay } from '../../src/trading/domain/tradingCalendar'
 import type { PositionStore } from '../../src/trading/state/PositionStore'
 import {
   emptySymbolState,
@@ -48,16 +49,16 @@ function makeStore(pre: SymbolState, post: SymbolState) {
   return { store, settlements }
 }
 
-describe('nextBusinessDay', () => {
+describe('nextTradingDay (US)', () => {
   it('rolls Fri → Mon', () => {
-    expect(nextBusinessDay(friday).toISOString().slice(0, 10)).toBe('2026-04-20')
+    expect(nextTradingDay(friday, 'US').toISOString().slice(0, 10)).toBe('2026-04-20')
   })
   it('rolls Sat → Mon', () => {
     const sat = new Date('2026-04-18T10:00:00.000Z')
-    expect(nextBusinessDay(sat).toISOString().slice(0, 10)).toBe('2026-04-20')
+    expect(nextTradingDay(sat, 'US').toISOString().slice(0, 10)).toBe('2026-04-20')
   })
   it('rolls Tue → Wed', () => {
-    expect(nextBusinessDay(tuesday).toISOString().slice(0, 10)).toBe('2026-04-22')
+    expect(nextTradingDay(tuesday, 'US').toISOString().slice(0, 10)).toBe('2026-04-22')
   })
 })
 

--- a/test/trading/domain/tradingCalendar.test.ts
+++ b/test/trading/domain/tradingCalendar.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import {
+  countTradingDaysBetween,
+  inferTradingMarket,
+  isTradingDay,
+  nextTradingDay,
+} from '../../../src/trading/domain/tradingCalendar'
+
+describe('isTradingDay', () => {
+  it('returns false for weekends', () => {
+    // Sat
+    expect(isTradingDay(new Date('2026-04-18T10:00:00.000Z'), 'US')).toBe(false)
+    // Sun
+    expect(isTradingDay(new Date('2026-04-19T10:00:00.000Z'), 'JP')).toBe(false)
+  })
+
+  it('returns false for JP/US holidays', () => {
+    // 2026-01-01 (Thu) US New Year's Day
+    expect(isTradingDay(new Date('2026-01-01T10:00:00.000Z'), 'US')).toBe(false)
+    // 2026-05-04 (Mon) JP みどりの日
+    expect(isTradingDay(new Date('2026-05-04T10:00:00.000Z'), 'JP')).toBe(false)
+  })
+
+  it('returns true for plain weekdays', () => {
+    // Wed 2026-04-15
+    expect(isTradingDay(new Date('2026-04-15T10:00:00.000Z'), 'US')).toBe(true)
+    expect(isTradingDay(new Date('2026-04-15T10:00:00.000Z'), 'JP')).toBe(true)
+  })
+})
+
+describe('nextTradingDay — year-end / new year roll', () => {
+  it('JP: 2026-12-30 (Wed) → 2027-01-04 (Mon) skipping 12/31 + 年始', () => {
+    // 2026-12-31 (Thu) TSE closed, 2027-01-01 (Fri) 元日,
+    // 2027-01-02 (Sat), 2027-01-03 (Sun) → next trading day is 2027-01-04 (Mon).
+    const tue = new Date('2026-12-30T10:00:00.000Z')
+    expect(nextTradingDay(tue, 'JP').toISOString().slice(0, 10)).toBe('2027-01-04')
+  })
+
+  it('US: 2025-12-31 (Wed) → 2026-01-02 (Fri) skipping New Year Day', () => {
+    const wed = new Date('2025-12-31T10:00:00.000Z')
+    expect(nextTradingDay(wed, 'US').toISOString().slice(0, 10)).toBe('2026-01-02')
+  })
+})
+
+describe('nextTradingDay — Golden Week', () => {
+  it('JP: 2026-05-01 (Fri) → 2026-05-07 (Thu) skipping GW', () => {
+    // 5/2 Sat, 5/3 Sun, 5/4 Mon みどりの日, 5/5 Tue こどもの日,
+    // 5/6 Wed 振替休日 (5/3 が Sun) → next trading day is 5/7 Thu.
+    const fri = new Date('2026-05-01T10:00:00.000Z')
+    expect(nextTradingDay(fri, 'JP').toISOString().slice(0, 10)).toBe('2026-05-07')
+  })
+})
+
+describe('countTradingDaysBetween — excludes holidays', () => {
+  it('JP: 2026-04-28 (Tue) → 2026-05-07 (Thu) counts 3 trading days', () => {
+    // Cursor から翌日以降をカウント:
+    // 4/29 Wed 昭和の日 ✗ / 4/30 Thu ○ / 5/1 Fri ○ / 5/2 Sat ✗ /
+    // 5/3 Sun ✗ / 5/4 Mon ✗ / 5/5 Tue ✗ / 5/6 Wed ✗ / 5/7 Thu ○ → 3
+    expect(
+      countTradingDaysBetween(
+        '2026-04-28T10:00:00.000Z',
+        new Date('2026-05-07T10:00:00.000Z'),
+        'JP',
+      ),
+    ).toBe(3)
+  })
+
+  it('US: 2026-06-18 (Thu) → 2026-06-22 (Mon) skips Juneteenth 6/19', () => {
+    // 6/19 Fri Juneteenth ✗ / 6/20 Sat ✗ / 6/21 Sun ✗ / 6/22 Mon ○ → 1
+    expect(
+      countTradingDaysBetween(
+        '2026-06-18T10:00:00.000Z',
+        new Date('2026-06-22T10:00:00.000Z'),
+        'US',
+      ),
+    ).toBe(1)
+  })
+
+  it('returns 0 for invalid ISO', () => {
+    expect(countTradingDaysBetween('not-a-date', new Date(), 'US')).toBe(0)
+  })
+})
+
+describe('inferTradingMarket', () => {
+  it('treats 4-digit symbols as JP', () => {
+    expect(inferTradingMarket('7203')).toBe('JP')
+  })
+  it('treats alphabetic symbols as US', () => {
+    expect(inferTradingMarket('SOXL')).toBe('US')
+    expect(inferTradingMarket('AAPL')).toBe('US')
+  })
+})

--- a/test/trading/strategy/indicators.test.ts
+++ b/test/trading/strategy/indicators.test.ts
@@ -33,21 +33,29 @@ describe('computePullbackIndicators', () => {
 })
 
 describe('computeHoldBusinessDays', () => {
-  it('counts weekday-only days between open and now', () => {
+  it('counts weekday-only days between open and now (US)', () => {
     // Mon 2026-04-13 open, Fri 2026-04-17 now → 4 business days
     expect(
-      computeHoldBusinessDays('2026-04-13T10:00:00.000Z', new Date('2026-04-17T10:00:00.000Z')),
+      computeHoldBusinessDays(
+        '2026-04-13T10:00:00.000Z',
+        new Date('2026-04-17T10:00:00.000Z'),
+        'US',
+      ),
     ).toBe(4)
   })
 
-  it('skips weekends', () => {
+  it('skips weekends (US)', () => {
     // Fri open, next Mon now → 1 business day (weekend does not count)
     expect(
-      computeHoldBusinessDays('2026-04-17T10:00:00.000Z', new Date('2026-04-20T10:00:00.000Z')),
+      computeHoldBusinessDays(
+        '2026-04-17T10:00:00.000Z',
+        new Date('2026-04-20T10:00:00.000Z'),
+        'US',
+      ),
     ).toBe(1)
   })
 
   it('returns 0 for an invalid ISO', () => {
-    expect(computeHoldBusinessDays('not-a-date', new Date())).toBe(0)
+    expect(computeHoldBusinessDays('not-a-date', new Date(), 'US')).toBe(0)
   })
 })


### PR DESCRIPTION
Closes #54 (#38 Phase 2b 残項目 E)。

## Summary

土日のみスキップだった `nextBusinessDay` / `computeHoldBusinessDays` を JP 東証 / NYSE の祝日カレンダーに拡張。T+1 settlement の `settleDate` と stop-out cooldown が連休明けに正しく着地するようになる。

## Scope (Phase 2b-E のみ)

- `src/trading/domain/tradingCalendar.ts` 新規 — `isTradingDay` / `nextTradingDay` / `countTradingDaysBetween` / `inferTradingMarket`、祝日 static テーブルに JP 東証 + NYSE の 2026/2027 分。
- `TradeEventHandler`: `nextBusinessDay` を削除し、`inferTradingMarket(symbol)` + `nextTradingDay(date, market)` 経由に差し替え。SELL fill の settlement と負けエグジット時の cooldown 双方に適用。
- `computeHoldBusinessDays` に `market` 引数を追加、`runPullbackScheduler` 側も `inferTradingMarket(upper)` を渡すよう更新。
- 既存テスト (土日スキップの挙動) は market 明示で維持、新規 `test/trading/domain/tradingCalendar.test.ts` で 年末年始 / GW / Juneteenth を検証。

## Out of scope

- 2028 以降の祝日追記 (module 冒頭に TODO コメント)。
- 米国 early close (感謝祭翌日 13:00 等) — POC 不要。
- portfolio cron reset への組み込み — 別 issue。

## 動作確認

- `pnpm run typecheck` — pass。
- `pnpm test` — 32 files / 191 tests pass (新規 9 テスト含む)。
- 新規ユニットテスト:
  - JP: 2026-12-30 (Wed) → 2027-01-04 (Mon) に 12/31 TSE closed + 年始 3 日 + 週末をまたいでロール。
  - JP GW: 2026-05-01 (Fri) → 2026-05-07 (Thu) に振替休日 5/6 まで連続スキップ。
  - US: 2025-12-31 (Wed) → 2026-01-02 (Fri) で New Year's Day を跨ぐ。
  - `countTradingDaysBetween` が 4/29 昭和の日 / 6/19 Juneteenth を除外。

## Notes for CodeRabbit

- Phase 2b-E 内に scope を限定。祝日テーブル拡張 / early close / cron 連携の指摘は個別 follow-up issue に回してください。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 米国（US）と日本（JP）向けUTCベースのトレーディングカレンダーを追加しました。市場ごとの祝日を考慮した営業日判定・翌営業日計算が可能です。
  * ティッカーから市場を推定する自動判定を追加しました。

* **改善**
  * 決済日やクールダウン判定で市場祝日を踏まえた正確な翌営業日を利用するようになりました。
  * 保有日数計算が市場別カレンダーに基づくように更新されました。

* **テスト**
  * トレーディングカレンダーと関連ロジックの単体テストを追加・更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->