### PR TITLE
feat(risk): spread guard (#38-D)

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -222,3 +222,33 @@ export function parseInversePairs(value: string | undefined): Record<string, str
 export interface Env {
   INVERSE_PAIRS?: string
 }
+
+// Spread guard config (Phase 2b #38-D append)
+export interface Env {
+  SPREAD_LIMIT_PCT_US?: string
+  SPREAD_LIMIT_PCT_JP?: string
+}
+
+/**
+ * Parses an optional numeric env var into a non-negative finite number. Returns
+ * `undefined` when the var is unset or empty so callers can fall back to a
+ * safe default. Invalid or negative values warn once and return `undefined` —
+ * a typo in a risk limit must not silently widen the limit.
+ */
+let didWarnInvalidSpreadLimit: Record<string, boolean> = {}
+export function parseOptionalNonNegativeNumberEnv(
+  value: string | undefined,
+  key: string,
+): number | undefined {
+  if (value === undefined || value.trim() === '') return undefined
+
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    if (!didWarnInvalidSpreadLimit[key]) {
+      didWarnInvalidSpreadLimit[key] = true
+      console.warn(`Invalid ${key} value '${value}'; using safe default`)
+    }
+    return undefined
+  }
+  return parsed
+}

--- a/src/routes/trade.ts
+++ b/src/routes/trade.ts
@@ -5,6 +5,7 @@ import {
   parseCsvEnv,
   parseInversePairs,
   parseNumberEnv,
+  parseOptionalNonNegativeNumberEnv,
   parseSymbolNotionalMap,
 } from '../config/env'
 import { createWebullHttpClient, type WebullClientEnv } from '../infrastructure/webull/WebullHttpClient'
@@ -64,6 +65,8 @@ export function createTradingService(
     DRY_RUN?: string
     SYMBOL_STATE?: DurableObjectNamespace<SymbolStateDO>
     INVERSE_PAIRS?: string
+    SPREAD_LIMIT_PCT_US?: string
+    SPREAD_LIMIT_PCT_JP?: string
   } & WebullClientEnv,
 ): TradingService {
   const execution = parseBooleanEnv(env.DRY_RUN, true)
@@ -77,6 +80,10 @@ export function createTradingService(
     {
       positionStore: env.SYMBOL_STATE ? new SymbolStateClient(env.SYMBOL_STATE) : undefined,
       inversePairs: parseInversePairs(env.INVERSE_PAIRS),
+      spreadLimits: {
+        US: parseOptionalNonNegativeNumberEnv(env.SPREAD_LIMIT_PCT_US, 'SPREAD_LIMIT_PCT_US') ?? 0.0025,
+        JP: parseOptionalNonNegativeNumberEnv(env.SPREAD_LIMIT_PCT_JP, 'SPREAD_LIMIT_PCT_JP') ?? 0.006,
+      },
     },
   )
 }

--- a/src/routes/trade.ts
+++ b/src/routes/trade.ts
@@ -81,8 +81,12 @@ export function createTradingService(
       positionStore: env.SYMBOL_STATE ? new SymbolStateClient(env.SYMBOL_STATE) : undefined,
       inversePairs: parseInversePairs(env.INVERSE_PAIRS),
       spreadLimits: {
-        US: parseOptionalNonNegativeNumberEnv(env.SPREAD_LIMIT_PCT_US, 'SPREAD_LIMIT_PCT_US') ?? 0.0025,
-        JP: parseOptionalNonNegativeNumberEnv(env.SPREAD_LIMIT_PCT_JP, 'SPREAD_LIMIT_PCT_JP') ?? 0.006,
+        US: parseOptionalNonNegativeNumberEnv(env.SPREAD_LIMIT_PCT_US, 'SPREAD_LIMIT_PCT_US') !== undefined
+          ? parseOptionalNonNegativeNumberEnv(env.SPREAD_LIMIT_PCT_US, 'SPREAD_LIMIT_PCT_US')! / 100
+          : 0.0025,
+        JP: parseOptionalNonNegativeNumberEnv(env.SPREAD_LIMIT_PCT_JP, 'SPREAD_LIMIT_PCT_JP') !== undefined
+          ? parseOptionalNonNegativeNumberEnv(env.SPREAD_LIMIT_PCT_JP, 'SPREAD_LIMIT_PCT_JP')! / 100
+          : 0.006,
       },
     },
   )

