### PR TITLE
feat(bridge): Cloudflare Containers で Webull gRPC bridge を常駐 (#33)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+**/node_modules
+**/.wrangler
+**/.dev.vars
+**/.dev.vars.*
+**/.env
+**/.env.*
+.git
+.github
+.local
+coverage
+dist
+docs
+*.log

--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -25,6 +25,11 @@ COPY bridge/ /app/bridge/
 COPY src/infrastructure/webull/TradeEventBridge.ts /app/src/infrastructure/webull/TradeEventBridge.ts
 COPY src/trading/domain/TradeEvent.ts /app/src/trading/domain/TradeEvent.ts
 
+# Drop root: outbound-only process, no reason to run as root.
+RUN addgroup -S bridge && adduser -S -G bridge -h /app bridge \
+ && chown -R bridge:bridge /app
+USER bridge
+
 WORKDIR /app/bridge
 ENV NODE_ENV=production
 CMD ["pnpm", "start"]

--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1.7
+#
+# Cloudflare Containers build. `wrangler deploy` uses the repo root as build
+# context (see containers.image in wrangler.jsonc), so paths here are relative
+# to the repo root.
+
+FROM node:24-alpine AS base
+WORKDIR /app
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+
+# --- deps: isolated bridge install ------------------------------------------
+FROM base AS deps
+COPY bridge/package.json bridge/pnpm-lock.yaml /app/bridge/
+WORKDIR /app/bridge
+RUN pnpm install --frozen-lockfile --prod=false
+
+# --- runtime: copy source + deps, run via tsx -------------------------------
+FROM base AS runtime
+# The bridge entry imports two .ts modules from the Worker `src/` tree by
+# relative path (`../../src/infrastructure/webull/TradeEventBridge`,
+# `../../src/trading/domain/TradeEvent`). They are TYPES + one string const —
+# copying the two files keeps the image tight.
+COPY --from=deps /app/bridge/node_modules /app/bridge/node_modules
+COPY bridge/ /app/bridge/
+COPY src/infrastructure/webull/TradeEventBridge.ts /app/src/infrastructure/webull/TradeEventBridge.ts
+COPY src/trading/domain/TradeEvent.ts /app/src/trading/domain/TradeEvent.ts
+
+WORKDIR /app/bridge
+ENV NODE_ENV=production
+CMD ["pnpm", "start"]

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -6,12 +6,18 @@ Runs as a **Cloudflare Container** attached to the `webull-trading` Worker (clas
 
 ## Environment
 
+### Secrets (`wrangler secret put`)
+
 - `WEBULL_APP_KEY`
 - `WEBULL_APP_SECRET`
 - `WEBULL_ACCOUNT_ID`
 - `WEBULL_GRPC_ENDPOINT` default sandbox target is `events-api.sandbox.webull.hk:443`
 - `EVENT_INGEST_URL` full Worker ingest URL such as `https://webull-trading-staging.<subdomain>.workers.dev/events/trade`
 - `EVENT_INGEST_SECRET`
+
+### Plain vars (`wrangler.jsonc` の `vars`)
+
+- `BRIDGE_RUN_MODE` — `auto` (default, 平日 JST のみ起動) / `always-on` / `disabled`。秘匿情報ではないので source-controlled。
 
 Secrets flow Worker `env` (投入は `wrangler secret put`) → `container.start({ envVars })` → container process env。image には焼き込まない。
 

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -8,12 +8,12 @@ Runs as a **Cloudflare Container** attached to the `webull-trading` Worker (clas
 
 ### Secrets (`wrangler secret put`)
 
-- `WEBULL_APP_KEY`
-- `WEBULL_APP_SECRET`
-- `WEBULL_ACCOUNT_ID`
-- `WEBULL_GRPC_ENDPOINT` default sandbox target is `events-api.sandbox.webull.hk:443`
-- `EVENT_INGEST_URL` full Worker ingest URL such as `https://webull-trading-staging.<subdomain>.workers.dev/events/trade`
-- `EVENT_INGEST_SECRET`
+- `WEBULL_APP_KEY` (required)
+- `WEBULL_APP_SECRET` (required)
+- `WEBULL_ACCOUNT_ID` (required)
+- `WEBULL_GRPC_ENDPOINT` (required) — Webull gRPC 疎通先 host:port。`keepBridgeAlive` は未設定だと skip するので必ず投入する。値は 1Password / Webull vendor 資料を参照
+- `EVENT_INGEST_URL` (required) — Worker `/events/trade` の完全 URL。deploy 先 subdomain に合わせる
+- `EVENT_INGEST_SECRET` (required)
 
 ### Plain vars (`wrangler.jsonc` の `vars`)
 

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -2,24 +2,78 @@
 
 Node bridge process for Webull trade-event gRPC streaming. It keeps a persistent server-streaming subscription open against Webull and forwards normalized trade events to the Worker ingest route.
 
-## Environment
+Runs as a **Cloudflare Container** attached to the `webull-trading` Worker (class `BridgeContainer`). Single instance (`max_instances: 1`), started on demand by the Worker's cron handler (`*/5 * * * *` → `keepBridgeAlive(env)`).
 
-`.env.example` をコピーして設定:
+## Environment
 
 - `WEBULL_APP_KEY`
 - `WEBULL_APP_SECRET`
 - `WEBULL_ACCOUNT_ID`
 - `WEBULL_GRPC_ENDPOINT` default sandbox target is `events-api.sandbox.webull.hk:443`
-- `EVENT_INGEST_URL` full Worker ingest URL such as `https://<staging-worker>/events/trade`
+- `EVENT_INGEST_URL` full Worker ingest URL such as `https://webull-trading-staging.<subdomain>.workers.dev/events/trade`
 - `EVENT_INGEST_SECRET`
 
-## Run
+Secrets flow Worker `env` (投入は `wrangler secret put`) → `container.start({ envVars })` → container process env。image には焼き込まない。
 
-`bridge/` ディレクトリで:
+## Local run
+
+`bridge/` ディレクトリで (Cloudflare Container でなく素の Node で動かす):
 
 ```bash
 pnpm install
 pnpm start
 ```
 
-The bridge uses TLS by default for the Webull endpoint and reconnects indefinitely with exponential backoff if the stream ends or errors.
+TLS for the Webull endpoint is on by default; reconnects indefinitely with exponential backoff if the stream ends or errors.
+
+## Deploy (Cloudflare Container 経由)
+
+### 前提
+
+- Docker Desktop (or Colima) が起動していること — `wrangler deploy` が build / push に Docker CLI を呼ぶ
+- Workers Paid plan (Containers は Free tier 非対応)
+
+### Secrets 投入 (staging)
+
+```bash
+for key in WEBULL_APP_KEY WEBULL_APP_SECRET WEBULL_ACCOUNT_ID \
+           WEBULL_GRPC_ENDPOINT EVENT_INGEST_URL EVENT_INGEST_SECRET; do
+  echo "enter $key:"
+  pnpm wrangler secret put "$key" --env=staging
+done
+```
+
+もしくは 1Password + stdin:
+
+```bash
+op read op://Personal/<item>/WEBULL_APP_KEY \
+  | pnpm wrangler secret put WEBULL_APP_KEY --env=staging
+# ...同じく他の key
+```
+
+### Deploy
+
+```bash
+pnpm wrangler deploy --env=staging
+```
+
+`wrangler.jsonc` の `containers[0].image = "./bridge/Dockerfile"` により、build context が repo root 扱いで Docker image が build → Cloudflare Registry に push → `BridgeContainer` DO class にアタッチされる。
+
+### 動作確認
+
+```bash
+pnpm wrangler tail --env=staging --format=pretty
+```
+
+次 cron (`*/5 * * * *`) で以下が順に出れば成功:
+
+1. `{"event":"bridge_keep_alive_ok"}` — Worker が container start を指示
+2. `{"event":"bridge_container_started"}` — Container が立ち上がった
+3. bridge (`grpc/index.ts`) の `console.log` — gRPC subscribe 確立
+4. 実発注 → bridge が fill event を POST → Worker `/events/trade` 200 応答
+
+## 選定理由
+
+- **Cloudflare Containers**: ログが Workers Logs に集約、Workers と 1 dashboard で完結
+- **Fly.io / Cloud Run 不採用**: ログ管理が分散する
+- 注意: Cloudflare Containers (β) は host restart がたまに発生する (日次レベル) 前提。Bridge 側の reconnect loop + Worker cron keep-alive でカバー

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "accounts": "tsx scripts/list-webull-accounts.ts"
   },
   "dependencies": {
+    "@cloudflare/containers": "^0.3.2",
     "hono": "^4.12.14"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@cloudflare/containers':
+        specifier: ^0.3.2
+        version: 0.3.2
       hono:
         specifier: ^4.12.14
         version: 4.12.14
@@ -29,6 +32,9 @@ importers:
         version: 4.83.0(@cloudflare/workers-types@4.20260417.1)
 
 packages:
+
+  '@cloudflare/containers@0.3.2':
+    resolution: {integrity: sha512-hWobJrpXCgFJ/HYii6E49eegnnlUDWGacjLd0Fb6nQwTD005+T2eHUPI6qOEq9KPJOd7xTWkhkuXEKxDFvfyqQ==}
 
   '@cloudflare/kv-asset-handler@0.4.2':
     resolution: {integrity: sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==}
@@ -1016,6 +1022,8 @@ packages:
     resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
 snapshots:
+
+  '@cloudflare/containers@0.3.2': {}
 
   '@cloudflare/kv-asset-handler@0.4.2': {}
 

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -257,10 +257,10 @@ export interface Env {
   WEBULL_GRPC_ENDPOINT?: string
   EVENT_INGEST_URL?: string
   /**
-   * `"true"` → 24/7 常駐。`"false"` → kill-switch、container を常に stop。
-   * 省略時は auto: 平日 UTC のみ起動 (土日は停止)。
+   * Bridge lifecycle policy — see {@link BridgeRunMode} (`always-on` /
+   * `disabled` / `auto`). 省略時は `auto`: 平日 UTC のみ起動。
    */
-  BRIDGE_ALWAYS_ON?: string
+  BRIDGE_RUN_MODE?: string
 }
 
 /**

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -249,6 +249,15 @@ export interface Env {
   DRAWDOWN_KILL_THRESHOLD?: string
 }
 
+// Bridge container binding (#33 append)
+import type { BridgeContainer } from '../trading/bridge/BridgeContainer'
+
+export interface Env {
+  BRIDGE?: DurableObjectNamespace<BridgeContainer>
+  WEBULL_GRPC_ENDPOINT?: string
+  EVENT_INGEST_URL?: string
+}
+
 /**
  * Parses an optional numeric env var into a non-negative finite number. Returns
  * `undefined` when the var is unset or empty so callers can fall back to a

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -256,6 +256,11 @@ export interface Env {
   BRIDGE?: DurableObjectNamespace<BridgeContainer>
   WEBULL_GRPC_ENDPOINT?: string
   EVENT_INGEST_URL?: string
+  /**
+   * `"true"` → 24/7 常駐。`"false"` → kill-switch、container を常に stop。
+   * 省略時は auto: 平日 UTC のみ起動 (土日は停止)。
+   */
+  BRIDGE_ALWAYS_ON?: string
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,6 @@ export default {
         },
       ),
     )
-    ctx.waitUntil(keepBridgeAlive(env))
+    ctx.waitUntil(keepBridgeAlive(env, { requestId }))
   },
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,11 @@
 import { createApp } from './app'
 import type { Env } from './config/env'
