### PR TITLE
chore(bridge): Fly.io deploy 配置 (Dockerfile / fly.toml / docs) (#33)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+**/node_modules
+**/.wrangler
+**/.dev.vars
+**/.dev.vars.*
+**/.env
+**/.env.*
+.git
+.github
+.local
+coverage
+dist
+docs
+*.log
+test
+tests

--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1.7
+
+FROM node:24-alpine AS base
+WORKDIR /app
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+
+# --- deps: isolated bridge install ------------------------------------------
+FROM base AS deps
+COPY bridge/package.json bridge/pnpm-lock.yaml /app/bridge/
+WORKDIR /app/bridge
+RUN pnpm install --frozen-lockfile --prod=false
+
+# --- runtime: copy source + deps, run via tsx -------------------------------
+FROM base AS runtime
+# The bridge entry imports two .ts modules from the Worker `src/` tree by
+# relative path (`../../src/infrastructure/webull/TradeEventBridge`,
+# `../../src/trading/domain/TradeEvent`). They are TYPES + one string const —
+# copying the two files keeps the image tight.
+COPY --from=deps /app/bridge/node_modules /app/bridge/node_modules
+COPY bridge/ /app/bridge/
+COPY src/infrastructure/webull/TradeEventBridge.ts /app/src/infrastructure/webull/TradeEventBridge.ts
+COPY src/trading/domain/TradeEvent.ts /app/src/trading/domain/TradeEvent.ts
+
+WORKDIR /app/bridge
+ENV NODE_ENV=production
+CMD ["pnpm", "start"]

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -13,7 +13,7 @@ Node bridge process for Webull trade-event gRPC streaming. It keeps a persistent
 - `EVENT_INGEST_URL` full Worker ingest URL such as `https://<staging-worker>/events/trade`
 - `EVENT_INGEST_SECRET`
 
-## Run
+## Local run
 
 `bridge/` ディレクトリで:
 
@@ -22,4 +22,53 @@ pnpm install
 pnpm start
 ```
 
-The bridge uses TLS by default for the Webull endpoint and reconnects indefinitely with exponential backoff if the stream ends or errors.
+TLS for the Webull endpoint is on by default; the bridge reconnects indefinitely with exponential backoff if the stream ends or errors.
+
+## Deploy to Fly.io
+
+POC では Fly.io を常駐先に選定 (長寿命 gRPC stream 向け、free allowance 内で運用可能)。`fly.toml` は **リポジトリルート** に置いてある。Dockerfile が `src/` を参照するため build context もルートから。
+
+### 初回セットアップ
+
+```bash
+fly auth login                       # 1Password 等から
+fly launch --config fly.toml --no-deploy --copy-config
+# 既存 fly.toml を利用して app 作成。app 名は fly.toml の `app` を編集 or --name で指定
+```
+
+### Secrets 投入 (repo に残さない)
+
+```bash
+fly secrets set \
+  --config fly.toml \
+  WEBULL_APP_KEY="$(op read op://Personal/.../WEBULL_APP_KEY)" \
+  WEBULL_APP_SECRET="$(op read op://Personal/.../WEBULL_APP_SECRET)" \
+  WEBULL_ACCOUNT_ID="$(op read op://Personal/.../WEBULL_ACCOUNT_ID)" \
+  WEBULL_GRPC_ENDPOINT="events-api.sandbox.webull.hk:443" \
+  EVENT_INGEST_URL="https://webull-trading-staging.teacatus.workers.dev/events/trade" \
+  EVENT_INGEST_SECRET="$(op read op://Personal/.../EVENT_INGEST_SECRET)"
+```
+
+### デプロイ
+
+```bash
+fly deploy --config fly.toml
+```
+
+### ログ監視
+
+```bash
+fly logs --config fly.toml
+```
+
+### Production
+
+`app` を `webull-trading-bridge-production` に差し替えて同じ手順。
+
+## Why Fly (not Cloudflare Containers / Cloud Run)
+
+- Cloudflare Containers (β): runtime 仕様が流動的、長寿命 stream は時間制限要確認
+- Cloud Run: gRPC ストリーミング OK だが常駐 billing が pay-as-you-go で割高、1-CPU 上限制約あり
+- Fly.io: 常駐 + gRPC 外向け + NRT region 即配置 + free allowance 内で POC 完結
+
+将来ブリッジ設計が変わって short-lived になれば Cloudflare Workers + Durable Object Alarms に戻す余地あり (現状は gRPC subscribe + reconnect の性質上 Node 常駐が簡潔)。

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,38 @@
+# Fly.io config for the Webull trade-event bridge.
+#
+# Runs as a Docker container — holds a persistent gRPC server-streaming
+# subscription to the Webull sandbox/live endpoint and POSTs normalised
+# events to the Worker `/events/trade` ingest. Outbound-only — no
+# `[services]` block.
+#
+# Deploy:
+#   fly launch --config fly.toml --dockerfile bridge/Dockerfile  # first time
+#   fly deploy --config fly.toml                                 # subsequent
+#
+# Staging / production は `app` 名を切り替えて使う:
+#   fly deploy --config fly.toml --app webull-trading-bridge-staging
+#   fly deploy --config fly.toml --app webull-trading-bridge-production
+
+app = "webull-trading-bridge-staging"
+primary_region = "nrt"
+
+[build]
+  dockerfile = "bridge/Dockerfile"
+
+[env]
+  NODE_ENV = "production"
+  # WEBULL_APP_KEY / WEBULL_APP_SECRET / WEBULL_ACCOUNT_ID /
+  # WEBULL_GRPC_ENDPOINT / EVENT_INGEST_URL / EVENT_INGEST_SECRET
+  # は `fly secrets set` で投入する (repo に残さない)。
+
+[processes]
+  bridge = "pnpm start"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "256mb"
+
+# Restart on exit — the bridge's own reconnect loop handles transient gRPC
+# errors, but any process crash should self-heal.
+[deploy]
+  strategy = "rolling"


### PR DESCRIPTION
## 概要

`bridge/` の常駐先を **Fly.io** に選定し、その deploy に必要な設定を追加。gRPC 長寿命 stream を抱える性質上、Workers の短時間 invocation モデルには乗らないので分離が必須。

## 選定理由

| 候補 | 判定 |
|---|---|
| Fly.io | ✅ 常駐 + gRPC 外向け + NRT region + free allowance 内で POC 完結 |
| Cloudflare Containers (β) | 仕様流動、長寿命 stream 時間制限要確認 |
| Cloud Run | gRPC OK だが常駐 billing が割高 |

将来 bridge が short-lived になれば Workers + Durable Object Alarms に戻す余地あり。

## 変更

- `bridge/Dockerfile` — `node:24-alpine` 2 stage (deps / runtime)。`src/` 配下の shared type 2 本 (`TradeEventBridge.ts` / `TradeEvent.ts`) も同梱
- `.dockerignore` — node_modules / .wrangler / secret / log 系を除外
- `fly.toml` (repo root) — build context をルートに固定、処理 1 プロセス `bridge = pnpm start`、outbound only なので `[services]` なし
- `bridge/README.md` — Fly 設定投入 / deploy / ログ監視手順追加

## scope 外 (follow-up)

- SIGTERM 受信時の grace shutdown (現状プロセス強制終了、reconnect loop で次回起動時に復帰)
- health endpoint (Fly 側の restart policy だけで十分)
- production app の準備 (secret 投入 + `--app webull-trading-bridge-production` で deploy 可能)

## 動作確認

- [x] `bridge/` で `pnpm test` (7 件 pass) / `pnpm run typecheck`
- [ ] `fly launch --config fly.toml --no-deploy --copy-config` で app 作成
- [ ] `fly secrets set ...` で WEBULL_* / EVENT_INGEST_* 投入
- [ ] `fly deploy` → `fly logs` で gRPC subscribe が確立、staging Worker `/events/trade` に到達することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Fly.ioへのデプロイメントサポートを追加しました。

* **ドキュメント**
  * デプロイメントガイドを追加しました。環境設定、秘密情報の管理、デプロイメント手順、ログ監視方法を含みます。

* **チューニング**
  * コンテナイメージの構築設定を追加し、本番環境での実行環境を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->