### PR TITLE
chore(deploy): deploy:staging / deploy:production scripts を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
+    "deploy:staging": "wrangler d1 migrations apply webull-trading-staging --env=staging --remote && wrangler deploy --env=staging",
+    "deploy:production": "wrangler d1 migrations apply webull-trading-production --env=production --remote && wrangler deploy --env=production",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## 概要

Cloudflare Workers Builds の Deploy command を一元スクリプトで指定できるようにする。dashboard 側のシェル文字列ベタ書き運用を `pnpm run deploy:staging` に差し替えて repo 管理化する。

## 変更

`package.json` に 2 scripts 追加:

```json
"deploy:staging": "wrangler d1 migrations apply webull-trading-staging --env=staging --remote && wrangler deploy --env=staging",
"deploy:production": "wrangler d1 migrations apply webull-trading-production --env=production --remote && wrangler deploy --env=production"
```

## 設計メモ

- **順序**: migration → deploy。`&&` で短絡するので migration 失敗時は deploy が走らず、壊れた schema に新 code を当てる事故を防ぐ。
- **idempotency**: `wrangler d1 migrations apply` は適用済みを skip するので毎 build 走らせて無害。
- **非対話**: CI 環境では wrangler が `🤖 Using fallback value in non-interactive context: yes` を自動選択する (ローカル検証済)。

## merge 後の operator 手順

1. Cloudflare dashboard → Workers & Pages → `webull-trading-staging` → Settings → Builds and deployments → **Deploy command** を `pnpm run deploy:staging` に変更
2. production も用意済みなら同様に `pnpm run deploy:production`

## 動作確認

- [x] `pnpm run typecheck`
- [x] `pnpm test` (273 件 pass)
- [ ] 次 main push で dashboard 側ビルドログに migrations apply → deploy の 2 段が出ることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ステージング環境と本番環境へのデプロイメントを自動化するスクリプトを追加しました。これにより、デプロイメントプロセスがより効率的かつ一貫性のあるものになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->