### PR TITLE
feat(admin): settledCash seeding endpoint (#55)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -4,7 +4,6 @@ import type { Env } from './config/env'
 import { auditLogger } from './infrastructure/logger/AuditLogger'
 import { basicAuthMiddleware } from './middleware/basicAuth'
 import { TRADE_EVENT_INGEST_SECRET_HEADER } from './infrastructure/webull/TradeEventBridge'
-import { admin } from './routes/admin'
 import { health } from './routes/health'
 import { trade } from './routes/trade'
 import { events } from './routes/events'
@@ -87,3 +86,4 @@ function timingSafeEqual(a: string, b: string) {
 
   return diff === 0
 }
+import { admin } from './routes/admin'

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,6 +4,7 @@ import type { Env } from './config/env'
 import { auditLogger } from './infrastructure/logger/AuditLogger'
 import { basicAuthMiddleware } from './middleware/basicAuth'
 import { TRADE_EVENT_INGEST_SECRET_HEADER } from './infrastructure/webull/TradeEventBridge'
+import { admin } from './routes/admin'
 import { health } from './routes/health'
 import { trade } from './routes/trade'
 import { events } from './routes/events'
@@ -64,6 +65,8 @@ export function createApp() {
   // Webull routes (Phase 2 append)
   app.use('/webull/*', basicAuthMiddleware())
   app.route('/webull', webull)
+  app.use('/admin/*', basicAuthMiddleware())
+  app.route('/admin', admin)
   app.onError(errorHandler)
   return app
 }

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,0 +1,37 @@
+import { Hono } from 'hono'
+import type { AppBindings } from '../app'
+import { ValidationError } from '../shared/errors'
+import { SymbolStateClient } from '../trading/state/SymbolStateClient'
+
+/**
+ * Operator-only endpoints. Basic-auth-protected by the same middleware as
+ * `/trade/*` at mount time. Use sparingly — these mutate DO state out-of-band
+ * and should only be called for initial seeding or reconciliation.
+ */
+export const admin = new Hono<AppBindings>().post('/symbols/:symbol/seed-cash', async (c) => {
+  const symbol = c.req.param('symbol').trim().toUpperCase()
+  if (symbol.length === 0) {
+    throw new ValidationError('symbol must be a non-empty path param', { field: 'symbol' })
+  }
+  if (!c.env.SYMBOL_STATE) {
+    throw new ValidationError('SYMBOL_STATE binding is not configured', { field: 'env' })
+  }
+
+  const body = (await c.req.json().catch(() => null)) as unknown
+  const amount = readAmount(body)
+
+  const client = new SymbolStateClient(c.env.SYMBOL_STATE)
+  const state = await client.seedSettledCash(symbol, amount)
+  return c.json({ symbol, settledCash: state.settledCash, updatedAt: state.updatedAt })
+})
+
+function readAmount(body: unknown): number {
+  if (body === null || typeof body !== 'object') {
+    throw new ValidationError('body must be a JSON object with { amount: number }', { field: 'body' })
+  }
+  const value = (body as { amount?: unknown }).amount
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    throw new ValidationError('amount must be a finite number >= 0', { field: 'amount' })
+  }
+  return value
+}

--- a/src/trading/state/PositionStore.ts
+++ b/src/trading/state/PositionStore.ts
@@ -18,4 +18,5 @@ export interface PositionStore {
   ): Promise<SymbolState>
   addPendingSettlement(symbol: string, settlement: PendingSettlement): Promise<SymbolState>
   setCooldown(symbol: string, untilIso: string): Promise<SymbolState>
+  seedSettledCash(symbol: string, amount: number): Promise<SymbolState>
 }

