### PR TITLE
fix(infra): Workers の global fetch を globalThis に bind

### DIFF
--- a/src/infrastructure/quotes/BarClient.ts
+++ b/src/infrastructure/quotes/BarClient.ts
@@ -41,7 +41,9 @@ export class WebullBarClient implements BarClient {
     this.baseUrl = (options.baseUrl ?? 'https://api.sandbox.webull.hk').replace(/\/+$/, '')
     this.barsPath = options.barsPath ?? '/market-data/candles'
     this.timeoutMs = options.timeoutMs ?? 5_000
-    this.fetchFn = options.fetchFn ?? fetch
+    // Workers の global `fetch` はメソッド呼び出し扱いで `this` を globalThis
+    // にひも付けないと "Illegal invocation" で落ちる。明示的に bind しておく。
+    this.fetchFn = options.fetchFn ?? fetch.bind(globalThis)
   }
 
   async getDailyBars(symbol: string, lookback: number): Promise<DailyBar[]> {

--- a/src/infrastructure/quotes/WebullQuoteClient.ts
+++ b/src/infrastructure/quotes/WebullQuoteClient.ts
@@ -58,7 +58,9 @@ export class WebullQuoteClient {
   constructor(private readonly options: WebullQuoteClientOptions) {
     this.baseUrl = (options.baseUrl ?? 'https://api.sandbox.webull.hk').replace(/\/+$/, '')
     this.timeoutMs = options.timeoutMs ?? 5000
-    this.fetchFn = options.fetchFn ?? fetch
+    // Workers の global `fetch` はメソッド呼び出し扱いで `this` を globalThis
+    // にひも付けないと "Illegal invocation" で落ちる。明示的に bind しておく。
+    this.fetchFn = options.fetchFn ?? fetch.bind(globalThis)
     this.now = options.now ?? (() => new Date())
   }
 

--- a/src/infrastructure/webull/WebullHttpClient.ts
+++ b/src/infrastructure/webull/WebullHttpClient.ts
@@ -38,7 +38,9 @@ export class WebullHttpClient {
     this.baseUrl = (options.baseUrl ?? 'https://api.sandbox.webull.hk').replace(/\/+$/, '')
     this.host = new URL(this.baseUrl).host
     this.timeoutMs = options.timeoutMs ?? 5000
-    this.fetchFn = options.fetchFn ?? fetch
+    // Workers の global `fetch` はメソッド呼び出し扱いで `this` を globalThis
+    // にひも付けないと "Illegal invocation" で落ちる。明示的に bind しておく。
+    this.fetchFn = options.fetchFn ?? fetch.bind(globalThis)
     this.retry = {
       maxAttempts: options.retry?.maxAttempts ?? 3,
       baseDelayMs: options.retry?.baseDelayMs ?? 200,


### PR DESCRIPTION
## 概要

staging cron ログで `quote_feed_run` が連続失敗していた:

```
Webull quote fetch failed: Illegal invocation: function called with incorrect `this` reference.
```

Cloudflare Workers では global `fetch` をプロパティ経由で呼ぶと `this` が undefined になり落ちる ([参考](https://developers.cloudflare.com/workers/observability/errors/#illegal-invocation-errors))。3 client (`WebullHttpClient` / `WebullQuoteClient` / `WebullBarClient`) 全てで同じパターンだったので一括で `fetch.bind(globalThis)` に変更。

## 動作確認

- [x] `pnpm run typecheck`
- [x] `pnpm test` (257 件 pass)
- [ ] staging redeploy 後、cron ログで `quote_feed_run` が `fetched > 0` になることを確認 (要 Webull secret 投入)