+import { keepBridgeAlive } from './trading/bridge/bridgeKeepAlive'
 import { runQuoteFeed } from './trading/quotes/quoteScheduler'
 
 export { SymbolStateDO } from './trading/state/SymbolStateDO'
 export { PortfolioStateDO } from './trading/state/PortfolioStateDO'
+export { BridgeContainer } from './trading/bridge/BridgeContainer'
 
 const app = createApp()
 
@@ -36,5 +38,6 @@ export default {
         },
       ),
     )
+    ctx.waitUntil(keepBridgeAlive(env))
   },
 }

--- a/src/trading/bridge/BridgeContainer.ts
+++ b/src/trading/bridge/BridgeContainer.ts
@@ -1,0 +1,45 @@
+import { Container } from '@cloudflare/containers'
+
+/**
+ * Always-on (best-effort) Webull gRPC trade-event bridge, run as a Cloudflare
+ * Container instance. The Worker's cron handler pings `start()` every 5 min so
+ * that if the host has been restarted or the container has been swept for
+ * inactivity, it comes back without operator intervention. Cloudflare does not
+ * guarantee arbitrary-length process lifetime, so the bridge Node entry still
+ * holds its own reconnect loop inside.
+ *
+ * Secrets (WEBULL_APP_KEY / _SECRET / _ACCOUNT_ID, WEBULL_GRPC_ENDPOINT,
+ * EVENT_INGEST_URL, EVENT_INGEST_SECRET) flow from Worker `env` → `.start({
+ * envVars: { ... } })` → container process env. They are never baked into the
+ * image.
+ */
+export class BridgeContainer extends Container {
+  // Outbound-only: no inbound HTTP. `defaultPort` omitted.
+  override sleepAfter = '24h'
+  override enableInternet = true
+
+  override onStart() {
+    console.log(JSON.stringify({ event: 'bridge_container_started', at: new Date().toISOString() }))
+  }
+
+  override onStop(params: { exitCode: number; reason: string }) {
+    console.log(
+      JSON.stringify({
+        event: 'bridge_container_stopped',
+        at: new Date().toISOString(),
+        exitCode: params.exitCode,
+        reason: params.reason,
+      }),
+    )
+  }
+
+  override onError(error: unknown) {
+    console.error(
+      JSON.stringify({
+        event: 'bridge_container_error',
+        at: new Date().toISOString(),
+        message: error instanceof Error ? error.message : String(error),
+      }),
+    )
+  }
+}

