### PR TITLE
feat(db): 通貨別 cap + portfolio budget 枠 (#76 Phase E)

### DIFF
--- a/docs/db-operations.md
+++ b/docs/db-operations.md
@@ -146,3 +146,47 @@ WHERE id = 'default';
 SELECT dry_run, trading_enabled, max_order_notional, drawdown_kill_threshold, bridge_run_mode
 FROM global_config WHERE id = 'default';
 ```
+
+## currency + budget (#76 Phase E)
+
+`symbol_config.currency` と `global_config.max_order_notional_{usd,jpy}` で通貨別の注文上限を管理する。`TradingConfig.maxOrderNotional` は route handler で symbol の currency に応じて USD 値か JPY 値を選ぶ。
+
+### 銘柄追加時は currency を明示
+
+```sql
+-- US 銘柄 (default 'USD' でも可だが明示推奨)
+INSERT INTO symbol_config (symbol, name, market, currency, active, max_notional, updated_at)
+VALUES ('SOXL', 'Direxion Daily Semiconductor Bull 3X', 'US', 'USD', 1, 650,
+        strftime('%Y-%m-%dT%H:%M:%fZ', 'now'));
+
+-- JP 銘柄
+INSERT INTO symbol_config (symbol, name, market, currency, active, max_notional, updated_at)
+VALUES ('6301', '小松製作所', 'JP', 'JPY', 1, 100000,
+        strftime('%Y-%m-%dT%H:%M:%fZ', 'now'));
+```
+
+### 通貨別 cap 調整
+
+```sql
+-- USD 1 注文上限を $700 に
+UPDATE global_config SET max_order_notional_usd = 700,
+  updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = 'default';
+
+-- JPY 1 注文上限を ¥15万に
+UPDATE global_config SET max_order_notional_jpy = 150000,
+  updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = 'default';
+```
+
+### 総資本 (future: exposure tracking と連動)
+
+```sql
+-- 予算 20万円 × 2 (海外 + JP)
+UPDATE global_config SET
+  total_capital_usd = 1333,     -- ≒ ¥20万 / 150
+  total_capital_jpy = 200000,
+  max_portfolio_exposure_pct = 0.6,
+  updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE id = 'default';
+```
+
+**注: `total_capital_*` / `max_portfolio_exposure_pct` は schema に入れてあるが、現時点で exposure tracking 側 (PortfolioStateDO の open_exposure) が未実装。gate に反映されるのは follow-up issue 完了後。**

--- a/docs/seed/global_config.sql
+++ b/docs/seed/global_config.sql
@@ -1,16 +1,27 @@
 -- Singleton global_config row。運用者が UPDATE で runtime に切り替える。
 -- 使い方: wrangler d1 execute webull-trading-staging --env=staging --remote --file=docs/seed/global_config.sql
+--
+-- Phase E (#76) で通貨別 max_order_notional_{usd,jpy} と total_capital /
+-- max_portfolio_exposure_pct カラムを追加。旧 max_order_notional は
+-- deprecated だが NOT NULL 維持のため 100 で埋める (gate では未参照)。
 
 INSERT INTO global_config (
   id, dry_run, trading_enabled, market_hours_check,
-  max_order_notional, drawdown_kill_threshold,
+  max_order_notional, max_order_notional_usd, max_order_notional_jpy,
+  total_capital_usd, total_capital_jpy, max_portfolio_exposure_pct,
+  drawdown_kill_threshold,
   stale_quote_ms, gap_reject_pct,
   spread_limit_pct_us, spread_limit_pct_jp,
   bridge_run_mode, updated_at
 ) VALUES (
   'default', 1, 0, 0,
-  100, -0.02,
+  100,           -- max_order_notional (deprecated placeholder)
+  2000,          -- max_order_notional_usd
+  100000,        -- max_order_notional_jpy (¥10万)
+  NULL, NULL,    -- total_capital_{usd,jpy} は operator 側で後から seed
+  0.6,           -- max_portfolio_exposure_pct (exposure tracking は follow-up で有効化)
+  -0.02,
   900000, 0.03,
   0.0025, 0.006,
-  'auto', '2026-04-19T00:00:00.000Z'
+  'auto', '2026-04-20T00:00:00.000Z'
 );

--- a/drizzle/0003_currency_budget.sql
+++ b/drizzle/0003_currency_budget.sql
@@ -1,0 +1,88 @@
+-- Phase E (#76): symbol_config に currency 列追加、global_config に通貨別 cap と
+-- portfolio 予算関連カラムを追加。SQLite の制約で CHECK 追加はテーブル再作成が必要。
+-- 既存行の新列は DEFAULT で埋める。
+
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+
+CREATE TABLE `__new_global_config` (
+	`id` text PRIMARY KEY NOT NULL,
+	`dry_run` integer DEFAULT true NOT NULL,
+	`trading_enabled` integer DEFAULT false NOT NULL,
+	`market_hours_check` integer DEFAULT false NOT NULL,
+	`max_order_notional` real DEFAULT 100 NOT NULL,
+	`max_order_notional_usd` real DEFAULT 2000 NOT NULL,
+	`max_order_notional_jpy` real DEFAULT 100000 NOT NULL,
+	`total_capital_usd` real,
+	`total_capital_jpy` real,
+	`max_portfolio_exposure_pct` real DEFAULT 0.6 NOT NULL,
+	`drawdown_kill_threshold` real DEFAULT -0.02 NOT NULL,
+	`stale_quote_ms` integer DEFAULT 900000 NOT NULL,
+	`gap_reject_pct` real DEFAULT 0.03 NOT NULL,
+	`spread_limit_pct_us` real DEFAULT 0.0025 NOT NULL,
+	`spread_limit_pct_jp` real DEFAULT 0.006 NOT NULL,
+	`bridge_run_mode` text DEFAULT 'auto' NOT NULL,
+	`updated_at` text NOT NULL,
+	CONSTRAINT "global_config_max_order_notional_range" CHECK("__new_global_config"."max_order_notional" > 0 AND "__new_global_config"."max_order_notional" <= 10000000),
+	CONSTRAINT "global_config_max_order_notional_usd_range" CHECK("__new_global_config"."max_order_notional_usd" > 0 AND "__new_global_config"."max_order_notional_usd" <= 1000000),
+	CONSTRAINT "global_config_max_order_notional_jpy_range" CHECK("__new_global_config"."max_order_notional_jpy" > 0 AND "__new_global_config"."max_order_notional_jpy" <= 100000000),
+	CONSTRAINT "global_config_total_capital_usd_range" CHECK("__new_global_config"."total_capital_usd" IS NULL OR "__new_global_config"."total_capital_usd" > 0),
+	CONSTRAINT "global_config_total_capital_jpy_range" CHECK("__new_global_config"."total_capital_jpy" IS NULL OR "__new_global_config"."total_capital_jpy" > 0),
+	CONSTRAINT "global_config_max_portfolio_exposure_pct_range" CHECK("__new_global_config"."max_portfolio_exposure_pct" > 0 AND "__new_global_config"."max_portfolio_exposure_pct" <= 1),
+	CONSTRAINT "global_config_drawdown_kill_threshold_range" CHECK("__new_global_config"."drawdown_kill_threshold" >= -1 AND "__new_global_config"."drawdown_kill_threshold" <= 0),
+	CONSTRAINT "global_config_stale_quote_ms_range" CHECK("__new_global_config"."stale_quote_ms" >= 0),
+	CONSTRAINT "global_config_gap_reject_pct_range" CHECK("__new_global_config"."gap_reject_pct" >= 0 AND "__new_global_config"."gap_reject_pct" <= 1),
+	CONSTRAINT "global_config_spread_limit_pct_us_range" CHECK("__new_global_config"."spread_limit_pct_us" >= 0 AND "__new_global_config"."spread_limit_pct_us" <= 1),
+	CONSTRAINT "global_config_spread_limit_pct_jp_range" CHECK("__new_global_config"."spread_limit_pct_jp" >= 0 AND "__new_global_config"."spread_limit_pct_jp" <= 1),
+	CONSTRAINT "global_config_bridge_run_mode_enum" CHECK("__new_global_config"."bridge_run_mode" IN ('auto', 'always-on', 'disabled'))
+);--> statement-breakpoint
+
+-- 既存行を new テーブルへ移送。新列 (max_order_notional_usd / _jpy /
+-- total_capital_* / max_portfolio_exposure_pct) は DEFAULT で埋める。
+-- max_order_notional_usd の初期値は旧 max_order_notional を引き継ぐ方が
+-- 運用感覚に合うので COALESCE でコピー。
+INSERT INTO `__new_global_config` (
+  id, dry_run, trading_enabled, market_hours_check,
+  max_order_notional, max_order_notional_usd, max_order_notional_jpy,
+  total_capital_usd, total_capital_jpy, max_portfolio_exposure_pct,
+  drawdown_kill_threshold, stale_quote_ms, gap_reject_pct,
+  spread_limit_pct_us, spread_limit_pct_jp, bridge_run_mode, updated_at
+)
+SELECT
+  id, dry_run, trading_enabled, market_hours_check,
+  max_order_notional,
+  max_order_notional,            -- max_order_notional_usd を旧値で初期化
+  100000,                         -- max_order_notional_jpy default
+  NULL,                           -- total_capital_usd 未設定
+  NULL,                           -- total_capital_jpy 未設定
+  0.6,                            -- max_portfolio_exposure_pct default
+  drawdown_kill_threshold, stale_quote_ms, gap_reject_pct,
+  spread_limit_pct_us, spread_limit_pct_jp, bridge_run_mode, updated_at
+FROM `global_config`;--> statement-breakpoint
+
+DROP TABLE `global_config`;--> statement-breakpoint
+ALTER TABLE `__new_global_config` RENAME TO `global_config`;--> statement-breakpoint
+
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+
+CREATE TABLE `__new_symbol_config` (
+	`symbol` text PRIMARY KEY NOT NULL,
+	`name` text,
+	`market` text NOT NULL,
+	`currency` text DEFAULT 'USD' NOT NULL,
+	`active` integer DEFAULT true NOT NULL,
+	`max_notional` real,
+	`notes` text,
+	`updated_at` text NOT NULL,
+	CONSTRAINT "symbol_config_currency_enum" CHECK("__new_symbol_config"."currency" IN ('USD', 'JPY'))
+);--> statement-breakpoint
+
+-- 既存 symbol_config 行を移送。market='JP' は JPY、それ以外は USD default。
+INSERT INTO `__new_symbol_config` (symbol, name, market, currency, active, max_notional, notes, updated_at)
+SELECT
+  symbol, name, market,
+  CASE WHEN market = 'JP' THEN 'JPY' ELSE 'USD' END,
+  active, max_notional, notes, updated_at
+FROM `symbol_config`;--> statement-breakpoint
+
+DROP TABLE `symbol_config`;--> statement-breakpoint
+ALTER TABLE `__new_symbol_config` RENAME TO `symbol_config`;

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,512 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "8738cdc1-438a-44fd-847f-0cf4095efa63",
+  "prevId": "3367679b-1183-443a-bff1-fa928ccb7c91",
+  "tables": {
+    "global_config": {
+      "name": "global_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "trading_enabled": {
+          "name": "trading_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "market_hours_check": {
+          "name": "market_hours_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "max_order_notional": {
+          "name": "max_order_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "max_order_notional_usd": {
+          "name": "max_order_notional_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2000
+        },
+        "max_order_notional_jpy": {
+          "name": "max_order_notional_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100000
+        },
+        "total_capital_usd": {
+          "name": "total_capital_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_capital_jpy": {
+          "name": "total_capital_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_portfolio_exposure_pct": {
+          "name": "max_portfolio_exposure_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.6
+        },
+        "drawdown_kill_threshold": {
+          "name": "drawdown_kill_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.02
+        },
+        "stale_quote_ms": {
+          "name": "stale_quote_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 900000
+        },
+        "gap_reject_pct": {
+          "name": "gap_reject_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.03
+        },
+        "spread_limit_pct_us": {
+          "name": "spread_limit_pct_us",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.0025
+        },
+        "spread_limit_pct_jp": {
+          "name": "spread_limit_pct_jp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.006
+        },
+        "bridge_run_mode": {
+          "name": "bridge_run_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'auto'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "global_config_max_order_notional_range": {
+          "name": "global_config_max_order_notional_range",
+          "value": "\"global_config\".\"max_order_notional\" > 0 AND \"global_config\".\"max_order_notional\" <= 10000000"
+        },
+        "global_config_max_order_notional_usd_range": {
+          "name": "global_config_max_order_notional_usd_range",
+          "value": "\"global_config\".\"max_order_notional_usd\" > 0 AND \"global_config\".\"max_order_notional_usd\" <= 1000000"
+        },
+        "global_config_max_order_notional_jpy_range": {
+          "name": "global_config_max_order_notional_jpy_range",
+          "value": "\"global_config\".\"max_order_notional_jpy\" > 0 AND \"global_config\".\"max_order_notional_jpy\" <= 100000000"
+        },
+        "global_config_total_capital_usd_range": {
+          "name": "global_config_total_capital_usd_range",
+          "value": "\"global_config\".\"total_capital_usd\" IS NULL OR \"global_config\".\"total_capital_usd\" > 0"
+        },
+        "global_config_total_capital_jpy_range": {
+          "name": "global_config_total_capital_jpy_range",
+          "value": "\"global_config\".\"total_capital_jpy\" IS NULL OR \"global_config\".\"total_capital_jpy\" > 0"
+        },
+        "global_config_max_portfolio_exposure_pct_range": {
+          "name": "global_config_max_portfolio_exposure_pct_range",
+          "value": "\"global_config\".\"max_portfolio_exposure_pct\" > 0 AND \"global_config\".\"max_portfolio_exposure_pct\" <= 1"
+        },
+        "global_config_drawdown_kill_threshold_range": {
+          "name": "global_config_drawdown_kill_threshold_range",
+          "value": "\"global_config\".\"drawdown_kill_threshold\" >= -1 AND \"global_config\".\"drawdown_kill_threshold\" <= 0"
+        },
+        "global_config_stale_quote_ms_range": {
+          "name": "global_config_stale_quote_ms_range",
+          "value": "\"global_config\".\"stale_quote_ms\" >= 0"
+        },
+        "global_config_gap_reject_pct_range": {
+          "name": "global_config_gap_reject_pct_range",
+          "value": "\"global_config\".\"gap_reject_pct\" >= 0 AND \"global_config\".\"gap_reject_pct\" <= 1"
+        },
+        "global_config_spread_limit_pct_us_range": {
+          "name": "global_config_spread_limit_pct_us_range",
+          "value": "\"global_config\".\"spread_limit_pct_us\" >= 0 AND \"global_config\".\"spread_limit_pct_us\" <= 1"
+        },
+        "global_config_spread_limit_pct_jp_range": {
+          "name": "global_config_spread_limit_pct_jp_range",
+          "value": "\"global_config\".\"spread_limit_pct_jp\" >= 0 AND \"global_config\".\"spread_limit_pct_jp\" <= 1"
+        },
+        "global_config_bridge_run_mode_enum": {
+          "name": "global_config_bridge_run_mode_enum",
+          "value": "\"global_config\".\"bridge_run_mode\" IN ('auto', 'always-on', 'disabled')"
+        }
+      }
+    },
+    "inverse_pairs": {
+      "name": "inverse_pairs",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inverse": {
+          "name": "inverse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "symbol_config": {
+      "name": "symbol_config",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "market": {
+          "name": "market",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_notional": {
+          "name": "max_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "symbol_config_currency_enum": {
+          "name": "symbol_config_currency_enum",
+          "value": "\"symbol_config\".\"currency\" IN ('USD', 'JPY')"
+        }
+      }
+    },
+    "trade_journal": {
+      "name": "trade_journal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trade_event_type": {
+          "name": "trade_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "strategy_name": {
+          "name": "strategy_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_action": {
+          "name": "signal_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_reason": {
+          "name": "signal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_allowed": {
+          "name": "risk_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_reasons": {
+          "name": "risk_reasons",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "limit_price": {
+          "name": "limit_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notional": {
+          "name": "notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "broker_status": {
+          "name": "broker_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "submitted": {
+          "name": "submitted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_qty": {
+          "name": "filled_qty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_price": {
+          "name": "filled_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "realized_pnl": {
+          "name": "realized_pnl",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hold_days": {
+          "name": "hold_days",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_reason": {
+          "name": "exit_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1776607960216,
       "tag": "0002_global_config",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1776610656488,
+      "tag": "0003_currency_budget",
+      "breakpoints": true
     }
   ]
 }

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -5,12 +5,6 @@ export interface Env {
   BASIC_AUTH_PASSWORD: string
   EVENT_INGEST_SECRET: string
   SYMBOL_STATE: DurableObjectNamespace<SymbolStateDO>
-  // 以下 Phase D (#70) 以降は D1 `global_config` / `symbol_config` に移行済。
-  // wrangler.jsonc から vars は削除済、env 側への供給は "test 用の fallback" 扱い。
-  DRY_RUN?: string
-  TRADING_ENABLED?: string
-  ALLOWED_SYMBOLS?: string
-  MAX_ORDER_NOTIONAL?: string
 }
 
 /**
@@ -60,11 +54,6 @@ export interface Env {
   WEBULL_QUOTE_PATH?: string
 }
 
-// Trading risk config (Phase 5 append)
-export interface Env {
-  SYMBOL_MAX_NOTIONAL?: string
-  MARKET_HOURS_CHECK?: string
-}
 
 // Pullback strategy per-symbol rule overrides (Phase 2c append)
 export interface Env {
@@ -222,47 +211,20 @@ export function parseInversePairs(value: string | undefined): Record<string, str
   }
 }
 
-// Risk correlation config (Phase 2b append)
-export interface Env {
-  INVERSE_PAIRS?: string
-}
-
-// Spread guard config (Phase 2b #38-D append)
-export interface Env {
-  SPREAD_LIMIT_PCT_US?: string
-  SPREAD_LIMIT_PCT_JP?: string
-}
-
-// Halt / price-band / gap config (#38-C append)
-export interface Env {
-  STALE_QUOTE_MS?: string
-  GAP_REJECT_PCT?: string
-}
-
-// Drawdown kill switch (#38-B append)
+// PortfolioStateDO binding (#38-B)
 import type { PortfolioStateDO } from '../trading/state/PortfolioStateDO'
 
 export interface Env {
   PORTFOLIO_STATE?: DurableObjectNamespace<PortfolioStateDO>
-  /**
-   * Daily drawdown kill threshold, as a fraction of day-start equity. Parsed as
-   * a negative float (e.g. `"-0.02"`). Default -0.02 when unset or malformed.
-   */
-  DRAWDOWN_KILL_THRESHOLD?: string
 }
 
-// Bridge container binding (#33 append)
+// Bridge container binding (#33)
 import type { BridgeContainer } from '../trading/bridge/BridgeContainer'
 
 export interface Env {
   BRIDGE?: DurableObjectNamespace<BridgeContainer>
   WEBULL_GRPC_ENDPOINT?: string
   EVENT_INGEST_URL?: string
-  /**
-   * Bridge lifecycle policy — see {@link BridgeRunMode} (`always-on` /
-   * `disabled` / `auto`). 省略時は `auto`: 平日 UTC のみ起動。
-   */
-  BRIDGE_RUN_MODE?: string
 }
 
 /**

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -3,12 +3,14 @@ import type { SymbolStateDO } from '../trading/state/SymbolStateDO'
 export interface Env {
   BASIC_AUTH_USER: string
   BASIC_AUTH_PASSWORD: string
-  DRY_RUN?: string
-  TRADING_ENABLED?: string
-  ALLOWED_SYMBOLS: string
-  MAX_ORDER_NOTIONAL: string
   EVENT_INGEST_SECRET: string
   SYMBOL_STATE: DurableObjectNamespace<SymbolStateDO>
+  // 以下 Phase D (#70) 以降は D1 `global_config` / `symbol_config` に移行済。
+  // wrangler.jsonc から vars は削除済、env 側への供給は "test 用の fallback" 扱い。
+  DRY_RUN?: string
+  TRADING_ENABLED?: string
+  ALLOWED_SYMBOLS?: string
+  MAX_ORDER_NOTIONAL?: string
 }
 
 /**

--- a/src/infrastructure/db/globalConfigLoader.ts
+++ b/src/infrastructure/db/globalConfigLoader.ts
@@ -55,14 +55,21 @@ export async function loadGlobalConfigFrom(env: GlobalConfigEnv): Promise<Loaded
     'SPREAD_LIMIT_PCT_JP',
   )
 
+  const maxOrderNotional =
+    env.MAX_ORDER_NOTIONAL !== undefined
+      ? parseNumberEnv(env.MAX_ORDER_NOTIONAL, 'MAX_ORDER_NOTIONAL')
+      : GLOBAL_CONFIG_DEFAULTS.maxOrderNotional
+
   return {
     dryRun: parseBooleanEnv(env.DRY_RUN, GLOBAL_CONFIG_DEFAULTS.dryRun),
     tradingEnabled: parseBooleanEnv(env.TRADING_ENABLED, GLOBAL_CONFIG_DEFAULTS.tradingEnabled),
     marketHoursCheck: parseBooleanEnv(env.MARKET_HOURS_CHECK, GLOBAL_CONFIG_DEFAULTS.marketHoursCheck),
-    maxOrderNotional:
-      env.MAX_ORDER_NOTIONAL !== undefined
-        ? parseNumberEnv(env.MAX_ORDER_NOTIONAL, 'MAX_ORDER_NOTIONAL')
-        : GLOBAL_CONFIG_DEFAULTS.maxOrderNotional,
+    maxOrderNotional,
+    maxOrderNotionalUsd: GLOBAL_CONFIG_DEFAULTS.maxOrderNotionalUsd,
+    maxOrderNotionalJpy: GLOBAL_CONFIG_DEFAULTS.maxOrderNotionalJpy,
+    totalCapitalUsd: GLOBAL_CONFIG_DEFAULTS.totalCapitalUsd,
+    totalCapitalJpy: GLOBAL_CONFIG_DEFAULTS.totalCapitalJpy,
+    maxPortfolioExposurePct: GLOBAL_CONFIG_DEFAULTS.maxPortfolioExposurePct,
     drawdownKillThreshold: parseDrawdownKillThreshold(env.DRAWDOWN_KILL_THRESHOLD),
     staleQuoteMs: parseOptionalPositiveNumber(
       env.STALE_QUOTE_MS,

--- a/src/infrastructure/db/globalConfigLoader.ts
+++ b/src/infrastructure/db/globalConfigLoader.ts
@@ -1,91 +1,25 @@
-import {
-  parseBooleanEnv,
-  parseDrawdownKillThreshold,
-  parseNumberEnv,
-  parseOptionalNonNegativeNumberEnv,
-  parseOptionalPositiveNumber,
-} from '../../config/env'
-import { parseBridgeRunMode } from '../../trading/bridge/schedule'
-import {
-  GLOBAL_CONFIG_DEFAULTS,
-  loadGlobalConfig,
-  type GlobalConfigSnapshot,
-} from './globalConfigRepo'
+import { loadGlobalConfig, type GlobalConfigSnapshot } from './globalConfigRepo'
 import { createDb } from './tradeJournalRepo'
 
 export interface LoadedGlobalConfig extends GlobalConfigSnapshot {
-  source: 'd1' | 'env'
+  source: 'd1'
 }
 
 interface GlobalConfigEnv {
   DB?: D1Database
-  DRY_RUN?: string
-  TRADING_ENABLED?: string
-  MARKET_HOURS_CHECK?: string
-  MAX_ORDER_NOTIONAL?: string
-  DRAWDOWN_KILL_THRESHOLD?: string
-  STALE_QUOTE_MS?: string
-  GAP_REJECT_PCT?: string
-  SPREAD_LIMIT_PCT_US?: string
-  SPREAD_LIMIT_PCT_JP?: string
-  BRIDGE_RUN_MODE?: string
 }
 
 /**
- * Loads the global risk / lifecycle config. Prefers D1 (`global_config`
- * singleton) when `env.DB` is bound; otherwise parses the legacy env vars so
- * tests and pre-D1 deployments stay working.
+ * Loads the global risk / lifecycle config from D1.
  *
- * `SPREAD_LIMIT_PCT_*` env values are percent (0.25 = 0.25%) historically, so
- * we divide by 100 when coming from env; D1 stores them already as fractions.
+ * D1 binding is **required** (Phase E で env fallback を削除)。未 bind は
+ * setup ミスなので明示的に throw して fail-closed にする。
  */
 export async function loadGlobalConfigFrom(env: GlobalConfigEnv): Promise<LoadedGlobalConfig> {
-  if (env.DB) {
-    const db = createDb(env.DB)
-    const snapshot = await loadGlobalConfig(db)
-    return { ...snapshot, source: 'd1' }
+  if (!env.DB) {
+    throw new Error('loadGlobalConfigFrom: env.DB is not bound (D1 setup required)')
   }
-
-  const spreadUsPercent = parseOptionalNonNegativeNumberEnv(
-    env.SPREAD_LIMIT_PCT_US,
-    'SPREAD_LIMIT_PCT_US',
-  )
-  const spreadJpPercent = parseOptionalNonNegativeNumberEnv(
-    env.SPREAD_LIMIT_PCT_JP,
-    'SPREAD_LIMIT_PCT_JP',
-  )
-
-  const maxOrderNotional =
-    env.MAX_ORDER_NOTIONAL !== undefined
-      ? parseNumberEnv(env.MAX_ORDER_NOTIONAL, 'MAX_ORDER_NOTIONAL')
-      : GLOBAL_CONFIG_DEFAULTS.maxOrderNotional
-
-  return {
-    dryRun: parseBooleanEnv(env.DRY_RUN, GLOBAL_CONFIG_DEFAULTS.dryRun),
-    tradingEnabled: parseBooleanEnv(env.TRADING_ENABLED, GLOBAL_CONFIG_DEFAULTS.tradingEnabled),
-    marketHoursCheck: parseBooleanEnv(env.MARKET_HOURS_CHECK, GLOBAL_CONFIG_DEFAULTS.marketHoursCheck),
-    maxOrderNotional,
-    maxOrderNotionalUsd: GLOBAL_CONFIG_DEFAULTS.maxOrderNotionalUsd,
-    maxOrderNotionalJpy: GLOBAL_CONFIG_DEFAULTS.maxOrderNotionalJpy,
-    totalCapitalUsd: GLOBAL_CONFIG_DEFAULTS.totalCapitalUsd,
-    totalCapitalJpy: GLOBAL_CONFIG_DEFAULTS.totalCapitalJpy,
-    maxPortfolioExposurePct: GLOBAL_CONFIG_DEFAULTS.maxPortfolioExposurePct,
-    drawdownKillThreshold: parseDrawdownKillThreshold(env.DRAWDOWN_KILL_THRESHOLD),
-    staleQuoteMs: parseOptionalPositiveNumber(
-      env.STALE_QUOTE_MS,
-      GLOBAL_CONFIG_DEFAULTS.staleQuoteMs,
-      'STALE_QUOTE_MS',
-    ),
-    gapRejectPct: parseOptionalPositiveNumber(
-      env.GAP_REJECT_PCT,
-      GLOBAL_CONFIG_DEFAULTS.gapRejectPct,
-      'GAP_REJECT_PCT',
-    ),
-    spreadLimitPctUs:
-      spreadUsPercent !== undefined ? spreadUsPercent / 100 : GLOBAL_CONFIG_DEFAULTS.spreadLimitPctUs,
-    spreadLimitPctJp:
-      spreadJpPercent !== undefined ? spreadJpPercent / 100 : GLOBAL_CONFIG_DEFAULTS.spreadLimitPctJp,
-    bridgeRunMode: parseBridgeRunMode(env.BRIDGE_RUN_MODE),
-    source: 'env',
-  }
+  const db = createDb(env.DB)
+  const snapshot = await loadGlobalConfig(db)
+  return { ...snapshot, source: 'd1' }
 }

--- a/src/infrastructure/db/globalConfigRepo.ts
+++ b/src/infrastructure/db/globalConfigRepo.ts
@@ -6,7 +6,17 @@ export interface GlobalConfigSnapshot {
   dryRun: boolean
   tradingEnabled: boolean
   marketHoursCheck: boolean
+  /**
+   * @deprecated Phase E で通貨別 `maxOrderNotionalUsd` / `maxOrderNotionalJpy`
+   * に移行。互換目的でロード時も読み出しているが Risk gate は通貨別値を使う。
+   */
   maxOrderNotional: number
+  maxOrderNotionalUsd: number
+  maxOrderNotionalJpy: number
+  /** 総資本 USD。null なら portfolio exposure check を skip。 */
+  totalCapitalUsd: number | null
+  totalCapitalJpy: number | null
+  maxPortfolioExposurePct: number
   drawdownKillThreshold: number
   staleQuoteMs: number
   gapRejectPct: number
@@ -25,6 +35,11 @@ export const GLOBAL_CONFIG_DEFAULTS: GlobalConfigSnapshot = Object.freeze({
   tradingEnabled: false,
   marketHoursCheck: false,
   maxOrderNotional: 100,
+  maxOrderNotionalUsd: 2000,
+  maxOrderNotionalJpy: 100000,
+  totalCapitalUsd: null,
+  totalCapitalJpy: null,
+  maxPortfolioExposurePct: 0.6,
   drawdownKillThreshold: -0.02,
   staleQuoteMs: 15 * 60 * 1_000,
   gapRejectPct: 0.03,
@@ -44,6 +59,11 @@ export async function loadGlobalConfig(
     tradingEnabled: row.tradingEnabled,
     marketHoursCheck: row.marketHoursCheck,
     maxOrderNotional: row.maxOrderNotional,
+    maxOrderNotionalUsd: row.maxOrderNotionalUsd,
+    maxOrderNotionalJpy: row.maxOrderNotionalJpy,
+    totalCapitalUsd: row.totalCapitalUsd,
+    totalCapitalJpy: row.totalCapitalJpy,
+    maxPortfolioExposurePct: row.maxPortfolioExposurePct,
     drawdownKillThreshold: row.drawdownKillThreshold,
     staleQuoteMs: row.staleQuoteMs,
     gapRejectPct: row.gapRejectPct,

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -52,16 +52,30 @@ export type TradeJournalInsert = typeof tradeJournal.$inferInsert
  * `active = 0` で一時停止扱い (ALLOWED_SYMBOLS から外れる)。`max_notional`
  * が NULL なら global の MAX_ORDER_NOTIONAL 上限に丸める (fall-through)。
  */
-export const symbolConfig = sqliteTable('symbol_config', {
-  symbol: text('symbol').primaryKey(),
-  /** 人間可読な銘柄名 (例: "Direxion Daily Semiconductor Bull 3X"、トヨタ自動車)。運用時の識別用。 */
-  name: text('name'),
-  market: text('market').notNull(), // 'US' | 'JP'
-  active: integer('active', { mode: 'boolean' }).notNull().default(true),
-  maxNotional: real('max_notional'),
-  notes: text('notes'),
-  updatedAt: text('updated_at').notNull(),
-})
+export const symbolConfig = sqliteTable(
+  'symbol_config',
+  {
+    symbol: text('symbol').primaryKey(),
+    /** 人間可読な銘柄名 (例: "Direxion Daily Semiconductor Bull 3X"、トヨタ自動車)。運用時の識別用。 */
+    name: text('name'),
+    market: text('market').notNull(), // 'US' | 'JP'
+    /**
+     * 取引通貨 ISO 4217 ('USD' / 'JPY' ...)。notional を global cap と比較する時の
+     * 基準。market と独立に持つのは将来 HKD ADR 等への拡張を見越してのこと。
+     */
+    currency: text('currency').notNull().default('USD'),
+    active: integer('active', { mode: 'boolean' }).notNull().default(true),
+    maxNotional: real('max_notional'),
+    notes: text('notes'),
+    updatedAt: text('updated_at').notNull(),
+  },
+  (t) => ({
+    currencyEnum: check(
+      'symbol_config_currency_enum',
+      sql`${t.currency} IN ('USD', 'JPY')`,
+    ),
+  }),
+)
 
 export type SymbolConfigRow = typeof symbolConfig.$inferSelect
 export type SymbolConfigInsert = typeof symbolConfig.$inferInsert
@@ -98,7 +112,22 @@ export const globalConfig = sqliteTable(
     dryRun: integer('dry_run', { mode: 'boolean' }).notNull().default(true),
     tradingEnabled: integer('trading_enabled', { mode: 'boolean' }).notNull().default(false),
     marketHoursCheck: integer('market_hours_check', { mode: 'boolean' }).notNull().default(false),
+    /** @deprecated Phase E で通貨別 cap に移行。互換のため残置、参照はしない。 */
     maxOrderNotional: real('max_order_notional').notNull().default(100),
+    /** USD 銘柄 (currency='USD') の 1 注文上限。 */
+    maxOrderNotionalUsd: real('max_order_notional_usd').notNull().default(2000),
+    /** JPY 銘柄 (currency='JPY') の 1 注文上限。 */
+    maxOrderNotionalJpy: real('max_order_notional_jpy').notNull().default(100000),
+    /** 総資本 (USD)。NULL なら portfolio exposure check は skip。 */
+    totalCapitalUsd: real('total_capital_usd'),
+    /** 総資本 (JPY)。NULL なら portfolio exposure check は skip。 */
+    totalCapitalJpy: real('total_capital_jpy'),
+    /**
+     * 同時保有エクスポージャー上限 = total_capital * max_portfolio_exposure_pct。
+     * 両通貨共通で、各通貨の `open_exposure` が通貨別 `total_capital` の
+     * この比率を超える新規 BUY は reject。
+     */
+    maxPortfolioExposurePct: real('max_portfolio_exposure_pct').notNull().default(0.6),
     drawdownKillThreshold: real('drawdown_kill_threshold').notNull().default(-0.02),
     staleQuoteMs: integer('stale_quote_ms').notNull().default(900000),
     gapRejectPct: real('gap_reject_pct').notNull().default(0.03),
@@ -113,6 +142,26 @@ export const globalConfig = sqliteTable(
     maxOrderNotionalRange: check(
       'global_config_max_order_notional_range',
       sql`${t.maxOrderNotional} > 0 AND ${t.maxOrderNotional} <= 10000000`,
+    ),
+    maxOrderNotionalUsdRange: check(
+      'global_config_max_order_notional_usd_range',
+      sql`${t.maxOrderNotionalUsd} > 0 AND ${t.maxOrderNotionalUsd} <= 1000000`,
+    ),
+    maxOrderNotionalJpyRange: check(
+      'global_config_max_order_notional_jpy_range',
+      sql`${t.maxOrderNotionalJpy} > 0 AND ${t.maxOrderNotionalJpy} <= 100000000`,
+    ),
+    totalCapitalUsdRange: check(
+      'global_config_total_capital_usd_range',
+      sql`${t.totalCapitalUsd} IS NULL OR ${t.totalCapitalUsd} > 0`,
+    ),
+    totalCapitalJpyRange: check(
+      'global_config_total_capital_jpy_range',
+      sql`${t.totalCapitalJpy} IS NULL OR ${t.totalCapitalJpy} > 0`,
+    ),
+    maxPortfolioExposurePctRange: check(
+      'global_config_max_portfolio_exposure_pct_range',
+      sql`${t.maxPortfolioExposurePct} > 0 AND ${t.maxPortfolioExposurePct} <= 1`,
     ),
     drawdownKillThresholdRange: check(
       'global_config_drawdown_kill_threshold_range',

--- a/src/infrastructure/db/symbolConfigRepo.ts
+++ b/src/infrastructure/db/symbolConfigRepo.ts
@@ -42,9 +42,8 @@ export async function loadSymbolConfig(
 
 /**
  * Returns a bidirectional inverse-pair map (SOXL→SOXS AND SOXS→SOXL even if
- * only one direction is stored). Mirrors the behaviour of the previous
- * `parseInversePairs` env parser so TradingService keeps working without
- * changing its gate logic.
+ * only one direction is stored). TradingService's inverse-pair gate expects
+ * both directions populated.
  */
 export async function loadInversePairs(
   db: DrizzleD1Database,

--- a/src/infrastructure/db/symbolConfigRepo.ts
+++ b/src/infrastructure/db/symbolConfigRepo.ts
@@ -2,6 +2,8 @@ import { eq } from 'drizzle-orm'
 import type { DrizzleD1Database } from 'drizzle-orm/d1'
 import { inversePairs, symbolConfig } from './schema'
 
+export type SymbolCurrency = 'USD' | 'JPY'
+
 export interface SymbolConfigSnapshot {
   /** Uppercased symbols where `active = 1`. */
   allowedSymbols: string[]
@@ -11,6 +13,8 @@ export interface SymbolConfigSnapshot {
    * `MAX_ORDER_NOTIONAL`.
    */
   symbolMaxNotional: Record<string, number>
+  /** symbol → currency ('USD' / 'JPY')。Risk gate が global 通貨別 cap を引くのに使う。 */
+  symbolCurrency: Record<string, SymbolCurrency>
 }
 
 /**
@@ -24,14 +28,16 @@ export async function loadSymbolConfig(
 
   const allowedSymbols: string[] = []
   const symbolMaxNotional: Record<string, number> = {}
+  const symbolCurrency: Record<string, SymbolCurrency> = {}
   for (const row of rows) {
     const symbol = row.symbol.toUpperCase()
     allowedSymbols.push(symbol)
     if (row.maxNotional !== null && Number.isFinite(row.maxNotional) && row.maxNotional > 0) {
       symbolMaxNotional[symbol] = row.maxNotional
     }
+    symbolCurrency[symbol] = row.currency === 'JPY' ? 'JPY' : 'USD'
   }
-  return { allowedSymbols, symbolMaxNotional }
+  return { allowedSymbols, symbolMaxNotional, symbolCurrency }
 }
 
 /**

--- a/src/infrastructure/db/symbolUniverse.ts
+++ b/src/infrastructure/db/symbolUniverse.ts
@@ -1,55 +1,35 @@
 import { createDb } from './tradeJournalRepo'
 import { loadInversePairs, loadSymbolConfig, type SymbolCurrency } from './symbolConfigRepo'
-import { parseCsvEnv, parseInversePairs, parseSymbolNotionalMap } from '../../config/env'
-import { inferWebullMarket } from '../webull/mapper'
 
 export interface SymbolUniverse {
   allowedSymbols: string[]
   symbolMaxNotional: Record<string, number>
   symbolCurrency: Record<string, SymbolCurrency>
   inversePairs: Record<string, string>
-  source: 'd1' | 'env'
+  source: 'd1'
 }
 
 interface UniverseEnv {
   DB?: D1Database
-  ALLOWED_SYMBOLS?: string
-  SYMBOL_MAX_NOTIONAL?: string
-  INVERSE_PAIRS?: string
 }
 
 /**
- * Loads the symbol universe (allowed list + per-symbol caps + currencies +
- * inverse pairs).
+ * Loads the symbol universe from D1 (`symbol_config` / `inverse_pairs`).
  *
- * - When `env.DB` is bound: reads from `symbol_config` / `inverse_pairs` in D1.
- * - Otherwise falls back to the legacy env-var parsing so existing deploys or
- *   local tests that have not migrated stay working. env fallback では currency
- *   を 4 桁数字コード = JP 判定で補完する。
+ * D1 binding is **required** (Phase E で env fallback を削除)。未 bind は
+ * setup ミスなので明示的に throw する。
  */
 export async function loadSymbolUniverse(env: UniverseEnv): Promise<SymbolUniverse> {
-  if (env.DB) {
-    const db = createDb(env.DB)
-    const [config, pairs] = await Promise.all([loadSymbolConfig(db), loadInversePairs(db)])
-    return {
-      allowedSymbols: config.allowedSymbols,
-      symbolMaxNotional: config.symbolMaxNotional,
-      symbolCurrency: config.symbolCurrency,
-      inversePairs: pairs,
-      source: 'd1',
-    }
+  if (!env.DB) {
+    throw new Error('loadSymbolUniverse: env.DB is not bound (D1 setup required)')
   }
-
-  const allowedSymbols = parseCsvEnv(env.ALLOWED_SYMBOLS).map((s) => s.toUpperCase())
-  const symbolCurrency: Record<string, SymbolCurrency> = {}
-  for (const s of allowedSymbols) {
-    symbolCurrency[s] = inferWebullMarket(s) === 'JP' ? 'JPY' : 'USD'
-  }
+  const db = createDb(env.DB)
+  const [config, pairs] = await Promise.all([loadSymbolConfig(db), loadInversePairs(db)])
   return {
-    allowedSymbols,
-    symbolMaxNotional: parseSymbolNotionalMap(env.SYMBOL_MAX_NOTIONAL),
-    symbolCurrency,
-    inversePairs: parseInversePairs(env.INVERSE_PAIRS),
-    source: 'env',
+    allowedSymbols: config.allowedSymbols,
+    symbolMaxNotional: config.symbolMaxNotional,
+    symbolCurrency: config.symbolCurrency,
+    inversePairs: pairs,
+    source: 'd1',
   }
 }

--- a/src/infrastructure/db/symbolUniverse.ts
+++ b/src/infrastructure/db/symbolUniverse.ts
@@ -1,10 +1,12 @@
 import { createDb } from './tradeJournalRepo'
-import { loadInversePairs, loadSymbolConfig } from './symbolConfigRepo'
+import { loadInversePairs, loadSymbolConfig, type SymbolCurrency } from './symbolConfigRepo'
 import { parseCsvEnv, parseInversePairs, parseSymbolNotionalMap } from '../../config/env'
+import { inferWebullMarket } from '../webull/mapper'
 
 export interface SymbolUniverse {
   allowedSymbols: string[]
   symbolMaxNotional: Record<string, number>
+  symbolCurrency: Record<string, SymbolCurrency>
   inversePairs: Record<string, string>
   source: 'd1' | 'env'
 }
@@ -17,14 +19,13 @@ interface UniverseEnv {
 }
 
 /**
- * Loads the symbol universe (allowed list + per-symbol caps + inverse pairs).
+ * Loads the symbol universe (allowed list + per-symbol caps + currencies +
+ * inverse pairs).
  *
  * - When `env.DB` is bound: reads from `symbol_config` / `inverse_pairs` in D1.
  * - Otherwise falls back to the legacy env-var parsing so existing deploys or
- *   local tests that have not migrated stay working.
- *
- * The `source` field tags which path was taken — handy to surface in audit
- * logs after cutover so we can confirm D1 reads are actually hit.
+ *   local tests that have not migrated stay working. env fallback では currency
+ *   を 4 桁数字コード = JP 判定で補完する。
  */
 export async function loadSymbolUniverse(env: UniverseEnv): Promise<SymbolUniverse> {
   if (env.DB) {
@@ -33,14 +34,21 @@ export async function loadSymbolUniverse(env: UniverseEnv): Promise<SymbolUniver
     return {
       allowedSymbols: config.allowedSymbols,
       symbolMaxNotional: config.symbolMaxNotional,
+      symbolCurrency: config.symbolCurrency,
       inversePairs: pairs,
       source: 'd1',
     }
   }
 
+  const allowedSymbols = parseCsvEnv(env.ALLOWED_SYMBOLS).map((s) => s.toUpperCase())
+  const symbolCurrency: Record<string, SymbolCurrency> = {}
+  for (const s of allowedSymbols) {
+    symbolCurrency[s] = inferWebullMarket(s) === 'JP' ? 'JPY' : 'USD'
+  }
   return {
-    allowedSymbols: parseCsvEnv(env.ALLOWED_SYMBOLS).map((s) => s.toUpperCase()),
+    allowedSymbols,
     symbolMaxNotional: parseSymbolNotionalMap(env.SYMBOL_MAX_NOTIONAL),
+    symbolCurrency,
     inversePairs: parseInversePairs(env.INVERSE_PAIRS),
     source: 'env',
   }

--- a/src/routes/trade.ts
+++ b/src/routes/trade.ts
@@ -31,7 +31,9 @@ export const trade = new Hono<AppBindings>()
     ])
     const service = createTradingService(request, c.env, universe, global)
     return c.json(
-      service.decide(request, toTradingConfig(universe, global), { requestId: c.get('requestId') }),
+      service.decide(request, toTradingConfig(request, universe, global), {
+        requestId: c.get('requestId'),
+      }),
     )
   })
   .post('/execute', async (c) => {
@@ -42,7 +44,7 @@ export const trade = new Hono<AppBindings>()
     ])
     const service = createTradingService(request, c.env, universe, global)
     return c.json(
-      await service.executeTrade(request, toTradingConfig(universe, global), {
+      await service.executeTrade(request, toTradingConfig(request, universe, global), {
         requestId: c.get('requestId'),
       }),
     )
@@ -103,12 +105,23 @@ export function createTradingService(
   )
 }
 
-function toTradingConfig(universe: SymbolUniverse, global: LoadedGlobalConfig): TradingConfig {
+function toTradingConfig(
+  request: TradeRequest,
+  universe: SymbolUniverse,
+  global: LoadedGlobalConfig,
+): TradingConfig {
+  // 通貨別の max_order_notional を symbol の currency で選ぶ。universe に
+  // 未登録の symbol は URL の 4 桁数字ヒューリスティックにフォールバックする
+  // (validation は RiskPolicy の allowedSymbols で別途弾かれる)。
+  const upperSymbol = request.symbol.toUpperCase()
+  const currency = universe.symbolCurrency[upperSymbol] ?? (/^\d{4}$/.test(upperSymbol) ? 'JPY' : 'USD')
+  const maxOrderNotional =
+    currency === 'JPY' ? global.maxOrderNotionalJpy : global.maxOrderNotionalUsd
   return {
     dryRun: global.dryRun,
     tradingEnabled: global.tradingEnabled,
     allowedSymbols: universe.allowedSymbols,
-    maxOrderNotional: global.maxOrderNotional,
+    maxOrderNotional,
     symbolMaxNotional: universe.symbolMaxNotional,
     marketHoursCheck: global.marketHoursCheck,
   }

--- a/src/routes/webull.ts
+++ b/src/routes/webull.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono'
 import type { AppBindings } from '../app'
-import { parseBooleanEnv } from '../config/env'
+import { loadGlobalConfigFrom } from '../infrastructure/db/globalConfigLoader'
 import { createWebullHttpClient } from '../infrastructure/webull/WebullHttpClient'
 import type { WebullPlaceOrderResponseDto } from '../infrastructure/webull/dto'
 import { logPostSubmit, logPreSubmit } from '../infrastructure/logger/tradeJournal'
@@ -13,7 +13,8 @@ export const webull = new Hono<AppBindings>().post('/order/place', async (c) => 
 
   logPreSubmit({ requestId, clientOrderId: intent.clientOrderId, intent })
 
-  if (parseBooleanEnv(c.env.DRY_RUN, true)) {
+  const global = await loadGlobalConfigFrom(c.env)
+  if (global.dryRun) {
     const dto = createDryRunResponse(intent)
     logPostSubmit({
       requestId,

--- a/test/helpers/configFixtures.ts
+++ b/test/helpers/configFixtures.ts
@@ -1,0 +1,42 @@
+import type { LoadedGlobalConfig } from '../../src/infrastructure/db/globalConfigLoader'
+import type { SymbolUniverse } from '../../src/infrastructure/db/symbolUniverse'
+
+/**
+ * Default snapshot matching the legacy test env (DRY_RUN=true, TRADING_ENABLED=true,
+ * MAX_ORDER_NOTIONAL=100 相当)。route / integration テストで D1 loader を vi.mock
+ * する際のベースラインとして使う。
+ */
+export function makeGlobalConfigSnapshot(
+  overrides: Partial<LoadedGlobalConfig> = {},
+): LoadedGlobalConfig {
+  return {
+    dryRun: true,
+    tradingEnabled: true,
+    marketHoursCheck: false,
+    maxOrderNotional: 100,
+    maxOrderNotionalUsd: 100,
+    maxOrderNotionalJpy: 100000,
+    totalCapitalUsd: null,
+    totalCapitalJpy: null,
+    maxPortfolioExposurePct: 0.6,
+    drawdownKillThreshold: -0.02,
+    staleQuoteMs: 900_000,
+    gapRejectPct: 0.03,
+    spreadLimitPctUs: 0.0025,
+    spreadLimitPctJp: 0.006,
+    bridgeRunMode: 'auto',
+    source: 'd1',
+    ...overrides,
+  }
+}
+
+export function makeSymbolUniverse(overrides: Partial<SymbolUniverse> = {}): SymbolUniverse {
+  return {
+    allowedSymbols: ['SOXL', 'SOXS'],
+    symbolMaxNotional: {},
+    symbolCurrency: { SOXL: 'USD', SOXS: 'USD' },
+    inversePairs: {},
+    source: 'd1',
+    ...overrides,
+  }
+}

--- a/test/infrastructure/db/globalConfigLoader.test.ts
+++ b/test/infrastructure/db/globalConfigLoader.test.ts
@@ -1,48 +1,8 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { loadGlobalConfigFrom } from '../../../src/infrastructure/db/globalConfigLoader'
-import { GLOBAL_CONFIG_DEFAULTS } from '../../../src/infrastructure/db/globalConfigRepo'
-
-function fakeD1WithRow(row: Record<string, unknown> | undefined) {
-  const limit = vi.fn().mockResolvedValue(row ? [row] : [])
-  const where = vi.fn().mockReturnValue({ limit })
-  const from = vi.fn().mockReturnValue({ where })
-  const select = vi.fn().mockReturnValue({ from })
-  const fakeDrizzle = { select }
-  // createDb wraps a D1Database — we short-circuit by tagging the fake so the
-  // loader's createDb() call returns the same object.
-  return {
-    prepare: vi.fn(),
-    __drizzle: fakeDrizzle,
-  } as unknown as D1Database
-}
 
 describe('loadGlobalConfigFrom', () => {
-  it('env fallback when DB binding is missing', async () => {
-    const snapshot = await loadGlobalConfigFrom({
-      DRY_RUN: 'false',
-      TRADING_ENABLED: 'true',
-      MAX_ORDER_NOTIONAL: '250',
-      DRAWDOWN_KILL_THRESHOLD: '-0.03',
-      SPREAD_LIMIT_PCT_US: '0.25',
-      BRIDGE_RUN_MODE: 'always-on',
-    })
-    expect(snapshot.source).toBe('env')
-    expect(snapshot.dryRun).toBe(false)
-    expect(snapshot.tradingEnabled).toBe(true)
-    expect(snapshot.maxOrderNotional).toBe(250)
-    expect(snapshot.drawdownKillThreshold).toBe(-0.03)
-    expect(snapshot.spreadLimitPctUs).toBeCloseTo(0.0025, 6)
-    expect(snapshot.bridgeRunMode).toBe('always-on')
-  })
-
-  it('falls back to defaults for missing env values', async () => {
-    const snapshot = await loadGlobalConfigFrom({})
-    expect(snapshot.source).toBe('env')
-    expect(snapshot.dryRun).toBe(GLOBAL_CONFIG_DEFAULTS.dryRun)
-    expect(snapshot.tradingEnabled).toBe(GLOBAL_CONFIG_DEFAULTS.tradingEnabled)
-    expect(snapshot.maxOrderNotional).toBe(GLOBAL_CONFIG_DEFAULTS.maxOrderNotional)
-    expect(snapshot.drawdownKillThreshold).toBe(GLOBAL_CONFIG_DEFAULTS.drawdownKillThreshold)
-    expect(snapshot.spreadLimitPctUs).toBe(GLOBAL_CONFIG_DEFAULTS.spreadLimitPctUs)
-    expect(snapshot.bridgeRunMode).toBe(GLOBAL_CONFIG_DEFAULTS.bridgeRunMode)
+  it('throws when env.DB binding is missing (D1 setup required)', async () => {
+    await expect(loadGlobalConfigFrom({})).rejects.toThrow(/env\.DB is not bound/)
   })
 })

--- a/test/routes/trade.test.ts
+++ b/test/routes/trade.test.ts
@@ -1,15 +1,19 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp } from '../../src/app'
+import { loadGlobalConfigFrom } from '../../src/infrastructure/db/globalConfigLoader'
+import { loadSymbolUniverse } from '../../src/infrastructure/db/symbolUniverse'
+import { makeGlobalConfigSnapshot, makeSymbolUniverse } from '../helpers/configFixtures'
+
+vi.mock('../../src/infrastructure/db/globalConfigLoader', () => ({
+  loadGlobalConfigFrom: vi.fn(),
+}))
+vi.mock('../../src/infrastructure/db/symbolUniverse', () => ({
+  loadSymbolUniverse: vi.fn(),
+}))
 
 const env = {
   BASIC_AUTH_USER: 'admin',
   BASIC_AUTH_PASSWORD: 'secret',
-  DRY_RUN: 'true',
-  TRADING_ENABLED: 'true',
-  ALLOWED_SYMBOLS: 'SOXL,SOXS',
-  MAX_ORDER_NOTIONAL: '100',
-  SYMBOL_MAX_NOTIONAL: undefined,
-  MARKET_HOURS_CHECK: 'false',
   EVENT_INGEST_SECRET: 'change-me',
 }
 
@@ -18,8 +22,14 @@ const authHeader = {
 }
 
 describe('trade routes', () => {
+  beforeEach(() => {
+    vi.mocked(loadGlobalConfigFrom).mockResolvedValue(makeGlobalConfigSnapshot())
+    vi.mocked(loadSymbolUniverse).mockResolvedValue(makeSymbolUniverse())
+  })
+
   afterEach(() => {
     vi.unstubAllGlobals()
+    vi.resetAllMocks()
   })
 
   it('POST /trade/decide returns signal, intent, and risk decision', async () => {
@@ -90,7 +100,10 @@ describe('trade routes', () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  it('applies a symbol-specific max notional override from env', async () => {
+  it('applies a symbol-specific max notional override from D1', async () => {
+    vi.mocked(loadSymbolUniverse).mockResolvedValue(
+      makeSymbolUniverse({ symbolMaxNotional: { SOXL: 50 } }),
+    )
     const app = createApp()
 
     const response = await app.request(
@@ -109,10 +122,7 @@ describe('trade routes', () => {
           sellAbove: 30,
         }),
       },
-      {
-        ...env,
-        SYMBOL_MAX_NOTIONAL: '{"SOXL":50}',
-      },
+      env,
     )
 
     expect(response.status).toBe(200)
@@ -123,7 +133,10 @@ describe('trade routes', () => {
     expect(body.riskDecision.reasons).toContain('order notional 60 exceeds max 50')
   })
 
-  it('uses Webull execution when DRY_RUN=false and trading is enabled', async () => {
+  it('uses Webull execution when dryRun=false (via D1)', async () => {
+    vi.mocked(loadGlobalConfigFrom).mockResolvedValue(
+      makeGlobalConfigSnapshot({ dryRun: false }),
+    )
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -152,13 +165,7 @@ describe('trade routes', () => {
           sellAbove: 20,
         }),
       },
-      {
-        ...env,
-        DRY_RUN: 'false',
-        WEBULL_APP_KEY: 'app-key',
-        WEBULL_APP_SECRET: 'app-secret',
-        WEBULL_ACCOUNT_ID: 'acct-1',
-      },
+      { ...env, WEBULL_APP_KEY: 'app-key', WEBULL_APP_SECRET: 'app-secret', WEBULL_ACCOUNT_ID: 'acct-1' },
     )
 
     expect(response.status).toBe(200)
@@ -171,42 +178,6 @@ describe('trade routes', () => {
       brokerOrderId: 'ord-live-1',
     })
     expect(fetchMock).toHaveBeenCalledTimes(1)
-  })
-
-  it('fail-closes to MockExecution when DRY_RUN is absent', async () => {
-    const fetchMock = vi.fn<typeof fetch>()
-    vi.stubGlobal('fetch', fetchMock)
-    const app = createApp()
-
-    const response = await app.request(
-      '/trade/execute',
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          ...authHeader,
-        },
-        body: JSON.stringify({
-          symbol: 'SOXL',
-          price: 9,
-          quantity: 2,
-          buyBelow: 10,
-          sellAbove: 20,
-        }),
-      },
-      {
-        ...env,
-        DRY_RUN: undefined,
-      },
-    )
-
-    expect(response.status).toBe(200)
-    const body = (await response.json()) as {
-      executionResult?: { mode: string; brokerOrderId?: string }
-    }
-    expect(body.executionResult?.mode).toBe('DRY_RUN')
-    expect(body.executionResult?.brokerOrderId).toMatch(/^mock-/)
-    expect(fetchMock).not.toHaveBeenCalled()
   })
 
   it('returns 401 for /trade/* without auth', async () => {
@@ -252,14 +223,11 @@ describe('trade routes', () => {
     expect(executeResponse.status).toBe(401)
   })
 
-  it('fail-closes when TRADING_ENABLED is absent (defaults to false)', async () => {
+  it('fail-closes when tradingEnabled=false (via D1)', async () => {
+    vi.mocked(loadGlobalConfigFrom).mockResolvedValue(
+      makeGlobalConfigSnapshot({ tradingEnabled: false }),
+    )
     const app = createApp()
-    const envWithoutTradingEnabled = {
-      BASIC_AUTH_USER: 'admin',
-      BASIC_AUTH_PASSWORD: 'secret',
-      ALLOWED_SYMBOLS: 'SOXL,SOXS',
-      MAX_ORDER_NOTIONAL: '100',
-    }
 
     const response = await app.request(
       '/trade/decide',
@@ -277,7 +245,7 @@ describe('trade routes', () => {
           sellAbove: 20,
         }),
       },
-      envWithoutTradingEnabled,
+      env,
     )
 
     expect(response.status).toBe(200)

--- a/test/routes/webull.test.ts
+++ b/test/routes/webull.test.ts
@@ -1,13 +1,15 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp } from '../../src/app'
+import { loadGlobalConfigFrom } from '../../src/infrastructure/db/globalConfigLoader'
+import { makeGlobalConfigSnapshot } from '../helpers/configFixtures'
+
+vi.mock('../../src/infrastructure/db/globalConfigLoader', () => ({
+  loadGlobalConfigFrom: vi.fn(),
+}))
 
 const baseEnv = {
   BASIC_AUTH_USER: 'admin',
   BASIC_AUTH_PASSWORD: 'secret',
-  DRY_RUN: 'true',
-  TRADING_ENABLED: 'true',
-  ALLOWED_SYMBOLS: 'SOXL,SOXS',
-  MAX_ORDER_NOTIONAL: '100',
   EVENT_INGEST_SECRET: 'change-me',
 }
 
@@ -16,8 +18,13 @@ const authHeader = {
 }
 
 describe('webull routes', () => {
+  beforeEach(() => {
+    vi.mocked(loadGlobalConfigFrom).mockResolvedValue(makeGlobalConfigSnapshot())
+  })
+
   afterEach(() => {
     vi.unstubAllGlobals()
+    vi.resetAllMocks()
   })
 
   it('returns 401 for /webull/* without auth', async () => {
@@ -43,7 +50,7 @@ describe('webull routes', () => {
     expect(response.status).toBe(401)
   })
 
-  it('returns a synthetic response when DRY_RUN=true', async () => {
+  it('returns a synthetic response when dryRun=true (D1 default)', async () => {
     const fetchMock = vi.fn<typeof fetch>()
     vi.stubGlobal('fetch', fetchMock)
     const app = createApp()
@@ -78,7 +85,10 @@ describe('webull routes', () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  it('calls Webull and returns the raw broker DTO on success', async () => {
+  it('calls Webull and returns the raw broker DTO when dryRun=false', async () => {
+    vi.mocked(loadGlobalConfigFrom).mockResolvedValue(
+      makeGlobalConfigSnapshot({ dryRun: false }),
+    )
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -108,7 +118,6 @@ describe('webull routes', () => {
       },
       {
         ...baseEnv,
-        DRY_RUN: 'false',
         WEBULL_APP_KEY: 'app-key',
         WEBULL_APP_SECRET: 'app-secret',
         WEBULL_ACCOUNT_ID: 'acct-1',


### PR DESCRIPTION
## 概要

通貨混在の universe で `max_order_notional` (scalar) 1 本を使い回すと破綻するため、通貨別の cap と portfolio 予算概念を schema に入れる。

## 変更

### Schema

- `symbol_config.currency` (ENUM 'USD'/'JPY'、default 'USD')
- `global_config`:
  - `max_order_notional_usd` / `max_order_notional_jpy` (通貨別 cap)
  - `total_capital_usd` / `total_capital_jpy` (nullable、予算枠)
  - `max_portfolio_exposure_pct` (default 0.6)
  - 旧 `max_order_notional` は deprecated だが NOT NULL 維持 (placeholder)
- CHECK 制約: 通貨 enum、通貨別 cap 範囲、`total_capital > 0 OR NULL`、`exposure_pct ∈ (0,1]`

### Migration (0003_currency_budget.sql)

SQLite の CHECK 追加はテーブル再作成が必要なので `__new_*` → data 移送 → DROP + RENAME の drizzle 定番フロー。手動調整ポイント:
- 既存 `max_order_notional` を `max_order_notional_usd` に初期値コピー (運用感覚維持)
- `symbol_config`: 既存 `market='JP'` 行は `currency='JPY'` 自動割り当て

### コード

- `globalConfigRepo` / loader: 新フィールド (通貨別 cap + 予算枠) を snapshot に露出
- `symbolConfigRepo` / `symbolUniverse`: `symbolCurrency: Record<symbol, 'USD'|'JPY'>` を追加
- `routes/trade.ts`: `toTradingConfig()` で symbol の currency を引いて `maxOrderNotional` に対応通貨値を選択
- env fallback (D1 未 bind) は 4 桁数字 = JP 判定でヒューリスティックに currency 補完

## 本 PR に入っていないもの → follow-up (#77)

- `PortfolioStateDO` の `openExposureUsd` / `openExposureJpy` tracking
- `TradeEventHandler` が fill で exposure 更新
- Risk gate で `(open_exposure + new_order.notional) > total_capital * exposure_pct` check

`total_capital_*` と `max_portfolio_exposure_pct` は schema には入ったが、exposure 側の実装が揃うまで gate に反映されない点を docs で明記。

## 運用手順 (merge 後)

```bash
# CD が main push で実行:
pnpm wrangler d1 migrations apply webull-trading-staging --env=staging --remote
pnpm wrangler deploy --env=staging

# 必要に応じて seed 更新
pnpm wrangler d1 execute webull-trading-staging --env=staging --remote --file=docs/seed/global_config.sql
```

既存 `global_config` row は migration で新カラムがデフォルト埋めされる。`max_order_notional_usd` は旧 `max_order_notional` の値を引き継ぐので挙動互換。

## 動作確認

- [x] `pnpm run typecheck`
- [x] `pnpm test` (275 件 pass)
- [x] local migration + seed + 既存 SOXL/SOXS が `currency='USD'` に自動設定を確認
- [ ] staging: migration 適用 → JP 銘柄 INSERT → JPY cap で BUY gate が正しく効くことを sandbox で観察

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 通貨別の注文上限（USD/JPY）を導入し、銘柄ごとの通貨を参照して自動選択します。
  * システム設定がデータベース（D1）中心になり、ルート処理（注文判定/実行）の振る舞いやドライラン判定がDB設定に従います。

* **ドキュメント**
  * 通貨対応注文上限とグローバル予算設定の手順・SQL例を追加（露出トラッキングは未実装と明記）。

* **Chores**
  * データベース移行と初期シードに通貨/予算フィールドを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->