### PR TITLE
feat(risk): daily drawdown kill + PortfolioStateDO (#38-B)

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -235,6 +235,18 @@ export interface Env {
   GAP_REJECT_PCT?: string
 }
 
+// Drawdown kill switch (#38-B append)
+import type { PortfolioStateDO } from '../trading/state/PortfolioStateDO'
+
+export interface Env {
+  PORTFOLIO_STATE?: DurableObjectNamespace<PortfolioStateDO>
+  /**
+   * Daily drawdown kill threshold, as a fraction of day-start equity. Parsed as
+   * a negative float (e.g. `"-0.02"`). Default -0.02 when unset or malformed.
+   */
+  DRAWDOWN_KILL_THRESHOLD?: string
+}
+
 /**
  * Parses an optional numeric env var into a non-negative finite number. Returns
  * `undefined` when the var is unset or empty so callers can fall back to a
@@ -274,6 +286,24 @@ export function parseOptionalPositiveNumber(
   if (!Number.isFinite(parsed) || parsed <= 0) {
     console.warn(`Invalid ${key ?? 'env'} value: '${value}'; using fallback ${fallback}`)
     return fallback
+  }
+  return parsed
+}
+
+const DEFAULT_DRAWDOWN_KILL_THRESHOLD = -0.02
+
+/**
+ * Parses DRAWDOWN_KILL_THRESHOLD. Must be a finite negative number; anything
+ * else falls back to the default so a typo cannot silently disarm the kill.
+ */
+export function parseDrawdownKillThreshold(value: string | undefined): number {
+  if (value === undefined) return DEFAULT_DRAWDOWN_KILL_THRESHOLD
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed >= 0) {
+    console.warn(
+      `Invalid DRAWDOWN_KILL_THRESHOLD '${value}'; using default ${DEFAULT_DRAWDOWN_KILL_THRESHOLD}`,
+    )
+    return DEFAULT_DRAWDOWN_KILL_THRESHOLD
   }
   return parsed
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import type { Env } from './config/env'
 import { runQuoteFeed } from './trading/quotes/quoteScheduler'
 
 export { SymbolStateDO } from './trading/state/SymbolStateDO'
+export { PortfolioStateDO } from './trading/state/PortfolioStateDO'
 
 const app = createApp()
 

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import type { AppBindings } from '../app'
 import { ValidationError } from '../shared/errors'
+import { PortfolioStateClient } from '../trading/state/PortfolioStateClient'
 import { SymbolStateClient } from '../trading/state/SymbolStateClient'
 
 /**
@@ -8,22 +9,40 @@ import { SymbolStateClient } from '../trading/state/SymbolStateClient'
  * `/trade/*` at mount time. Use sparingly — these mutate DO state out-of-band
  * and should only be called for initial seeding or reconciliation.
  */
-export const admin = new Hono<AppBindings>().post('/symbols/:symbol/seed-cash', async (c) => {
-  const symbol = c.req.param('symbol').trim().toUpperCase()
-  if (symbol.length === 0) {
-    throw new ValidationError('symbol must be a non-empty path param', { field: 'symbol' })
-  }
-  if (!c.env.SYMBOL_STATE) {
-    throw new ValidationError('SYMBOL_STATE binding is not configured', { field: 'env' })
-  }
+export const admin = new Hono<AppBindings>()
+  .post('/symbols/:symbol/seed-cash', async (c) => {
+    const symbol = c.req.param('symbol').trim().toUpperCase()
+    if (symbol.length === 0) {
+      throw new ValidationError('symbol must be a non-empty path param', { field: 'symbol' })
+    }
+    if (!c.env.SYMBOL_STATE) {
+      throw new ValidationError('SYMBOL_STATE binding is not configured', { field: 'env' })
+    }
 
-  const body = (await c.req.json().catch(() => null)) as unknown
-  const amount = readAmount(body)
+    const body = (await c.req.json().catch(() => null)) as unknown
+    const amount = readAmount(body)
 
-  const client = new SymbolStateClient(c.env.SYMBOL_STATE)
-  const state = await client.seedSettledCash(symbol, amount)
-  return c.json({ symbol, settledCash: state.settledCash, updatedAt: state.updatedAt })
-})
+    const client = new SymbolStateClient(c.env.SYMBOL_STATE)
+    const state = await client.seedSettledCash(symbol, amount)
+    return c.json({ symbol, settledCash: state.settledCash, updatedAt: state.updatedAt })
+  })
+  .post('/portfolio/seed-equity', async (c) => {
+    if (!c.env.PORTFOLIO_STATE) {
+      throw new ValidationError('PORTFOLIO_STATE binding is not configured', { field: 'env' })
+    }
+
+    const body = (await c.req.json().catch(() => null)) as unknown
+    const amount = readAmount(body)
+
+    const client = new PortfolioStateClient(c.env.PORTFOLIO_STATE)
+    const state = await client.seedDailyStartEquity(amount)
+    return c.json({
+      dailyStartEquity: state.dailyStartEquity,
+      dailyRealizedPnl: state.dailyRealizedPnl,
+      tradingDisabledUntil: state.tradingDisabledUntil,
+      updatedAt: state.updatedAt,
+    })
+  })
 
 function readAmount(body: unknown): number {
   if (body === null || typeof body !== 'object') {

--- a/src/routes/events.ts
+++ b/src/routes/events.ts
@@ -4,6 +4,7 @@ import type { TradeEventIngestRequest } from '../infrastructure/webull/TradeEven
 import { ValidationError } from '../shared/errors'
 import { TradeEventService } from '../trading/application/TradeEventService'
 import { isTradeEventType, isTradeStatus, type TradeEvent } from '../trading/domain/TradeEvent'
+import { PortfolioStateClient } from '../trading/state/PortfolioStateClient'
 import { SymbolStateClient } from '../trading/state/SymbolStateClient'
 
 export const events = new Hono<AppBindings>().post('/trade', async (c) => {
@@ -15,6 +16,9 @@ export const events = new Hono<AppBindings>().post('/trade', async (c) => {
 
   const service = new TradeEventService({
     positionStore: c.env.SYMBOL_STATE ? new SymbolStateClient(c.env.SYMBOL_STATE) : undefined,
+    portfolioStore: c.env.PORTFOLIO_STATE
+      ? new PortfolioStateClient(c.env.PORTFOLIO_STATE)
+      : undefined,
   })
   await service.handle(payload.event)
 

--- a/src/routes/trade.ts
+++ b/src/routes/trade.ts
@@ -3,6 +3,7 @@ import type { AppBindings } from '../app'
 import {
   parseBooleanEnv,
   parseCsvEnv,
+  parseDrawdownKillThreshold,
   parseInversePairs,
   parseNumberEnv,
   parseOptionalNonNegativeNumberEnv,
@@ -15,6 +16,8 @@ import { TradingService, type TradingConfig } from '../trading/application/Tradi
 import { MockExecution } from '../trading/execution/MockExecution'
 import { WebullExecution } from '../trading/execution/WebullExecution'
 import { DefaultRiskPolicy } from '../trading/risk/DefaultRiskPolicy'
+import { PortfolioStateClient } from '../trading/state/PortfolioStateClient'
+import type { PortfolioStateDO } from '../trading/state/PortfolioStateDO'
 import { SymbolStateClient } from '../trading/state/SymbolStateClient'
 import type { SymbolStateDO } from '../trading/state/SymbolStateDO'
 import { FixedRuleStrategy } from '../trading/strategy/strategies/FixedRuleStrategy'
@@ -65,11 +68,13 @@ export function createTradingService(
   env: {
     DRY_RUN?: string
     SYMBOL_STATE?: DurableObjectNamespace<SymbolStateDO>
+    PORTFOLIO_STATE?: DurableObjectNamespace<PortfolioStateDO>
     INVERSE_PAIRS?: string
     SPREAD_LIMIT_PCT_US?: string
     SPREAD_LIMIT_PCT_JP?: string
     STALE_QUOTE_MS?: string
     GAP_REJECT_PCT?: string
+    DRAWDOWN_KILL_THRESHOLD?: string
   } & WebullClientEnv,
 ): TradingService {
   const execution = parseBooleanEnv(env.DRY_RUN, true)
@@ -85,6 +90,9 @@ export function createTradingService(
     execution,
     {
       positionStore: env.SYMBOL_STATE ? new SymbolStateClient(env.SYMBOL_STATE) : undefined,
+      portfolioStore: env.PORTFOLIO_STATE
+        ? new PortfolioStateClient(env.PORTFOLIO_STATE)
+        : undefined,
       inversePairs: parseInversePairs(env.INVERSE_PAIRS),
       spreadLimits: {
         US: spreadUsRaw !== undefined ? spreadUsRaw / 100 : 0.0025,
@@ -92,6 +100,7 @@ export function createTradingService(
       },
       staleQuoteMs: parseOptionalPositiveNumber(env.STALE_QUOTE_MS, 15 * 60 * 1_000, 'STALE_QUOTE_MS'),
       gapRejectPct: parseOptionalPositiveNumber(env.GAP_REJECT_PCT, 0.03, 'GAP_REJECT_PCT'),
+      drawdownKillThreshold: parseDrawdownKillThreshold(env.DRAWDOWN_KILL_THRESHOLD),
     },
   )
 }

--- a/src/trading/application/TradingService.ts
+++ b/src/trading/application/TradingService.ts
@@ -6,6 +6,7 @@ import type { Execution } from '../execution/Execution'
 import type { RiskPolicy } from '../risk/RiskPolicy'
 import { isWithinJpPriceBand } from '../risk/jpPriceBand'
 import { computeSpreadPct } from '../risk/spreadGuard'
+import type { PortfolioStore } from '../state/PortfolioStore'
 import type { PositionStore } from '../state/PositionStore'
 import type { QuoteSnapshot, SymbolState } from '../state/types'
 import type { Strategy, StrategyInput } from '../strategy/Strategy'
@@ -43,6 +44,17 @@ export interface TradeCallContext {
 
 export interface TradingServiceOptions {
   positionStore?: PositionStore
+  /**
+   * Portfolio-level state (daily equity / realized PnL / kill switch). Separate
+   * from {@link PositionStore} because drawdown is account-wide, not per-symbol.
+   */
+  portfolioStore?: PortfolioStore
+  /**
+   * Drawdown threshold as a fraction of `dailyStartEquity`. When
+   * `dailyRealizedPnl / dailyStartEquity <= threshold`, the kill switch arms
+   * and rejects every submit until EOD. Default -0.02 (i.e. -2%).
+   */
+  drawdownKillThreshold?: number
   /** How long a pending-order lock stays live before a new submit can replace it. */
   pendingLockTtlMs?: number
   /**
@@ -73,9 +85,12 @@ const DEFAULT_PENDING_LOCK_TTL_MS = 60_000
 const DEFAULT_SPREAD_LIMITS = { US: 0.0025, JP: 0.006 } as const
 const DEFAULT_STALE_QUOTE_MS = 15 * 60 * 1_000
 const DEFAULT_GAP_REJECT_PCT = 0.03
+const DEFAULT_DRAWDOWN_KILL_THRESHOLD = -0.02
 
 export class TradingService {
   private readonly positionStore?: PositionStore
+  private readonly portfolioStore?: PortfolioStore
+  private readonly drawdownKillThreshold: number
   private readonly pendingLockTtlMs: number
   private readonly inversePairs: Record<string, string>
   private readonly spreadLimits: { US: number; JP: number }
@@ -90,6 +105,13 @@ export class TradingService {
     options: TradingServiceOptions = {},
   ) {
     this.positionStore = options.positionStore
+    this.portfolioStore = options.portfolioStore
+    this.drawdownKillThreshold =
+      options.drawdownKillThreshold !== undefined &&
+      Number.isFinite(options.drawdownKillThreshold) &&
+      options.drawdownKillThreshold < 0
+        ? options.drawdownKillThreshold
+        : DEFAULT_DRAWDOWN_KILL_THRESHOLD
     this.pendingLockTtlMs =
       options.pendingLockTtlMs !== undefined &&
       Number.isFinite(options.pendingLockTtlMs) &&
@@ -220,6 +242,39 @@ export class TradingService {
       return {
         allowed: false,
         riskDecision: appendReason(decision.riskDecision, `cooldown active until ${state.cooldownUntil}`),
+      }
+    }
+
+    // Portfolio-level drawdown kill switch. Fires before pending-lock acquisition
+    // so the lock is never taken when trading is disabled. Unseeded equity
+    // (0) is treated as fail-open so existing flows keep working.
+    if (this.portfolioStore) {
+      const portfolio = await this.portfolioStore.getPortfolio()
+      if (
+        portfolio.tradingDisabledUntil &&
+        new Date(portfolio.tradingDisabledUntil).getTime() > now.getTime()
+      ) {
+        return {
+          allowed: false,
+          riskDecision: appendReason(
+            decision.riskDecision,
+            `trading disabled until ${portfolio.tradingDisabledUntil}`,
+          ),
+        }
+      }
+      if (portfolio.dailyStartEquity > 0) {
+        const ratio = portfolio.dailyRealizedPnl / portfolio.dailyStartEquity
+        if (ratio <= this.drawdownKillThreshold) {
+          const eodIso = endOfUtcDay(now).toISOString()
+          await this.portfolioStore.setTradingDisabledUntil(eodIso).catch(() => undefined)
+          return {
+            allowed: false,
+            riskDecision: appendReason(
+              decision.riskDecision,
+              `daily drawdown kill: realized ${portfolio.dailyRealizedPnl} / start ${portfolio.dailyStartEquity} (ratio ${ratio.toFixed(4)}) <= threshold ${this.drawdownKillThreshold}; disabled until ${eodIso}`,
+            ),
+          }
+        }
       }
     }
 
@@ -381,6 +436,15 @@ function evaluateGap(state: SymbolState, thresholdPct: number): string | null {
     return `gap re-eval: |${gap.toFixed(4)}| > ${thresholdPct} (avgPrice ${position.avgPrice} vs quote ${quote.price})`
   }
   return null
+}
+
+function endOfUtcDay(now: Date): Date {
+  return new Date(Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate(),
+    23, 59, 59, 999,
+  ))
 }
 
 function appendReason(decision: RiskDecision, reason: string): RiskDecision {

--- a/src/trading/events/TradeEventHandler.ts
+++ b/src/trading/events/TradeEventHandler.ts
@@ -1,5 +1,6 @@
 import type { TradeEvent } from '../domain/TradeEvent'
 import { inferTradingMarket, nextTradingDay } from '../domain/tradingCalendar'
+import type { PortfolioStore } from '../state/PortfolioStore'
 import type { PositionStore } from '../state/PositionStore'
 import { logFill, logExit } from '../../infrastructure/logger/tradeJournal'
 
@@ -15,6 +16,11 @@ export interface TradeEventAuditRecord {
 
 export interface TradeEventHandlerOptions {
   positionStore?: PositionStore
+  /**
+   * Portfolio-level store. When provided, SELL realized PnL is accumulated so
+   * the drawdown kill switch can fire at the TradingService gate.
+   */
+  portfolioStore?: PortfolioStore
   now?: () => Date
 }
 
@@ -22,6 +28,7 @@ const MS_PER_DAY = 86_400_000
 
 export class TradeEventHandler {
   private readonly positionStore?: PositionStore
+  private readonly portfolioStore?: PortfolioStore
   private readonly now: () => Date
 
   constructor(
@@ -29,6 +36,7 @@ export class TradeEventHandler {
     options: TradeEventHandlerOptions = {},
   ) {
     this.positionStore = options.positionStore
+    this.portfolioStore = options.portfolioStore
     this.now = options.now ?? (() => new Date())
   }
 
@@ -154,6 +162,20 @@ export class TradeEventHandler {
           holdDays,
           exitReason: 'OTHER',
         })
+
+        // Feed portfolio-level realized PnL so the drawdown kill switch can
+        // fire on the next submit attempt.
+        if (this.portfolioStore) {
+          await this.portfolioStore.applyRealizedPnl(realizedPnl).catch((error) => {
+            this.log(
+              JSON.stringify({
+                warning: 'portfolio-realized-pnl-failed',
+                symbol,
+                message: error instanceof Error ? error.message : String(error),
+              }),
+            )
+          })
+        }
 
         // Stop-out cooldown: a losing exit parks the symbol until the next
         // business day so a whipsaw re-entry cannot compound the loss.

--- a/src/trading/state/PortfolioStateClient.ts
+++ b/src/trading/state/PortfolioStateClient.ts
@@ -1,0 +1,34 @@
+import type { PortfolioStateDO } from './PortfolioStateDO'
+import type { PortfolioStore } from './PortfolioStore'
+import type { PortfolioState } from './portfolioTypes'
+
+const SINGLETON_NAME = 'default'
+
+/**
+ * Thin adapter from {@link DurableObjectNamespace} to {@link PortfolioStore}.
+ * Always routes to a single DO instance (`idFromName('default')`) because
+ * portfolio state is account-wide.
+ */
+export class PortfolioStateClient implements PortfolioStore {
+  constructor(private readonly namespace: DurableObjectNamespace<PortfolioStateDO>) {}
+
+  private stub(): DurableObjectStub<PortfolioStateDO> {
+    return this.namespace.get(this.namespace.idFromName(SINGLETON_NAME))
+  }
+
+  getPortfolio(): Promise<PortfolioState> {
+    return this.stub().getPortfolio()
+  }
+
+  seedDailyStartEquity(amount: number): Promise<PortfolioState> {
+    return this.stub().seedDailyStartEquity(amount)
+  }
+
+  applyRealizedPnl(delta: number): Promise<PortfolioState> {
+    return this.stub().applyRealizedPnl(delta)
+  }
+
+  setTradingDisabledUntil(iso: string | null): Promise<PortfolioState> {
+    return this.stub().setTradingDisabledUntil(iso)
+  }
+}

--- a/src/trading/state/PortfolioStateDO.ts
+++ b/src/trading/state/PortfolioStateDO.ts
@@ -1,0 +1,56 @@
+import { DurableObject } from 'cloudflare:workers'
+import {
+  applyRealizedPnl,
+  seedDailyStartEquity,
+  setTradingDisabledUntil,
+  type PortfolioTransitionContext,
+} from './portfolioStateTransitions'
+import { emptyPortfolioState, type PortfolioState } from './portfolioTypes'
+
+const STATE_KEY = 'portfolio'
+
+/**
+ * Account-level (singleton) state held in a Durable Object. Use a fixed id
+ * (e.g. `PORTFOLIO_STATE.idFromName('default')`) so every caller lands on the
+ * same instance — there is no per-symbol sharding here.
+ */
+export class PortfolioStateDO extends DurableObject<object> {
+  private readonly transitionCtx: PortfolioTransitionContext = { now: () => new Date() }
+
+  async getPortfolio(): Promise<PortfolioState> {
+    return this.load()
+  }
+
+  async seedDailyStartEquity(amount: number): Promise<PortfolioState> {
+    const state = await this.load()
+    const next = seedDailyStartEquity(state, amount, this.transitionCtx)
+    await this.save(next)
+    return next
+  }
+
+  async applyRealizedPnl(delta: number): Promise<PortfolioState> {
+    const state = await this.load()
+    const next = applyRealizedPnl(state, delta, this.transitionCtx)
+    await this.save(next)
+    return next
+  }
+
+  async setTradingDisabledUntil(iso: string | null): Promise<PortfolioState> {
+    const state = await this.load()
+    const next = setTradingDisabledUntil(state, iso, this.transitionCtx)
+    await this.save(next)
+    return next
+  }
+
+  private async load(): Promise<PortfolioState> {
+    const stored = await this.ctx.storage.get<PortfolioState>(STATE_KEY)
+    if (stored !== undefined) {
+      return stored
+    }
+    return emptyPortfolioState(this.transitionCtx.now)
+  }
+
+  private async save(state: PortfolioState): Promise<void> {
+    await this.ctx.storage.put(STATE_KEY, state)
+  }
+}

--- a/src/trading/state/PortfolioStore.ts
+++ b/src/trading/state/PortfolioStore.ts
@@ -1,0 +1,13 @@
+import type { PortfolioState } from './portfolioTypes'
+
+/**
+ * The subset of {@link PortfolioStateDO} that TradingService and
+ * TradeEventHandler need. Kept independent from {@link PositionStore} on
+ * purpose — portfolio-level state is not per-symbol.
+ */
+export interface PortfolioStore {
+  getPortfolio(): Promise<PortfolioState>
+  seedDailyStartEquity(amount: number): Promise<PortfolioState>
+  applyRealizedPnl(delta: number): Promise<PortfolioState>
+  setTradingDisabledUntil(iso: string | null): Promise<PortfolioState>
+}

--- a/src/trading/state/portfolioStateTransitions.ts
+++ b/src/trading/state/portfolioStateTransitions.ts
@@ -1,0 +1,74 @@
+import type { PortfolioState } from './portfolioTypes'
+
+/**
+ * Pure state transitions for {@link PortfolioStateDO}. Split from the DO class
+ * so they are testable without a Durable Object runtime, mirroring the shape of
+ * `stateTransitions.ts` for SymbolState.
+ */
+
+export interface PortfolioTransitionContext {
+  now: () => Date
+}
+
+const defaultCtx: PortfolioTransitionContext = { now: () => new Date() }
+
+/**
+ * Overwrites `dailyStartEquity` with an operator- or EOD-cron-provided value
+ * and resets `dailyRealizedPnl` back to 0. Called once per trading day.
+ */
+export function seedDailyStartEquity(
+  state: PortfolioState,
+  amount: number,
+  ctx: PortfolioTransitionContext = defaultCtx,
+): PortfolioState {
+  if (!Number.isFinite(amount) || amount < 0) {
+    throw new Error(`Invalid seedDailyStartEquity amount: ${amount} (must be a finite number >= 0)`)
+  }
+  return {
+    ...state,
+    dailyStartEquity: amount,
+    dailyRealizedPnl: 0,
+    updatedAt: ctx.now().toISOString(),
+  }
+}
+
+/**
+ * Accumulates realized PnL for the day. Called from TradeEventHandler when a
+ * SELL closes (or partially closes) a position.
+ */
+export function applyRealizedPnl(
+  state: PortfolioState,
+  delta: number,
+  ctx: PortfolioTransitionContext = defaultCtx,
+): PortfolioState {
+  if (!Number.isFinite(delta)) {
+    throw new Error(`Invalid applyRealizedPnl delta: ${delta} (must be a finite number)`)
+  }
+  return {
+    ...state,
+    dailyRealizedPnl: state.dailyRealizedPnl + delta,
+    updatedAt: ctx.now().toISOString(),
+  }
+}
+
+/**
+ * Arms the kill switch by storing an ISO timestamp. While `tradingDisabledUntil`
+ * is in the future, TradingService rejects every submit. Pass `null` to clear.
+ */
+export function setTradingDisabledUntil(
+  state: PortfolioState,
+  iso: string | null,
+  ctx: PortfolioTransitionContext = defaultCtx,
+): PortfolioState {
+  if (iso !== null) {
+    const ms = new Date(iso).getTime()
+    if (!Number.isFinite(ms)) {
+      throw new Error(`Invalid setTradingDisabledUntil iso: ${iso}`)
+    }
+  }
+  return {
+    ...state,
+    tradingDisabledUntil: iso,
+    updatedAt: ctx.now().toISOString(),
+  }
+}

--- a/src/trading/state/portfolioTypes.ts
+++ b/src/trading/state/portfolioTypes.ts
@@ -1,0 +1,18 @@
+export interface PortfolioState {
+  /** Account equity captured at the start of the current trading day. */
+  dailyStartEquity: number
+  /** Cumulative realized PnL since `dailyStartEquity` was seeded. */
+  dailyRealizedPnl: number
+  /** ISO timestamp until which the kill switch blocks submits, or `null` when inactive. */
+  tradingDisabledUntil: string | null
+  updatedAt: string
+}
+
+export function emptyPortfolioState(now: () => Date = () => new Date()): PortfolioState {
+  return {
+    dailyStartEquity: 0,
+    dailyRealizedPnl: 0,
+    tradingDisabledUntil: null,
+    updatedAt: now().toISOString(),
+  }
+}

--- a/test/routes/adminPortfolio.test.ts
+++ b/test/routes/adminPortfolio.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import { createApp } from '../../src/app'
+
+const baseEnv = {
+  BASIC_AUTH_USER: 'admin',
+  BASIC_AUTH_PASSWORD: 'secret',
+  DRY_RUN: 'true',
+  TRADING_ENABLED: 'false',
+  ALLOWED_SYMBOLS: 'SOXL',
+  MAX_ORDER_NOTIONAL: '100',
+  EVENT_INGEST_SECRET: 'change-me',
+}
+
+const authHeader = { Authorization: `Basic ${btoa('admin:secret')}` }
+
+function fakePortfolioState(captured: { calls: Array<{ amount: number }> }) {
+  const stub = {
+    async seedDailyStartEquity(amount: number) {
+      captured.calls.push({ amount })
+      return {
+        dailyStartEquity: amount,
+        dailyRealizedPnl: 0,
+        tradingDisabledUntil: null,
+        updatedAt: '2026-04-21T10:00:00.000Z',
+      }
+    },
+  }
+  return {
+    idFromName: (_name: string) => 'id',
+    get: (_id: string) => stub,
+  } as unknown
+}
+
+describe('POST /admin/portfolio/seed-equity', () => {
+  it('401s without Basic Auth', async () => {
+    const app = createApp()
+    const res = await app.request(
+      '/admin/portfolio/seed-equity',
+      { method: 'POST', body: JSON.stringify({ amount: 100_000 }) },
+      baseEnv,
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it('400s on negative amount', async () => {
+    const app = createApp()
+    const captured = { calls: [] as Array<{ amount: number }> }
+    const res = await app.request(
+      '/admin/portfolio/seed-equity',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeader },
+        body: JSON.stringify({ amount: -1 }),
+      },
+      { ...baseEnv, PORTFOLIO_STATE: fakePortfolioState(captured) },
+    )
+    expect(res.status).toBe(400)
+    expect(captured.calls).toEqual([])
+  })
+
+  it('200s and forwards the amount to PORTFOLIO_STATE.seedDailyStartEquity', async () => {
+    const app = createApp()
+    const captured = { calls: [] as Array<{ amount: number }> }
+    const res = await app.request(
+      '/admin/portfolio/seed-equity',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeader },
+        body: JSON.stringify({ amount: 100_000 }),
+      },
+      { ...baseEnv, PORTFOLIO_STATE: fakePortfolioState(captured) },
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      dailyStartEquity: number
+      dailyRealizedPnl: number
+      tradingDisabledUntil: string | null
+      updatedAt: string
+    }
+    expect(body).toEqual({
+      dailyStartEquity: 100_000,
+      dailyRealizedPnl: 0,
+      tradingDisabledUntil: null,
+      updatedAt: '2026-04-21T10:00:00.000Z',
+    })
+    expect(captured.calls).toEqual([{ amount: 100_000 }])
+  })
+})

--- a/test/trading/application/tradingServiceDrawdown.test.ts
+++ b/test/trading/application/tradingServiceDrawdown.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest'
+import { TradingService, type TradingConfig } from '../../../src/trading/application/TradingService'
+import { MockExecution } from '../../../src/trading/execution/MockExecution'
+import { DefaultRiskPolicy } from '../../../src/trading/risk/DefaultRiskPolicy'
+import type { PortfolioStore } from '../../../src/trading/state/PortfolioStore'
+import type { PositionStore } from '../../../src/trading/state/PositionStore'
+import {
+  emptyPortfolioState,
+  type PortfolioState,
+} from '../../../src/trading/state/portfolioTypes'
+import { emptySymbolState, type SymbolState } from '../../../src/trading/state/types'
+import { FixedRuleStrategy } from '../../../src/trading/strategy/strategies/FixedRuleStrategy'
+
+const fixedNow = new Date('2026-04-20T14:00:00.000Z')
+
+const config: TradingConfig = {
+  dryRun: true,
+  tradingEnabled: true,
+  allowedSymbols: ['SOXL'],
+  maxOrderNotional: 1_000,
+  symbolMaxNotional: {},
+  marketHoursCheck: false,
+}
+
+const buyInput = {
+  symbol: 'SOXL',
+  price: 9,
+  quantity: 3,
+  buyBelow: 10,
+  sellAbove: 20,
+}
+
+function makePositionStore(state: SymbolState): PositionStore {
+  return {
+    async getState() {
+      return state
+    },
+    async lockPendingOrder() {
+      return { ok: true, state }
+    },
+    async clearPendingOrder() {
+      return state
+    },
+    async recordFill() {
+      return state
+    },
+    async addPendingSettlement() {
+      return state
+    },
+    async setCooldown() {
+      return state
+    },
+    async seedSettledCash() {
+      return state
+    },
+  }
+}
+
+function makePortfolioStore(initial: PortfolioState): {
+  store: PortfolioStore
+  captured: { setDisabledCalls: Array<string | null> }
+  current: () => PortfolioState
+} {
+  let current = initial
+  const captured = { setDisabledCalls: [] as Array<string | null> }
+  const store: PortfolioStore = {
+    async getPortfolio() {
+      return current
+    },
+    async seedDailyStartEquity(amount: number) {
+      current = { ...current, dailyStartEquity: amount, dailyRealizedPnl: 0 }
+      return current
+    },
+    async applyRealizedPnl(delta: number) {
+      current = { ...current, dailyRealizedPnl: current.dailyRealizedPnl + delta }
+      return current
+    },
+    async setTradingDisabledUntil(iso: string | null) {
+      captured.setDisabledCalls.push(iso)
+      current = { ...current, tradingDisabledUntil: iso }
+      return current
+    },
+  }
+  return { store, captured, current: () => current }
+}
+
+function makeService(positionStore: PositionStore, portfolioStore: PortfolioStore): TradingService {
+  return new TradingService(
+    new FixedRuleStrategy(buyInput.buyBelow, buyInput.sellAbove),
+    new DefaultRiskPolicy(),
+    new MockExecution(),
+    { positionStore, portfolioStore, now: () => fixedNow },
+  )
+}
+
+describe('TradingService drawdown kill switch', () => {
+  it('rejects BUY when realized PnL breaches the -2% threshold and arms tradingDisabledUntil', async () => {
+    const symbolState = emptySymbolState('SOXL', () => fixedNow)
+    const portfolio: PortfolioState = {
+      ...emptyPortfolioState(() => fixedNow),
+      dailyStartEquity: 100_000,
+      dailyRealizedPnl: -2_000,
+    }
+    const { store, captured } = makePortfolioStore(portfolio)
+
+    const result = await makeService(makePositionStore(symbolState), store).executeTrade(
+      buyInput,
+      config,
+    )
+
+    expect(result.riskDecision.allowed).toBe(false)
+    expect(result.riskDecision.reasons.some((r) => r.includes('daily drawdown kill'))).toBe(true)
+    expect(captured.setDisabledCalls).toHaveLength(1)
+    expect(captured.setDisabledCalls[0]).toMatch(/^2026-04-20T23:59:59\.999Z$/)
+    expect(result.executionResult).toBeUndefined()
+  })
+
+  it('does not reject when realized PnL is above threshold (-1%)', async () => {
+    const symbolState = emptySymbolState('SOXL', () => fixedNow)
+    const portfolio: PortfolioState = {
+      ...emptyPortfolioState(() => fixedNow),
+      dailyStartEquity: 100_000,
+      dailyRealizedPnl: -1_000,
+    }
+    const { store, captured } = makePortfolioStore(portfolio)
+
+    const result = await makeService(makePositionStore(symbolState), store).executeTrade(
+      buyInput,
+      config,
+    )
+
+    expect(result.riskDecision.allowed).toBe(true)
+    expect(captured.setDisabledCalls).toEqual([])
+  })
+
+  it('rejects submits while tradingDisabledUntil is in the future even before threshold is re-evaluated', async () => {
+    const symbolState = emptySymbolState('SOXL', () => fixedNow)
+    const portfolio: PortfolioState = {
+      ...emptyPortfolioState(() => fixedNow),
+      dailyStartEquity: 100_000,
+      dailyRealizedPnl: 0,
+      tradingDisabledUntil: '2026-04-20T23:59:59.999Z',
+    }
+    const { store } = makePortfolioStore(portfolio)
+
+    const result = await makeService(makePositionStore(symbolState), store).executeTrade(
+      buyInput,
+      config,
+    )
+
+    expect(result.riskDecision.allowed).toBe(false)
+    expect(result.riskDecision.reasons.some((r) => r.includes('trading disabled until'))).toBe(true)
+  })
+
+  it('allows the BUY when portfolio equity is unseeded (fail-open)', async () => {
+    const symbolState = emptySymbolState('SOXL', () => fixedNow)
+    const { store } = makePortfolioStore(emptyPortfolioState(() => fixedNow))
+
+    const result = await makeService(makePositionStore(symbolState), store).executeTrade(
+      buyInput,
+      config,
+    )
+
+    expect(result.riskDecision.allowed).toBe(true)
+  })
+})

--- a/test/trading/state/portfolioStateTransitions.test.ts
+++ b/test/trading/state/portfolioStateTransitions.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyRealizedPnl,
+  seedDailyStartEquity,
+  setTradingDisabledUntil,
+} from '../../../src/trading/state/portfolioStateTransitions'
+import { emptyPortfolioState } from '../../../src/trading/state/portfolioTypes'
+
+const fixedNow = () => new Date('2026-04-21T10:00:00.000Z')
+
+describe('portfolioStateTransitions', () => {
+  describe('seedDailyStartEquity', () => {
+    it('overwrites dailyStartEquity, resets realized PnL to 0, bumps updatedAt', () => {
+      const seeded = { ...emptyPortfolioState(fixedNow), dailyRealizedPnl: -500 }
+      const next = seedDailyStartEquity(seeded, 100_000, { now: fixedNow })
+      expect(next.dailyStartEquity).toBe(100_000)
+      expect(next.dailyRealizedPnl).toBe(0)
+      expect(next.updatedAt).toBe('2026-04-21T10:00:00.000Z')
+    })
+
+    it('rejects NaN', () => {
+      expect(() =>
+        seedDailyStartEquity(emptyPortfolioState(fixedNow), NaN, { now: fixedNow }),
+      ).toThrow('Invalid seedDailyStartEquity')
+    })
+
+    it('rejects negative amounts', () => {
+      expect(() =>
+        seedDailyStartEquity(emptyPortfolioState(fixedNow), -1, { now: fixedNow }),
+      ).toThrow('Invalid seedDailyStartEquity')
+    })
+  })
+
+  describe('applyRealizedPnl', () => {
+    it('accumulates deltas (losses and gains)', () => {
+      const s0 = emptyPortfolioState(fixedNow)
+      const s1 = applyRealizedPnl(s0, -1_000, { now: fixedNow })
+      const s2 = applyRealizedPnl(s1, -1_500, { now: fixedNow })
+      const s3 = applyRealizedPnl(s2, 400, { now: fixedNow })
+      expect(s3.dailyRealizedPnl).toBe(-2_100)
+    })
+
+    it('rejects non-finite delta', () => {
+      expect(() =>
+        applyRealizedPnl(emptyPortfolioState(fixedNow), Number.POSITIVE_INFINITY, { now: fixedNow }),
+      ).toThrow('Invalid applyRealizedPnl')
+    })
+  })
+
+  describe('setTradingDisabledUntil', () => {
+    it('accepts a valid ISO timestamp', () => {
+      const next = setTradingDisabledUntil(
+        emptyPortfolioState(fixedNow),
+        '2026-04-21T23:59:59.999Z',
+        { now: fixedNow },
+      )
+      expect(next.tradingDisabledUntil).toBe('2026-04-21T23:59:59.999Z')
+    })
+
+    it('clears on null', () => {
+      const armed = {
+        ...emptyPortfolioState(fixedNow),
+        tradingDisabledUntil: '2026-04-21T23:59:59.999Z',
+      }
+      const next = setTradingDisabledUntil(armed, null, { now: fixedNow })
+      expect(next.tradingDisabledUntil).toBeNull()
+    })
+
+    it('rejects malformed ISO', () => {
+      expect(() =>
+        setTradingDisabledUntil(emptyPortfolioState(fixedNow), 'not-a-date', { now: fixedNow }),
+      ).toThrow('Invalid setTradingDisabledUntil')
+    })
+  })
+})

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -13,11 +13,13 @@
   },
   "durable_objects": {
     "bindings": [
-      { "name": "SYMBOL_STATE", "class_name": "SymbolStateDO" }
+      { "name": "SYMBOL_STATE", "class_name": "SymbolStateDO" },
+      { "name": "PORTFOLIO_STATE", "class_name": "PortfolioStateDO" }
     ]
   },
   "migrations": [
-    { "tag": "v1", "new_sqlite_classes": ["SymbolStateDO"] }
+    { "tag": "v1", "new_sqlite_classes": ["SymbolStateDO"] },
+    { "tag": "v2", "new_sqlite_classes": ["PortfolioStateDO"] }
   ],
   "triggers": {
     "crons": ["*/5 * * * *"]
@@ -32,7 +34,8 @@
       },
       "durable_objects": {
         "bindings": [
-          { "name": "SYMBOL_STATE", "class_name": "SymbolStateDO" }
+          { "name": "SYMBOL_STATE", "class_name": "SymbolStateDO" },
+          { "name": "PORTFOLIO_STATE", "class_name": "PortfolioStateDO" }
         ]
       }
     },
@@ -45,7 +48,8 @@
       },
       "durable_objects": {
         "bindings": [
-          { "name": "SYMBOL_STATE", "class_name": "SymbolStateDO" }
+          { "name": "SYMBOL_STATE", "class_name": "SymbolStateDO" },
+          { "name": "PORTFOLIO_STATE", "class_name": "PortfolioStateDO" }
         ]
       }
     }


### PR DESCRIPTION
closes #50

## 概要

口座 equity が day-start 比で閾値 (既定 -2%) を割ったら、その日 (UTC EOD まで) 当サービス側で新規発注を停止する daily drawdown kill switch を追加。portfolio 状態は新設の `PortfolioStateDO` (account-scoped singleton DO) に持たせる。

## 変更点

- 新 DO `src/trading/state/PortfolioStateDO.ts` + pure transitions (`portfolioStateTransitions.ts`) / types (`portfolioTypes.ts`)
- `PortfolioStore` interface + `PortfolioStateClient` を `SymbolState` と同形で新設 (domain 層には置かず、state 層で独立)
- `wrangler.jsonc`: root / staging / production の 3 env 全てに `PORTFOLIO_STATE` binding を追加、migrations v2 で `new_sqlite_classes: ["PortfolioStateDO"]`
- `TradingService.applyStateGate`: cooldown 直後に portfolio gate を追加
  - `tradingDisabledUntil` が未来なら `trading disabled until ...` で reject
  - `dailyStartEquity > 0` かつ `dailyRealizedPnl / dailyStartEquity <= threshold` なら `setTradingDisabledUntil(EOD UTC ISO)` を呼んで reject
  - threshold default `-0.02`、`drawdownKillThreshold` / `DRAWDOWN_KILL_THRESHOLD` env で override
- `TradeEventHandler`: position closing SELL で算出している realized PnL を optional な `portfolioStore?.applyRealizedPnl(pnl)` に流す
- admin route `POST /admin/portfolio/seed-equity` (Basic Auth 配下、既存 `/admin/symbols/:symbol/seed-cash` と同じ認証チェーン)
- `src/config/env.ts`: `PORTFOLIO_STATE` binding と `DRAWDOWN_KILL_THRESHOLD` optional env + parser

## Safety

- portfolio state 未 seed (`dailyStartEquity === 0`) は fail-open (既存 flow を壊さない)
- threshold parser は non-finite / 非負値を default に fallback (typo 無効化防止)
- drawdown 発火時は pending-order lock 取得 "前" に reject (locks を触らない)
- `setTradingDisabledUntil` 失敗時も reject は継続 (fail-closed)

## 動作確認

- `pnpm run typecheck` pass
- `pnpm test` — 219 tests pass (既存 210 + 新規 9; drawdown transitions 8 / service gate 4 / admin route 3、うち既存 ServiceSettlement 系影響なし)
- 新テスト:
  - `test/trading/state/portfolioStateTransitions.test.ts` seed / applyPnl / setDisabled / validation
  - `test/trading/application/tradingServiceDrawdown.test.ts` day-start 100k + realized -2k BUY reject / -1% 許可 / disabled-until / unseeded fail-open
  - `test/routes/adminPortfolio.test.ts` 401 / 400 / 200

## Out of scope

- EOD 自動 reset cron (別 issue 予定、本 PR は手動 seed 前提)
- account balance API からの自動 seed
- short side / bracketed stop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ポートフォリオレベルの損失管理を追加。日次初期資本の設定・実現損失の追跡が可能になりました。
  * ドローダウン保護を導入。デフォルトで日次-2%を下回ると自動的に取引を停止します（閾値は設定可能）。
  * 管理者向けにポートフォリオの初期資本を設定する新しいエンドポイントを追加。

* **Tests**
  * ポートフォリオ管理・ドローダウン動作を検証するテスト群を追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->