--- a/src/trading/bridge/bridgeKeepAlive.ts
+++ b/src/trading/bridge/bridgeKeepAlive.ts
@@ -1,5 +1,6 @@
 import { getContainer } from '@cloudflare/containers'
 import type { BridgeContainer } from './BridgeContainer'
+import { isBridgeActive } from './schedule'
 
 export interface BridgeKeepAliveEnv {
   BRIDGE?: DurableObjectNamespace<BridgeContainer>
@@ -9,12 +10,18 @@ export interface BridgeKeepAliveEnv {
   WEBULL_GRPC_ENDPOINT?: string
   EVENT_INGEST_URL?: string
   EVENT_INGEST_SECRET?: string
+  /**
+   * `"true"` → always keep the container up (ignore schedule).
+   * `"false"` → never start the container (kill-switch).
+   * Anything else / missing → auto (weekdays UTC only, weekends skipped).
+   */
+  BRIDGE_ALWAYS_ON?: string
 }
 
 /**
- * Called from the Worker cron handler. Ensures the single bridge container
- * instance is running and has the current set of secrets. Idempotent: if the
- * container is already up, `start()` is a no-op.
+ * Called from the Worker cron handler. On active hours ensures the single
+ * bridge container instance is running; on inactive hours issues a stop() so
+ * idle time is not billed. Idempotent in both directions.
  *
  * Fails open — any error is logged and swallowed so the rest of the scheduled
  * handler (e.g. quote feed) is unaffected.
@@ -22,6 +29,17 @@ export interface BridgeKeepAliveEnv {
 export async function keepBridgeAlive(env: BridgeKeepAliveEnv): Promise<void> {
   if (!env.BRIDGE) {
     console.log(JSON.stringify({ event: 'bridge_keep_alive_skipped', reason: 'BRIDGE binding missing' }))
+    return
+  }
+
+  if (env.BRIDGE_ALWAYS_ON === 'false') {
+    await stopContainer(env, 'kill-switch')
+    return
+  }
+
+  const activeNow = env.BRIDGE_ALWAYS_ON === 'true' || isBridgeActive(new Date())
+  if (!activeNow) {
+    await stopContainer(env, 'outside market hours')
     return
   }
 
@@ -40,8 +58,6 @@ export async function keepBridgeAlive(env: BridgeKeepAliveEnv): Promise<void> {
   }
 
   try {
-    // Single bridge instance — not a per-symbol DO. Pin the name so every
-    // Worker invocation lands on the same container stub.
     const container = getContainer(env.BRIDGE, 'default')
     await container.start({
       envVars: {
@@ -59,6 +75,27 @@ export async function keepBridgeAlive(env: BridgeKeepAliveEnv): Promise<void> {
       JSON.stringify({
         event: 'bridge_keep_alive_error',
         at: new Date().toISOString(),
+        message: error instanceof Error ? error.message : String(error),
+      }),
+    )
+  }
+}
+
+async function stopContainer(env: BridgeKeepAliveEnv, reason: string): Promise<void> {
+  if (!env.BRIDGE) return
+  try {
+    const container = getContainer(env.BRIDGE, 'default')
+    await container.stop()
+    console.log(
+      JSON.stringify({ event: 'bridge_keep_alive_stopped', at: new Date().toISOString(), reason }),
+    )
+  } catch (error) {
+    // `stop()` against a container that was never started is not exceptional;
+    // swallow silently at debug level.
+    console.log(
+      JSON.stringify({
+        event: 'bridge_keep_alive_stop_noop',
+        reason,
         message: error instanceof Error ? error.message : String(error),
       }),
     )

--- a/src/trading/bridge/bridgeKeepAlive.ts
+++ b/src/trading/bridge/bridgeKeepAlive.ts
@@ -1,6 +1,6 @@
 import { getContainer } from '@cloudflare/containers'
 import type { BridgeContainer } from './BridgeContainer'
-import { isBridgeActive } from './schedule'
+import { isBridgeActive, parseBridgeRunMode } from './schedule'
 
 export interface BridgeKeepAliveEnv {
   BRIDGE?: DurableObjectNamespace<BridgeContainer>
@@ -10,12 +10,8 @@ export interface BridgeKeepAliveEnv {
   WEBULL_GRPC_ENDPOINT?: string
   EVENT_INGEST_URL?: string
   EVENT_INGEST_SECRET?: string
-  /**
-   * `"true"` → always keep the container up (ignore schedule).
-   * `"false"` → never start the container (kill-switch).
-   * Anything else / missing → auto (weekdays UTC only, weekends skipped).
-   */
-  BRIDGE_ALWAYS_ON?: string
+  /** See {@link BridgeRunMode}: `always-on` / `disabled` / `auto` (default). */
+  BRIDGE_RUN_MODE?: string
 }
 
 /**
@@ -32,14 +28,10 @@ export async function keepBridgeAlive(env: BridgeKeepAliveEnv): Promise<void> {
     return
   }
 
-  if (env.BRIDGE_ALWAYS_ON === 'false') {
-    await stopContainer(env, 'kill-switch')
-    return
-  }
+  const mode = parseBridgeRunMode(env.BRIDGE_RUN_MODE)
 
-  const activeNow = env.BRIDGE_ALWAYS_ON === 'true' || isBridgeActive(new Date())
-  if (!activeNow) {
-    await stopContainer(env, 'outside market hours')
+  if (!isBridgeActive(new Date(), mode)) {
+    await stopContainer(env, mode === 'disabled' ? 'kill-switch' : 'outside market hours')
     return
   }
 
@@ -69,7 +61,9 @@ export async function keepBridgeAlive(env: BridgeKeepAliveEnv): Promise<void> {
         EVENT_INGEST_SECRET: env.EVENT_INGEST_SECRET!,
       },
     })
-    console.log(JSON.stringify({ event: 'bridge_keep_alive_ok', at: new Date().toISOString() }))
+    console.log(
+      JSON.stringify({ event: 'bridge_keep_alive_ok', at: new Date().toISOString(), mode }),
+    )
   } catch (error) {
     console.error(
       JSON.stringify({

--- a/src/trading/bridge/bridgeKeepAlive.ts
+++ b/src/trading/bridge/bridgeKeepAlive.ts
@@ -14,6 +14,11 @@ export interface BridgeKeepAliveEnv {
   BRIDGE_RUN_MODE?: string
 }
 
+export interface KeepBridgeAliveOptions {
+  /** Correlates every log line emitted by a single cron tick. */
+  requestId?: string
+}
+
 /**
  * Called from the Worker cron handler. On active hours ensures the single
  * bridge container instance is running; on inactive hours issues a stop() so
@@ -22,16 +27,30 @@ export interface BridgeKeepAliveEnv {
  * Fails open — any error is logged and swallowed so the rest of the scheduled
  * handler (e.g. quote feed) is unaffected.
  */
