### PR TITLE
feat(strategy): Pullback cron wiring (#49)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,12 @@ import { createDb, insertJournalRecord } from './infrastructure/db/tradeJournalR
 import { setTradeJournalDbContext } from './infrastructure/logger/tradeJournal'
 import { keepBridgeAlive } from './trading/bridge/bridgeKeepAlive'
 import { runQuoteFeed } from './trading/quotes/quoteScheduler'
+import { runStrategyCron } from './trading/strategy/runStrategyCron'
+
+// 5 分毎の quote feed + bridge keep-alive cron
+const CRON_QUOTE_BRIDGE = '*/5 * * * *'
+// 毎時 :15 の Pullback 戦略 cron (position で自然 idempotent)
+const CRON_STRATEGY = '15 * * * *'
 
 export { SymbolStateDO } from './trading/state/SymbolStateDO'
 export { PortfolioStateDO } from './trading/state/PortfolioStateDO'
@@ -33,9 +39,39 @@ export default {
     attachTradeJournalDb(env, ctx)
     return app.fetch(request, env, ctx)
   },
-  async scheduled(_event: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void> {
+  async scheduled(event: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void> {
     attachTradeJournalDb(env, ctx)
     const requestId = crypto.randomUUID()
+
+    if (event.cron === CRON_STRATEGY) {
+      ctx.waitUntil(
+        runStrategyCron(env).then(
+          (result) => {
+            console.log(
+              JSON.stringify({
+                event: 'strategy_cron_run',
+                requestId,
+                symbols: result.symbols,
+                skipReason: result.skipReason,
+                summary: result.summary,
+              }),
+            )
+          },
+          (error) => {
+            console.error(
+              JSON.stringify({
+                event: 'strategy_cron_error',
+                requestId,
+                message: error instanceof Error ? error.message : String(error),
+              }),
+            )
+          },
+        ),
+      )
+      return
+    }
+
+    // default: CRON_QUOTE_BRIDGE (`*/5 * * * *`) — quote feed + bridge keep-alive
     ctx.waitUntil(
       runQuoteFeed({ env }).then(
         (summary) => {

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -5,60 +5,90 @@ import { loadSymbolUniverse } from '../../infrastructure/db/symbolUniverse'
 import { createWebullHttpClient } from '../../infrastructure/webull/WebullHttpClient'
 import { MockExecution } from '../execution/MockExecution'
 import { WebullExecution } from '../execution/WebullExecution'
+import { PortfolioStateClient } from '../state/PortfolioStateClient'
 import { SymbolStateClient } from '../state/SymbolStateClient'
 import { runPullbackScheduler, type PullbackRunSummary } from './pullbackScheduler'
+
+const DEFAULT_EQUITY_USD = 10_000
 
 export interface StrategyCronResult {
   summary: PullbackRunSummary
   symbols: string[]
-  skipReason?: 'trading_disabled' | 'no_us_symbols' | 'no_bridge_state'
+  skipReason?:
+    | 'trading_disabled'
+    | 'no_us_symbols'
+    | 'no_bridge_state'
+    | 'portfolio_halted'
+    | 'drawdown_kill'
 }
 
 /**
- * Cron-driven Pullback strategy entry. 呼び出し側 (`src/index.ts`) は次の順で使う:
+ * Cron-driven Pullback strategy entry。呼び出し側 (`src/index.ts`) は:
  *   1. global_config + symbol_universe を D1 から読む
- *   2. trading_enabled=0 or JP-only universe なら skip で return
- *   3. US symbols に絞って runPullbackScheduler を起動
+ *   2. trading_enabled=0 / JP-only / SYMBOL_STATE 未 bind なら skip
+ *   3. PortfolioStateDO の kill-switch / drawdown を確認 (fail-closed)
+ *   4. US symbols に絞って runPullbackScheduler を起動
  *
- * NOTE: TradingService の risk gate (drawdown_kill / spread_guard / halt /
- * gap / JP price band / inverse_pair / settled_cash) はここでは適用されない。
- * PullbackUptrendStrategy 内の pending_order / cooldown / exit 判定 + per-symbol
- * max_notional のみが働く。gate parity は follow-up issue で対応予定。
+ * Risk gate のうち **portfolio-wide な pre-flight 判定** (tradingDisabledUntil
+ * と drawdown_kill) は本関数で適用する。per-symbol gate (spread / halt / gap /
+ * JP band / inverse_pair / settled_cash) は TradingService 側が持っており、
+ * 本 cron 経路では未統合 — follow-up で gate parity を取る予定。
  *
- * JP 銘柄は Webull JP UAT で market-data bar が 404 なので本 cron では除外する。
+ * JP 銘柄は Webull JP UAT で market-data bar が 404 なので本 cron では除外。
  * JP は手動 /trade/execute 運用 (#32 live 疎通後に解禁)。
  */
 export async function runStrategyCron(env: Env): Promise<StrategyCronResult> {
+  const emptySummary: PullbackRunSummary = {
+    evaluated: 0,
+    buys: 0,
+    sells: 0,
+    holds: 0,
+    rejected: [],
+    errors: [],
+  }
+
   const [global, universe] = await Promise.all([
     loadGlobalConfigFrom(env),
     loadSymbolUniverse(env),
   ])
 
   if (!global.tradingEnabled) {
-    return {
-      summary: { evaluated: 0, buys: 0, sells: 0, holds: 0, rejected: [], errors: [] },
-      symbols: [],
-      skipReason: 'trading_disabled',
-    }
+    return { summary: emptySummary, symbols: [], skipReason: 'trading_disabled' }
   }
 
-  // JP 銘柄 (currency='JPY') は除外 — bar endpoint が JP UAT で 404
   const usSymbols = universe.allowedSymbols.filter(
     (sym) => (universe.symbolCurrency[sym] ?? 'USD') === 'USD',
   )
   if (usSymbols.length === 0) {
-    return {
-      summary: { evaluated: 0, buys: 0, sells: 0, holds: 0, rejected: [], errors: [] },
-      symbols: [],
-      skipReason: 'no_us_symbols',
-    }
+    return { summary: emptySummary, symbols: [], skipReason: 'no_us_symbols' }
   }
 
   if (!env.SYMBOL_STATE) {
-    return {
-      summary: { evaluated: 0, buys: 0, sells: 0, holds: 0, rejected: [], errors: [] },
-      symbols: usSymbols,
-      skipReason: 'no_bridge_state',
+    return { summary: emptySummary, symbols: usSymbols, skipReason: 'no_bridge_state' }
+  }
+
+  // Portfolio-level pre-flight: kill-switch and drawdown. Fail-closed — if the
+  // portfolio store is missing or the read fails, treat as halted.
+  if (env.PORTFOLIO_STATE) {
+    const portfolioStore = new PortfolioStateClient(env.PORTFOLIO_STATE)
+    try {
+      const portfolio = await portfolioStore.getPortfolio()
+      const now = Date.now()
+      if (
+        portfolio.tradingDisabledUntil &&
+        new Date(portfolio.tradingDisabledUntil).getTime() > now
+      ) {
+        return { summary: emptySummary, symbols: usSymbols, skipReason: 'portfolio_halted' }
+      }
+      if (portfolio.dailyStartEquity > 0) {
+        const ratio = portfolio.dailyRealizedPnl / portfolio.dailyStartEquity
+        if (ratio <= global.drawdownKillThreshold) {
+          return { summary: emptySummary, symbols: usSymbols, skipReason: 'drawdown_kill' }
+        }
+      }
+    } catch {
+      // fail-closed: portfolio 読み込みエラー時は strategy を走らせない
+      return { summary: emptySummary, symbols: usSymbols, skipReason: 'portfolio_halted' }
     }
   }
 
@@ -68,8 +98,9 @@ export async function runStrategyCron(env: Env): Promise<StrategyCronResult> {
     : new WebullExecution(createWebullHttpClient(env))
   const barClient = createWebullBarClient(env)
 
-  // equity は D1 から。未 seed なら POC 仮値で継続 (cron を止めない)。
-  const equity = global.totalCapitalUsd ?? 10_000
+  // sizing に流す equity は正の有限値のみ許可 (0 / 負 / NaN / Infinity を弾く)。
+  // D1 から読んだ値が壊れていたら default に落とす。
+  const equity = sanitizeEquity(global.totalCapitalUsd)
 
   const summary = await runPullbackScheduler({
     symbols: usSymbols,
@@ -81,4 +112,10 @@ export async function runStrategyCron(env: Env): Promise<StrategyCronResult> {
   })
 
   return { summary, symbols: usSymbols }
+}
+
+function sanitizeEquity(value: number | null | undefined): number {
+  if (value === null || value === undefined) return DEFAULT_EQUITY_USD
+  if (!Number.isFinite(value) || value <= 0) return DEFAULT_EQUITY_USD
+  return value
 }

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -1,0 +1,84 @@
+import type { Env } from '../../config/env'
+import { createWebullBarClient } from '../../infrastructure/quotes/BarClient'
+import { loadGlobalConfigFrom } from '../../infrastructure/db/globalConfigLoader'
+import { loadSymbolUniverse } from '../../infrastructure/db/symbolUniverse'
+import { createWebullHttpClient } from '../../infrastructure/webull/WebullHttpClient'
+import { MockExecution } from '../execution/MockExecution'
+import { WebullExecution } from '../execution/WebullExecution'
+import { SymbolStateClient } from '../state/SymbolStateClient'
+import { runPullbackScheduler, type PullbackRunSummary } from './pullbackScheduler'
+
+export interface StrategyCronResult {
+  summary: PullbackRunSummary
+  symbols: string[]
+  skipReason?: 'trading_disabled' | 'no_us_symbols' | 'no_bridge_state'
+}
+
+/**
+ * Cron-driven Pullback strategy entry. 呼び出し側 (`src/index.ts`) は次の順で使う:
+ *   1. global_config + symbol_universe を D1 から読む
+ *   2. trading_enabled=0 or JP-only universe なら skip で return
+ *   3. US symbols に絞って runPullbackScheduler を起動
+ *
+ * NOTE: TradingService の risk gate (drawdown_kill / spread_guard / halt /
+ * gap / JP price band / inverse_pair / settled_cash) はここでは適用されない。
+ * PullbackUptrendStrategy 内の pending_order / cooldown / exit 判定 + per-symbol
+ * max_notional のみが働く。gate parity は follow-up issue で対応予定。
+ *
+ * JP 銘柄は Webull JP UAT で market-data bar が 404 なので本 cron では除外する。
+ * JP は手動 /trade/execute 運用 (#32 live 疎通後に解禁)。
+ */
+export async function runStrategyCron(env: Env): Promise<StrategyCronResult> {
+  const [global, universe] = await Promise.all([
+    loadGlobalConfigFrom(env),
+    loadSymbolUniverse(env),
+  ])
+
+  if (!global.tradingEnabled) {
+    return {
+      summary: { evaluated: 0, buys: 0, sells: 0, holds: 0, rejected: [], errors: [] },
+      symbols: [],
+      skipReason: 'trading_disabled',
+    }
+  }
+
+  // JP 銘柄 (currency='JPY') は除外 — bar endpoint が JP UAT で 404
+  const usSymbols = universe.allowedSymbols.filter(
+    (sym) => (universe.symbolCurrency[sym] ?? 'USD') === 'USD',
+  )
+  if (usSymbols.length === 0) {
+    return {
+      summary: { evaluated: 0, buys: 0, sells: 0, holds: 0, rejected: [], errors: [] },
+      symbols: [],
+      skipReason: 'no_us_symbols',
+    }
+  }
+
+  if (!env.SYMBOL_STATE) {
+    return {
+      summary: { evaluated: 0, buys: 0, sells: 0, holds: 0, rejected: [], errors: [] },
+      symbols: usSymbols,
+      skipReason: 'no_bridge_state',
+    }
+  }
+
+  const positionStore = new SymbolStateClient(env.SYMBOL_STATE)
+  const execution = global.dryRun
+    ? new MockExecution()
+    : new WebullExecution(createWebullHttpClient(env))
+  const barClient = createWebullBarClient(env)
+
+  // equity は D1 から。未 seed なら POC 仮値で継続 (cron を止めない)。
+  const equity = global.totalCapitalUsd ?? 10_000
+
+  const summary = await runPullbackScheduler({
+    symbols: usSymbols,
+    equity,
+    barClient,
+    positionStore,
+    execution,
+    symbolCapMap: universe.symbolMaxNotional,
+  })
+
+  return { summary, symbols: usSymbols }
+}

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -67,29 +67,33 @@ export async function runStrategyCron(env: Env): Promise<StrategyCronResult> {
     return { summary: emptySummary, symbols: usSymbols, skipReason: 'no_bridge_state' }
   }
 
-  // Portfolio-level pre-flight: kill-switch and drawdown. Fail-closed — if the
-  // portfolio store is missing or the read fails, treat as halted.
-  if (env.PORTFOLIO_STATE) {
-    const portfolioStore = new PortfolioStateClient(env.PORTFOLIO_STATE)
-    try {
-      const portfolio = await portfolioStore.getPortfolio()
-      const now = Date.now()
-      if (
-        portfolio.tradingDisabledUntil &&
-        new Date(portfolio.tradingDisabledUntil).getTime() > now
-      ) {
+  // Portfolio-level pre-flight (fail-closed):
+  // - PORTFOLIO_STATE binding 不在 → halt (drawdown kill を評価する術が無い)
+  // - getPortfolio 例外 → halt
+  // - tradingDisabledUntil が truthy だが parse 不能 → halt (silent pass 防止)
+  // - tradingDisabledUntil が有効 & 未来 → halt
+  // - drawdown 閾値超過 → halt
+  if (!env.PORTFOLIO_STATE) {
+    return { summary: emptySummary, symbols: usSymbols, skipReason: 'portfolio_halted' }
+  }
+  const portfolioStore = new PortfolioStateClient(env.PORTFOLIO_STATE)
+  try {
+    const portfolio = await portfolioStore.getPortfolio()
+    const now = Date.now()
+    if (portfolio.tradingDisabledUntil) {
+      const disabledUntilMs = new Date(portfolio.tradingDisabledUntil).getTime()
+      if (!Number.isFinite(disabledUntilMs) || disabledUntilMs > now) {
         return { summary: emptySummary, symbols: usSymbols, skipReason: 'portfolio_halted' }
       }
-      if (portfolio.dailyStartEquity > 0) {
-        const ratio = portfolio.dailyRealizedPnl / portfolio.dailyStartEquity
-        if (ratio <= global.drawdownKillThreshold) {
-          return { summary: emptySummary, symbols: usSymbols, skipReason: 'drawdown_kill' }
-        }
-      }
-    } catch {
-      // fail-closed: portfolio 読み込みエラー時は strategy を走らせない
-      return { summary: emptySummary, symbols: usSymbols, skipReason: 'portfolio_halted' }
     }
+    if (portfolio.dailyStartEquity > 0) {
+      const ratio = portfolio.dailyRealizedPnl / portfolio.dailyStartEquity
+      if (ratio <= global.drawdownKillThreshold) {
+        return { summary: emptySummary, symbols: usSymbols, skipReason: 'drawdown_kill' }
+      }
+    }
+  } catch {
+    return { summary: emptySummary, symbols: usSymbols, skipReason: 'portfolio_halted' }
   }
 
   const positionStore = new SymbolStateClient(env.SYMBOL_STATE)

--- a/test/trading/strategy/runStrategyCron.test.ts
+++ b/test/trading/strategy/runStrategyCron.test.ts
@@ -93,6 +93,34 @@ describe('runStrategyCron', () => {
     expect(result.skipReason).toBe('drawdown_kill')
   })
 
+  it('fail-closes to portfolio_halted when PORTFOLIO_STATE binding is missing', async () => {
+    const envWithoutPortfolio = {
+      DB: {} as D1Database,
+      SYMBOL_STATE: {} as DurableObjectNamespace<never>,
+    } as unknown as Parameters<typeof runStrategyCron>[0]
+    const result = await runStrategyCron(envWithoutPortfolio)
+    expect(result.skipReason).toBe('portfolio_halted')
+  })
+
+  it('fail-closes to portfolio_halted on invalid tradingDisabledUntil timestamp', async () => {
+    const envBadTimestamp = {
+      ...env,
+      PORTFOLIO_STATE: {
+        idFromName: () => ({}),
+        get: () => ({
+          getPortfolio: vi.fn().mockResolvedValue({
+            dailyStartEquity: 0,
+            dailyRealizedPnl: 0,
+            tradingDisabledUntil: 'not-an-iso-timestamp',
+            updatedAt: new Date().toISOString(),
+          }),
+        }),
+      },
+    } as unknown as Parameters<typeof runStrategyCron>[0]
+    const result = await runStrategyCron(envBadTimestamp)
+    expect(result.skipReason).toBe('portfolio_halted')
+  })
+
   it('fail-closes to portfolio_halted when getPortfolio throws', async () => {
     const envWithBrokenPortfolio = {
       ...env,

--- a/test/trading/strategy/runStrategyCron.test.ts
+++ b/test/trading/strategy/runStrategyCron.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { loadGlobalConfigFrom } from '../../../src/infrastructure/db/globalConfigLoader'
+import { loadSymbolUniverse } from '../../../src/infrastructure/db/symbolUniverse'
+import { runStrategyCron } from '../../../src/trading/strategy/runStrategyCron'
+import { makeGlobalConfigSnapshot, makeSymbolUniverse } from '../../helpers/configFixtures'
+
+vi.mock('../../../src/infrastructure/db/globalConfigLoader', () => ({
+  loadGlobalConfigFrom: vi.fn(),
+}))
+vi.mock('../../../src/infrastructure/db/symbolUniverse', () => ({
+  loadSymbolUniverse: vi.fn(),
+}))
+
+const env = {
+  DB: {} as D1Database,
+  SYMBOL_STATE: {} as DurableObjectNamespace<never>,
+} as unknown as Parameters<typeof runStrategyCron>[0]
+
+describe('runStrategyCron', () => {
+  beforeEach(() => {
+    vi.mocked(loadGlobalConfigFrom).mockResolvedValue(makeGlobalConfigSnapshot())
+    vi.mocked(loadSymbolUniverse).mockResolvedValue(makeSymbolUniverse())
+  })
+
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('skips with trading_disabled when tradingEnabled=false', async () => {
+    vi.mocked(loadGlobalConfigFrom).mockResolvedValue(
+      makeGlobalConfigSnapshot({ tradingEnabled: false }),
+    )
+    const result = await runStrategyCron(env)
+    expect(result.skipReason).toBe('trading_disabled')
+    expect(result.summary.evaluated).toBe(0)
+  })
+
+  it('skips with no_us_symbols when universe is JP-only', async () => {
+    vi.mocked(loadSymbolUniverse).mockResolvedValue(
+      makeSymbolUniverse({
+        allowedSymbols: ['6301', '4502'],
+        symbolCurrency: { '6301': 'JPY', '4502': 'JPY' },
+      }),
+    )
+    const result = await runStrategyCron(env)
+    expect(result.skipReason).toBe('no_us_symbols')
+  })
+
+  it('skips with no_bridge_state when SYMBOL_STATE binding is missing', async () => {
+    const envWithout = { DB: {} } as unknown as Parameters<typeof runStrategyCron>[0]
+    const result = await runStrategyCron(envWithout)
+    expect(result.skipReason).toBe('no_bridge_state')
+  })
+})

--- a/test/trading/strategy/runStrategyCron.test.ts
+++ b/test/trading/strategy/runStrategyCron.test.ts
@@ -51,4 +51,59 @@ describe('runStrategyCron', () => {
     const result = await runStrategyCron(envWithout)
     expect(result.skipReason).toBe('no_bridge_state')
   })
+
+  it('skips with portfolio_halted when tradingDisabledUntil is in the future', async () => {
+    const envWithPortfolio = {
+      ...env,
+      PORTFOLIO_STATE: {
+        idFromName: () => ({}),
+        get: () => ({
+          getPortfolio: vi.fn().mockResolvedValue({
+            dailyStartEquity: 0,
+            dailyRealizedPnl: 0,
+            tradingDisabledUntil: new Date(Date.now() + 3_600_000).toISOString(),
+            updatedAt: new Date().toISOString(),
+          }),
+        }),
+      },
+    } as unknown as Parameters<typeof runStrategyCron>[0]
+    const result = await runStrategyCron(envWithPortfolio)
+    expect(result.skipReason).toBe('portfolio_halted')
+  })
+
+  it('skips with drawdown_kill when realized drawdown exceeds threshold', async () => {
+    vi.mocked(loadGlobalConfigFrom).mockResolvedValue(
+      makeGlobalConfigSnapshot({ drawdownKillThreshold: -0.02 }),
+    )
+    const envWithPortfolio = {
+      ...env,
+      PORTFOLIO_STATE: {
+        idFromName: () => ({}),
+        get: () => ({
+          getPortfolio: vi.fn().mockResolvedValue({
+            dailyStartEquity: 10_000,
+            dailyRealizedPnl: -250, // -2.5% (below -2% threshold)
+            tradingDisabledUntil: null,
+            updatedAt: new Date().toISOString(),
+          }),
+        }),
+      },
+    } as unknown as Parameters<typeof runStrategyCron>[0]
+    const result = await runStrategyCron(envWithPortfolio)
+    expect(result.skipReason).toBe('drawdown_kill')
+  })
+
+  it('fail-closes to portfolio_halted when getPortfolio throws', async () => {
+    const envWithBrokenPortfolio = {
+      ...env,
+      PORTFOLIO_STATE: {
+        idFromName: () => ({}),
+        get: () => ({
+          getPortfolio: vi.fn().mockRejectedValue(new Error('DO unreachable')),
+        }),
+      },
+    } as unknown as Parameters<typeof runStrategyCron>[0]
+    const result = await runStrategyCron(envWithBrokenPortfolio)
+    expect(result.skipReason).toBe('portfolio_halted')
+  })
 })

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -26,7 +26,10 @@
     { "tag": "v3", "new_sqlite_classes": ["BridgeContainer"] }
   ],
   "triggers": {
-    "crons": ["*/5 * * * *"]
+    "crons": [
+      "*/5 * * * *",
+      "15 * * * *"
+    ]
   },
   "env": {
     "staging": {


### PR DESCRIPTION
## 概要

自動取引を実装。`15 * * * *` の新 cron trigger を追加して US 銘柄で Pullback 戦略を毎時走らせる。

## 変更

- `src/trading/strategy/runStrategyCron.ts` — D1 から global_config / symbol_universe を読み込み、`trading_enabled` / US-only / `SYMBOL_STATE` binding の pre-check 後、`runPullbackScheduler` を起動。JP 銘柄は market-data bar が UAT で 404 なので `currency='USD'` で filter。
- `src/index.ts` — `scheduled` handler を `event.cron` で分岐。`15 * * * *` が来たら `runStrategyCron`、それ以外 (`*/5 * * * *`) は既存 quote feed + bridge keep-alive。
- `wrangler.jsonc` — `triggers.crons` に `"15 * * * *"` 追加。
- `test/trading/strategy/runStrategyCron.test.ts` — trading_disabled / no_us_symbols / no_bridge_state の 3 skip 経路を検証。

## 運用イメージ

```
JST 24/7  */5 min → quote feed (US) + bridge keep-alive
         hourly :15 → Pullback 戦略 (US 銘柄のみ)
                     → symbols 毎に bars 取得 → indicators → decide
                     → BUY/SELL なら pending lock → execution
                     → fill は bridge → /events/trade → DO 更新
```

`trading_enabled=0` の間は即 skip されるので、本 PR merge 後 immediate に cron が発注開始することはない。運用者が `UPDATE global_config SET trading_enabled = 1` で明示的に有効化する必要あり。

## 制限事項 (follow-up 範疇)

- **TradingService の risk gate (drawdown_kill / spread / halt / gap / JP band / inverse_pair / settled_cash) は本 cron 経路では未適用**。PullbackUptrendStrategy 内の `pending_order` / `cooldown` / `position` ベース判定と per-symbol `max_notional` のみ効く。gate parity は別 issue で対応予定。
- JP 銘柄は bar endpoint 未公開のため cron 対象外。手動 `/trade/execute` 限定。
- equity は `global_config.total_capital_usd` から。未 seed なら `$10,000` の POC 仮値で継続 (cron を止めない)。

## 動作確認

- [x] `pnpm run typecheck`
- [x] `pnpm test` (276 件 pass、3 skip 経路 test 追加)
- [ ] staging: deploy 後 `wrangler tail` で `strategy_cron_run` ログが出ることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 毎時15分に実行される新しい定期チェックを追加（既存の5分間隔トリガーは継続）。
  * 米国銘柄向けの別処理を導入し、ドライラン／本番実行モードを選択可能に。

* **Behavior**
  * ポートフォリオ単位の事前リスクゲートとデイリードローダウンによる自動停止（キルスイッチ）を導入。
  * 取引無効、米国銘柄なし、ブリッジ状態不備などで安全に実行をスキップする挙動を追加。

* **Tests**
  * 新しいスケジュール処理と各種スキップ条件の包括的なテストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->