### PR TITLE
docs(readme): Phase D 以降の実態に合わせて書き直し

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,55 +1,97 @@
 # webull-trading
 
-Retail auto-trading **POC** on Cloudflare Workers + Hono + TypeScript, speaking Webull OpenAPI directly (no SDK) with a separate Node-runtime gRPC bridge for trade-event streaming.
+Retail auto-trading **POC** on Cloudflare Workers + Hono + TypeScript, speaking Webull OpenAPI directly (no SDK). Trade-event streaming via a Node-runtime gRPC bridge hosted in a Cloudflare Container.
 
-**Status**: POC 全 Phase 完了 (Issue #1 closed)。実口座での疎通検証と Webull canonical signing の本実装は別フェーズ扱い。
+**Status**: POC Phase 1–5 完了 (#1 closed)。以降は follow-up issues (#21-#24) と D1 化 (#68-#70) が merged。
+
+## アーキテクチャ概要
+
+```
+ ┌──────────────┐  */5 cron       ┌──────────────────────────┐
+ │  Cloudflare  │────────────────▶│  quote feed (DO write)    │
+ │   Workers    │                 │  bridge keep-alive        │
+ │              │  /trade/* HTTP  └──────────────────────────┘
+ │              │────▶ decide / execute → Webull HTTP
+ │              │  /events/trade  ◀────── bridge Container
+ │              │  /admin/*       operator (Basic Auth)
+ └──────┬───────┘
+        │
+ ┌──────┴────────────────────────────────────────────────────┐
+ │              Durable Objects  +  D1                         │
+ │  SYMBOL_STATE (per-symbol: position / pending / cooldown)   │
+ │  PORTFOLIO_STATE (daily equity / drawdown kill)             │
+ │  BRIDGE (Container lifecycle)                               │
+ │  DB: trade_journal / symbol_config / inverse_pairs /        │
+ │      global_config                                          │
+ └─────────────────────────────────────────────────────────────┘
+```
 
 ## Safety defaults (fail-closed)
 
-- `DRY_RUN=true` (unset も true 扱い) — broker に実発注しない
-- `TRADING_ENABLED=false` — Risk で全注文を reject
-- `ALLOWED_SYMBOLS` に含まれないシンボルは Risk で reject
-- `MAX_ORDER_NOTIONAL` + `SYMBOL_MAX_NOTIONAL` (JSON) で発注金額上限
-- `MARKET_HOURS_CHECK=true` にすると UTC 13:30-20:00 Mon-Fri 以外を reject
+`global_config` singleton (D1 `id='default'`) で保持。未シード時は `GLOBAL_CONFIG_DEFAULTS` にフォールバック:
+
+| フィールド | 既定 | 意味 |
+|---|---|---|
+| `dry_run` | `1` | Execution Mock に固定、broker へ送らない |
+| `trading_enabled` | `0` | Risk layer が全注文 reject |
+| `market_hours_check` | `0` | UTC 13:30-20:00 Mon-Fri チェック |
+| `max_order_notional` | `100` | 1 注文上限 ($ / ¥) |
+| `drawdown_kill_threshold` | `-0.02` | 日次 realized_pnl / start_equity 比で自動 kill |
+| `stale_quote_ms` | `900000` | halt 判定 (15 min) |
+| `spread_limit_pct_{us,jp}` | `0.0025` / `0.006` | spread guard |
+| `bridge_run_mode` | `auto` | 平日 JST のみ bridge 稼働 (auto / always-on / disabled) |
+
+加えて:
+- `symbol_config.active = 0` にすれば ALLOWED から外れて cron から除外
+- `inverse_pairs` で SOXL/SOXS 同時保有を構造的に禁止
+- Basic Auth で `/trade/*` / `/webull/*` / `/admin/*` 保護
 - `EVENT_INGEST_SECRET` header + timing-safe 比較で `/events/trade` 保護
-- Basic Auth で `/trade/*` / `/webull/*` を保護
 
 ## Layout
 
 ```
 src/
-  app.ts, index.ts          Hono factory + Workers entry
-  routes/                   health / trade / webull / events
+  app.ts / index.ts           Hono factory + Workers entry (fetch / scheduled)
+  routes/                     health / trade / webull / events / admin
   trading/
-    application/            TradingService / TradeEventService
-    domain/                 Signal / OrderIntent / RiskDecision / ExecutionResult / TradeEvent
-    strategy/               Strategy interface + FixedRuleStrategy
-    risk/                   RiskPolicy + DefaultRiskPolicy
-    execution/              Execution interface + MockExecution / WebullExecution
-    events/                 TradeEventHandler
+    application/              TradingService / TradeEventService
+    domain/                   Signal / OrderIntent / RiskDecision / ExecutionResult / TradeEvent
+    strategy/                 Strategy + FixedRuleStrategy + PullbackUptrendStrategy + pullbackSizing / indicators / scheduler
+    risk/                     RiskPolicy + DefaultRiskPolicy + jpPriceBand + spreadGuard
+    execution/                Execution + MockExecution + WebullExecution
+    events/                   TradeEventHandler
+    state/                    SymbolStateDO / PortfolioStateDO + clients / transitions
+    bridge/                   BridgeContainer (Cloudflare Container DO class) + keepAlive + schedule
+    quotes/                   quoteScheduler
   infrastructure/
-    webull/                 WebullHttpClient / WebullAuth (placeholder signing) / dto / mapper / TradeEventBridge (contract)
-    logger/                 AuditLogger (JSON + requestId + errorClass/errorMessage scrubber)
-  middleware/               basicAuth
-  shared/                   errors (TradingError / ValidationError / BrokerRequestError)
-  config/                   env
-bridge/                     Node runtime (non-Workers) — gRPC trade event subscriber + ingest POST
-test/                       vitest (unit + route integration)
+    webull/                   WebullHttpClient / WebullAuth / mapper / TradeEventBridge
+    quotes/                   WebullQuoteClient / BarClient
+    logger/                   AuditLogger + tradeJournal (console + D1 sink)
+    db/                       drizzle schema + tradeJournalRepo / symbolConfigRepo / globalConfigRepo + loaders
+  middleware/                 basicAuth
+  shared/                     errors
+  config/                     env (少数: secret 参照のみ)
+Dockerfile                    bridge Container image (repo root context)
+bridge/                       Node gRPC subscriber (pnpm start)
+drizzle/                      generated D1 migrations (0000_init / 0001_symbol_config / 0002_global_config)
+docs/                         db-operations.md / seed/*.sql
+test/                         vitest suite (275 cases)
 ```
 
 ## Dev
 
 ```bash
 pnpm install
-pnpm run typecheck        # tsc --noEmit
-pnpm test                 # vitest run (main + bridge)
-pnpm dev                  # wrangler dev
+pnpm run typecheck                # tsc --noEmit
+pnpm test                         # vitest (Worker + bridge)
+pnpm dev                          # wrangler dev (ローカル D1 自動作成)
 pnpm exec wrangler deploy --dry-run
-# bridge 単体の typecheck
-cd bridge && pnpm install && pnpm exec tsc --noEmit -p .
+
+# bridge 単体 typecheck
+cd bridge && pnpm install && pnpm run typecheck
 ```
 
-`.dev.vars.example` を `.dev.vars` にコピーして編集して `pnpm dev` で起動。
+`.dev.vars.template` を `.dev.vars` にコピーして 1Password `op inject` で値埋め。
 
 ## Endpoints
 
@@ -57,30 +99,46 @@ cd bridge && pnpm install && pnpm exec tsc --noEmit -p .
 |---|---|---|---|
 | GET | `/health` | none | `{status, timestamp}` |
 | POST | `/trade/decide` | Basic | Signal + OrderIntent + RiskDecision を返す (発注しない) |
-| POST | `/trade/execute` | Basic | 上記 + ExecutionResult (`DRY_RUN=true`/未設定で Mock、それ以外で Webull) |
-| POST | `/webull/order/place` | Basic | POC 用低レベル疎通 endpoint (DRY_RUN 時は synthetic response) |
+| POST | `/trade/execute` | Basic | 上記 + ExecutionResult (`dry_run=1` で Mock、0 で Webull) |
+| POST | `/webull/order/place` | Basic | 低レベル疎通 endpoint (`dry_run=1` で synthetic response) |
 | POST | `/events/trade` | secret header | bridge からの trade event ingest |
+| POST | `/admin/symbols/:symbol/seed-cash` | Basic | `settled_cash` の初期値投入 (#55) |
+| POST | `/admin/portfolio/seed-equity` | Basic | `daily_start_equity` 投入 (#50) |
 
-## Env
+Cron: `*/5 * * * *` で quote feed + bridge keep-alive。
 
-実値は `.dev.vars.example` 参照。
+## Bindings (wrangler.jsonc)
 
-| 変数 | 既定 | 用途 |
+| 種別 | 名前 | 説明 |
 |---|---|---|
-| `BASIC_AUTH_USER` / `BASIC_AUTH_PASSWORD` | — | `/trade/*` / `/webull/*` の Basic Auth |
-| `DRY_RUN` | `true` (fail-closed) | Execution 切替 (Mock vs Webull) |
-| `TRADING_ENABLED` | `false` (fail-closed) | Risk の trading 全体スイッチ |
-| `ALLOWED_SYMBOLS` | — | CSV 許可リスト (case-insensitive → 上書き大文字正規化) |
-| `MAX_ORDER_NOTIONAL` | — | 1 注文あたり上限金額 (数値) |
-| `SYMBOL_MAX_NOTIONAL` | `{}` | JSON inline で symbol 別上書き |
-| `MARKET_HOURS_CHECK` | `false` | UTC 13:30-20:00 Mon-Fri チェック |
-| `EVENT_INGEST_SECRET` | — | `/events/trade` の secret header 値 |
-| `WEBULL_APP_KEY` / `WEBULL_APP_SECRET` / `WEBULL_ACCOUNT_ID` | — | Webull 認証 |
-| `WEBULL_API_BASE` | `https://openapi.webull.com` | Webull HTTP base |
+| Durable Object | `SYMBOL_STATE` | 銘柄ごとの position / pending / cooldown |
+| Durable Object | `PORTFOLIO_STATE` | 日次 equity / drawdown kill |
+| Durable Object | `BRIDGE` | Cloudflare Container (Node gRPC bridge) のライフサイクル |
+| Container | `BridgeContainer` | `./Dockerfile` から build、`max_instances: 1` |
+| D1 Database | `DB` | trade_journal / symbol_config / inverse_pairs / global_config |
+
+## Secrets (`wrangler secret put`)
+
+運用可変値は D1 に逃げたので、ここに残るのは **認証情報と非公開 URL のみ**:
+
+| Secret | 用途 |
+|---|---|
+| `BASIC_AUTH_USER` / `BASIC_AUTH_PASSWORD` | `/trade/*` / `/webull/*` / `/admin/*` 認証 |
+| `WEBULL_APP_KEY` / `WEBULL_APP_SECRET` / `WEBULL_ACCOUNT_ID` | broker 署名・口座 |
+| `WEBULL_API_BASE` | sandbox host (非公開) |
+| `WEBULL_GRPC_ENDPOINT` | bridge の gRPC 接続先 (非公開) |
+| `EVENT_INGEST_URL` | bridge 側から叩く Worker URL (`https://.../events/trade`) |
+| `EVENT_INGEST_SECRET` | `/events/trade` header |
+
+```bash
+pnpm wrangler secret put BASIC_AUTH_USER --env=staging
+# ... 1 件ずつ、誤 env 防止のため loop 化しない
+pnpm wrangler secret list --env=staging   # 9 件揃ったか確認
+```
 
 ### Webull account_id を取得する
 
-Webull sandbox は公開 dashboard で account_id を表示しないので、app_key + app_secret だけで API を叩いて取得する:
+Webull sandbox は dashboard で account_id を見られないので、app_key + app_secret だけで API を叩いて取得する:
 
 ```bash
 WEBULL_APP_KEY="$(op read 'op://Personal/WEBULL_APP_KEY/credential')" \
@@ -89,98 +147,79 @@ WEBULL_API_BASE=https://api.sandbox.webull.hk \
   pnpm run accounts
 ```
 
-返ってきた JSON の `account_id` を `.dev.vars` の `WEBULL_ACCOUNT_ID` に、deploy 時は `wrangler secret put WEBULL_ACCOUNT_ID --env staging` に投入。
+## D1 セットアップ (初回のみ)
 
-## Deploy / Secrets (Cloudflare Workers)
-
-`wrangler.jsonc` に **staging / production** 2つの environments を定義してある。既定環境 (env 指定なし) はローカル dev 用、デプロイは必ず `--env` 付きで。
-
-| env | worker name | 用途 |
-|---|---|---|
-| default (no `--env`) | `webull-trading` | `wrangler dev` ローカル実行専用 |
-| `staging` | `webull-trading-staging` | 検証環境 |
-| `production` | `webull-trading-production` | 本番 |
-
-### 初回セットアップ
+staging:
 
 ```bash
-# 1. Cloudflare へログイン (ブラウザが開く)
-pnpm exec wrangler login
+# 1. DB 作成 → 出力される database_id を wrangler.jsonc に貼る
+pnpm wrangler d1 create webull-trading-staging
 
-# 2. Worker を空で作成して secrets 枠を用意
-pnpm exec wrangler deploy --env staging
-pnpm exec wrangler deploy --env production
+# 2. migration 適用
+pnpm wrangler d1 migrations apply webull-trading-staging --env=staging --remote
+
+# 3. 初期シード
+pnpm wrangler d1 execute webull-trading-staging --env=staging --remote --file=docs/seed/symbol_config.sql
+pnpm wrangler d1 execute webull-trading-staging --env=staging --remote --file=docs/seed/global_config.sql
 ```
 
-### 運用フラグ (`wrangler.jsonc::env.<target>.vars`)
+schema 変更・運用 SQL レシピは [`docs/db-operations.md`](docs/db-operations.md) に集約。
 
-`DRY_RUN` / `TRADING_ENABLED` / `MARKET_HOURS_CHECK` の 3つは純粋な運用フラグとして wrangler.jsonc に env ごと記述済。変更は **ファイルを編集して再デプロイ** (git 差分 = 監査トレイル)。
+## Deploy
 
-**fail-closed 前提で両 env とも初期値は `DRY_RUN=true` / `TRADING_ENABLED=false`。** 本番で LIVE 発注に切り替える時は wrangler.jsonc の `env.production.vars` を編集してコミット + `wrangler deploy --env production`。staging で十分疎通確認してから本番を触る。
+CD (Cloudflare Workers Builds) が main push で `pnpm run deploy:staging` を実行:
 
-### Secrets 投入 (`wrangler secret put`)
+```
+wrangler d1 migrations apply webull-trading-staging --env=staging --remote
+  && wrangler deploy --env=staging
+```
 
-以下は個人戦略・認証情報・非公開 endpoint を含むので全て secret 扱い:
-
-- `BASIC_AUTH_USER` / `BASIC_AUTH_PASSWORD` — 管理 API の認証
-- `EVENT_INGEST_SECRET` — `/events/trade` の secret header
-- `WEBULL_APP_KEY` / `WEBULL_APP_SECRET` / `WEBULL_ACCOUNT_ID` — broker 認証
-- `WEBULL_API_BASE` — sandbox URL が非公開のため
-- `ALLOWED_SYMBOLS` — 取引対象銘柄 (個人戦略)
-- `MAX_ORDER_NOTIONAL` — 1注文上限 (個人の資金規模)
-- `SYMBOL_MAX_NOTIONAL` — symbol 別上限 (同上)
-
-`wrangler secret put` は対話プロンプトで値を入力する。**1 件ずつ実行して、入力値と対象 env を都度目視確認する** ことを推奨 (ループ化すると誤 env 投入のリスクが高い)。
+手動 deploy:
 
 ```bash
-# staging
-pnpm exec wrangler secret put BASIC_AUTH_USER --env staging
-pnpm exec wrangler secret put BASIC_AUTH_PASSWORD --env staging
-pnpm exec wrangler secret put EVENT_INGEST_SECRET --env staging
-pnpm exec wrangler secret put WEBULL_APP_KEY --env staging
-pnpm exec wrangler secret put WEBULL_APP_SECRET --env staging
-pnpm exec wrangler secret put WEBULL_ACCOUNT_ID --env staging
-pnpm exec wrangler secret put WEBULL_API_BASE --env staging
-pnpm exec wrangler secret put ALLOWED_SYMBOLS --env staging
-pnpm exec wrangler secret put MAX_ORDER_NOTIONAL --env staging
-pnpm exec wrangler secret put SYMBOL_MAX_NOTIONAL --env staging
-
-# production は --env production で同じ 10 件
+pnpm run deploy:staging
+pnpm run deploy:production
 ```
 
-投入後に `pnpm exec wrangler secret list --env staging` で 10 件揃ったことを確認。
+`pnpm run deploy:*` が migration → deploy を `&&` で繋ぐので、migration 失敗時は worker がデプロイされない (壊れた schema に新 code が当たる事故を防ぐ)。
 
-`wrangler secret put` は同名 var を上書きするので、一時的に `DRY_RUN` などを var と違う値にしたい場合のエスケープハッチにも使える (通常は wrangler.jsonc 編集が望ましい)。
+### bridge Container (Cloudflare Containers β)
 
-### デプロイ
+`wrangler deploy` が Dockerfile を build → Cloudflare Registry push → `BridgeContainer` DO に配置する。前提:
+
+- Workers **Paid** plan ($5/月) — Containers は Free tier 非対応
+- ローカル build に Docker CLI 互換環境 (Colima 推奨)
+- bridge-specific env (`WEBULL_GRPC_ENDPOINT` / `EVENT_INGEST_URL`) を secret に投入済
+
+詳細は [`bridge/README.md`](bridge/README.md) 参照。
+
+## 運用 (wrangler d1 execute で D1 直編集)
+
+admin API は作らず、wrangler CLI から直接 SQL を叩く運用:
 
 ```bash
-pnpm exec wrangler deploy --env staging       # staging に反映
-pnpm exec wrangler deploy --env production    # production に反映
+# 新 symbol 追加
+pnpm wrangler d1 execute webull-trading-staging --env=staging --remote \
+  --command "INSERT INTO symbol_config (symbol, name, market, active, max_notional, updated_at) \
+             VALUES ('GLD', 'SPDR Gold Shares', 'US', 1, 5000, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+
+# 実発注 ON
+pnpm wrangler d1 execute webull-trading-staging --env=staging --remote \
+  --command "UPDATE global_config SET dry_run = 0, trading_enabled = 1, \
+             updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = 'default'"
+
+# 緊急 kill-switch
+pnpm wrangler d1 execute webull-trading-staging --env=staging --remote \
+  --command "UPDATE global_config SET trading_enabled = 0 WHERE id = 'default'"
+
+# 振り返りクエリ
+pnpm wrangler d1 execute webull-trading-staging --env=staging --remote \
+  --command "SELECT trade_event_type, COUNT(*) FROM trade_journal GROUP BY trade_event_type"
 ```
 
-### Secrets のローテーション
-
-```bash
-pnpm exec wrangler secret put WEBULL_APP_SECRET --env production  # 上書き投入
-pnpm exec wrangler secret list --env production                   # 現在の secrets (値は出ない)
-pnpm exec wrangler secret delete WEBULL_APP_SECRET --env staging  # 削除
-```
-
-### 1Password 連携 (推奨、dotfile 手元運用)
-
-`~/.coderabbit` の OAuth トークンと同じく、発行した credential を 1Password に保管して `op read` で解決する流れが安全:
-
-```bash
-export CLOUDFLARE_API_TOKEN="$(op read 'op://Personal/CLOUDFLARE_API_TOKEN/credential')"
-pnpm exec wrangler deploy --env staging
-```
-
-GitHub Actions での自動デプロイは **別 PR 予定** (CI/CD 拡張時、follow-up [#24](https://github.com/ochanuco/webull-trading/issues/24))。本 PR は手動デプロイ前提の runbook のみ。
+より多くのレシピは [`docs/db-operations.md`](docs/db-operations.md) 参照。
 
 ## AI エージェント / レビュー設定
-
-このリポジトリは AI (Claude Code / Codex / CodeRabbit) で作業することを前提に設定ファイルを整備している:
 
 - `CLAUDE.md` — Claude 用エントリ (skill / agent index)
 - `AGENTS.md` — Codex 用エントリ
@@ -194,3 +233,6 @@ GitHub Actions での自動デプロイは **別 PR 予定** (CI/CD 拡張時、
 
 - [#1](https://github.com/ochanuco/webull-trading/issues/1) POC 設計書 (closed)
 - Phase 1: PR #2 / Phase 2: PR #3 / Phase 3: PR #4 / Phase 4: PR #5 / Phase 5: PR #6
+- D1 化: #68 / #69 / #70
+- Bridge (Cloudflare Containers): #33 / PR #65
+- Risk hardening: #38 サブ PR 47/59/60/61


### PR DESCRIPTION
## 概要

README が Phase D (D1 化) で古くなっていたのを現状に合わせて整備。

### 修正したズレ

- **運用フラグ**: `DRY_RUN` / `TRADING_ENABLED` / `MARKET_HOURS_CHECK` / `MAX_ORDER_NOTIONAL` / `BRIDGE_RUN_MODE` 等を wrangler.jsonc vars 前提で書いていたが、すべて D1 `global_config` に移行済。fail-closed defaults もそちらを参照するよう書き換え。
- **secret list**: `ALLOWED_SYMBOLS` / `MAX_ORDER_NOTIONAL` / `SYMBOL_MAX_NOTIONAL` の記述を削除 (D1 に移行)。残る 9 件 (`BASIC_AUTH_*` / `WEBULL_APP_*` / `WEBULL_ACCOUNT_ID` / `WEBULL_API_BASE` / `WEBULL_GRPC_ENDPOINT` / `EVENT_INGEST_SECRET` / `EVENT_INGEST_URL`) に整合。
- **endpoints**: `/admin/symbols/:symbol/seed-cash` / `/admin/portfolio/seed-equity` を追加。
- **インフラ**: DO / Container / D1 を実態通りに bindings 表 + アーキテクチャ図で表現。
- **Deploy**: Cloudflare Workers Builds + `pnpm run deploy:staging` (migration + deploy) を前提に書き直し。bridge Container の前提条件 (Paid plan / Docker / 追加 secret) も追記。
- **D1 運用**: 初回 `d1 create` → migration → seed の手順、および `wrangler d1 execute` による直編集レシピを掲載。詳細は `docs/db-operations.md` 参照。
- **Layout**: state/ / bridge/ / quotes/ / db/ と drizzle/ を追加。test 件数も 275 に更新。

### 機能変更無し

ドキュメントのみ。code 変更なし、`pnpm run typecheck` / `pnpm test` (275 件) pass。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * アーキテクチャドキュメントを更新。gRPCブリッジとCloudflare Containerの統合について説明を追加
  * 設定管理システムを環境変数からD1ベースのグローバル設定スキームに変更
  * デプロイメントワークフローとローカル開発セットアップの手順を更新
  * Durable ObjectsおよびD1データベースを含む拡張アーキテクチャ図を追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->