-export async function keepBridgeAlive(env: BridgeKeepAliveEnv): Promise<void> {
+export async function keepBridgeAlive(
+  env: BridgeKeepAliveEnv,
+  options: KeepBridgeAliveOptions = {},
+): Promise<void> {
+  const requestId = options.requestId ?? crypto.randomUUID()
+
   if (!env.BRIDGE) {
-    console.log(JSON.stringify({ event: 'bridge_keep_alive_skipped', reason: 'BRIDGE binding missing' }))
+    console.log(
+      JSON.stringify({
+        event: 'bridge_keep_alive_skipped',
+        requestId,
+        reason: 'BRIDGE binding missing',
+      }),
+    )
     return
   }
 
   const mode = parseBridgeRunMode(env.BRIDGE_RUN_MODE)
 
   if (!isBridgeActive(new Date(), mode)) {
-    await stopContainer(env, mode === 'disabled' ? 'kill-switch' : 'outside market hours')
+    await stopContainer(env, {
+      requestId,
+      reason: mode === 'disabled' ? 'kill-switch' : 'outside market hours',
+    })
     return
   }
 
@@ -42,6 +61,7 @@ export async function keepBridgeAlive(env: BridgeKeepAliveEnv): Promise<void> {
     console.log(
       JSON.stringify({
         event: 'bridge_keep_alive_skipped',
+        requestId,
         reason: 'required secret missing',
         missing,
       }),
@@ -62,12 +82,18 @@ export async function keepBridgeAlive(env: BridgeKeepAliveEnv): Promise<void> {
       },
     })
     console.log(
-      JSON.stringify({ event: 'bridge_keep_alive_ok', at: new Date().toISOString(), mode }),
+      JSON.stringify({
+        event: 'bridge_keep_alive_ok',
+        requestId,
+        at: new Date().toISOString(),
+        mode,
+      }),
     )
   } catch (error) {
     console.error(
       JSON.stringify({
         event: 'bridge_keep_alive_error',
+        requestId,
         at: new Date().toISOString(),
         message: error instanceof Error ? error.message : String(error),
       }),
@@ -75,13 +101,21 @@ export async function keepBridgeAlive(env: BridgeKeepAliveEnv): Promise<void> {
   }
 }
 
-async function stopContainer(env: BridgeKeepAliveEnv, reason: string): Promise<void> {
+async function stopContainer(
+  env: BridgeKeepAliveEnv,
+  ctx: { requestId: string; reason: string },
+): Promise<void> {
   if (!env.BRIDGE) return
   try {
     const container = getContainer(env.BRIDGE, 'default')
     await container.stop()
     console.log(
-      JSON.stringify({ event: 'bridge_keep_alive_stopped', at: new Date().toISOString(), reason }),
+      JSON.stringify({
+        event: 'bridge_keep_alive_stopped',
+        requestId: ctx.requestId,
+        at: new Date().toISOString(),
+        reason: ctx.reason,
+      }),
     )
   } catch (error) {
     // `stop()` against a container that was never started is not exceptional;
@@ -89,7 +123,8 @@ async function stopContainer(env: BridgeKeepAliveEnv, reason: string): Promise<v
     console.log(
       JSON.stringify({
         event: 'bridge_keep_alive_stop_noop',
-        reason,
+        requestId: ctx.requestId,
+        reason: ctx.reason,
         message: error instanceof Error ? error.message : String(error),
       }),
     )

--- a/src/trading/bridge/bridgeKeepAlive.ts
+++ b/src/trading/bridge/bridgeKeepAlive.ts
@@ -1,0 +1,75 @@
+import { getContainer } from '@cloudflare/containers'
+import type { BridgeContainer } from './BridgeContainer'
+
+export interface BridgeKeepAliveEnv {
+  BRIDGE?: DurableObjectNamespace<BridgeContainer>
+  WEBULL_APP_KEY?: string
+  WEBULL_APP_SECRET?: string
+  WEBULL_ACCOUNT_ID?: string
+  WEBULL_GRPC_ENDPOINT?: string
+  EVENT_INGEST_URL?: string
+  EVENT_INGEST_SECRET?: string
+}
+
+/**
+ * Called from the Worker cron handler. Ensures the single bridge container
+ * instance is running and has the current set of secrets. Idempotent: if the
+ * container is already up, `start()` is a no-op.
+ *
+ * Fails open — any error is logged and swallowed so the rest of the scheduled
+ * handler (e.g. quote feed) is unaffected.
+ */
+export async function keepBridgeAlive(env: BridgeKeepAliveEnv): Promise<void> {
+  if (!env.BRIDGE) {
+    console.log(JSON.stringify({ event: 'bridge_keep_alive_skipped', reason: 'BRIDGE binding missing' }))
+    return
+  }
+
+  const missing = requiredSecrets
+    .filter((key) => !env[key] || String(env[key]).length === 0)
+    .map((key) => key as string)
+  if (missing.length > 0) {
+    console.log(
+      JSON.stringify({
+        event: 'bridge_keep_alive_skipped',
+        reason: 'required secret missing',
+        missing,
+      }),
+    )
+    return
+  }
+
+  try {
+    // Single bridge instance — not a per-symbol DO. Pin the name so every
+    // Worker invocation lands on the same container stub.
+    const container = getContainer(env.BRIDGE, 'default')
+    await container.start({
+      envVars: {
+        WEBULL_APP_KEY: env.WEBULL_APP_KEY!,
+        WEBULL_APP_SECRET: env.WEBULL_APP_SECRET!,
+        WEBULL_ACCOUNT_ID: env.WEBULL_ACCOUNT_ID!,
+        WEBULL_GRPC_ENDPOINT: env.WEBULL_GRPC_ENDPOINT!,
+        EVENT_INGEST_URL: env.EVENT_INGEST_URL!,
+        EVENT_INGEST_SECRET: env.EVENT_INGEST_SECRET!,
+      },
+    })
+    console.log(JSON.stringify({ event: 'bridge_keep_alive_ok', at: new Date().toISOString() }))
+  } catch (error) {
+    console.error(
+      JSON.stringify({
+        event: 'bridge_keep_alive_error',
+        at: new Date().toISOString(),
+        message: error instanceof Error ? error.message : String(error),
+      }),
+    )
+  }
+}
+
+const requiredSecrets = [
+  'WEBULL_APP_KEY',
+  'WEBULL_APP_SECRET',
+  'WEBULL_ACCOUNT_ID',
+  'WEBULL_GRPC_ENDPOINT',
+  'EVENT_INGEST_URL',
+  'EVENT_INGEST_SECRET',
+] as const satisfies ReadonlyArray<keyof BridgeKeepAliveEnv>

--- a/src/trading/bridge/schedule.ts
+++ b/src/trading/bridge/schedule.ts
@@ -1,0 +1,12 @@
+/**
+ * Active = weekday in UTC. 土日は両市場とも休場なので bridge も止めて
+ * Cloudflare Container の課金を削る。US / JP の祝日カレンダーは #54 系で
+ * 別途カバー。`BRIDGE_ALWAYS_ON=true` で override 可能。
+ *
+ * Kept as a dependency-free module so it can be unit-tested without pulling
+ * in the `@cloudflare/containers` runtime.
+ */
+export function isBridgeActive(now: Date): boolean {
+  const utcDay = now.getUTCDay()
+  return utcDay >= 1 && utcDay <= 5
+}

--- a/src/trading/bridge/schedule.ts
+++ b/src/trading/bridge/schedule.ts
@@ -27,13 +27,17 @@ export function parseBridgeRunMode(value: string | undefined): BridgeRunMode {
   return DEFAULT_MODE
 }
 
+const JST_OFFSET_MS = 9 * 60 * 60 * 1_000
+
 /**
- * True when the bridge should be running now. 平日 UTC のみ true を返す。
- * 祝日カレンダーは #54 系で強化予定。
+ * True when the bridge should be running now. 平日 **JST** のみ true を返す。
+ * JP 市場の営業日境界が UTC だと日跨ぎするため、JST で判定した方が運用感覚に
+ * 一致する (e.g. 土曜 0:30 JST は UTC で金曜 15:30、UTC 判定だと平日扱いに
+ * なり bridge を動かしてしまう)。祝日カレンダーは #54 系で強化予定。
  */
 export function isBridgeActive(now: Date, mode: BridgeRunMode = 'auto'): boolean {
   if (mode === 'always-on') return true
   if (mode === 'disabled') return false
-  const utcDay = now.getUTCDay()
-  return utcDay >= 1 && utcDay <= 5
+  const jstDay = new Date(now.getTime() + JST_OFFSET_MS).getUTCDay()
+  return jstDay >= 1 && jstDay <= 5
 }

--- a/src/trading/bridge/schedule.ts
+++ b/src/trading/bridge/schedule.ts
@@ -1,12 +1,39 @@
 /**
- * Active = weekday in UTC. 土日は両市場とも休場なので bridge も止めて
- * Cloudflare Container の課金を削る。US / JP の祝日カレンダーは #54 系で
- * 別途カバー。`BRIDGE_ALWAYS_ON=true` で override 可能。
+ * Bridge lifecycle policy.
+ *
+ * - `always-on`: ignore schedule, keep the container running 24/7
+ * - `disabled`: kill switch — stop the container every tick
+ * - `auto` (default): start on weekdays UTC, stop on weekends
  *
  * Kept as a dependency-free module so it can be unit-tested without pulling
  * in the `@cloudflare/containers` runtime.
  */
-export function isBridgeActive(now: Date): boolean {
+export const BRIDGE_RUN_MODES = ['always-on', 'disabled', 'auto'] as const
+export type BridgeRunMode = (typeof BRIDGE_RUN_MODES)[number]
+
+const DEFAULT_MODE: BridgeRunMode = 'auto'
+
+/**
+ * Parses the `BRIDGE_RUN_MODE` env string into the enum. Unknown / undefined
+ * values fall back to `auto` — never throw, because this is a non-critical
+ * knob and staging should not break on a typo.
+ */
+export function parseBridgeRunMode(value: string | undefined): BridgeRunMode {
+  if (value === undefined || value === '') return DEFAULT_MODE
+  if ((BRIDGE_RUN_MODES as readonly string[]).includes(value)) {
+    return value as BridgeRunMode
+  }
+  console.warn(`Invalid BRIDGE_RUN_MODE '${value}'; using '${DEFAULT_MODE}'`)
+  return DEFAULT_MODE
+}
+
+/**
+ * True when the bridge should be running now. 平日 UTC のみ true を返す。
+ * 祝日カレンダーは #54 系で強化予定。
+ */
+export function isBridgeActive(now: Date, mode: BridgeRunMode = 'auto'): boolean {
+  if (mode === 'always-on') return true
+  if (mode === 'disabled') return false
   const utcDay = now.getUTCDay()
   return utcDay >= 1 && utcDay <= 5
 }

--- a/src/trading/bridge/schedule.ts
+++ b/src/trading/bridge/schedule.ts
@@ -3,7 +3,7 @@
  *
  * - `always-on`: ignore schedule, keep the container running 24/7
  * - `disabled`: kill switch — stop the container every tick
- * - `auto` (default): start on weekdays UTC, stop on weekends
+ * - `auto` (default): 平日 JST に起動、週末は停止
  *
  * Kept as a dependency-free module so it can be unit-tested without pulling
  * in the `@cloudflare/containers` runtime.

--- a/test/trading/bridge/schedule.test.ts
+++ b/test/trading/bridge/schedule.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it, vi } from 'vitest'
 import { isBridgeActive, parseBridgeRunMode } from '../../../src/trading/bridge/schedule'
 
-const weekday = new Date('2026-04-20T12:00:00.000Z') // Mon
-const weekend = new Date('2026-04-25T12:00:00.000Z') // Sat
+const monJstNoon = new Date('2026-04-20T03:00:00.000Z') // Mon 12:00 JST
+const satJstMidnight = new Date('2026-04-24T15:00:00.000Z') // Sat 00:00 JST (= Fri 15:00 UTC)
+const monJstMidnight = new Date('2026-04-26T15:00:00.000Z') // Mon 00:00 JST (= Sun 15:00 UTC)
 
 describe('parseBridgeRunMode', () => {
   it('defaults to auto when undefined / empty', () => {
@@ -25,23 +26,32 @@ describe('parseBridgeRunMode', () => {
 })
 
 describe('isBridgeActive', () => {
-  it('auto: weekday UTC → true, weekend → false', () => {
-    expect(isBridgeActive(weekday, 'auto')).toBe(true)
-    expect(isBridgeActive(weekend, 'auto')).toBe(false)
+  it('auto: weekday JST → true', () => {
+    expect(isBridgeActive(monJstNoon, 'auto')).toBe(true)
+  })
+
+  it('auto: crosses the day boundary in JST — Saturday 00:00 JST is weekend', () => {
+    expect(isBridgeActive(satJstMidnight, 'auto')).toBe(false)
+  })
+
+  it('auto: crosses the day boundary in JST — Monday 00:00 JST is weekday', () => {
+    expect(isBridgeActive(monJstMidnight, 'auto')).toBe(true)
+  })
+
+  it('auto: mid-Saturday JST → false', () => {
+    expect(isBridgeActive(new Date('2026-04-25T03:00:00.000Z'), 'auto')).toBe(false) // Sat 12:00 JST
   })
 
   it('always-on: true regardless of day', () => {
-    expect(isBridgeActive(weekday, 'always-on')).toBe(true)
-    expect(isBridgeActive(weekend, 'always-on')).toBe(true)
+    expect(isBridgeActive(satJstMidnight, 'always-on')).toBe(true)
   })
 
   it('disabled: false regardless of day', () => {
-    expect(isBridgeActive(weekday, 'disabled')).toBe(false)
-    expect(isBridgeActive(weekend, 'disabled')).toBe(false)
+    expect(isBridgeActive(monJstNoon, 'disabled')).toBe(false)
   })
 
   it('defaults the mode to auto when omitted', () => {
-    expect(isBridgeActive(weekday)).toBe(true)
-    expect(isBridgeActive(weekend)).toBe(false)
+    expect(isBridgeActive(monJstNoon)).toBe(true)
+    expect(isBridgeActive(satJstMidnight)).toBe(false)
   })
 })

--- a/test/trading/bridge/schedule.test.ts
+++ b/test/trading/bridge/schedule.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { isBridgeActive } from '../../../src/trading/bridge/schedule'
+
+describe('isBridgeActive', () => {
+  it('returns true Mon-Fri UTC', () => {
+    expect(isBridgeActive(new Date('2026-04-20T12:00:00.000Z'))).toBe(true) // Mon
+    expect(isBridgeActive(new Date('2026-04-21T12:00:00.000Z'))).toBe(true) // Tue
+    expect(isBridgeActive(new Date('2026-04-24T23:00:00.000Z'))).toBe(true) // Fri
+  })
+
+  it('returns false on Saturday and Sunday UTC', () => {
+    expect(isBridgeActive(new Date('2026-04-25T12:00:00.000Z'))).toBe(false) // Sat
+    expect(isBridgeActive(new Date('2026-04-26T12:00:00.000Z'))).toBe(false) // Sun
+  })
+})

--- a/test/trading/bridge/schedule.test.ts
+++ b/test/trading/bridge/schedule.test.ts
@@ -1,15 +1,47 @@
-import { describe, expect, it } from 'vitest'
-import { isBridgeActive } from '../../../src/trading/bridge/schedule'
+import { describe, expect, it, vi } from 'vitest'
+import { isBridgeActive, parseBridgeRunMode } from '../../../src/trading/bridge/schedule'
 
-describe('isBridgeActive', () => {
-  it('returns true Mon-Fri UTC', () => {
-    expect(isBridgeActive(new Date('2026-04-20T12:00:00.000Z'))).toBe(true) // Mon
-    expect(isBridgeActive(new Date('2026-04-21T12:00:00.000Z'))).toBe(true) // Tue
-    expect(isBridgeActive(new Date('2026-04-24T23:00:00.000Z'))).toBe(true) // Fri
+const weekday = new Date('2026-04-20T12:00:00.000Z') // Mon
+const weekend = new Date('2026-04-25T12:00:00.000Z') // Sat
+
+describe('parseBridgeRunMode', () => {
+  it('defaults to auto when undefined / empty', () => {
+    expect(parseBridgeRunMode(undefined)).toBe('auto')
+    expect(parseBridgeRunMode('')).toBe('auto')
   })
 
-  it('returns false on Saturday and Sunday UTC', () => {
-    expect(isBridgeActive(new Date('2026-04-25T12:00:00.000Z'))).toBe(false) // Sat
-    expect(isBridgeActive(new Date('2026-04-26T12:00:00.000Z'))).toBe(false) // Sun
+  it('accepts the three enum values as-is', () => {
+    expect(parseBridgeRunMode('always-on')).toBe('always-on')
+    expect(parseBridgeRunMode('disabled')).toBe('disabled')
+    expect(parseBridgeRunMode('auto')).toBe('auto')
+  })
+
+  it('falls back to auto on an unknown value (typo-safe)', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(parseBridgeRunMode('yes')).toBe('auto')
+    expect(spy).toHaveBeenCalled()
+    spy.mockRestore()
+  })
+})
+
+describe('isBridgeActive', () => {
+  it('auto: weekday UTC → true, weekend → false', () => {
+    expect(isBridgeActive(weekday, 'auto')).toBe(true)
+    expect(isBridgeActive(weekend, 'auto')).toBe(false)
+  })
+
+  it('always-on: true regardless of day', () => {
+    expect(isBridgeActive(weekday, 'always-on')).toBe(true)
+    expect(isBridgeActive(weekend, 'always-on')).toBe(true)
+  })
+
+  it('disabled: false regardless of day', () => {
+    expect(isBridgeActive(weekday, 'disabled')).toBe(false)
+    expect(isBridgeActive(weekend, 'disabled')).toBe(false)
+  })
+
+  it('defaults the mode to auto when omitted', () => {
+    expect(isBridgeActive(weekday)).toBe(true)
+    expect(isBridgeActive(weekend)).toBe(false)
   })
 })

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -14,12 +14,21 @@
   "durable_objects": {
     "bindings": [
       { "name": "SYMBOL_STATE", "class_name": "SymbolStateDO" },
-      { "name": "PORTFOLIO_STATE", "class_name": "PortfolioStateDO" }
+      { "name": "PORTFOLIO_STATE", "class_name": "PortfolioStateDO" },
+      { "name": "BRIDGE", "class_name": "BridgeContainer" }
     ]
   },
+  "containers": [
+    {
+      "class_name": "BridgeContainer",
+      "image": "./bridge/Dockerfile",
+      "max_instances": 1
+    }
+  ],
   "migrations": [
     { "tag": "v1", "new_sqlite_classes": ["SymbolStateDO"] },
-    { "tag": "v2", "new_sqlite_classes": ["PortfolioStateDO"] }
+    { "tag": "v2", "new_sqlite_classes": ["PortfolioStateDO"] },
+    { "tag": "v3", "new_sqlite_classes": ["BridgeContainer"] }
   ],
   "triggers": {
     "crons": ["*/5 * * * *"]
@@ -35,9 +44,17 @@
       "durable_objects": {
         "bindings": [
           { "name": "SYMBOL_STATE", "class_name": "SymbolStateDO" },
-          { "name": "PORTFOLIO_STATE", "class_name": "PortfolioStateDO" }
+          { "name": "PORTFOLIO_STATE", "class_name": "PortfolioStateDO" },
+          { "name": "BRIDGE", "class_name": "BridgeContainer" }
         ]
-      }
+      },
+      "containers": [
+        {
+          "class_name": "BridgeContainer",
+          "image": "./bridge/Dockerfile",
+          "max_instances": 1
+        }
+      ]
     },
     "production": {
       "name": "webull-trading-production",
@@ -49,9 +66,17 @@
       "durable_objects": {
         "bindings": [
           { "name": "SYMBOL_STATE", "class_name": "SymbolStateDO" },
-          { "name": "PORTFOLIO_STATE", "class_name": "PortfolioStateDO" }
+          { "name": "PORTFOLIO_STATE", "class_name": "PortfolioStateDO" },
+          { "name": "BRIDGE", "class_name": "BridgeContainer" }
         ]
-      }
+      },
+      "containers": [
+        {
+          "class_name": "BridgeContainer",
+          "image": "./bridge/Dockerfile",
+          "max_instances": 1
+        }
+      ]
     }
   }
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -9,7 +9,8 @@
   "vars": {
     "DRY_RUN": "true",
     "TRADING_ENABLED": "false",
-    "MARKET_HOURS_CHECK": "false"
+    "MARKET_HOURS_CHECK": "false",
+    "BRIDGE_RUN_MODE": "auto"
   },
   "durable_objects": {
     "bindings": [
@@ -39,7 +40,8 @@
       "vars": {
         "DRY_RUN": "true",
         "TRADING_ENABLED": "false",
-        "MARKET_HOURS_CHECK": "false"
+        "MARKET_HOURS_CHECK": "false",
+        "BRIDGE_RUN_MODE": "auto"
       },
       "durable_objects": {
         "bindings": [
@@ -61,7 +63,8 @@
       "vars": {
         "DRY_RUN": "true",
         "TRADING_ENABLED": "false",
-        "MARKET_HOURS_CHECK": "false"
+        "MARKET_HOURS_CHECK": "false",
+        "BRIDGE_RUN_MODE": "auto"
       },
       "durable_objects": {
         "bindings": [


### PR DESCRIPTION
## 概要

ログを Cloudflare Workers Logs に集約する方針に沿って、bridge の常駐先を **Cloudflare Containers (β)** に。PR #64 (Fly.io 案) は close 済。

## アーキテクチャ

```
[Webull gRPC] ←(long-lived stream)── [Container: Node bridge]
                                            ↓ HTTP POST (x-event-ingest-secret)
[Cron */5 * * * *] → Worker.scheduled() → keepBridgeAlive() → container.start() / stop()
                  → runQuoteFeed()                               ↓
                                                     [Worker: /events/trade]
                                                                 ↓
                                                      [SymbolStateDO.recordFill]
```

## 変更

- `BridgeContainer` (`src/trading/bridge/BridgeContainer.ts`): `@cloudflare/containers` の `Container` を継承、`sleepAfter=24h`、`enableInternet=true`、`defaultPort` 非設定 (outbound only)。`onStart` / `onStop` / `onError` をログ出し
- `keepBridgeAlive` (`src/trading/bridge/bridgeKeepAlive.ts`): cron から idempotent に `container.start()` / `stop()` を呼ぶ。必要 secret 欠けなら warn して skip
- `schedule.isBridgeActive(now)`: UTC 平日のみ true を返す純関数 (`@cloudflare/containers` 非依存なのでユニットテスト可能)
- `BRIDGE_ALWAYS_ON` env: `"true"` → 常駐、`"false"` → kill-switch、省略 → 平日のみ (auto)
- `src/index.ts`: `scheduled` に `keepBridgeAlive` 呼び出し追加、`BridgeContainer` を export
- `wrangler.jsonc`: `containers` + `BRIDGE` DO binding + migration `v3` (root / staging / production 3 env 全て)
- `bridge/Dockerfile`: `node:24-alpine` 2 stage、shared type (`TradeEventBridge.ts` / `TradeEvent.ts`) 同梱
- `.dockerignore` / `bridge/README.md` (Cloudflare Container deploy 手順に差し替え)

## コスト見込み (hobby 規模)

- 24/7: Workers Paid $5/月 + Container 超過 ~$1.7/月 ≈ **$6.7/月**
- 平日 auto (本 PR default): Workers Paid $5/月 + Container 超過 ~$1.2/月 ≈ **$6.2/月**
- `BRIDGE_ALWAYS_ON=false` で一時 kill-switch 可能

## 前提

- Workers Paid plan (Containers は Free tier 非対応)
- `wrangler deploy` 時に Docker Desktop / Colima などが起動していること

## scope 外 (follow-up)

- Host restart (数日に 1 回) 時の backlog replay — Webull 側の trade-event 再送 API or Worker Queue 経由で対応、別 issue
- SIGTERM graceful shutdown (現状 reconnect loop で復帰)
- 祝日カレンダー対応 — `#38-E` の取引所カレンダーを再利用予定
- GitHub Actions からの自動デプロイ (`#24` production ops の範疇)

## 動作確認

- [x] `pnpm run typecheck`
- [x] `pnpm test` (259 件 pass、`schedule.test.ts` 2 ケース追加)
- [x] `pnpm exec wrangler deploy --env=staging --dry-run` config validation OK (Docker 未起動のため build 不可)
- [ ] staging: `wrangler secret put` で WEBULL_APP_KEY 等 6 本投入 → `wrangler deploy --env=staging` → `wrangler tail` で `bridge_keep_alive_ok` / `bridge_container_started` / gRPC subscribe ログの順に出ることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cloudflare Containersベースの Bridge サービスを追加し、Durable Object経由での起動管理、定期キープアライブ、ライフサイクルの構成と構造化ログ出力を導入。
  * 環境変数で動作モード（always-on / auto / disabled）を切替可能に。スケジュール判定で平日/週末を考慮。

* **Documentation**
  * デプロイ手順、シークレット注入フロー、コンテナ運用の検証チェックリストを大幅に拡張。

* **Chores**
  * コンテナ向けDocker設定とビルド除外リストを追加。コンテナ関連パッケージを依存に追加。

* **Tests**
  * 稼働判定ロジックのユニットテストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->