--- a/src/trading/application/TradingService.ts
+++ b/src/trading/application/TradingService.ts
@@ -82,7 +82,20 @@ export class TradingService {
         ? options.pendingLockTtlMs
         : DEFAULT_PENDING_LOCK_TTL_MS
     this.inversePairs = options.inversePairs ?? {}
-    this.spreadLimits = options.spreadLimits ?? { ...DEFAULT_SPREAD_LIMITS }
+    this.spreadLimits = {
+      US:
+        options.spreadLimits?.US !== undefined &&
+        Number.isFinite(options.spreadLimits.US) &&
+        options.spreadLimits.US >= 0
+          ? options.spreadLimits.US
+          : DEFAULT_SPREAD_LIMITS.US,
+      JP:
+        options.spreadLimits?.JP !== undefined &&
+        Number.isFinite(options.spreadLimits.JP) &&
+        options.spreadLimits.JP >= 0
+          ? options.spreadLimits.JP
+          : DEFAULT_SPREAD_LIMITS.JP,
+    }
     this.now = options.now ?? (() => new Date())
   }
 

--- a/src/trading/application/TradingService.ts
+++ b/src/trading/application/TradingService.ts
@@ -288,7 +288,7 @@ export class TradingService {
     const limit = market === 'JP' ? this.spreadLimits.JP : this.spreadLimits.US
     const spreadPct = computeSpreadPct(bid, ask)
     if (spreadPct === null) {
-      return 'spread unknown, bid/ask missing'
+      return 'spread invalid: crossed book, non-finite, or non-positive bid/ask'
     }
     if (spreadPct > limit) {
       return `spread ${(spreadPct * 100).toFixed(3)}% exceeds ${market} limit ${(limit * 100).toFixed(3)}%`

--- a/src/trading/application/TradingService.ts
+++ b/src/trading/application/TradingService.ts
@@ -4,8 +4,11 @@ import type { RiskDecision } from '../domain/RiskDecision'
 import type { Signal } from '../domain/Signal'
 import type { Execution } from '../execution/Execution'
 import type { RiskPolicy } from '../risk/RiskPolicy'
+import { computeSpreadPct } from '../risk/spreadGuard'
 import type { PositionStore } from '../state/PositionStore'
+import type { QuoteSnapshot } from '../state/types'
 import type { Strategy, StrategyInput } from '../strategy/Strategy'
+import { inferWebullMarket } from '../../infrastructure/webull/mapper'
 import {
   logPostSubmit,
   logPreSubmit,
@@ -46,15 +49,23 @@ export interface TradingServiceOptions {
    * shows an open position for the inverse, BUY is rejected (P&L decay trap).
    */
   inversePairs?: Record<string, string>
+  /**
+   * Per-market spread limits (fraction of mid price). A submit is rejected if
+   * `(ask - bid) / mid` exceeds the market's limit. Defaults to US 0.25% and
+   * JP 0.60% — US liquid-name depth is tighter than JP individual names.
+   */
+  spreadLimits?: { US: number; JP: number }
   now?: () => Date
 }
 
 const DEFAULT_PENDING_LOCK_TTL_MS = 60_000
+const DEFAULT_SPREAD_LIMITS = { US: 0.0025, JP: 0.006 } as const
 
 export class TradingService {
   private readonly positionStore?: PositionStore
   private readonly pendingLockTtlMs: number
   private readonly inversePairs: Record<string, string>
+  private readonly spreadLimits: { US: number; JP: number }
   private readonly now: () => Date
 
   constructor(
@@ -71,6 +82,7 @@ export class TradingService {
         ? options.pendingLockTtlMs
         : DEFAULT_PENDING_LOCK_TTL_MS
     this.inversePairs = options.inversePairs ?? {}
+    this.spreadLimits = options.spreadLimits ?? { ...DEFAULT_SPREAD_LIMITS }
     this.now = options.now ?? (() => new Date())
   }
 
@@ -212,6 +224,17 @@ export class TradingService {
       }
     }
 
+    // Spread guard: wide spread at submit turns into slippage on market orders
+    // and stale fills on marketable limits. Fail-closed when bid/ask are
+    // missing — an unknown spread must not be silently treated as tight.
+    const spreadGate = this.evaluateSpreadGate(symbol, state.lastQuote)
+    if (spreadGate !== null) {
+      return {
+        allowed: false,
+        riskDecision: appendReason(decision.riskDecision, spreadGate),
+      }
+    }
+
     const lock = {
       clientOrderId: decision.orderIntent.clientOrderId,
       side: decision.orderIntent.side,
@@ -227,6 +250,37 @@ export class TradingService {
     }
 
     return { allowed: true }
+  }
+
+  /**
+   * Returns a rejection reason string when the spread gate blocks submit, or
+   * null when the gate passes. Fail-closed: missing bid or ask is a reject —
+   * we must never silently treat an unknown spread as tight.
+   */
+  private evaluateSpreadGate(
+    symbol: string,
+    lastQuote: QuoteSnapshot | null,
+  ): string | null {
+    // No quote has ever been seeded for this symbol: treat as unseeded and skip
+    // the gate, consistent with the settled-cash seeding convention.
+    if (lastQuote === null) return null
+
+    const bid = lastQuote.bid
+    const ask = lastQuote.ask
+    if (bid === undefined || ask === undefined) {
+      return 'spread unknown, bid/ask missing'
+    }
+
+    const market = inferWebullMarket(symbol)
+    const limit = market === 'JP' ? this.spreadLimits.JP : this.spreadLimits.US
+    const spreadPct = computeSpreadPct(bid, ask)
+    if (spreadPct === null) {
+      return 'spread unknown, bid/ask missing'
+    }
+    if (spreadPct > limit) {
+      return `spread ${(spreadPct * 100).toFixed(3)}% exceeds ${market} limit ${(limit * 100).toFixed(3)}%`
+    }
+    return null
   }
 
   private createOrderIntent(signal: Signal): OrderIntent | undefined {

--- a/src/trading/risk/spreadGuard.ts
+++ b/src/trading/risk/spreadGuard.ts
@@ -1,0 +1,38 @@
+/**
+ * Spread guard: reject submit when the bid/ask spread is too wide relative to mid.
+ *
+ * Rationale: a wide spread at the moment of submit turns into slippage on market
+ * orders and stale fills on marketable limits. Small retail accounts cannot absorb
+ * that cost, so we fail-closed per (market, symbol) when spread exceeds a limit.
+ *
+ * See issue #38-D.
+ */
+
+/**
+ * Returns (ask - bid) / mid, where mid = (bid + ask) / 2.
+ *
+ * Returns null for degenerate inputs that should never be trusted as a spread
+ * signal: non-positive bid or ask, or a crossed book (ask < bid). A zero spread
+ * (bid == ask) is a valid lit-book state and returns 0, not null.
+ */
+export function computeSpreadPct(bid: number, ask: number): number | null {
+  if (!Number.isFinite(bid) || !Number.isFinite(ask)) return null
+  if (bid <= 0 || ask <= 0) return null
+  if (ask < bid) return null
+
+  const mid = (bid + ask) / 2
+  if (mid <= 0) return null
+
+  return (ask - bid) / mid
+}
+
+/**
+ * True when the spread percentage is within (or equal to) `limitPct`.
+ * Degenerate bid/ask returns false — fail-closed: unknown spread blocks submit.
+ */
+export function isSpreadWithinLimit(bid: number, ask: number, limitPct: number): boolean {
+  const spreadPct = computeSpreadPct(bid, ask)
+  if (spreadPct === null) return false
+  if (!Number.isFinite(limitPct) || limitPct < 0) return false
+  return spreadPct <= limitPct
+}

--- a/test/risk/spreadGuard.test.ts
+++ b/test/risk/spreadGuard.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { computeSpreadPct, isSpreadWithinLimit } from '../../src/trading/risk/spreadGuard'
+
+describe('computeSpreadPct', () => {
+  it('returns (ask-bid)/mid for a normal book', () => {
+    // bid 99.9, ask 100.1 -> mid 100, spread 0.2, pct 0.002
+    const pct = computeSpreadPct(99.9, 100.1)
+    expect(pct).not.toBeNull()
+    expect(pct!).toBeCloseTo(0.002, 10)
+  })
+
+  it('returns 0 when bid equals ask (tight/locked book)', () => {
+    expect(computeSpreadPct(100, 100)).toBe(0)
+  })
+
+  it('returns null when bid is zero or negative', () => {
+    expect(computeSpreadPct(0, 100)).toBeNull()
+    expect(computeSpreadPct(-1, 100)).toBeNull()
+  })
+
+  it('returns null when ask is zero or negative', () => {
+    expect(computeSpreadPct(100, 0)).toBeNull()
+    expect(computeSpreadPct(100, -1)).toBeNull()
+  })
+
+  it('returns null for a crossed book (ask < bid)', () => {
+    expect(computeSpreadPct(101, 100)).toBeNull()
+  })
+
+  it('returns null for non-finite inputs', () => {
+    expect(computeSpreadPct(Number.NaN, 100)).toBeNull()
+    expect(computeSpreadPct(100, Number.POSITIVE_INFINITY)).toBeNull()
+  })
+})
+
+describe('isSpreadWithinLimit', () => {
+  it('returns true when spread is within limit', () => {
+    // spread 0.2% <= 0.25% limit
+    expect(isSpreadWithinLimit(99.9, 100.1, 0.0025)).toBe(true)
+  })
+
+  it('returns true when spread equals limit exactly', () => {
+    // 99.875 / 100.125 -> mid 100, spread 0.25, pct 0.0025
+    expect(isSpreadWithinLimit(99.875, 100.125, 0.0025)).toBe(true)
+  })
+
+  it('returns false when spread exceeds limit', () => {
+    // 99.85 / 100.15 -> pct 0.003 > 0.0025
+    expect(isSpreadWithinLimit(99.85, 100.15, 0.0025)).toBe(false)
+  })
+
+  it('fail-closed on degenerate book', () => {
+    expect(isSpreadWithinLimit(0, 100, 0.01)).toBe(false)
+    expect(isSpreadWithinLimit(101, 100, 0.01)).toBe(false)
+  })
+
+  it('fail-closed on invalid limit', () => {
+    expect(isSpreadWithinLimit(99.9, 100.1, -0.01)).toBe(false)
+    expect(isSpreadWithinLimit(99.9, 100.1, Number.NaN)).toBe(false)
+  })
+})

--- a/test/trading/application/tradingServiceSpread.test.ts
+++ b/test/trading/application/tradingServiceSpread.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest'
+import { TradingService, type TradingConfig } from '../../../src/trading/application/TradingService'
+import { MockExecution } from '../../../src/trading/execution/MockExecution'
+import { DefaultRiskPolicy } from '../../../src/trading/risk/DefaultRiskPolicy'
+import type { PositionStore } from '../../../src/trading/state/PositionStore'
+import {
+  emptySymbolState,
+  type QuoteSnapshot,
+  type SymbolState,
+} from '../../../src/trading/state/types'
+import { FixedRuleStrategy } from '../../../src/trading/strategy/strategies/FixedRuleStrategy'
+
+const now = new Date('2026-04-21T14:30:00.000Z')
+
+const baseConfig: TradingConfig = {
+  dryRun: true,
+  tradingEnabled: true,
+  allowedSymbols: ['SPY', '7203'],
+  maxOrderNotional: 100_000,
+  symbolMaxNotional: {},
+  marketHoursCheck: false,
+}
+
+function buy(symbol: string): { symbol: string; price: number; quantity: number; buyBelow: number; sellAbove: number } {
+  return { symbol, price: 100, quantity: 1, buyBelow: 150, sellAbove: 200 }
+}
+
+function quote(bid: number | undefined, ask: number | undefined): QuoteSnapshot {
+  return {
+    price: 100,
+    asOf: now.toISOString(),
+    fetchedAt: now.toISOString(),
+    source: 'test',
+    bid,
+    ask,
+  }
+}
+
+function makeStore(stateBySymbol: Record<string, SymbolState>): PositionStore {
+  return {
+    async getState(symbol) {
+      return stateBySymbol[symbol.toUpperCase()] ?? emptySymbolState(symbol, () => now)
+    },
+    async lockPendingOrder(_symbol, _lock) {
+      return { ok: true, state: emptySymbolState('_', () => now) }
+    },
+    async clearPendingOrder(symbol) {
+      return emptySymbolState(symbol, () => now)
+    },
+    async recordFill(symbol) {
+      return emptySymbolState(symbol, () => now)
+    },
+    async addPendingSettlement(symbol) {
+      return emptySymbolState(symbol, () => now)
+    },
+    async setCooldown(symbol) {
+      return emptySymbolState(symbol, () => now)
+    },
+    async seedSettledCash(symbol) {
+      return emptySymbolState(symbol, () => now)
+    },
+  }
+}
+
+function service(store: PositionStore, overrides: { US?: number; JP?: number } = {}) {
+  return new TradingService(
+    new FixedRuleStrategy(150, 200),
+    new DefaultRiskPolicy(),
+    new MockExecution(),
+    {
+      positionStore: store,
+      spreadLimits: {
+        US: overrides.US ?? 0.0025,
+        JP: overrides.JP ?? 0.006,
+      },
+      now: () => now,
+    },
+  )
+}
+
+describe('TradingService spread guard (#38-D)', () => {
+  it('rejects BUY for US liquid name when spread is 0.3% (above 0.25% limit)', async () => {
+    // 99.85 / 100.15 -> mid 100, spread 0.3 / 100 = 0.003
+    const store = makeStore({
+      SPY: { ...emptySymbolState('SPY', () => now), lastQuote: quote(99.85, 100.15) },
+    })
+    const result = await service(store).executeTrade(buy('SPY'), baseConfig)
+    expect(result.riskDecision.allowed).toBe(false)
+    expect(result.riskDecision.reasons.some((r) => r.includes('spread'))).toBe(true)
+    expect(result.executionResult).toBeUndefined()
+  })
+
+  it('allows BUY for US liquid name when spread is 0.2% (within 0.25% limit)', async () => {
+    // 99.9 / 100.1 -> pct 0.002
+    const store = makeStore({
+      SPY: { ...emptySymbolState('SPY', () => now), lastQuote: quote(99.9, 100.1) },
+    })
+    const result = await service(store).executeTrade(buy('SPY'), baseConfig)
+    expect(result.riskDecision.allowed).toBe(true)
+  })
+
+  it('rejects BUY for JP name when spread is 0.7% (above 0.6% limit)', async () => {
+    // 99.65 / 100.35 -> mid 100, spread 0.7 / 100 = 0.007
+    const store = makeStore({
+      '7203': { ...emptySymbolState('7203', () => now), lastQuote: quote(99.65, 100.35) },
+    })
+    const result = await service(store).executeTrade(buy('7203'), baseConfig)
+    expect(result.riskDecision.allowed).toBe(false)
+    expect(result.riskDecision.reasons.some((r) => r.includes('spread'))).toBe(true)
+  })
+
+  it('allows BUY for JP name when spread is 0.5% (within 0.6% limit)', async () => {
+    // 99.75 / 100.25 -> pct 0.005
+    const store = makeStore({
+      '7203': { ...emptySymbolState('7203', () => now), lastQuote: quote(99.75, 100.25) },
+    })
+    const result = await service(store).executeTrade(buy('7203'), baseConfig)
+    expect(result.riskDecision.allowed).toBe(true)
+  })
+
+  it('fail-closed: rejects BUY when lastQuote is present but bid is missing', async () => {
+    const store = makeStore({
+      SPY: { ...emptySymbolState('SPY', () => now), lastQuote: quote(undefined, 100.1) },
+    })
+    const result = await service(store).executeTrade(buy('SPY'), baseConfig)
+    expect(result.riskDecision.allowed).toBe(false)
+    expect(result.riskDecision.reasons.some((r) => r.includes('bid/ask missing'))).toBe(true)
+  })
+
+  it('fail-closed: rejects BUY when lastQuote is present but ask is missing', async () => {
+    const store = makeStore({
+      SPY: { ...emptySymbolState('SPY', () => now), lastQuote: quote(99.9, undefined) },
+    })
+    const result = await service(store).executeTrade(buy('SPY'), baseConfig)
+    expect(result.riskDecision.allowed).toBe(false)
+    expect(result.riskDecision.reasons.some((r) => r.includes('bid/ask missing'))).toBe(true)
+  })
+
+  it('skips the gate when lastQuote is null (unseeded symbol) to preserve legacy flow', async () => {
+    const store = makeStore({})
+    const result = await service(store).executeTrade(buy('SPY'), baseConfig)
+    expect(result.riskDecision.allowed).toBe(true)
+  })
+
+  it('uses the US limit for non-JP symbols and the JP limit for 4-digit codes', async () => {
+    // Same spread 0.4% — pass for JP (< 0.6%), reject for US (> 0.25%)
+    const storeUs = makeStore({
+      SPY: { ...emptySymbolState('SPY', () => now), lastQuote: quote(99.8, 100.2) },
+    })
+    const storeJp = makeStore({
+      '7203': { ...emptySymbolState('7203', () => now), lastQuote: quote(99.8, 100.2) },
+    })
+    const us = await service(storeUs).executeTrade(buy('SPY'), baseConfig)
+    const jp = await service(storeJp).executeTrade(buy('7203'), baseConfig)
+    expect(us.riskDecision.allowed).toBe(false)
+    expect(jp.riskDecision.allowed).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- `src/trading/risk/spreadGuard.ts` を新設: `computeSpreadPct` / `isSpreadWithinLimit`。bid/ask が degenerate (非正値 / crossed book / 非有限値) の時は `null` を返し、fail-closed 側に倒す。
- `TradingService.applyStateGate` に spread check を追加 (cooldown / settled-cash / inverse-pair の後)。market 判定は既存の `inferWebullMarket` を再利用、default 閾値は US 0.25% / JP 0.60%。
- `TradingServiceOptions.spreadLimits` を追加、`src/routes/trade.ts` で `SPREAD_LIMIT_PCT_US` / `SPREAD_LIMIT_PCT_JP` を env から読む (`parseOptionalNonNegativeNumberEnv`)。不正値は warn して default にフォールバック。

## Fail-closed 設計
- `lastQuote` が null (未 seed) の symbol は従来どおり通過。既存の settled-cash seed 規約と揃える。
- `lastQuote` は存在するが `bid` / `ask` のどちらかが欠損 → reject (`spread unknown, bid/ask missing`)。Stale な部分 quote を tight spread と誤認しない。
- crossed book (ask<bid) / 非有限値 → 同じく reject。

## 動作確認
- [x] `pnpm typecheck` pass
- [x] `pnpm test` pass (37 files / 223 tests)
- [x] 新 unit test `test/risk/spreadGuard.test.ts` (11 cases): normal / zero / crossed / edge
- [x] 新 integration test `test/trading/application/tradingServiceSpread.test.ts` (8 cases): US 0.3% reject / 0.2% pass、JP 0.7% reject / 0.5% pass、bid/ask 欠損 reject、lastQuote=null skip、同じ spread で US reject / JP pass
- [ ] 実環境での dry-run 挙動確認 (follow-up、本 PR 範囲外)

## Rebase 予告
`#50` / `#52` が同じ `applyStateGate` を編集する。後着した側が rebase で解決する想定。

## Refs
- Issue: #53 (#38-D Spread guard)
- 依存: #51 (bid/ask 拡張、merged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 市場別（米国/日本）スプレッド上限を設定可能にし、上限超過時は取引を拒否するリスクゲートを導入。
  * 環境変数で上限を任意指定でき、未設定時は安全なデフォルトが適用。

* **不具合修正 / 安全性**
  * スプレッド算出・入力検証を強化し、異常値や不完全な価格情報ではフェイルクローズ（取引拒否）に。

* **テスト**
  * スプレッド判定の単体・連携テストを追加し、許可／拒否／フェイルクローズ動作を網羅。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->