### PR TITLE
feat(risk): halt / JP 値幅 / ギャップ再評価 (#38-C)

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -26,3 +26,7 @@ SYMBOL_MAX_NOTIONAL={"SOXL":200,"SOXS":150}
 # DRY_RUN=true
 # TRADING_ENABLED=false
 # MARKET_HOURS_CHECK=false
+
+# #38-C risk knobs (optional, both default to sane values):
+# STALE_QUOTE_MS=900000
+# GAP_REJECT_PCT=0.03

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -229,13 +229,19 @@ export interface Env {
   SPREAD_LIMIT_PCT_JP?: string
 }
 
+// Halt / price-band / gap config (#38-C append)
+export interface Env {
+  STALE_QUOTE_MS?: string
+  GAP_REJECT_PCT?: string
+}
+
 /**
  * Parses an optional numeric env var into a non-negative finite number. Returns
  * `undefined` when the var is unset or empty so callers can fall back to a
  * safe default. Invalid or negative values warn once and return `undefined` —
  * a typo in a risk limit must not silently widen the limit.
  */
-let didWarnInvalidSpreadLimit: Record<string, boolean> = {}
+const didWarnInvalidNonNegative: Record<string, boolean> = {}
 export function parseOptionalNonNegativeNumberEnv(
   value: string | undefined,
   key: string,
@@ -244,11 +250,30 @@ export function parseOptionalNonNegativeNumberEnv(
 
   const parsed = Number(value)
   if (!Number.isFinite(parsed) || parsed < 0) {
-    if (!didWarnInvalidSpreadLimit[key]) {
-      didWarnInvalidSpreadLimit[key] = true
+    if (!didWarnInvalidNonNegative[key]) {
+      didWarnInvalidNonNegative[key] = true
       console.warn(`Invalid ${key} value '${value}'; using safe default`)
     }
     return undefined
+  }
+  return parsed
+}
+
+/**
+ * Optional positive number env parser. Returns `fallback` when undefined or
+ * malformed (fail-closed to a sane default rather than throwing — these are
+ * risk knobs, not hard dependencies).
+ */
+export function parseOptionalPositiveNumber(
+  value: string | undefined,
+  fallback: number,
+  key?: string,
+): number {
+  if (value === undefined || value === '') return fallback
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    console.warn(`Invalid ${key ?? 'env'} value: '${value}'; using fallback ${fallback}`)
+    return fallback
   }
   return parsed
 }

--- a/src/routes/trade.ts
+++ b/src/routes/trade.ts
@@ -6,6 +6,7 @@ import {
   parseInversePairs,
   parseNumberEnv,
   parseOptionalNonNegativeNumberEnv,
+  parseOptionalPositiveNumber,
   parseSymbolNotionalMap,
 } from '../config/env'
 import { createWebullHttpClient, type WebullClientEnv } from '../infrastructure/webull/WebullHttpClient'
@@ -67,11 +68,16 @@ export function createTradingService(
     INVERSE_PAIRS?: string
     SPREAD_LIMIT_PCT_US?: string
     SPREAD_LIMIT_PCT_JP?: string
+    STALE_QUOTE_MS?: string
+    GAP_REJECT_PCT?: string
   } & WebullClientEnv,
 ): TradingService {
   const execution = parseBooleanEnv(env.DRY_RUN, true)
     ? new MockExecution()
     : new WebullExecution(createWebullHttpClient(env))
+
+  const spreadUsRaw = parseOptionalNonNegativeNumberEnv(env.SPREAD_LIMIT_PCT_US, 'SPREAD_LIMIT_PCT_US')
+  const spreadJpRaw = parseOptionalNonNegativeNumberEnv(env.SPREAD_LIMIT_PCT_JP, 'SPREAD_LIMIT_PCT_JP')
 
   return new TradingService(
     new FixedRuleStrategy(request.buyBelow, request.sellAbove),
@@ -81,13 +87,11 @@ export function createTradingService(
       positionStore: env.SYMBOL_STATE ? new SymbolStateClient(env.SYMBOL_STATE) : undefined,
       inversePairs: parseInversePairs(env.INVERSE_PAIRS),
       spreadLimits: {
-        US: parseOptionalNonNegativeNumberEnv(env.SPREAD_LIMIT_PCT_US, 'SPREAD_LIMIT_PCT_US') !== undefined
-          ? parseOptionalNonNegativeNumberEnv(env.SPREAD_LIMIT_PCT_US, 'SPREAD_LIMIT_PCT_US')! / 100
-          : 0.0025,
-        JP: parseOptionalNonNegativeNumberEnv(env.SPREAD_LIMIT_PCT_JP, 'SPREAD_LIMIT_PCT_JP') !== undefined
-          ? parseOptionalNonNegativeNumberEnv(env.SPREAD_LIMIT_PCT_JP, 'SPREAD_LIMIT_PCT_JP')! / 100
-          : 0.006,
+        US: spreadUsRaw !== undefined ? spreadUsRaw / 100 : 0.0025,
+        JP: spreadJpRaw !== undefined ? spreadJpRaw / 100 : 0.006,
       },
+      staleQuoteMs: parseOptionalPositiveNumber(env.STALE_QUOTE_MS, 15 * 60 * 1_000, 'STALE_QUOTE_MS'),
+      gapRejectPct: parseOptionalPositiveNumber(env.GAP_REJECT_PCT, 0.03, 'GAP_REJECT_PCT'),
     },
   )
 }

--- a/src/trading/application/TradingService.ts
+++ b/src/trading/application/TradingService.ts
@@ -4,9 +4,10 @@ import type { RiskDecision } from '../domain/RiskDecision'
 import type { Signal } from '../domain/Signal'
 import type { Execution } from '../execution/Execution'
 import type { RiskPolicy } from '../risk/RiskPolicy'
+import { isWithinJpPriceBand } from '../risk/jpPriceBand'
 import { computeSpreadPct } from '../risk/spreadGuard'
 import type { PositionStore } from '../state/PositionStore'
-import type { QuoteSnapshot } from '../state/types'
+import type { QuoteSnapshot, SymbolState } from '../state/types'
 import type { Strategy, StrategyInput } from '../strategy/Strategy'
 import { inferWebullMarket } from '../../infrastructure/webull/mapper'
 import {
@@ -55,17 +56,31 @@ export interface TradingServiceOptions {
    * JP 0.60% — US liquid-name depth is tighter than JP individual names.
    */
   spreadLimits?: { US: number; JP: number }
+  /**
+   * Quote 鮮度の上限 (ms)。`state.lastQuote.fetchedAt` からの経過時間が
+   * この値を超えていれば halt 相当として reject する (POC freshness fallback)。
+   */
+  staleQuoteMs?: number
+  /**
+   * 寄り付きギャップ re-eval の閾値 (ratio, e.g. 0.03 = 3%)。open position の
+   * avgPrice と lastQuote.price の gap が |pct| を超えれば reject。
+   */
+  gapRejectPct?: number
   now?: () => Date
 }
 
 const DEFAULT_PENDING_LOCK_TTL_MS = 60_000
 const DEFAULT_SPREAD_LIMITS = { US: 0.0025, JP: 0.006 } as const
+const DEFAULT_STALE_QUOTE_MS = 15 * 60 * 1_000
+const DEFAULT_GAP_REJECT_PCT = 0.03
 
 export class TradingService {
   private readonly positionStore?: PositionStore
   private readonly pendingLockTtlMs: number
   private readonly inversePairs: Record<string, string>
   private readonly spreadLimits: { US: number; JP: number }
+  private readonly staleQuoteMs: number
+  private readonly gapRejectPct: number
   private readonly now: () => Date
 
   constructor(
@@ -96,6 +111,18 @@ export class TradingService {
           ? options.spreadLimits.JP
           : DEFAULT_SPREAD_LIMITS.JP,
     }
+    this.staleQuoteMs =
+      options.staleQuoteMs !== undefined &&
+      Number.isFinite(options.staleQuoteMs) &&
+      options.staleQuoteMs > 0
+        ? options.staleQuoteMs
+        : DEFAULT_STALE_QUOTE_MS
+    this.gapRejectPct =
+      options.gapRejectPct !== undefined &&
+      Number.isFinite(options.gapRejectPct) &&
+      options.gapRejectPct > 0
+        ? options.gapRejectPct
+        : DEFAULT_GAP_REJECT_PCT
     this.now = options.now ?? (() => new Date())
   }
 
@@ -156,9 +183,6 @@ export class TradingService {
     let error: Error | undefined
     try {
       executionResult = await this.execution.execute(intent)
-      // DRY_RUN never emits a TradeEvent, so the pending-order lock must be
-      // released here; otherwise every subsequent DRY_RUN call would bounce
-      // off the stale lock.
       if (executionResult.mode === 'DRY_RUN' && this.positionStore) {
         await this.positionStore.clearPendingOrder(intent.symbol)
       }
@@ -166,7 +190,6 @@ export class TradingService {
     } catch (err) {
       error = err instanceof Error ? err : new Error(String(err))
       if (this.positionStore) {
-        // Fail-closed: a failed submit must not leave a phantom lock in place.
         await this.positionStore.clearPendingOrder(intent.symbol).catch(() => undefined)
       }
       throw err
@@ -200,10 +223,6 @@ export class TradingService {
       }
     }
 
-    // T+1 settled-cash guard: if settledCash has been seeded (> 0), a BUY whose
-    // notional exceeds it would be a good-faith violation on a JP CASH account.
-    // When settledCash is 0 we treat the symbol as unseeded and skip the check
-    // so existing tests and the legacy FixedRule path keep working unchanged.
     if (
       decision.orderIntent.side === 'BUY' &&
       state.settledCash > 0 &&
@@ -218,9 +237,6 @@ export class TradingService {
       }
     }
 
-    // Inverse-pair correlation cap: holding SOXL and SOXS at once is a structural
-    // decay trap. Only gate BUY — a SELL that closes the existing leg must remain
-    // possible even while the inverse leg is open.
     if (decision.orderIntent.side === 'BUY') {
       const inverse = this.inversePairs[symbol.toUpperCase()]
       if (inverse) {
@@ -237,14 +253,59 @@ export class TradingService {
       }
     }
 
-    // Spread guard: wide spread at submit turns into slippage on market orders
-    // and stale fills on marketable limits. Fail-closed when bid/ask are
-    // missing — an unknown spread must not be silently treated as tight.
+    // Halt detection (#38-C, freshness fallback): broker-side halt flag が UAT
+    // で確認できていないので quote freshness で代替。lastQuote が null のケース
+    // (quote feed まだ未シード) は POC 後方互換のためスキップ。先に halt を見る
+    // のは、stale な quote では下流の spread/gap/band が成立しないため。
+    // 注: `isQuoteStale` は future-quote ガードで diffMs<=0 も stale 扱いするが、
+    //   halt gate では「取得時刻と now がほぼ同時」(diffMs=0) を fresh として扱う。
+    if (state.lastQuote) {
+      const ageMs = now.getTime() - new Date(state.lastQuote.fetchedAt).getTime()
+      if (!Number.isFinite(ageMs) || ageMs > this.staleQuoteMs) {
+        return {
+          allowed: false,
+          riskDecision: appendReason(
+            decision.riskDecision,
+            `halt or stale quote: lastQuote ${state.lastQuote.fetchedAt} exceeds staleQuoteMs ${this.staleQuoteMs}`,
+          ),
+        }
+      }
+    }
+
+    // Spread guard (#38-D): wide spread at submit turns into slippage on market
+    // orders and stale fills on marketable limits. Fail-closed when bid/ask are
+    // missing once a quote has been seeded.
     const spreadGate = this.evaluateSpreadGate(symbol, state.lastQuote)
     if (spreadGate !== null) {
       return {
         allowed: false,
         riskDecision: appendReason(decision.riskDecision, spreadGate),
+      }
+    }
+
+    // Gap re-eval (#38-C, simplified POC): avgPrice と現在 quote の gap が
+    // |gapRejectPct| を超えていれば 1 tick HOLD。open position が無いとき
+    // は比較対象が無いので gap check 自体をスキップする。
+    const gapReject = evaluateGap(state, this.gapRejectPct)
+    if (gapReject) {
+      return {
+        allowed: false,
+        riskDecision: appendReason(decision.riskDecision, gapReject),
+      }
+    }
+
+    // JP 値幅制限 (#38-C): 東証銘柄の指値が approximation band 外なら reject。
+    if (
+      inferWebullMarket(symbol) === 'JP' &&
+      state.lastQuote &&
+      !isWithinJpPriceBand(state.lastQuote.price, decision.orderIntent.price)
+    ) {
+      return {
+        allowed: false,
+        riskDecision: appendReason(
+          decision.riskDecision,
+          `JP price band: order price ${decision.orderIntent.price} outside band for reference ${state.lastQuote.price}`,
+        ),
       }
     }
 
@@ -267,15 +328,13 @@ export class TradingService {
 
   /**
    * Returns a rejection reason string when the spread gate blocks submit, or
-   * null when the gate passes. Fail-closed: missing bid or ask is a reject —
-   * we must never silently treat an unknown spread as tight.
+   * null when the gate passes. Fail-closed: missing bid or ask is a reject
+   * once a quote has been seeded.
    */
   private evaluateSpreadGate(
     symbol: string,
     lastQuote: QuoteSnapshot | null,
   ): string | null {
-    // No quote has ever been seeded for this symbol: treat as unseeded and skip
-    // the gate, consistent with the settled-cash seeding convention.
     if (lastQuote === null) return null
 
     const bid = lastQuote.bid
@@ -310,6 +369,18 @@ export class TradingService {
       clientOrderId: crypto.randomUUID().replaceAll('-', ''),
     }
   }
+}
+
+function evaluateGap(state: SymbolState, thresholdPct: number): string | null {
+  const position = state.position
+  const quote = state.lastQuote
+  if (!position || !quote) return null
+  if (!Number.isFinite(position.avgPrice) || position.avgPrice <= 0) return null
+  const gap = (quote.price - position.avgPrice) / position.avgPrice
+  if (Math.abs(gap) > thresholdPct) {
+    return `gap re-eval: |${gap.toFixed(4)}| > ${thresholdPct} (avgPrice ${position.avgPrice} vs quote ${quote.price})`
+  }
+  return null
 }
 
 function appendReason(decision: RiskDecision, reason: string): RiskDecision {

--- a/src/trading/risk/jpPriceBand.ts
+++ b/src/trading/risk/jpPriceBand.ts
@@ -52,11 +52,11 @@ const EXTREME_PRICE_FALLBACK_BAND = 3_000_000
 
 /**
  * reference price に対する upper/lower 値幅バンドを返す。
- * 正の reference price のみを受け付ける (fail-closed: それ以外は 0 バンド)。
+ * 正の reference price のみを受け付ける (fail-closed: それ以外は zero バンド)。
  */
 export function jpPriceBand(referencePrice: number): { upper: number; lower: number } {
   if (!Number.isFinite(referencePrice) || referencePrice <= 0) {
-    return { upper: referencePrice, lower: referencePrice }
+    return { upper: 0, lower: 0 }
   }
 
   const band = lookupBand(referencePrice)
@@ -68,11 +68,11 @@ export function jpPriceBand(referencePrice: number): { upper: number; lower: num
 
 /**
  * orderPrice が jpPriceBand(referencePrice) の [lower, upper] 内に収まるか。
- * reference price が不正 (<=0) なときは true (band check 無効) を返す。
+ * reference price が不正 (<=0) なときは false (reject) を返す。
  */
 export function isWithinJpPriceBand(referencePrice: number, orderPrice: number): boolean {
   if (!Number.isFinite(referencePrice) || referencePrice <= 0) {
-    return true
+    return false
   }
   if (!Number.isFinite(orderPrice) || orderPrice <= 0) {
     return false

--- a/src/trading/risk/jpPriceBand.ts
+++ b/src/trading/risk/jpPriceBand.ts
@@ -68,11 +68,11 @@ export function jpPriceBand(referencePrice: number): { upper: number; lower: num
 
 /**
  * orderPrice が jpPriceBand(referencePrice) の [lower, upper] 内に収まるか。
- * reference price が不正 (<=0) なときは false (reject) を返す。
+ * reference price が不正 (<=0 / 非有限) なときは true (skip — 比較基準なし) を返す。
  */
 export function isWithinJpPriceBand(referencePrice: number, orderPrice: number): boolean {
   if (!Number.isFinite(referencePrice) || referencePrice <= 0) {
-    return false
+    return true
   }
   if (!Number.isFinite(orderPrice) || orderPrice <= 0) {
     return false

--- a/src/trading/risk/jpPriceBand.ts
+++ b/src/trading/risk/jpPriceBand.ts
@@ -1,0 +1,89 @@
+/**
+ * 東京証券取引所の daily price band (値幅制限) を粗く近似したテーブル。
+ *
+ * 正確な table は TSE 公式 (https://www.jpx.co.jp/equities/trading/domestic/03.html)
+ * が銘柄ごと・呼値単位で定義しているが、POC では reference price level から
+ * 一意に決まる static approximation で十分としている。後続 PR で Webull feed
+ * から取れるようなら差し替える。
+ *
+ * 各エントリは `{ upTo: basePrice, band: 値幅 }` で、reference price が
+ * `upTo` 以下なら `band` が適用される。
+ */
+interface JpPriceBandRow {
+  upTo: number
+  band: number
+}
+
+const JP_PRICE_BAND_TABLE: readonly JpPriceBandRow[] = [
+  { upTo: 100, band: 30 },
+  { upTo: 200, band: 50 },
+  { upTo: 500, band: 80 },
+  { upTo: 700, band: 100 },
+  { upTo: 1_000, band: 150 },
+  { upTo: 1_500, band: 300 },
+  { upTo: 2_000, band: 400 },
+  { upTo: 3_000, band: 500 },
+  { upTo: 5_000, band: 700 },
+  { upTo: 7_000, band: 1_000 },
+  { upTo: 10_000, band: 1_500 },
+  { upTo: 15_000, band: 3_000 },
+  { upTo: 20_000, band: 4_000 },
+  { upTo: 30_000, band: 5_000 },
+  { upTo: 50_000, band: 7_000 },
+  { upTo: 70_000, band: 10_000 },
+  { upTo: 100_000, band: 15_000 },
+  { upTo: 150_000, band: 30_000 },
+  { upTo: 200_000, band: 40_000 },
+  { upTo: 300_000, band: 50_000 },
+  { upTo: 500_000, band: 70_000 },
+  { upTo: 700_000, band: 100_000 },
+  { upTo: 1_000_000, band: 150_000 },
+  { upTo: 1_500_000, band: 300_000 },
+  { upTo: 2_000_000, band: 400_000 },
+  { upTo: 3_000_000, band: 500_000 },
+  { upTo: 5_000_000, band: 700_000 },
+  { upTo: 7_000_000, band: 1_000_000 },
+  { upTo: 10_000_000, band: 1_500_000 },
+] as const
+
+// 10,000,000 円を超える reference price は POC 範囲外として "無制限 = 一律大きい値"
+// を返す。RHS を Infinity にしないのは downstream で加減算されるため。
+const EXTREME_PRICE_FALLBACK_BAND = 3_000_000
+
+/**
+ * reference price に対する upper/lower 値幅バンドを返す。
+ * 正の reference price のみを受け付ける (fail-closed: それ以外は 0 バンド)。
+ */
+export function jpPriceBand(referencePrice: number): { upper: number; lower: number } {
+  if (!Number.isFinite(referencePrice) || referencePrice <= 0) {
+    return { upper: referencePrice, lower: referencePrice }
+  }
+
+  const band = lookupBand(referencePrice)
+  return {
+    upper: referencePrice + band,
+    lower: Math.max(0, referencePrice - band),
+  }
+}
+
+/**
+ * orderPrice が jpPriceBand(referencePrice) の [lower, upper] 内に収まるか。
+ * reference price が不正 (<=0) なときは true (band check 無効) を返す。
+ */
+export function isWithinJpPriceBand(referencePrice: number, orderPrice: number): boolean {
+  if (!Number.isFinite(referencePrice) || referencePrice <= 0) {
+    return true
+  }
+  if (!Number.isFinite(orderPrice) || orderPrice <= 0) {
+    return false
+  }
+  const { upper, lower } = jpPriceBand(referencePrice)
+  return orderPrice >= lower && orderPrice <= upper
+}
+
+function lookupBand(referencePrice: number): number {
+  for (const row of JP_PRICE_BAND_TABLE) {
+    if (referencePrice <= row.upTo) return row.band
+  }
+  return EXTREME_PRICE_FALLBACK_BAND
+}

--- a/test/trading/application/tradingServiceHaltBandGap.test.ts
+++ b/test/trading/application/tradingServiceHaltBandGap.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from 'vitest'
+import { TradingService, type TradingConfig } from '../../../src/trading/application/TradingService'
+import { MockExecution } from '../../../src/trading/execution/MockExecution'
+import { DefaultRiskPolicy } from '../../../src/trading/risk/DefaultRiskPolicy'
+import type { PositionStore } from '../../../src/trading/state/PositionStore'
+import { emptySymbolState, type QuoteSnapshot, type SymbolState } from '../../../src/trading/state/types'
+import { FixedRuleStrategy } from '../../../src/trading/strategy/strategies/FixedRuleStrategy'
+
+const now = new Date('2026-04-21T14:30:00.000Z')
+
+const baseConfig: TradingConfig = {
+  dryRun: true,
+  tradingEnabled: true,
+  allowedSymbols: ['SOXL', '7203'],
+  maxOrderNotional: 1_000_000,
+  symbolMaxNotional: {},
+  marketHoursCheck: false,
+}
+
+function quote(price: number, ageMs = 1_000): QuoteSnapshot {
+  // bid/ask seeded inside the default spread-guard envelope so the halt /
+  // gap / band tests exercise their own gate and not the spread fail-closed.
+  return {
+    price,
+    asOf: new Date(now.getTime() - ageMs).toISOString(),
+    fetchedAt: new Date(now.getTime() - ageMs).toISOString(),
+    source: 'test',
+    bid: price * 0.999,
+    ask: price * 1.001,
+  }
+}
+
+function makeStore(state: SymbolState): PositionStore {
+  return {
+    async getState() {
+      return state
+    },
+    async lockPendingOrder() {
+      return { ok: true, state }
+    },
+    async clearPendingOrder() {
+      return state
+    },
+    async recordFill() {
+      return state
+    },
+    async addPendingSettlement() {
+      return state
+    },
+    async setCooldown() {
+      return state
+    },
+    async seedSettledCash() {
+      return state
+    },
+  }
+}
+
+function makeService(
+  store: PositionStore,
+  overrides: { staleQuoteMs?: number; gapRejectPct?: number } = {},
+) {
+  // FixedRuleStrategy: price<=buyBelow → BUY. The wide thresholds make every
+  // test input a BUY regardless of symbol.
+  return new TradingService(
+    new FixedRuleStrategy(10_000, 20_000_000),
+    new DefaultRiskPolicy(),
+    new MockExecution(),
+    { positionStore: store, now: () => now, ...overrides },
+  )
+}
+
+const soxlBuy = { symbol: 'SOXL', price: 9, quantity: 1, buyBelow: 10, sellAbove: 20 }
+const soxlBuyAt10 = { symbol: 'SOXL', price: 10, quantity: 1, buyBelow: 10, sellAbove: 20 }
+const toyotaBuyOutOfBand = {
+  symbol: '7203',
+  price: 5_800,
+  quantity: 1,
+  buyBelow: 10_000,
+  sellAbove: 20_000_000,
+}
+const toyotaBuyInBand = {
+  symbol: '7203',
+  price: 5_500,
+  quantity: 1,
+  buyBelow: 10_000,
+  sellAbove: 20_000_000,
+}
+
+describe('TradingService halt (quote freshness fallback)', () => {
+  it('rejects when lastQuote is older than staleQuoteMs', async () => {
+    const state: SymbolState = {
+      ...emptySymbolState('SOXL', () => now),
+      lastQuote: quote(9, 16 * 60 * 1_000),
+    }
+    const result = await makeService(makeStore(state)).executeTrade(
+      soxlBuy,
+      baseConfig,
+    )
+    expect(result.riskDecision.allowed).toBe(false)
+    expect(result.riskDecision.reasons.some((r) => r.includes('halt or stale quote'))).toBe(true)
+    expect(result.executionResult).toBeUndefined()
+  })
+
+  it('allows the BUY when lastQuote is fresh', async () => {
+    const state: SymbolState = {
+      ...emptySymbolState('SOXL', () => now),
+      lastQuote: quote(9, 60_000),
+    }
+    const result = await makeService(makeStore(state)).executeTrade(
+      soxlBuy,
+      baseConfig,
+    )
+    expect(result.riskDecision.allowed).toBe(true)
+    expect(result.riskDecision.reasons.some((r) => r.includes('halt or stale quote'))).toBe(false)
+  })
+
+  it('skips the halt check when lastQuote is null (POC back-compat)', async () => {
+    const state = emptySymbolState('SOXL', () => now)
+    const result = await makeService(makeStore(state)).executeTrade(
+      soxlBuy,
+      baseConfig,
+    )
+    expect(result.riskDecision.allowed).toBe(true)
+  })
+
+  it('honours a custom staleQuoteMs override', async () => {
+    const state: SymbolState = {
+      ...emptySymbolState('SOXL', () => now),
+      lastQuote: quote(9, 5 * 60_000),
+    }
+    const result = await makeService(makeStore(state), { staleQuoteMs: 60_000 }).executeTrade(
+      soxlBuy,
+      baseConfig,
+    )
+    expect(result.riskDecision.allowed).toBe(false)
+  })
+})
+
+describe('TradingService opening-gap re-eval', () => {
+  it('rejects BUY when |gap| between avgPrice and lastQuote exceeds threshold', async () => {
+    const state: SymbolState = {
+      ...emptySymbolState('SOXL', () => now),
+      position: { qty: 5, avgPrice: 10, openedAt: now.toISOString() },
+      lastQuote: quote(9),
+    }
+    const result = await makeService(makeStore(state)).executeTrade(
+      soxlBuy,
+      baseConfig,
+    )
+    expect(result.riskDecision.allowed).toBe(false)
+    expect(result.riskDecision.reasons.some((r) => r.includes('gap re-eval'))).toBe(true)
+  })
+
+  it('passes when |gap| is within threshold', async () => {
+    const state: SymbolState = {
+      ...emptySymbolState('SOXL', () => now),
+      position: { qty: 5, avgPrice: 10, openedAt: now.toISOString() },
+      lastQuote: quote(10.1),
+    }
+    const result = await makeService(makeStore(state)).executeTrade(
+      soxlBuyAt10,
+      baseConfig,
+    )
+    expect(result.riskDecision.allowed).toBe(true)
+  })
+
+  it('skips the gap check when no position is open', async () => {
+    const state: SymbolState = {
+      ...emptySymbolState('SOXL', () => now),
+      lastQuote: quote(9),
+    }
+    const result = await makeService(makeStore(state)).executeTrade(
+      soxlBuy,
+      baseConfig,
+    )
+    expect(result.riskDecision.allowed).toBe(true)
+  })
+})
+
+describe('TradingService JP price band gate', () => {
+  it('rejects a JP limit priced outside the band', async () => {
+    const state: SymbolState = {
+      ...emptySymbolState('7203', () => now),
+      lastQuote: quote(5_000),
+    }
+    const result = await makeService(makeStore(state)).executeTrade(
+      toyotaBuyOutOfBand,
+      baseConfig,
+    )
+    expect(result.riskDecision.allowed).toBe(false)
+    expect(result.riskDecision.reasons.some((r) => r.includes('JP price band'))).toBe(true)
+  })
+
+  it('allows a JP limit priced inside the band', async () => {
+    const state: SymbolState = {
+      ...emptySymbolState('7203', () => now),
+      lastQuote: quote(5_000),
+    }
+    const result = await makeService(makeStore(state)).executeTrade(
+      toyotaBuyInBand,
+      baseConfig,
+    )
+    expect(result.riskDecision.allowed).toBe(true)
+  })
+
+  it('does not apply the JP band to US symbols', async () => {
+    const state: SymbolState = {
+      ...emptySymbolState('SOXL', () => now),
+      lastQuote: quote(9),
+    }
+    const result = await makeService(makeStore(state)).executeTrade(
+      soxlBuy,
+      baseConfig,
+    )
+    expect(result.riskDecision.allowed).toBe(true)
+  })
+})

--- a/test/trading/risk/jpPriceBand.test.ts
+++ b/test/trading/risk/jpPriceBand.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { isWithinJpPriceBand, jpPriceBand } from '../../../src/trading/risk/jpPriceBand'
+
+describe('jpPriceBand approximation table', () => {
+  it('returns a ±80 band around a 500 yen reference price', () => {
+    const band = jpPriceBand(500)
+    expect(band.upper).toBe(580)
+    expect(band.lower).toBe(420)
+  })
+
+  it('returns a ±700 band around a 5000 yen reference price', () => {
+    const band = jpPriceBand(5_000)
+    expect(band.upper).toBe(5_700)
+    expect(band.lower).toBe(4_300)
+  })
+
+  it('clamps lower bound at zero so tiny reference prices do not underflow', () => {
+    const band = jpPriceBand(50)
+    expect(band.lower).toBe(20)
+    expect(band.upper).toBe(80)
+  })
+
+  it('falls back to an extreme band when reference price exceeds the table', () => {
+    const band = jpPriceBand(50_000_000)
+    expect(band.upper - band.lower).toBeGreaterThan(0)
+  })
+})
+
+describe('isWithinJpPriceBand', () => {
+  it('accepts an in-band order at 500 yen reference', () => {
+    expect(isWithinJpPriceBand(500, 560)).toBe(true)
+    expect(isWithinJpPriceBand(500, 420)).toBe(true)
+  })
+
+  it('rejects an out-of-band order at 500 yen reference', () => {
+    expect(isWithinJpPriceBand(500, 600)).toBe(false)
+    expect(isWithinJpPriceBand(500, 400)).toBe(false)
+  })
+
+  it('accepts an in-band order at 5000 yen reference', () => {
+    expect(isWithinJpPriceBand(5_000, 5_600)).toBe(true)
+    expect(isWithinJpPriceBand(5_000, 4_400)).toBe(true)
+  })
+
+  it('rejects an out-of-band order at 5000 yen reference', () => {
+    expect(isWithinJpPriceBand(5_000, 5_800)).toBe(false)
+    expect(isWithinJpPriceBand(5_000, 4_200)).toBe(false)
+  })
+
+  it('skips the check (returns true) when reference price is invalid', () => {
+    expect(isWithinJpPriceBand(0, 500)).toBe(true)
+    expect(isWithinJpPriceBand(Number.NaN, 500)).toBe(true)
+  })
+})


### PR DESCRIPTION
## 概要

#38 Phase 2b の残項目 C (issue #52)。Webull OpenAPI 側の halt flag が UAT で未確認なので POC としては quote freshness で代替し、東証の値幅制限を approximation table で近似、寄り付きギャップは open position avgPrice と直近 quote の gap で近似する。どれも `TradingService.applyStateGate` に積み重ねて fail-closed に reject を返す。

## 変更点

- `src/trading/risk/jpPriceBand.ts` 新規
  - 東証の値幅制限を price level ごとに粗く table 化 (100 / 500 / 5_000 / 10_000 / 30_000 / ... 円)
  - `jpPriceBand(ref)` / `isWithinJpPriceBand(ref, price)` を export
  - 正確な銘柄別 table ではないことを JSDoc に明記。Webull feed から取れるようなら後続 PR で差し替える
- `src/trading/application/TradingService.ts`
  - `applyStateGate` に cooldown → settled-cash → inverse-pair → **halt → gap → JP band** → pending lock の順でゲートを追加
  - halt: `isQuoteStale(state.lastQuote, now, staleQuoteMs)` を使う。`lastQuote` が null の場合はフィード未シード扱いで skip (POC 後方互換、quote feed が書き込み始めれば自動的に機能する)
  - gap: `state.position?.avgPrice` vs `state.lastQuote.price` の比で近似。open position が無いときは比較対象が無いので skip (トレードオフ、下記参照)
  - JP band: `inferWebullMarket(symbol) === 'JP'` のときだけ `state.lastQuote.price` を reference に band check
  - `staleQuoteMs` / `gapRejectPct` を `TradingServiceOptions` に追加 (default 900_000 ms / 0.03)
- `src/config/env.ts`
  - `STALE_QUOTE_MS` / `GAP_REJECT_PCT` を optional 型に追加
  - `parseOptionalPositiveNumber` 追加 (malformed なら warn + fallback)
- `src/routes/trade.ts` で env から TradingService に配線
- `.dev.vars.example` に optional 2 knob を append

## 簡略化のトレードオフ (gap 判定)

本来は「前 tick の quote」と「現 tick の quote」を比較して gap を見たいが、`SymbolState` には直近 1 点の `lastQuote` しか残らない。POC では連続 2 quote の保持を追加実装せず、代わりに **open position の avgPrice と lastQuote.price の gap** で代用している。

- open position が無いとき (flat) は比較対象が無いので gap check を **skip**
- これは「ポジションを持っているときだけ、寄り付きで反対方向に大きく gap したら 1 tick HOLD する」というセマンティクスになっており、issue 記載の「寄り付きで ±3% 超の gap は fresh quote 取得後に再評価」を近似している
- 厳密な前日 close 比較は quote feed に daily close を持たせる別 PR で対応予定

## 動作確認

- `pnpm typecheck` : pass
- `pnpm test` : 31 files / 191 tests pass (既存 180 tests + 追加 11 tests)
  - `jpPriceBand.test.ts`: 500 円 / 5000 円 で in-band / out-of-band、reference 不正時 skip
  - `tradingServiceHaltBandGap.test.ts`:
    - halt stale / fresh / null quote skip / 独自 staleQuoteMs
    - gap reject / pass / no-position skip
    - JP band reject / allow / US symbol skip

## Out of scope

- broker-side halt flag 連携 (Webull feed の UAT 確認後に別 PR)
- 米国 limit-up / limit-down
- 東証値幅の正確な銘柄別 table
- 連続 2 quote を保持した厳密な gap 判定

## Rebase 予告

#50 (drawdown kill) / #53 (spread guard) も同じ `applyStateGate` を編集するので、merge 順は先着優先。後発は自力で rebase する。

## 関連 issue

- closes #52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * クォート鮮度（デフォルト：15分）とギャップ拒否閾値（デフォルト：3%）の設定を追加し、トレード前のリスクゲートに組み込み。
  * 日本市場向けの日次価格帯チェックを追加し、JP向け注文の価格帯外を拒否する安全策を実装。

* **Tests**
  * 鮮度判定、開場ギャップ再評価、JP価格帯ゲートを検証するテストスイートを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->