--- a/src/trading/state/SymbolStateClient.ts
+++ b/src/trading/state/SymbolStateClient.ts
@@ -43,4 +43,8 @@ export class SymbolStateClient implements PositionStore {
   setCooldown(symbol: string, untilIso: string): Promise<SymbolState> {
     return this.stub(symbol).setCooldown(symbol, untilIso)
   }
+
+  seedSettledCash(symbol: string, amount: number): Promise<SymbolState> {
+    return this.stub(symbol).seedSettledCash(symbol, amount)
+  }
 }

--- a/src/trading/state/SymbolStateDO.ts
+++ b/src/trading/state/SymbolStateDO.ts
@@ -6,6 +6,7 @@ import {
   recordFill,
   recordSignal,
   rollSettlements,
+  seedSettledCash,
   setCooldown,
   setQuote,
   type TransitionContext,
@@ -93,6 +94,13 @@ export class SymbolStateDO extends DurableObject<object> {
   ): Promise<SymbolState> {
     const state = await this.load(symbol)
     const next = addPendingSettlement(state, settlement, this.transitionCtx)
+    await this.save(next)
+    return next
+  }
+
+  async seedSettledCash(symbol: string, amount: number): Promise<SymbolState> {
+    const state = await this.load(symbol)
+    const next = seedSettledCash(state, amount, this.transitionCtx)
     await this.save(next)
     return next
   }

--- a/src/trading/state/stateTransitions.ts
+++ b/src/trading/state/stateTransitions.ts
@@ -127,6 +127,22 @@ export function addPendingSettlement(
 }
 
 /**
+ * Overwrites `settledCash` with an operator-provided value. POC seed path —
+ * used once during initial setup or after a manual reconciliation with the
+ * broker. Not part of the regular fill/roll flow.
+ */
+export function seedSettledCash(
+  state: SymbolState,
+  amount: number,
+  ctx: TransitionContext = defaultCtx,
+): SymbolState {
+  if (!Number.isFinite(amount) || amount < 0) {
+    throw new Error(`Invalid seedSettledCash amount: ${amount} (must be a finite number >= 0)`)
+  }
+  return { ...state, settledCash: amount, updatedAt: ctx.now().toISOString() }
+}
+
+/**
  * Any pendingSettlement whose settleDate is on or before `asOf` moves its
  * amount into `settledCash` and is removed from the queue. Used both
  * proactively (T+1 EOD roll) and defensively on read.

--- a/test/events/tradeEventHandlerCooldown.test.ts
+++ b/test/events/tradeEventHandlerCooldown.test.ts
@@ -36,6 +36,9 @@ function makeStore(pre: SymbolState, post: SymbolState) {
       cooldownCalls.push({ symbol, untilIso })
       return state
     },
+    async seedSettledCash() {
+      return state
+    },
   }
   return { store, cooldownCalls }
 }

--- a/test/events/tradeEventHandlerSettlement.test.ts
+++ b/test/events/tradeEventHandlerSettlement.test.ts
@@ -44,6 +44,9 @@ function makeStore(pre: SymbolState, post: SymbolState) {
     async setCooldown() {
       return state
     },
+    async seedSettledCash() {
+      return state
+    },
   }
   return { store, settlements }
 }

--- a/test/events/tradeEventHandlerState.test.ts
+++ b/test/events/tradeEventHandlerState.test.ts
@@ -37,6 +37,9 @@ function makeStore(
     async setCooldown() {
       return state
     },
+    async seedSettledCash() {
+      return state
+    },
   }
 }
 

--- a/test/routes/admin.test.ts
+++ b/test/routes/admin.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+import { createApp } from '../../src/app'
+
+const baseEnv = {
+  BASIC_AUTH_USER: 'admin',
+  BASIC_AUTH_PASSWORD: 'secret',
+  DRY_RUN: 'true',
+  TRADING_ENABLED: 'false',
+  ALLOWED_SYMBOLS: 'SOXL',
+  MAX_ORDER_NOTIONAL: '100',
+  EVENT_INGEST_SECRET: 'change-me',
+}
+
+const authHeader = { Authorization: `Basic ${btoa('admin:secret')}` }
+
+function fakeSymbolState(captured: { calls: Array<{ symbol: string; amount: number }> }) {
+  const stub = {
+    async seedSettledCash(symbol: string, amount: number) {
+      captured.calls.push({ symbol, amount })
+      return {
+        symbol,
+        position: null,
+        pendingOrder: null,
+        lastSignalAt: null,
+        cooldownUntil: null,
+        settledCash: amount,
+        pendingSettlement: [],
+        lastExecutedPrice: null,
+        lastQuote: null,
+        updatedAt: '2026-04-21T10:00:00.000Z',
+      }
+    },
+  }
+  // Minimal DurableObjectNamespace shape for the SymbolStateClient wrapper.
+  return {
+    idFromName: (_name: string) => 'id',
+    get: (_id: string) => stub,
+  } as unknown
+}
+
+describe('POST /admin/symbols/:symbol/seed-cash', () => {
+  it('401s without Basic Auth', async () => {
+    const app = createApp()
+    const res = await app.request(
+      '/admin/symbols/SOXL/seed-cash',
+      { method: 'POST', body: JSON.stringify({ amount: 100 }) },
+      baseEnv,
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it('400s when body is not a JSON object', async () => {
+    const app = createApp()
+    const captured = { calls: [] as Array<{ symbol: string; amount: number }> }
+    const res = await app.request(
+      '/admin/symbols/SOXL/seed-cash',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeader },
+        body: 'not-json',
+      },
+      { ...baseEnv, SYMBOL_STATE: fakeSymbolState(captured) },
+    )
+    expect(res.status).toBe(400)
+    expect(captured.calls).toEqual([])
+  })
+
+  it('400s on negative amount', async () => {
+    const app = createApp()
+    const captured = { calls: [] as Array<{ symbol: string; amount: number }> }
+    const res = await app.request(
+      '/admin/symbols/SOXL/seed-cash',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeader },
+        body: JSON.stringify({ amount: -5 }),
+      },
+      { ...baseEnv, SYMBOL_STATE: fakeSymbolState(captured) },
+    )
+    expect(res.status).toBe(400)
+    expect(captured.calls).toEqual([])
+  })
+
+  it('200s and forwards the amount to SYMBOL_STATE.seedSettledCash', async () => {
+    const app = createApp()
+    const captured = { calls: [] as Array<{ symbol: string; amount: number }> }
+    const res = await app.request(
+      '/admin/symbols/soxl/seed-cash',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeader },
+        body: JSON.stringify({ amount: 12_345 }),
+      },
+      { ...baseEnv, SYMBOL_STATE: fakeSymbolState(captured) },
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { symbol: string; settledCash: number }
+    expect(body).toEqual({
+      symbol: 'SOXL',
+      settledCash: 12_345,
+      updatedAt: '2026-04-21T10:00:00.000Z',
+    })
+    expect(captured.calls).toEqual([{ symbol: 'SOXL', amount: 12_345 }])
+  })
+})

--- a/test/trading/application/tradingServiceCorrelation.test.ts
+++ b/test/trading/application/tradingServiceCorrelation.test.ts
@@ -39,6 +39,9 @@ function makeStore(statesBySymbol: Record<string, SymbolState>): PositionStore {
     async setCooldown(symbol) {
       return emptySymbolState(symbol, () => now)
     },
+    async seedSettledCash(symbol) {
+      return emptySymbolState(symbol, () => now)
+    },
   }
 }
 

--- a/test/trading/application/tradingServiceSettlement.test.ts
+++ b/test/trading/application/tradingServiceSettlement.test.ts
@@ -45,6 +45,9 @@ function makeStore(state: SymbolState): PositionStore {
     async setCooldown() {
       return state
     },
+    async seedSettledCash() {
+      return state
+    },
   }
 }
 

--- a/test/trading/application/tradingServiceState.test.ts
+++ b/test/trading/application/tradingServiceState.test.ts
@@ -62,6 +62,10 @@ function makeStore(initial?: SymbolState): PositionStore & { state: SymbolState;
       calls.push('setCooldown')
       return state
     },
+    async seedSettledCash() {
+      calls.push('seedSettledCash')
+      return state
+    },
   }
 }
 

--- a/test/trading/state/seedSettledCash.test.ts
+++ b/test/trading/state/seedSettledCash.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { seedSettledCash } from '../../../src/trading/state/stateTransitions'
+import { emptySymbolState } from '../../../src/trading/state/types'
+
+const fixedNow = () => new Date('2026-04-21T10:00:00.000Z')
+
+describe('seedSettledCash', () => {
+  it('overwrites settledCash and bumps updatedAt', () => {
+    const state = emptySymbolState('SOXL', fixedNow)
+    const next = seedSettledCash(state, 100_000, { now: fixedNow })
+    expect(next.settledCash).toBe(100_000)
+    expect(next.updatedAt).toBe('2026-04-21T10:00:00.000Z')
+  })
+
+  it('accepts 0 (explicit reset)', () => {
+    const state = { ...emptySymbolState('SOXL', fixedNow), settledCash: 5_000 }
+    expect(seedSettledCash(state, 0, { now: fixedNow }).settledCash).toBe(0)
+  })
+
+  it('rejects NaN', () => {
+    const state = emptySymbolState('SOXL', fixedNow)
+    expect(() => seedSettledCash(state, NaN, { now: fixedNow })).toThrow('Invalid seedSettledCash')
+  })
+
+  it('rejects negative amount', () => {
+    const state = emptySymbolState('SOXL', fixedNow)
+    expect(() => seedSettledCash(state, -1, { now: fixedNow })).toThrow('Invalid seedSettledCash')
+  })
+})

--- a/test/trading/strategy/pullbackScheduler.test.ts
+++ b/test/trading/strategy/pullbackScheduler.test.ts
@@ -50,6 +50,9 @@ function makeStore(states: Record<string, SymbolState>) {
     async setCooldown(symbol: string) {
       return emptySymbolState(symbol, () => now)
     },
+    async seedSettledCash(symbol: string) {
+      return emptySymbolState(symbol, () => now)
+    },
   } satisfies PositionStore
 }
 


### PR DESCRIPTION
## 概要

#37-D T+1 settled-cash guard は \`settledCash > 0\` の symbol しか gate しない fail-open 設計。実取引モードに切り替える前に operator が初期値を入れられる経路が必要なので、最小の admin endpoint を追加。

## 変更

- \`seedSettledCash\` transition (純関数): 負の値 / NaN を reject、0 は許可 (reset 用)
- \`SymbolStateDO.seedSettledCash\` を expose → \`PositionStore\` / \`SymbolStateClient\` 経由で叩ける
- \`POST /admin/symbols/:symbol/seed-cash\` — Basic Auth 配下、body は \`{ amount: number }\`
  - symbol path param は upper-case 正規化
  - invalid body / negative amount → 400

## scope 外

- PortfolioStateDO の \`daily_start_equity\` seed — #50 で同じ \`/admin/*\` prefix に追加予定
- 自動 reconcile (account balance API から毎朝 seed) — live 疎通後

## 動作確認

- [x] \`pnpm run typecheck\`
- [x] \`pnpm test\` (188 件 pass、追加: \`seedSettledCash\` transition + \`admin.route\`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 管理者向けにシンボルの確定済みキャッシュを初期化（シード）する新しい管理APIを追加しました。
  * 管理APIへのアクセスに基本認証を適用し、保護を強化しました。
  * バックエンドの状態管理とクライアントにシード操作を受け渡す処理を追加しました。

* **テスト**
  * 管理APIとシード処理の包括的な単体テストを追加・更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->