### PR TITLE
fix(bridge): Node 24 container 起動失敗を修正 (import.meta.main)

### DIFF
--- a/bridge/grpc/index.ts
+++ b/bridge/grpc/index.ts
@@ -150,7 +150,19 @@ function getRetryDelayMs({
   return Math.max(0, Math.round(exponentialDelay * jitterFactor))
 }
 
-if (import.meta.main) {
+// `import.meta.main` is Node 24.10+ only; our Cloudflare Container image uses an
+// older 24.x tag where it is undefined, which caused the entry to be skipped
+// and Node to exit immediately (Cloudflare reports this as `exitCode: 1 reason:
+// "exit"`). Use the canonical pathToFileURL comparison so tests (which import
+// named exports) stay inert while the container entry still fires.
+const { pathToFileURL } = await import('node:url')
+const isMain =
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+
+if (isMain) {
+  console.log(JSON.stringify({ event: 'bridge_node_starting', at: new Date().toISOString() }))
+
   const eventIngestUrl = process.env.EVENT_INGEST_URL
   const ingestSecret = process.env.EVENT_INGEST_SECRET
   const grpcEndpoint = process.env.WEBULL_GRPC_ENDPOINT


### PR DESCRIPTION
## 概要

staging cron で Cloudflare Container (`BridgeContainer`) が毎 tick 起動 → 3-5s で `exitCode: 1 reason: "exit"` で落ちる現象を修正。

## 原因

bridge entry (\`bridge/grpc/index.ts\`) で使っていた \`import.meta.main\` は **Node 24.10+** で追加された新しい API。\`node:24-alpine\` の default タグが引いた Node 24 系バージョンがそれ以前だと \`undefined\` になり、\`if (import.meta.main) { ... }\` 分岐が skip。結果、entry の \`startTradeEventBridge\` が呼ばれず、Node プロセスに待つべき async task が無いまま終了 → Cloudflare Containers は "server が勝手に終了した" と解釈して \`exitCode:1\` 記録。

## 修正

- \`import.meta.main\` → \`import.meta.url === pathToFileURL(process.argv[1]).href\` へ置換 (Node 10+ の canonical パターン)。test は named import なので inert を維持。
- entry 先頭に \`bridge_node_starting\` ログを 1 本追加、次 deploy 以降の起動成否がログに残る。

## 動作確認

- [x] \`cd bridge && pnpm run typecheck\`
- [x] \`cd bridge && pnpm test\` (7 件 pass)
- [ ] merge + redeploy 後、tail で \`bridge_node_starting\` ログが出て container が exit しないことを確認

## scope 外

- gRPC endpoint / creds の実疎通検証は merge 後の live 確認で判明する別論点
- base image を \`node:24-slim\` に変える案もあるが、現状のまま起動が通れば不要

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * ノード環境での起動時にスタートアップログを記録するようになりました。タイムスタンプ付きで起動状態を追跡できます。
  * ブリッジの起動判定処理を改善し、より堅牢な条件チェックを実装しました。これにより、環境変数の読み込みと設定の検証がより確実に実行されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->