### PR TITLE
feat(db): global_config を D1 化 + env cleanup (#70 Phase D)

### DIFF
--- a/docs/db-operations.md
+++ b/docs/db-operations.md
@@ -112,3 +112,39 @@ pnpm wrangler d1 execute webull-trading-staging --env=staging --remote \
   --command "SELECT * FROM inverse_pairs"
 ```
 
+```
+
+## global_config 運用 (#70 Phase D)
+
+singleton row (`id = 'default'`) で runtime な risk / lifecycle knob を保持。env var 側からは削除済み。
+
+### 初期シード
+
+```bash
+pnpm wrangler d1 execute webull-trading-staging --env=staging --remote \
+  --file=docs/seed/global_config.sql
+```
+
+### 運用サンプル
+
+```sql
+-- 実発注 ON に切替 (慎重に)
+UPDATE global_config SET dry_run = 0, trading_enabled = 1, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE id = 'default';
+
+-- 緊急 kill-switch
+UPDATE global_config SET trading_enabled = 0, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE id = 'default';
+
+-- drawdown 閾値を -3% に緩和
+UPDATE global_config SET drawdown_kill_threshold = -0.03, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE id = 'default';
+
+-- bridge を週末も常駐させる (値: auto / always-on / disabled)
+UPDATE global_config SET bridge_run_mode = 'always-on', updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE id = 'default';
+
+-- 現状確認
+SELECT dry_run, trading_enabled, max_order_notional, drawdown_kill_threshold, bridge_run_mode
+FROM global_config WHERE id = 'default';
+```

--- a/docs/db-operations.md
+++ b/docs/db-operations.md
@@ -112,8 +112,6 @@ pnpm wrangler d1 execute webull-trading-staging --env=staging --remote \
   --command "SELECT * FROM inverse_pairs"
 ```
 
-```
-
 ## global_config 運用 (#70 Phase D)
 
 singleton row (`id = 'default'`) で runtime な risk / lifecycle knob を保持。env var 側からは削除済み。

--- a/docs/seed/global_config.sql
+++ b/docs/seed/global_config.sql
@@ -1,0 +1,16 @@
+-- Singleton global_config row。運用者が UPDATE で runtime に切り替える。
+-- 使い方: wrangler d1 execute webull-trading-staging --env=staging --remote --file=docs/seed/global_config.sql
+
+INSERT INTO global_config (
+  id, dry_run, trading_enabled, market_hours_check,
+  max_order_notional, drawdown_kill_threshold,
+  stale_quote_ms, gap_reject_pct,
+  spread_limit_pct_us, spread_limit_pct_jp,
+  bridge_run_mode, updated_at
+) VALUES (
+  'default', 1, 0, 0,
+  100, -0.02,
+  900000, 0.03,
+  0.0025, 0.006,
+  'auto', '2026-04-19T00:00:00.000Z'
+);

--- a/drizzle/0002_global_config.sql
+++ b/drizzle/0002_global_config.sql
@@ -10,5 +10,12 @@ CREATE TABLE `global_config` (
 	`spread_limit_pct_us` real DEFAULT 0.0025 NOT NULL,
 	`spread_limit_pct_jp` real DEFAULT 0.006 NOT NULL,
 	`bridge_run_mode` text DEFAULT 'auto' NOT NULL,
-	`updated_at` text NOT NULL
+	`updated_at` text NOT NULL,
+	CONSTRAINT "global_config_max_order_notional_range" CHECK("global_config"."max_order_notional" > 0 AND "global_config"."max_order_notional" <= 10000000),
+	CONSTRAINT "global_config_drawdown_kill_threshold_range" CHECK("global_config"."drawdown_kill_threshold" >= -1 AND "global_config"."drawdown_kill_threshold" <= 0),
+	CONSTRAINT "global_config_stale_quote_ms_range" CHECK("global_config"."stale_quote_ms" >= 0),
+	CONSTRAINT "global_config_gap_reject_pct_range" CHECK("global_config"."gap_reject_pct" >= 0 AND "global_config"."gap_reject_pct" <= 1),
+	CONSTRAINT "global_config_spread_limit_pct_us_range" CHECK("global_config"."spread_limit_pct_us" >= 0 AND "global_config"."spread_limit_pct_us" <= 1),
+	CONSTRAINT "global_config_spread_limit_pct_jp_range" CHECK("global_config"."spread_limit_pct_jp" >= 0 AND "global_config"."spread_limit_pct_jp" <= 1),
+	CONSTRAINT "global_config_bridge_run_mode_enum" CHECK("global_config"."bridge_run_mode" IN ('auto', 'always-on', 'disabled'))
 );

--- a/drizzle/0002_global_config.sql
+++ b/drizzle/0002_global_config.sql
@@ -1,0 +1,14 @@
+CREATE TABLE `global_config` (
+	`id` text PRIMARY KEY NOT NULL,
+	`dry_run` integer DEFAULT true NOT NULL,
+	`trading_enabled` integer DEFAULT false NOT NULL,
+	`market_hours_check` integer DEFAULT false NOT NULL,
+	`max_order_notional` real DEFAULT 100 NOT NULL,
+	`drawdown_kill_threshold` real DEFAULT -0.02 NOT NULL,
+	`stale_quote_ms` integer DEFAULT 900000 NOT NULL,
+	`gap_reject_pct` real DEFAULT 0.03 NOT NULL,
+	`spread_limit_pct_us` real DEFAULT 0.0025 NOT NULL,
+	`spread_limit_pct_jp` real DEFAULT 0.006 NOT NULL,
+	`bridge_run_mode` text DEFAULT 'auto' NOT NULL,
+	`updated_at` text NOT NULL
+);

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "4227368c-566f-44c7-95ce-b7dcb7e115f0",
+  "id": "3367679b-1183-443a-bff1-fa928ccb7c91",
   "prevId": "f8198cae-7277-4cc7-a2c0-d67da1fe48bb",
   "tables": {
     "global_config": {
@@ -106,7 +106,36 @@
       "foreignKeys": {},
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
-      "checkConstraints": {}
+      "checkConstraints": {
+        "global_config_max_order_notional_range": {
+          "name": "global_config_max_order_notional_range",
+          "value": "\"global_config\".\"max_order_notional\" > 0 AND \"global_config\".\"max_order_notional\" <= 10000000"
+        },
+        "global_config_drawdown_kill_threshold_range": {
+          "name": "global_config_drawdown_kill_threshold_range",
+          "value": "\"global_config\".\"drawdown_kill_threshold\" >= -1 AND \"global_config\".\"drawdown_kill_threshold\" <= 0"
+        },
+        "global_config_stale_quote_ms_range": {
+          "name": "global_config_stale_quote_ms_range",
+          "value": "\"global_config\".\"stale_quote_ms\" >= 0"
+        },
+        "global_config_gap_reject_pct_range": {
+          "name": "global_config_gap_reject_pct_range",
+          "value": "\"global_config\".\"gap_reject_pct\" >= 0 AND \"global_config\".\"gap_reject_pct\" <= 1"
+        },
+        "global_config_spread_limit_pct_us_range": {
+          "name": "global_config_spread_limit_pct_us_range",
+          "value": "\"global_config\".\"spread_limit_pct_us\" >= 0 AND \"global_config\".\"spread_limit_pct_us\" <= 1"
+        },
+        "global_config_spread_limit_pct_jp_range": {
+          "name": "global_config_spread_limit_pct_jp_range",
+          "value": "\"global_config\".\"spread_limit_pct_jp\" >= 0 AND \"global_config\".\"spread_limit_pct_jp\" <= 1"
+        },
+        "global_config_bridge_run_mode_enum": {
+          "name": "global_config_bridge_run_mode_enum",
+          "value": "\"global_config\".\"bridge_run_mode\" IN ('auto', 'always-on', 'disabled')"
+        }
+      }
     },
     "inverse_pairs": {
       "name": "inverse_pairs",

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,412 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "4227368c-566f-44c7-95ce-b7dcb7e115f0",
+  "prevId": "f8198cae-7277-4cc7-a2c0-d67da1fe48bb",
+  "tables": {
+    "global_config": {
+      "name": "global_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "trading_enabled": {
+          "name": "trading_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "market_hours_check": {
+          "name": "market_hours_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "max_order_notional": {
+          "name": "max_order_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "drawdown_kill_threshold": {
+          "name": "drawdown_kill_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.02
+        },
+        "stale_quote_ms": {
+          "name": "stale_quote_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 900000
+        },
+        "gap_reject_pct": {
+          "name": "gap_reject_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.03
+        },
+        "spread_limit_pct_us": {
+          "name": "spread_limit_pct_us",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.0025
+        },
+        "spread_limit_pct_jp": {
+          "name": "spread_limit_pct_jp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.006
+        },
+        "bridge_run_mode": {
+          "name": "bridge_run_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'auto'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inverse_pairs": {
+      "name": "inverse_pairs",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inverse": {
+          "name": "inverse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "symbol_config": {
+      "name": "symbol_config",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "market": {
+          "name": "market",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_notional": {
+          "name": "max_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trade_journal": {
+      "name": "trade_journal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trade_event_type": {
+          "name": "trade_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "strategy_name": {
+          "name": "strategy_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_action": {
+          "name": "signal_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_reason": {
+          "name": "signal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_allowed": {
+          "name": "risk_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_reasons": {
+          "name": "risk_reasons",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "limit_price": {
+          "name": "limit_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notional": {
+          "name": "notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "broker_status": {
+          "name": "broker_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "submitted": {
+          "name": "submitted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_qty": {
+          "name": "filled_qty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_price": {
+          "name": "filled_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "realized_pnl": {
+          "name": "realized_pnl",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hold_days": {
+          "name": "hold_days",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_reason": {
+          "name": "exit_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1776605803427,
       "tag": "0001_symbol_config",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1776606915177,
+      "tag": "0002_global_config",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -19,7 +19,7 @@
     {
       "idx": 2,
       "version": "6",
-      "when": 1776606915177,
+      "when": 1776607960216,
       "tag": "0002_global_config",
       "breakpoints": true
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,8 +72,15 @@ export default {
               message: error instanceof Error ? error.message : String(error),
             }),
           )
-          // D1 読めなかったら env fallback (keepBridgeAlive が env.BRIDGE_RUN_MODE を見る)
-          return keepBridgeAlive(env, { requestId })
+          // D1 binding がある deploy は "config が読めるはず" が正の状態。
+          // そこで読めなかった場合は fail-closed で bridge を停止する
+          // (runMode='disabled')。env-only (D1 未 bind) の legacy 環境は
+          // 従来どおり env.BRIDGE_RUN_MODE / default 'auto' に寄せる。
+          const isDbBound = env.DB !== undefined
+          return keepBridgeAlive(env, {
+            requestId,
+            ...(isDbBound ? { runMode: 'disabled' } : {}),
+          })
         },
       ),
     )

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { createApp } from './app'
 import type { Env } from './config/env'
+import { loadGlobalConfigFrom } from './infrastructure/db/globalConfigLoader'
 import { createDb, insertJournalRecord } from './infrastructure/db/tradeJournalRepo'
 import { setTradeJournalDbContext } from './infrastructure/logger/tradeJournal'
 import { keepBridgeAlive } from './trading/bridge/bridgeKeepAlive'
@@ -60,6 +61,21 @@ export default {
         },
       ),
     )
-    ctx.waitUntil(keepBridgeAlive(env, { requestId }))
+    ctx.waitUntil(
+      loadGlobalConfigFrom(env).then(
+        (global) => keepBridgeAlive(env, { requestId, runMode: global.bridgeRunMode }),
+        (error) => {
+          console.error(
+            JSON.stringify({
+              event: 'global_config_load_error',
+              requestId,
+              message: error instanceof Error ? error.message : String(error),
+            }),
+          )
+          // D1 読めなかったら env fallback (keepBridgeAlive が env.BRIDGE_RUN_MODE を見る)
+          return keepBridgeAlive(env, { requestId })
+        },
+      ),
+    )
   },
 }

--- a/src/infrastructure/db/globalConfigLoader.ts
+++ b/src/infrastructure/db/globalConfigLoader.ts
@@ -1,0 +1,84 @@
+import {
+  parseBooleanEnv,
+  parseDrawdownKillThreshold,
+  parseNumberEnv,
+  parseOptionalNonNegativeNumberEnv,
+  parseOptionalPositiveNumber,
+} from '../../config/env'
+import { parseBridgeRunMode } from '../../trading/bridge/schedule'
+import {
+  GLOBAL_CONFIG_DEFAULTS,
+  loadGlobalConfig,
+  type GlobalConfigSnapshot,
+} from './globalConfigRepo'
+import { createDb } from './tradeJournalRepo'
+
+export interface LoadedGlobalConfig extends GlobalConfigSnapshot {
+  source: 'd1' | 'env'
+}
+
+interface GlobalConfigEnv {
+  DB?: D1Database
+  DRY_RUN?: string
+  TRADING_ENABLED?: string
+  MARKET_HOURS_CHECK?: string
+  MAX_ORDER_NOTIONAL?: string
+  DRAWDOWN_KILL_THRESHOLD?: string
+  STALE_QUOTE_MS?: string
+  GAP_REJECT_PCT?: string
+  SPREAD_LIMIT_PCT_US?: string
+  SPREAD_LIMIT_PCT_JP?: string
+  BRIDGE_RUN_MODE?: string
+}
+
+/**
+ * Loads the global risk / lifecycle config. Prefers D1 (`global_config`
+ * singleton) when `env.DB` is bound; otherwise parses the legacy env vars so
+ * tests and pre-D1 deployments stay working.
+ *
+ * `SPREAD_LIMIT_PCT_*` env values are percent (0.25 = 0.25%) historically, so
+ * we divide by 100 when coming from env; D1 stores them already as fractions.
+ */
+export async function loadGlobalConfigFrom(env: GlobalConfigEnv): Promise<LoadedGlobalConfig> {
+  if (env.DB) {
+    const db = createDb(env.DB)
+    const snapshot = await loadGlobalConfig(db)
+    return { ...snapshot, source: 'd1' }
+  }
+
+  const spreadUsPercent = parseOptionalNonNegativeNumberEnv(
+    env.SPREAD_LIMIT_PCT_US,
+    'SPREAD_LIMIT_PCT_US',
+  )
+  const spreadJpPercent = parseOptionalNonNegativeNumberEnv(
+    env.SPREAD_LIMIT_PCT_JP,
+    'SPREAD_LIMIT_PCT_JP',
+  )
+
+  return {
+    dryRun: parseBooleanEnv(env.DRY_RUN, GLOBAL_CONFIG_DEFAULTS.dryRun),
+    tradingEnabled: parseBooleanEnv(env.TRADING_ENABLED, GLOBAL_CONFIG_DEFAULTS.tradingEnabled),
+    marketHoursCheck: parseBooleanEnv(env.MARKET_HOURS_CHECK, GLOBAL_CONFIG_DEFAULTS.marketHoursCheck),
+    maxOrderNotional:
+      env.MAX_ORDER_NOTIONAL !== undefined
+        ? parseNumberEnv(env.MAX_ORDER_NOTIONAL, 'MAX_ORDER_NOTIONAL')
+        : GLOBAL_CONFIG_DEFAULTS.maxOrderNotional,
+    drawdownKillThreshold: parseDrawdownKillThreshold(env.DRAWDOWN_KILL_THRESHOLD),
+    staleQuoteMs: parseOptionalPositiveNumber(
+      env.STALE_QUOTE_MS,
+      GLOBAL_CONFIG_DEFAULTS.staleQuoteMs,
+      'STALE_QUOTE_MS',
+    ),
+    gapRejectPct: parseOptionalPositiveNumber(
+      env.GAP_REJECT_PCT,
+      GLOBAL_CONFIG_DEFAULTS.gapRejectPct,
+      'GAP_REJECT_PCT',
+    ),
+    spreadLimitPctUs:
+      spreadUsPercent !== undefined ? spreadUsPercent / 100 : GLOBAL_CONFIG_DEFAULTS.spreadLimitPctUs,
+    spreadLimitPctJp:
+      spreadJpPercent !== undefined ? spreadJpPercent / 100 : GLOBAL_CONFIG_DEFAULTS.spreadLimitPctJp,
+    bridgeRunMode: parseBridgeRunMode(env.BRIDGE_RUN_MODE),
+    source: 'env',
+  }
+}

--- a/src/infrastructure/db/globalConfigRepo.ts
+++ b/src/infrastructure/db/globalConfigRepo.ts
@@ -1,0 +1,54 @@
+import { eq } from 'drizzle-orm'
+import type { DrizzleD1Database } from 'drizzle-orm/d1'
+import { globalConfig } from './schema'
+
+export interface GlobalConfigSnapshot {
+  dryRun: boolean
+  tradingEnabled: boolean
+  marketHoursCheck: boolean
+  maxOrderNotional: number
+  drawdownKillThreshold: number
+  staleQuoteMs: number
+  gapRejectPct: number
+  spreadLimitPctUs: number
+  spreadLimitPctJp: number
+  bridgeRunMode: string
+}
+
+/**
+ * Hard defaults used when D1 does not have a `global_config` row yet (i.e.
+ * before the initial seed is applied). Matches the previous env-var defaults
+ * so existing deployments keep the same behaviour through the cutover.
+ */
+export const GLOBAL_CONFIG_DEFAULTS: GlobalConfigSnapshot = Object.freeze({
+  dryRun: true,
+  tradingEnabled: false,
+  marketHoursCheck: false,
+  maxOrderNotional: 100,
+  drawdownKillThreshold: -0.02,
+  staleQuoteMs: 15 * 60 * 1_000,
+  gapRejectPct: 0.03,
+  spreadLimitPctUs: 0.0025,
+  spreadLimitPctJp: 0.006,
+  bridgeRunMode: 'auto',
+})
+
+export async function loadGlobalConfig(
+  db: DrizzleD1Database,
+): Promise<GlobalConfigSnapshot> {
+  const rows = await db.select().from(globalConfig).where(eq(globalConfig.id, 'default')).limit(1)
+  const row = rows[0]
+  if (!row) return { ...GLOBAL_CONFIG_DEFAULTS }
+  return {
+    dryRun: row.dryRun,
+    tradingEnabled: row.tradingEnabled,
+    marketHoursCheck: row.marketHoursCheck,
+    maxOrderNotional: row.maxOrderNotional,
+    drawdownKillThreshold: row.drawdownKillThreshold,
+    staleQuoteMs: row.staleQuoteMs,
+    gapRejectPct: row.gapRejectPct,
+    spreadLimitPctUs: row.spreadLimitPctUs,
+    spreadLimitPctJp: row.spreadLimitPctJp,
+    bridgeRunMode: row.bridgeRunMode,
+  }
+}

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -80,3 +80,30 @@ export const inversePairs = sqliteTable('inverse_pairs', {
 
 export type InversePairRow = typeof inversePairs.$inferSelect
 export type InversePairInsert = typeof inversePairs.$inferInsert
+
+/**
+ * Singleton global risk / lifecycle config。`id = 'default'` の 1 行のみ。
+ * 運用者が `wrangler d1 execute` で UPDATE して runtime 変更する (実発注
+ * ON / drawdown 閾値 / kill-switch 等)。env var 側と完全一致のフィールド
+ * を持ち、Worker 起動時に loadGlobalConfig で取得する。
+ *
+ * bridge_run_mode は 'auto' / 'always-on' / 'disabled' の文字列。
+ * drawdown_kill_threshold は負の float (例: -0.02 = -2%)。
+ */
+export const globalConfig = sqliteTable('global_config', {
+  id: text('id').primaryKey(), // 'default' 固定
+  dryRun: integer('dry_run', { mode: 'boolean' }).notNull().default(true),
+  tradingEnabled: integer('trading_enabled', { mode: 'boolean' }).notNull().default(false),
+  marketHoursCheck: integer('market_hours_check', { mode: 'boolean' }).notNull().default(false),
+  maxOrderNotional: real('max_order_notional').notNull().default(100),
+  drawdownKillThreshold: real('drawdown_kill_threshold').notNull().default(-0.02),
+  staleQuoteMs: integer('stale_quote_ms').notNull().default(900000),
+  gapRejectPct: real('gap_reject_pct').notNull().default(0.03),
+  spreadLimitPctUs: real('spread_limit_pct_us').notNull().default(0.0025),
+  spreadLimitPctJp: real('spread_limit_pct_jp').notNull().default(0.006),
+  bridgeRunMode: text('bridge_run_mode').notNull().default('auto'),
+  updatedAt: text('updated_at').notNull(),
+})
+
+export type GlobalConfigRow = typeof globalConfig.$inferSelect
+export type GlobalConfigInsert = typeof globalConfig.$inferInsert

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -1,4 +1,5 @@
-import { integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { sql } from 'drizzle-orm'
+import { check, integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core'
 
 /**
  * append-only trade decision / order lifecycle log. A single row per logical
@@ -90,20 +91,55 @@ export type InversePairInsert = typeof inversePairs.$inferInsert
  * bridge_run_mode は 'auto' / 'always-on' / 'disabled' の文字列。
  * drawdown_kill_threshold は負の float (例: -0.02 = -2%)。
  */
-export const globalConfig = sqliteTable('global_config', {
-  id: text('id').primaryKey(), // 'default' 固定
-  dryRun: integer('dry_run', { mode: 'boolean' }).notNull().default(true),
-  tradingEnabled: integer('trading_enabled', { mode: 'boolean' }).notNull().default(false),
-  marketHoursCheck: integer('market_hours_check', { mode: 'boolean' }).notNull().default(false),
-  maxOrderNotional: real('max_order_notional').notNull().default(100),
-  drawdownKillThreshold: real('drawdown_kill_threshold').notNull().default(-0.02),
-  staleQuoteMs: integer('stale_quote_ms').notNull().default(900000),
-  gapRejectPct: real('gap_reject_pct').notNull().default(0.03),
-  spreadLimitPctUs: real('spread_limit_pct_us').notNull().default(0.0025),
-  spreadLimitPctJp: real('spread_limit_pct_jp').notNull().default(0.006),
-  bridgeRunMode: text('bridge_run_mode').notNull().default('auto'),
-  updatedAt: text('updated_at').notNull(),
-})
+export const globalConfig = sqliteTable(
+  'global_config',
+  {
+    id: text('id').primaryKey(), // 'default' 固定
+    dryRun: integer('dry_run', { mode: 'boolean' }).notNull().default(true),
+    tradingEnabled: integer('trading_enabled', { mode: 'boolean' }).notNull().default(false),
+    marketHoursCheck: integer('market_hours_check', { mode: 'boolean' }).notNull().default(false),
+    maxOrderNotional: real('max_order_notional').notNull().default(100),
+    drawdownKillThreshold: real('drawdown_kill_threshold').notNull().default(-0.02),
+    staleQuoteMs: integer('stale_quote_ms').notNull().default(900000),
+    gapRejectPct: real('gap_reject_pct').notNull().default(0.03),
+    spreadLimitPctUs: real('spread_limit_pct_us').notNull().default(0.0025),
+    spreadLimitPctJp: real('spread_limit_pct_jp').notNull().default(0.006),
+    bridgeRunMode: text('bridge_run_mode').notNull().default('auto'),
+    updatedAt: text('updated_at').notNull(),
+  },
+  (t) => ({
+    // DB レベルで typo / 桁違いの UPDATE を弾く。上限値は POC としての上限
+    // (例: 1 回の発注で $10M は明らかに誤入力) を想定。
+    maxOrderNotionalRange: check(
+      'global_config_max_order_notional_range',
+      sql`${t.maxOrderNotional} > 0 AND ${t.maxOrderNotional} <= 10000000`,
+    ),
+    drawdownKillThresholdRange: check(
+      'global_config_drawdown_kill_threshold_range',
+      sql`${t.drawdownKillThreshold} >= -1 AND ${t.drawdownKillThreshold} <= 0`,
+    ),
+    staleQuoteMsRange: check(
+      'global_config_stale_quote_ms_range',
+      sql`${t.staleQuoteMs} >= 0`,
+    ),
+    gapRejectPctRange: check(
+      'global_config_gap_reject_pct_range',
+      sql`${t.gapRejectPct} >= 0 AND ${t.gapRejectPct} <= 1`,
+    ),
+    spreadLimitPctUsRange: check(
+      'global_config_spread_limit_pct_us_range',
+      sql`${t.spreadLimitPctUs} >= 0 AND ${t.spreadLimitPctUs} <= 1`,
+    ),
+    spreadLimitPctJpRange: check(
+      'global_config_spread_limit_pct_jp_range',
+      sql`${t.spreadLimitPctJp} >= 0 AND ${t.spreadLimitPctJp} <= 1`,
+    ),
+    bridgeRunModeEnum: check(
+      'global_config_bridge_run_mode_enum',
+      sql`${t.bridgeRunMode} IN ('auto', 'always-on', 'disabled')`,
+    ),
+  }),
+)
 
 export type GlobalConfigRow = typeof globalConfig.$inferSelect
 export type GlobalConfigInsert = typeof globalConfig.$inferInsert

--- a/src/routes/trade.ts
+++ b/src/routes/trade.ts
@@ -1,12 +1,6 @@
 import { Hono } from 'hono'
 import type { AppBindings } from '../app'
-import {
-  parseBooleanEnv,
-  parseDrawdownKillThreshold,
-  parseNumberEnv,
-  parseOptionalNonNegativeNumberEnv,
-  parseOptionalPositiveNumber,
-} from '../config/env'
+import { loadGlobalConfigFrom, type LoadedGlobalConfig } from '../infrastructure/db/globalConfigLoader'
 import { loadSymbolUniverse, type SymbolUniverse } from '../infrastructure/db/symbolUniverse'
 import { createWebullHttpClient, type WebullClientEnv } from '../infrastructure/webull/WebullHttpClient'
 import { ValidationError } from '../shared/errors'
@@ -31,18 +25,24 @@ interface TradeRequest {
 export const trade = new Hono<AppBindings>()
   .post('/decide', async (c) => {
     const request = await parseTradeRequest(c.req.json())
-    const universe = await loadSymbolUniverse(c.env)
-    const service = createTradingService(request, c.env, universe)
+    const [universe, global] = await Promise.all([
+      loadSymbolUniverse(c.env),
+      loadGlobalConfigFrom(c.env),
+    ])
+    const service = createTradingService(request, c.env, universe, global)
     return c.json(
-      service.decide(request, readTradingConfig(c.env, universe), { requestId: c.get('requestId') }),
+      service.decide(request, toTradingConfig(universe, global), { requestId: c.get('requestId') }),
     )
   })
   .post('/execute', async (c) => {
     const request = await parseTradeRequest(c.req.json())
-    const universe = await loadSymbolUniverse(c.env)
-    const service = createTradingService(request, c.env, universe)
+    const [universe, global] = await Promise.all([
+      loadSymbolUniverse(c.env),
+      loadGlobalConfigFrom(c.env),
+    ])
+    const service = createTradingService(request, c.env, universe, global)
     return c.json(
-      await service.executeTrade(request, readTradingConfig(c.env, universe), {
+      await service.executeTrade(request, toTradingConfig(universe, global), {
         requestId: c.get('requestId'),
       }),
     )
@@ -72,23 +72,15 @@ async function parseTradeRequest(payload: Promise<unknown>): Promise<TradeReques
 export function createTradingService(
   request: TradeRequest,
   env: {
-    DRY_RUN?: string
     SYMBOL_STATE?: DurableObjectNamespace<SymbolStateDO>
     PORTFOLIO_STATE?: DurableObjectNamespace<PortfolioStateDO>
-    SPREAD_LIMIT_PCT_US?: string
-    SPREAD_LIMIT_PCT_JP?: string
-    STALE_QUOTE_MS?: string
-    GAP_REJECT_PCT?: string
-    DRAWDOWN_KILL_THRESHOLD?: string
   } & WebullClientEnv,
   universe: SymbolUniverse,
+  global: LoadedGlobalConfig,
 ): TradingService {
-  const execution = parseBooleanEnv(env.DRY_RUN, true)
+  const execution = global.dryRun
     ? new MockExecution()
     : new WebullExecution(createWebullHttpClient(env))
-
-  const spreadUsRaw = parseOptionalNonNegativeNumberEnv(env.SPREAD_LIMIT_PCT_US, 'SPREAD_LIMIT_PCT_US')
-  const spreadJpRaw = parseOptionalNonNegativeNumberEnv(env.SPREAD_LIMIT_PCT_JP, 'SPREAD_LIMIT_PCT_JP')
 
   return new TradingService(
     new FixedRuleStrategy(request.buyBelow, request.sellAbove),
@@ -101,32 +93,24 @@ export function createTradingService(
         : undefined,
       inversePairs: universe.inversePairs,
       spreadLimits: {
-        US: spreadUsRaw !== undefined ? spreadUsRaw / 100 : 0.0025,
-        JP: spreadJpRaw !== undefined ? spreadJpRaw / 100 : 0.006,
+        US: global.spreadLimitPctUs,
+        JP: global.spreadLimitPctJp,
       },
-      staleQuoteMs: parseOptionalPositiveNumber(env.STALE_QUOTE_MS, 15 * 60 * 1_000, 'STALE_QUOTE_MS'),
-      gapRejectPct: parseOptionalPositiveNumber(env.GAP_REJECT_PCT, 0.03, 'GAP_REJECT_PCT'),
-      drawdownKillThreshold: parseDrawdownKillThreshold(env.DRAWDOWN_KILL_THRESHOLD),
+      staleQuoteMs: global.staleQuoteMs,
+      gapRejectPct: global.gapRejectPct,
+      drawdownKillThreshold: global.drawdownKillThreshold,
     },
   )
 }
 
-function readTradingConfig(
-  env: {
-    DRY_RUN?: string
-    TRADING_ENABLED?: string
-    MAX_ORDER_NOTIONAL: string
-    MARKET_HOURS_CHECK?: string
-  },
-  universe: SymbolUniverse,
-): TradingConfig {
+function toTradingConfig(universe: SymbolUniverse, global: LoadedGlobalConfig): TradingConfig {
   return {
-    dryRun: parseBooleanEnv(env.DRY_RUN, true),
-    tradingEnabled: parseBooleanEnv(env.TRADING_ENABLED, false),
+    dryRun: global.dryRun,
+    tradingEnabled: global.tradingEnabled,
     allowedSymbols: universe.allowedSymbols,
-    maxOrderNotional: parseNumberEnv(env.MAX_ORDER_NOTIONAL, 'MAX_ORDER_NOTIONAL'),
+    maxOrderNotional: global.maxOrderNotional,
     symbolMaxNotional: universe.symbolMaxNotional,
-    marketHoursCheck: parseBooleanEnv(env.MARKET_HOURS_CHECK, false),
+    marketHoursCheck: global.marketHoursCheck,
   }
 }
 

--- a/src/trading/bridge/bridgeKeepAlive.ts
+++ b/src/trading/bridge/bridgeKeepAlive.ts
@@ -17,6 +17,12 @@ export interface BridgeKeepAliveEnv {
 export interface KeepBridgeAliveOptions {
   /** Correlates every log line emitted by a single cron tick. */
   requestId?: string
+  /**
+   * Override the env-derived run mode. When the caller already loaded the
+   * global config (`global_config.bridge_run_mode`), pass it here so we don't
+   * re-read `env.BRIDGE_RUN_MODE` (which becomes stale after Phase D).
+   */
+  runMode?: string
 }
 
 /**
@@ -44,7 +50,7 @@ export async function keepBridgeAlive(
     return
   }
 
-  const mode = parseBridgeRunMode(env.BRIDGE_RUN_MODE)
+  const mode = parseBridgeRunMode(options.runMode ?? env.BRIDGE_RUN_MODE)
 
   if (!isBridgeActive(new Date(), mode)) {
     await stopContainer(env, {

--- a/test/infrastructure/db/globalConfigLoader.test.ts
+++ b/test/infrastructure/db/globalConfigLoader.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest'
+import { loadGlobalConfigFrom } from '../../../src/infrastructure/db/globalConfigLoader'
+import { GLOBAL_CONFIG_DEFAULTS } from '../../../src/infrastructure/db/globalConfigRepo'
+
+function fakeD1WithRow(row: Record<string, unknown> | undefined) {
+  const limit = vi.fn().mockResolvedValue(row ? [row] : [])
+  const where = vi.fn().mockReturnValue({ limit })
+  const from = vi.fn().mockReturnValue({ where })
+  const select = vi.fn().mockReturnValue({ from })
+  const fakeDrizzle = { select }
+  // createDb wraps a D1Database — we short-circuit by tagging the fake so the
+  // loader's createDb() call returns the same object.
+  return {
+    prepare: vi.fn(),
+    __drizzle: fakeDrizzle,
+  } as unknown as D1Database
+}
+
+describe('loadGlobalConfigFrom', () => {
+  it('env fallback when DB binding is missing', async () => {
+    const snapshot = await loadGlobalConfigFrom({
+      DRY_RUN: 'false',
+      TRADING_ENABLED: 'true',
+      MAX_ORDER_NOTIONAL: '250',
+      DRAWDOWN_KILL_THRESHOLD: '-0.03',
+      SPREAD_LIMIT_PCT_US: '0.25',
+      BRIDGE_RUN_MODE: 'always-on',
+    })
+    expect(snapshot.source).toBe('env')
+    expect(snapshot.dryRun).toBe(false)
+    expect(snapshot.tradingEnabled).toBe(true)
+    expect(snapshot.maxOrderNotional).toBe(250)
+    expect(snapshot.drawdownKillThreshold).toBe(-0.03)
+    expect(snapshot.spreadLimitPctUs).toBeCloseTo(0.0025, 6)
+    expect(snapshot.bridgeRunMode).toBe('always-on')
+  })
+
+  it('falls back to defaults for missing env values', async () => {
+    const snapshot = await loadGlobalConfigFrom({})
+    expect(snapshot.source).toBe('env')
+    expect(snapshot.dryRun).toBe(GLOBAL_CONFIG_DEFAULTS.dryRun)
+    expect(snapshot.tradingEnabled).toBe(GLOBAL_CONFIG_DEFAULTS.tradingEnabled)
+    expect(snapshot.maxOrderNotional).toBe(GLOBAL_CONFIG_DEFAULTS.maxOrderNotional)
+    expect(snapshot.drawdownKillThreshold).toBe(GLOBAL_CONFIG_DEFAULTS.drawdownKillThreshold)
+    expect(snapshot.spreadLimitPctUs).toBe(GLOBAL_CONFIG_DEFAULTS.spreadLimitPctUs)
+    expect(snapshot.bridgeRunMode).toBe(GLOBAL_CONFIG_DEFAULTS.bridgeRunMode)
+  })
+})

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -6,12 +6,6 @@
   "observability": {
     "enabled": true
   },
-  "vars": {
-    "DRY_RUN": "true",
-    "TRADING_ENABLED": "false",
-    "MARKET_HOURS_CHECK": "false",
-    "BRIDGE_RUN_MODE": "auto"
-  },
   "durable_objects": {
     "bindings": [
       { "name": "SYMBOL_STATE", "class_name": "SymbolStateDO" },
@@ -37,12 +31,6 @@
   "env": {
     "staging": {
       "name": "webull-trading-staging",
-      "vars": {
-        "DRY_RUN": "true",
-        "TRADING_ENABLED": "false",
-        "MARKET_HOURS_CHECK": "false",
-        "BRIDGE_RUN_MODE": "auto"
-      },
       "durable_objects": {
         "bindings": [
           { "name": "SYMBOL_STATE", "class_name": "SymbolStateDO" },
@@ -68,12 +56,6 @@
     },
     "production": {
       "name": "webull-trading-production",
-      "vars": {
-        "DRY_RUN": "true",
-        "TRADING_ENABLED": "false",
-        "MARKET_HOURS_CHECK": "false",
-        "BRIDGE_RUN_MODE": "auto"
-      },
       "durable_objects": {
         "bindings": [
           { "name": "SYMBOL_STATE", "class_name": "SymbolStateDO" },


### PR DESCRIPTION
## 概要

Phase A/B で入れた D1 基盤の仕上げ。残っていた risk / lifecycle knob を singleton `global_config` row に集約し、`wrangler d1 execute UPDATE` で runtime 切替できるようにする。env var 側は秘匿情報 (WEBULL_* / BASIC_AUTH_* / EVENT_INGEST_*) のみを残して掃除。

## 移行するフィールド

| 旧 env | 新 D1 カラム | 初期値 |
|---|---|---|
| `DRY_RUN` | `dry_run` | 1 (true) |
| `TRADING_ENABLED` | `trading_enabled` | 0 |
| `MARKET_HOURS_CHECK` | `market_hours_check` | 0 |
| `MAX_ORDER_NOTIONAL` | `max_order_notional` | 100 |
| `DRAWDOWN_KILL_THRESHOLD` | `drawdown_kill_threshold` | -0.02 |
| `STALE_QUOTE_MS` | `stale_quote_ms` | 900000 |
| `GAP_REJECT_PCT` | `gap_reject_pct` | 0.03 |
| `SPREAD_LIMIT_PCT_US` | `spread_limit_pct_us` | 0.0025 |
| `SPREAD_LIMIT_PCT_JP` | `spread_limit_pct_jp` | 0.006 |
| `BRIDGE_RUN_MODE` | `bridge_run_mode` | 'auto' |

## 変更

- drizzle schema に `global_config` 追加、migration `0002_global_config.sql`
- `globalConfigRepo.ts` — `loadGlobalConfig` + `GLOBAL_CONFIG_DEFAULTS`
- `globalConfigLoader.ts` — `env.DB` があれば D1、無ければ env parse (test/レガシー互換)
- `routes/trade.ts` — `loadSymbolUniverse` + `loadGlobalConfigFrom` を並列 await、`TradingService` / `TradingConfig` に注入
- `bridgeKeepAlive` — `options.runMode` を受けて D1 値を優先、env.BRIDGE_RUN_MODE はフォールバック
- `src/index.ts` — `scheduled` 内で `loadGlobalConfigFrom(env)` → `keepBridgeAlive(env, {requestId, runMode})`
- `wrangler.jsonc` — `vars` を root / env.staging / env.production 全てから削除
- `docs/seed/global_config.sql` / `docs/db-operations.md` — 初期 row + 運用レシピ (実発注 ON / kill-switch / drawdown 調整 / bridge mode)

## 運用手順 (merge 後)

main push で CD が走ると以下が自動実行:
```
wrangler d1 migrations apply webull-trading-staging --env=staging --remote
wrangler deploy --env=staging
```

migration 後に singleton row をシードしておく (初回のみ):
```bash
pnpm wrangler d1 execute webull-trading-staging --env=staging --remote \
  --file=docs/seed/global_config.sql
```

## 下位互換

- `env.DB` 未 bind の環境では引き続き env parse で動作 (既存 275 tests pass)
- 未シード状態でも `GLOBAL_CONFIG_DEFAULTS` にフォールバック

## 動作確認

- [x] `pnpm run typecheck`
- [x] `pnpm test` (275 件 pass、`globalConfigLoader.test.ts` を追加)
- [x] local migration + seed + SELECT round-trip
- [ ] staging: migrations apply (CD) → `UPDATE global_config SET trading_enabled = 1` で次 cron から反映されることを確認

## これで完了

Phase A (#71) / B (#72) / D (#73) まで揃って、取引ログ分析 + 運用パラメータ runtime 変更が D1 直編集で可能に。Phase C は B/D に吸収済。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * グローバル設定を永続化して実行時に更新可能に（ドライラン、取引の有効化/停止、ドローダウン閾値、スプレッド制限、ブリッジ実行モードなど）。
  * スケジュール処理と取引ルートがこのグローバル設定を参照するようになりました。

* **ドキュメント**
  * 設定の管理手順と初期シード用SQL、実運用サンプルを追加。

* **テスト**
  * グローバル設定の読み込み挙動を検証するユニットテストを追加。

* **その他**
  * 環境変数ベースの設定からの切替を反映。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->