### PR TITLE
feat(db): symbol_config / inverse_pairs を D1 化 (#69 Phase B)

### DIFF
--- a/docs/db-operations.md
+++ b/docs/db-operations.md
@@ -64,3 +64,47 @@ pnpm wrangler d1 execute webull-trading-staging --env=staging --remote \
 ```
 
 `--remote` 無しだと local の開発 DB (`wrangler dev` 用の SQLite ファイル) に当たるので注意。
+
+## symbol_config / inverse_pairs 運用 (#69 Phase B)
+
+### 初期シード
+
+```bash
+pnpm wrangler d1 execute webull-trading-staging --env=staging --remote \
+  --file=docs/seed/symbol_config.sql
+```
+
+### よく使う編集
+
+```sql
+-- 新 symbol を universe に追加 (US)
+INSERT INTO symbol_config (symbol, market, active, max_notional, updated_at)
+VALUES ('GLD', 'US', 1, 5000, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'));
+
+-- JP 個別
+INSERT INTO symbol_config (symbol, market, active, max_notional, updated_at)
+VALUES ('7203', 'JP', 1, 100000, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'));
+
+-- 一時停止 (ALLOWED_SYMBOLS から外れる / 次 cron から反映)
+UPDATE symbol_config SET active = 0, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE symbol = 'SOXS';
+
+-- 上限変更
+UPDATE symbol_config SET max_notional = 3000, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE symbol = 'SOXL';
+
+-- 逆相関ペア (単方向で書けば bidirectional に展開される)
+INSERT INTO inverse_pairs (symbol, inverse, updated_at)
+VALUES ('TQQQ', 'SQQQ', strftime('%Y-%m-%dT%H:%M:%fZ', 'now'));
+```
+
+### 現状確認
+
+```bash
+pnpm wrangler d1 execute webull-trading-staging --env=staging --remote \
+  --command "SELECT symbol, market, active, max_notional FROM symbol_config ORDER BY symbol"
+
+pnpm wrangler d1 execute webull-trading-staging --env=staging --remote \
+  --command "SELECT * FROM inverse_pairs"
+```
+

--- a/docs/db-operations.md
+++ b/docs/db-operations.md
@@ -78,12 +78,12 @@ pnpm wrangler d1 execute webull-trading-staging --env=staging --remote \
 
 ```sql
 -- 新 symbol を universe に追加 (US)
-INSERT INTO symbol_config (symbol, market, active, max_notional, updated_at)
-VALUES ('GLD', 'US', 1, 5000, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'));
+INSERT INTO symbol_config (symbol, name, market, active, max_notional, updated_at)
+VALUES ('GLD', 'SPDR Gold Shares', 'US', 1, 5000, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'));
 
 -- JP 個別
-INSERT INTO symbol_config (symbol, market, active, max_notional, updated_at)
-VALUES ('7203', 'JP', 1, 100000, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'));
+INSERT INTO symbol_config (symbol, name, market, active, max_notional, updated_at)
+VALUES ('7203', 'トヨタ自動車', 'JP', 1, 100000, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'));
 
 -- 一時停止 (ALLOWED_SYMBOLS から外れる / 次 cron から反映)
 UPDATE symbol_config SET active = 0, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
@@ -91,6 +91,10 @@ WHERE symbol = 'SOXS';
 
 -- 上限変更
 UPDATE symbol_config SET max_notional = 3000, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE symbol = 'SOXL';
+
+-- 銘柄名だけ更新
+UPDATE symbol_config SET name = 'Direxion Daily Semiconductor Bull 3X', updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
 WHERE symbol = 'SOXL';
 
 -- 逆相関ペア (単方向で書けば bidirectional に展開される)
@@ -102,7 +106,7 @@ VALUES ('TQQQ', 'SQQQ', strftime('%Y-%m-%dT%H:%M:%fZ', 'now'));
 
 ```bash
 pnpm wrangler d1 execute webull-trading-staging --env=staging --remote \
-  --command "SELECT symbol, market, active, max_notional FROM symbol_config ORDER BY symbol"
+  --command "SELECT symbol, name, market, active, max_notional FROM symbol_config ORDER BY symbol"
 
 pnpm wrangler d1 execute webull-trading-staging --env=staging --remote \
   --command "SELECT * FROM inverse_pairs"

--- a/docs/seed/symbol_config.sql
+++ b/docs/seed/symbol_config.sql
@@ -1,0 +1,10 @@
+-- 初期 symbol_config seed。現 ALLOWED_SYMBOLS / SYMBOL_MAX_NOTIONAL を反映した最小構成。
+-- 使い方: wrangler d1 execute webull-trading-staging --env=staging --remote --file=docs/seed/symbol_config.sql
+
+INSERT INTO symbol_config (symbol, market, active, max_notional, updated_at) VALUES
+  ('SOXL', 'US', 1, NULL, '2026-04-19T00:00:00.000Z'),
+  ('SOXS', 'US', 1, NULL, '2026-04-19T00:00:00.000Z');
+
+-- 3x ETF の逆相関ペア
+INSERT INTO inverse_pairs (symbol, inverse, updated_at) VALUES
+  ('SOXL', 'SOXS', '2026-04-19T00:00:00.000Z');

--- a/docs/seed/symbol_config.sql
+++ b/docs/seed/symbol_config.sql
@@ -1,9 +1,9 @@
 -- 初期 symbol_config seed。現 ALLOWED_SYMBOLS / SYMBOL_MAX_NOTIONAL を反映した最小構成。
 -- 使い方: wrangler d1 execute webull-trading-staging --env=staging --remote --file=docs/seed/symbol_config.sql
 
-INSERT INTO symbol_config (symbol, market, active, max_notional, updated_at) VALUES
-  ('SOXL', 'US', 1, NULL, '2026-04-19T00:00:00.000Z'),
-  ('SOXS', 'US', 1, NULL, '2026-04-19T00:00:00.000Z');
+INSERT INTO symbol_config (symbol, name, market, active, max_notional, updated_at) VALUES
+  ('SOXL', 'Direxion Daily Semiconductor Bull 3X Shares', 'US', 1, NULL, '2026-04-19T00:00:00.000Z'),
+  ('SOXS', 'Direxion Daily Semiconductor Bear 3X Shares', 'US', 1, NULL, '2026-04-19T00:00:00.000Z');
 
 -- 3x ETF の逆相関ペア
 INSERT INTO inverse_pairs (symbol, inverse, updated_at) VALUES

--- a/drizzle/0001_symbol_config.sql
+++ b/drizzle/0001_symbol_config.sql
@@ -6,6 +6,7 @@ CREATE TABLE `inverse_pairs` (
 --> statement-breakpoint
 CREATE TABLE `symbol_config` (
 	`symbol` text PRIMARY KEY NOT NULL,
+	`name` text,
 	`market` text NOT NULL,
 	`active` integer DEFAULT true NOT NULL,
 	`max_notional` real,

--- a/drizzle/0001_symbol_config.sql
+++ b/drizzle/0001_symbol_config.sql
@@ -1,0 +1,14 @@
+CREATE TABLE `inverse_pairs` (
+	`symbol` text PRIMARY KEY NOT NULL,
+	`inverse` text NOT NULL,
+	`updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `symbol_config` (
+	`symbol` text PRIMARY KEY NOT NULL,
+	`market` text NOT NULL,
+	`active` integer DEFAULT true NOT NULL,
+	`max_notional` real,
+	`notes` text,
+	`updated_at` text NOT NULL
+);

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "b1ac7e6c-31fe-4a30-8c53-52b99858dd44",
+  "id": "f8198cae-7277-4cc7-a2c0-d67da1fe48bb",
   "prevId": "44c1ec22-a2ec-434d-aa7c-9fc93bd9488f",
   "tables": {
     "inverse_pairs": {
@@ -43,6 +43,13 @@
           "type": "text",
           "primaryKey": true,
           "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
           "autoincrement": false
         },
         "market": {

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,301 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b1ac7e6c-31fe-4a30-8c53-52b99858dd44",
+  "prevId": "44c1ec22-a2ec-434d-aa7c-9fc93bd9488f",
+  "tables": {
+    "inverse_pairs": {
+      "name": "inverse_pairs",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inverse": {
+          "name": "inverse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "symbol_config": {
+      "name": "symbol_config",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "market": {
+          "name": "market",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_notional": {
+          "name": "max_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trade_journal": {
+      "name": "trade_journal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trade_event_type": {
+          "name": "trade_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "strategy_name": {
+          "name": "strategy_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_action": {
+          "name": "signal_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_reason": {
+          "name": "signal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_allowed": {
+          "name": "risk_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_reasons": {
+          "name": "risk_reasons",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "limit_price": {
+          "name": "limit_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notional": {
+          "name": "notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "broker_status": {
+          "name": "broker_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "submitted": {
+          "name": "submitted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_qty": {
+          "name": "filled_qty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_price": {
+          "name": "filled_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "realized_pnl": {
+          "name": "realized_pnl",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hold_days": {
+          "name": "hold_days",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_reason": {
+          "name": "exit_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -12,7 +12,7 @@
     {
       "idx": 1,
       "version": "6",
-      "when": 1776605204838,
+      "when": 1776605803427,
       "tag": "0001_symbol_config",
       "breakpoints": true
     }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1776603743000,
       "tag": "0000_init",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1776605204838,
+      "tag": "0001_symbol_config",
+      "breakpoints": true
     }
   ]
 }

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -41,3 +41,40 @@ export const tradeJournal = sqliteTable('trade_journal', {
 
 export type TradeJournalRow = typeof tradeJournal.$inferSelect
 export type TradeJournalInsert = typeof tradeJournal.$inferInsert
+
+/**
+ * Per-symbol universe + trading policy. Replaces `ALLOWED_SYMBOLS` and
+ * `SYMBOL_MAX_NOTIONAL` env vars so changes do not require redeploy. Operator
+ * edits via `wrangler d1 execute "INSERT / UPDATE ..."`. See
+ * docs/db-operations.md for recipes.
+ *
+ * `active = 0` で一時停止扱い (ALLOWED_SYMBOLS から外れる)。`max_notional`
+ * が NULL なら global の MAX_ORDER_NOTIONAL 上限に丸める (fall-through)。
+ */
+export const symbolConfig = sqliteTable('symbol_config', {
+  symbol: text('symbol').primaryKey(),
+  market: text('market').notNull(), // 'US' | 'JP'
+  active: integer('active', { mode: 'boolean' }).notNull().default(true),
+  maxNotional: real('max_notional'),
+  notes: text('notes'),
+  updatedAt: text('updated_at').notNull(),
+})
+
+export type SymbolConfigRow = typeof symbolConfig.$inferSelect
+export type SymbolConfigInsert = typeof symbolConfig.$inferInsert
+
+/**
+ * Structurally anti-correlated pairs (SOXL/SOXS, TQQQ/SQQQ 等)。相手 symbol
+ * で position を抱えている間の BUY を拒否するために使う (#38-A inverse-pair
+ * correlation cap の env 置換)。
+ *
+ * 1 方向だけ書き込めば十分 — repo 側で bidirectional に展開する。
+ */
+export const inversePairs = sqliteTable('inverse_pairs', {
+  symbol: text('symbol').primaryKey(),
+  inverse: text('inverse').notNull(),
+  updatedAt: text('updated_at').notNull(),
+})
+
+export type InversePairRow = typeof inversePairs.$inferSelect
+export type InversePairInsert = typeof inversePairs.$inferInsert

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -53,6 +53,8 @@ export type TradeJournalInsert = typeof tradeJournal.$inferInsert
  */
 export const symbolConfig = sqliteTable('symbol_config', {
   symbol: text('symbol').primaryKey(),
+  /** 人間可読な銘柄名 (例: "Direxion Daily Semiconductor Bull 3X"、トヨタ自動車)。運用時の識別用。 */
+  name: text('name'),
   market: text('market').notNull(), // 'US' | 'JP'
   active: integer('active', { mode: 'boolean' }).notNull().default(true),
   maxNotional: real('max_notional'),

--- a/src/infrastructure/db/symbolConfigRepo.ts
+++ b/src/infrastructure/db/symbolConfigRepo.ts
@@ -1,0 +1,58 @@
+import { eq } from 'drizzle-orm'
+import type { DrizzleD1Database } from 'drizzle-orm/d1'
+import { inversePairs, symbolConfig } from './schema'
+
+export interface SymbolConfigSnapshot {
+  /** Uppercased symbols where `active = 1`. */
+  allowedSymbols: string[]
+  /**
+   * symbol → max_notional (positive number). Symbols with `max_notional` NULL
+   * are absent from the map — caller falls through to the global
+   * `MAX_ORDER_NOTIONAL`.
+   */
+  symbolMaxNotional: Record<string, number>
+}
+
+/**
+ * Loads the per-symbol config from D1. A single query is cheap; no cache at
+ * this layer — call sites hold the snapshot for the duration of one handler.
+ */
+export async function loadSymbolConfig(
+  db: DrizzleD1Database,
+): Promise<SymbolConfigSnapshot> {
+  const rows = await db.select().from(symbolConfig).where(eq(symbolConfig.active, true))
+
+  const allowedSymbols: string[] = []
+  const symbolMaxNotional: Record<string, number> = {}
+  for (const row of rows) {
+    const symbol = row.symbol.toUpperCase()
+    allowedSymbols.push(symbol)
+    if (row.maxNotional !== null && Number.isFinite(row.maxNotional) && row.maxNotional > 0) {
+      symbolMaxNotional[symbol] = row.maxNotional
+    }
+  }
+  return { allowedSymbols, symbolMaxNotional }
+}
+
+/**
+ * Returns a bidirectional inverse-pair map (SOXL→SOXS AND SOXS→SOXL even if
+ * only one direction is stored). Mirrors the behaviour of the previous
+ * `parseInversePairs` env parser so TradingService keeps working without
+ * changing its gate logic.
+ */
+export async function loadInversePairs(
+  db: DrizzleD1Database,
+): Promise<Record<string, string>> {
+  const rows = await db.select().from(inversePairs)
+  const result: Record<string, string> = {}
+  for (const row of rows) {
+    const left = row.symbol.toUpperCase()
+    const right = row.inverse.toUpperCase()
+    if (left === right) continue
+    result[left] = right
+    if (result[right] === undefined) {
+      result[right] = left
+    }
+  }
+  return result
+}

--- a/src/infrastructure/db/symbolUniverse.ts
+++ b/src/infrastructure/db/symbolUniverse.ts
@@ -1,0 +1,47 @@
+import { createDb } from './tradeJournalRepo'
+import { loadInversePairs, loadSymbolConfig } from './symbolConfigRepo'
+import { parseCsvEnv, parseInversePairs, parseSymbolNotionalMap } from '../../config/env'
+
+export interface SymbolUniverse {
+  allowedSymbols: string[]
+  symbolMaxNotional: Record<string, number>
+  inversePairs: Record<string, string>
+  source: 'd1' | 'env'
+}
+
+interface UniverseEnv {
+  DB?: D1Database
+  ALLOWED_SYMBOLS?: string
+  SYMBOL_MAX_NOTIONAL?: string
+  INVERSE_PAIRS?: string
+}
+
+/**
+ * Loads the symbol universe (allowed list + per-symbol caps + inverse pairs).
+ *
+ * - When `env.DB` is bound: reads from `symbol_config` / `inverse_pairs` in D1.
+ * - Otherwise falls back to the legacy env-var parsing so existing deploys or
+ *   local tests that have not migrated stay working.
+ *
+ * The `source` field tags which path was taken — handy to surface in audit
+ * logs after cutover so we can confirm D1 reads are actually hit.
+ */
+export async function loadSymbolUniverse(env: UniverseEnv): Promise<SymbolUniverse> {
+  if (env.DB) {
+    const db = createDb(env.DB)
+    const [config, pairs] = await Promise.all([loadSymbolConfig(db), loadInversePairs(db)])
+    return {
+      allowedSymbols: config.allowedSymbols,
+      symbolMaxNotional: config.symbolMaxNotional,
+      inversePairs: pairs,
+      source: 'd1',
+    }
+  }
+
+  return {
+    allowedSymbols: parseCsvEnv(env.ALLOWED_SYMBOLS).map((s) => s.toUpperCase()),
+    symbolMaxNotional: parseSymbolNotionalMap(env.SYMBOL_MAX_NOTIONAL),
+    inversePairs: parseInversePairs(env.INVERSE_PAIRS),
+    source: 'env',
+  }
+}

--- a/src/routes/trade.ts
+++ b/src/routes/trade.ts
@@ -2,14 +2,12 @@ import { Hono } from 'hono'
 import type { AppBindings } from '../app'
 import {
   parseBooleanEnv,
-  parseCsvEnv,
   parseDrawdownKillThreshold,
-  parseInversePairs,
   parseNumberEnv,
   parseOptionalNonNegativeNumberEnv,
   parseOptionalPositiveNumber,
-  parseSymbolNotionalMap,
 } from '../config/env'
+import { loadSymbolUniverse, type SymbolUniverse } from '../infrastructure/db/symbolUniverse'
 import { createWebullHttpClient, type WebullClientEnv } from '../infrastructure/webull/WebullHttpClient'
 import { ValidationError } from '../shared/errors'
 import { TradingService, type TradingConfig } from '../trading/application/TradingService'
@@ -30,17 +28,25 @@ interface TradeRequest {
   sellAbove: number
 }
 
-export const trade = new Hono<AppBindings>().post('/decide', async (c) => {
-  const request = await parseTradeRequest(c.req.json())
-  const service = createTradingService(request, c.env)
-  return c.json(service.decide(request, readTradingConfig(c.env), { requestId: c.get('requestId') }))
-}).post('/execute', async (c) => {
-  const request = await parseTradeRequest(c.req.json())
-  const service = createTradingService(request, c.env)
-  return c.json(
-    await service.executeTrade(request, readTradingConfig(c.env), { requestId: c.get('requestId') }),
-  )
-})
+export const trade = new Hono<AppBindings>()
+  .post('/decide', async (c) => {
+    const request = await parseTradeRequest(c.req.json())
+    const universe = await loadSymbolUniverse(c.env)
+    const service = createTradingService(request, c.env, universe)
+    return c.json(
+      service.decide(request, readTradingConfig(c.env, universe), { requestId: c.get('requestId') }),
+    )
+  })
+  .post('/execute', async (c) => {
+    const request = await parseTradeRequest(c.req.json())
+    const universe = await loadSymbolUniverse(c.env)
+    const service = createTradingService(request, c.env, universe)
+    return c.json(
+      await service.executeTrade(request, readTradingConfig(c.env, universe), {
+        requestId: c.get('requestId'),
+      }),
+    )
+  })
 
 async function parseTradeRequest(payload: Promise<unknown>): Promise<TradeRequest> {
   const body = asRecord(await payload)
@@ -69,13 +75,13 @@ export function createTradingService(
     DRY_RUN?: string
     SYMBOL_STATE?: DurableObjectNamespace<SymbolStateDO>
     PORTFOLIO_STATE?: DurableObjectNamespace<PortfolioStateDO>
-    INVERSE_PAIRS?: string
     SPREAD_LIMIT_PCT_US?: string
     SPREAD_LIMIT_PCT_JP?: string
     STALE_QUOTE_MS?: string
     GAP_REJECT_PCT?: string
     DRAWDOWN_KILL_THRESHOLD?: string
   } & WebullClientEnv,
+  universe: SymbolUniverse,
 ): TradingService {
   const execution = parseBooleanEnv(env.DRY_RUN, true)
     ? new MockExecution()
@@ -93,7 +99,7 @@ export function createTradingService(
       portfolioStore: env.PORTFOLIO_STATE
         ? new PortfolioStateClient(env.PORTFOLIO_STATE)
         : undefined,
-      inversePairs: parseInversePairs(env.INVERSE_PAIRS),
+      inversePairs: universe.inversePairs,
       spreadLimits: {
         US: spreadUsRaw !== undefined ? spreadUsRaw / 100 : 0.0025,
         JP: spreadJpRaw !== undefined ? spreadJpRaw / 100 : 0.006,
@@ -105,20 +111,21 @@ export function createTradingService(
   )
 }
 
-function readTradingConfig(env: {
-  DRY_RUN?: string
-  TRADING_ENABLED?: string
-  ALLOWED_SYMBOLS: string
-  MAX_ORDER_NOTIONAL: string
-  SYMBOL_MAX_NOTIONAL?: string
-  MARKET_HOURS_CHECK?: string
-}): TradingConfig {
+function readTradingConfig(
+  env: {
+    DRY_RUN?: string
+    TRADING_ENABLED?: string
+    MAX_ORDER_NOTIONAL: string
+    MARKET_HOURS_CHECK?: string
+  },
+  universe: SymbolUniverse,
+): TradingConfig {
   return {
     dryRun: parseBooleanEnv(env.DRY_RUN, true),
     tradingEnabled: parseBooleanEnv(env.TRADING_ENABLED, false),
-    allowedSymbols: parseCsvEnv(env.ALLOWED_SYMBOLS).map((symbol) => symbol.toUpperCase()),
+    allowedSymbols: universe.allowedSymbols,
     maxOrderNotional: parseNumberEnv(env.MAX_ORDER_NOTIONAL, 'MAX_ORDER_NOTIONAL'),
-    symbolMaxNotional: parseSymbolNotionalMap(env.SYMBOL_MAX_NOTIONAL),
+    symbolMaxNotional: universe.symbolMaxNotional,
     marketHoursCheck: parseBooleanEnv(env.MARKET_HOURS_CHECK, false),
   }
 }

--- a/src/trading/quotes/quoteScheduler.ts
+++ b/src/trading/quotes/quoteScheduler.ts
@@ -1,5 +1,5 @@
 import type { Env } from '../../config/env'
-import { parseCsvEnv } from '../../config/env'
+import { loadSymbolUniverse } from '../../infrastructure/db/symbolUniverse'
 import {
   groupSymbolsByCategory,
   WebullQuoteClient,
@@ -33,7 +33,8 @@ interface RunQuoteFeedOptions {
 export async function runQuoteFeed(options: RunQuoteFeedOptions): Promise<QuoteRunSummary> {
   const { env } = options
   const now = options.now ?? (() => new Date())
-  const symbols = parseCsvEnv(env.ALLOWED_SYMBOLS)
+  const universe = await loadSymbolUniverse(env)
+  const symbols = universe.allowedSymbols
 
   const summary: QuoteRunSummary = { fetched: 0, persisted: 0, skipped: [], errors: [] }
   if (symbols.length === 0) return summary

--- a/test/infrastructure/db/symbolConfigRepo.test.ts
+++ b/test/infrastructure/db/symbolConfigRepo.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  loadInversePairs,
+  loadSymbolConfig,
+} from '../../../src/infrastructure/db/symbolConfigRepo'
+
+function fakeDb(rows: unknown[]) {
+  return {
+    select() {
+      return {
+        from() {
+          return {
+            where: vi.fn().mockResolvedValue(rows),
+          }
+        },
+      }
+    },
+  } as unknown as Parameters<typeof loadSymbolConfig>[0]
+}
+
+function fakeDbAll(rows: unknown[]) {
+  return {
+    select() {
+      return {
+        from: vi.fn().mockResolvedValue(rows),
+      }
+    },
+  } as unknown as Parameters<typeof loadInversePairs>[0]
+}
+
+describe('loadSymbolConfig', () => {
+  it('returns upper-cased allowed symbols and max notional map', async () => {
+    const rows = [
+      { symbol: 'soxl', market: 'US', active: true, maxNotional: 50000, notes: null, updatedAt: '' },
+      { symbol: '7203', market: 'JP', active: true, maxNotional: null, notes: null, updatedAt: '' },
+    ]
+    const result = await loadSymbolConfig(fakeDb(rows))
+    expect(result.allowedSymbols).toEqual(['SOXL', '7203'])
+    expect(result.symbolMaxNotional).toEqual({ SOXL: 50000 })
+  })
+
+  it('drops non-positive or non-finite maxNotional', async () => {
+    const rows = [
+      { symbol: 'A', market: 'US', active: true, maxNotional: 0, notes: null, updatedAt: '' },
+      { symbol: 'B', market: 'US', active: true, maxNotional: -5, notes: null, updatedAt: '' },
+      { symbol: 'C', market: 'US', active: true, maxNotional: 100, notes: null, updatedAt: '' },
+    ]
+    const result = await loadSymbolConfig(fakeDb(rows))
+    expect(result.symbolMaxNotional).toEqual({ C: 100 })
+  })
+})
+
+describe('loadInversePairs', () => {
+  it('expands a one-sided row into a bidirectional map', async () => {
+    const rows = [{ symbol: 'SOXL', inverse: 'SOXS', updatedAt: '' }]
+    expect(await loadInversePairs(fakeDbAll(rows))).toEqual({ SOXL: 'SOXS', SOXS: 'SOXL' })
+  })
+
+  it('uppercases both sides and drops self-pairs', async () => {
+    const rows = [
+      { symbol: 'soxl', inverse: 'soxs', updatedAt: '' },
+      { symbol: 'XX', inverse: 'XX', updatedAt: '' },
+    ]
+    expect(await loadInversePairs(fakeDbAll(rows))).toEqual({ SOXL: 'SOXS', SOXS: 'SOXL' })
+  })
+})


### PR DESCRIPTION
## 概要

Phase A (#71) で入れた D1 基盤の上に、`ALLOWED_SYMBOLS` / `SYMBOL_MAX_NOTIONAL` / `INVERSE_PAIRS` を移植。運用者は `wrangler d1 execute` で直編集可能、redeploy 不要。

## 変更

- `drizzle/0001_symbol_config.sql` — drizzle-kit 生成 (`symbol_config` 6 列 + `inverse_pairs` 3 列)
- `src/infrastructure/db/symbolConfigRepo.ts` — `loadSymbolConfig` / `loadInversePairs` (bidirectional 展開)
- `src/infrastructure/db/symbolUniverse.ts` — `env.DB` があれば D1、無ければ env fallback (下位互換)
- `src/routes/trade.ts` — async `loadSymbolUniverse(env)` を handler 先頭で呼ぶ。`TradingService` / `TradingConfig` に注入
- `src/trading/quotes/quoteScheduler.ts` — cron からも同じ universe を取得
- `docs/db-operations.md` — 追加 / 停止 / cap 変更 / inverse pair の SQL レシピ
- `docs/seed/symbol_config.sql` — 初期シード (現 SOXL/SOXS 構成)

## 運用手順 (merge 後)

```bash
# 1. migration (new tables)
pnpm wrangler d1 migrations apply webull-trading-staging --env=staging --remote

# 2. 初期シード
pnpm wrangler d1 execute webull-trading-staging --env=staging --remote \
  --file=docs/seed/symbol_config.sql

# 3. deploy
pnpm wrangler deploy --env=staging

# 4. 状態確認
pnpm wrangler d1 execute webull-trading-staging --env=staging --remote \
  --command "SELECT symbol, market, active, max_notional FROM symbol_config"
```

## 下位互換

- `env.DB` が bind されていない環境では従来どおり `ALLOWED_SYMBOLS` 等の env 値を使う
- 既存 273 tests pass (env mock 経路が引き続き動く)
- env vars 自体の wrangler.jsonc からの削除は Phase D (#70) で対応

## 動作確認

- [x] `pnpm run typecheck`
- [x] `pnpm test` (273 件 pass、`symbolConfigRepo.test.ts` を追加)
- [ ] staging: migration + seed 適用後、`SELECT active FROM symbol_config WHERE symbol='SOXS'` を `0` にして次 cron で quote feed 対象から外れることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * シンボル構成とインバースペアを永続化するDBスキーマとシードが追加され、実行時にDBから読み込めるようになりました
  * APIルートと見積りスケジューラがDBベースのシンボル情報を参照するようになりました

* **ドキュメント**
  * DB操作手順（シード実行例、編集/検証コマンド）を追加しました

* **テスト**
  * シンボル構成／インバースペア読み込みの単体テストを追加しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->