### PR TITLE
feat(quotes): WEBULL_QUOTE_PATH env override + default /openapi prefix

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -54,6 +54,8 @@ export interface Env {
   WEBULL_APP_SECRET?: string
   WEBULL_ACCOUNT_ID?: string
   WEBULL_API_BASE?: string
+  /** Override the snapshot endpoint path (POC: UAT 未確定なので env で差し替え). */
+  WEBULL_QUOTE_PATH?: string
 }
 
 // Trading risk config (Phase 5 append)

--- a/src/infrastructure/quotes/WebullQuoteClient.ts
+++ b/src/infrastructure/quotes/WebullQuoteClient.ts
@@ -16,11 +16,18 @@ export interface WebullQuoteClientEnv {
   WEBULL_APP_KEY?: string
   WEBULL_APP_SECRET?: string
   WEBULL_API_BASE?: string
+  /**
+   * Optional override for the snapshot endpoint path. Webull UAT endpoints are
+   * not finalised for this POC, so the path is kept configurable per
+   * environment. Defaults to {@link DEFAULT_QUOTE_PATH}.
+   */
+  WEBULL_QUOTE_PATH?: string
 }
 
 interface WebullQuoteClientOptions {
   auth: WebullAuth
   baseUrl?: string
+  quotePath?: string
   timeoutMs?: number
   fetchFn?: typeof fetch
   now?: () => Date
@@ -41,7 +48,7 @@ interface RawSnapshotEntry {
   ap?: number | string
 }
 
-const QUOTE_PATH = '/market-data/snapshot'
+const DEFAULT_QUOTE_PATH = '/openapi/market/snapshot'
 
 /**
  * Minimal Webull market-data snapshot client. Signs requests with the same
@@ -51,12 +58,14 @@ const QUOTE_PATH = '/market-data/snapshot'
  */
 export class WebullQuoteClient {
   private readonly baseUrl: string
+  private readonly quotePath: string
   private readonly timeoutMs: number
   private readonly fetchFn: typeof fetch
   private readonly now: () => Date
 
   constructor(private readonly options: WebullQuoteClientOptions) {
     this.baseUrl = (options.baseUrl ?? 'https://api.sandbox.webull.hk').replace(/\/+$/, '')
+    this.quotePath = options.quotePath ?? DEFAULT_QUOTE_PATH
     this.timeoutMs = options.timeoutMs ?? 5000
     // Workers の global `fetch` はメソッド呼び出し扱いで `this` を globalThis
     // にひも付けないと "Illegal invocation" で落ちる。明示的に bind しておく。
@@ -68,7 +77,7 @@ export class WebullQuoteClient {
     if (symbols.length === 0) return []
 
     const query = { symbols: symbols.join(','), category }
-    const url = new URL(QUOTE_PATH, `${this.baseUrl}/`)
+    const url = new URL(this.quotePath, `${this.baseUrl}/`)
     for (const [key, value] of Object.entries(query)) {
       url.searchParams.set(key, value)
     }
@@ -85,7 +94,7 @@ export class WebullQuoteClient {
     } catch (error) {
       throw new BrokerRequestError(
         `Webull quote auth failed: ${error instanceof Error ? error.message : String(error)}`,
-        `GET ${QUOTE_PATH}`,
+        `GET ${this.quotePath}`,
         { cause: error instanceof Error ? error : undefined },
       )
     }
@@ -102,7 +111,7 @@ export class WebullQuoteClient {
     } catch (error) {
       throw new BrokerRequestError(
         `Webull quote fetch failed: ${error instanceof Error ? error.message : String(error)}`,
-        `GET ${QUOTE_PATH}`,
+        `GET ${this.quotePath}`,
         { cause: error instanceof Error ? error : undefined },
       )
     } finally {
@@ -112,7 +121,7 @@ export class WebullQuoteClient {
     if (!response.ok) {
       throw new BrokerRequestError(
         `Webull quote request failed with status ${response.status}`,
-        `GET ${QUOTE_PATH}`,
+        `GET ${this.quotePath}`,
       )
     }
 
@@ -122,7 +131,7 @@ export class WebullQuoteClient {
     } catch (error) {
       throw new BrokerRequestError(
         `Webull quote response parse failed: ${error instanceof Error ? error.message : String(error)}`,
-        `GET ${QUOTE_PATH}`,
+        `GET ${this.quotePath}`,
         { cause: error instanceof Error ? error : undefined },
       )
     }
@@ -139,6 +148,7 @@ export function createWebullQuoteClient(
       appSecret: env.WEBULL_APP_SECRET,
     }),
     baseUrl: env.WEBULL_API_BASE,
+    quotePath: env.WEBULL_QUOTE_PATH,
     timeoutMs: options?.timeoutMs,
     fetchFn: options?.fetchFn,
     now: options?.now,


### PR DESCRIPTION
## 概要

staging cron で Webull snapshot が 404:

```
Webull quote request failed with status 404
```

place order (#36) が v2 `/openapi/account/orders/place` を使っているので、snapshot も `/openapi` 配下の可能性が高いと判断。default を `/openapi/market/snapshot` に変更しつつ、UAT で正確な path が確定したら env で即差し替えられるよう `WEBULL_QUOTE_PATH` を追加。

## 変更

- `WEBULL_QUOTE_PATH` env を追加 (optional)
- `WebullQuoteClient` に `quotePath` option を追加、default 変更
- `createWebullQuoteClient` が env から path を受け取る

## 次に UAT で確認すべきこと

- `/openapi/market/snapshot?symbols=SOXL&category=US_STOCK` が 200 を返すか
- 返らない場合 Webull Python SDK の `get_snapshot_request.py` 参照で正しい path を確定
- 正しい path が分かったら `WEBULL_QUOTE_PATH` secret に入れて再デプロイ or 本 PR の default を差し替え

## 動作確認

- [x] `pnpm run typecheck`
- [x] `pnpm test` (257 件 pass)
- [ ] staging redeploy 後、cron ログで status 404 が消えることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Webullブローカーの株価エンドポイントパスを環境変数でカスタマイズできるようになりました。管理者はデフォルトの設定をオーバーライドして、エンドポイントパスを柔軟に設定できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->