### PR TITLE
fix(webull): sign canonical path without query (dedupe account_id)

### DIFF
--- a/src/infrastructure/webull/WebullHttpClient.ts
+++ b/src/infrastructure/webull/WebullHttpClient.ts
@@ -88,7 +88,7 @@ export class WebullHttpClient {
     try {
       authHeaders = await this.options.auth.createHeaders({
         method,
-        path: resolvedUrl.pathname + resolvedUrl.search,
+        path: resolvedUrl.pathname,
         query,
         body: payload,
         host: resolvedUrl.host,

--- a/test/infrastructure/webull/webullHttpClient.test.ts
+++ b/test/infrastructure/webull/webullHttpClient.test.ts
@@ -32,6 +32,32 @@ function createClient(fetchFn: typeof fetch, timeoutMs?: number): WebullHttpClie
 }
 
 describe('WebullHttpClient', () => {
+  it('signs using pathname only (query stays in canonical sorted pairs, not the path prefix)', async () => {
+    // Regression: previously we passed `pathname + search` to auth.createHeaders,
+    // which duplicated `account_id` in the canonical string (once inside the path,
+    // once in the sorted pairs) and triggered Webull 401 UNAUTHORIZED.
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ client_order_id: 'c', order_id: 'o' }), { status: 200 }),
+    )
+    const auth = new WebullAuth({ appKey: 'app-key', appSecret: 'app-secret' })
+    const spy = vi.spyOn(auth, 'createHeaders')
+    const client = new WebullHttpClient({
+      auth,
+      accountId: 'acct-1',
+      baseUrl: 'https://broker.example.test',
+      retry: { maxAttempts: 1, baseDelayMs: 0, multiplier: 2, jitter: 0 },
+      fetchFn: fetchMock,
+    })
+
+    await client.placeOrder(intent)
+
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy.mock.calls[0]![0]).toMatchObject({
+      path: '/openapi/account/orders/place',
+      query: { account_id: 'acct-1' },
+    })
+  })
+
   it('places an order via the v2 endpoint with the expected body and auth headers', async () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(


### PR DESCRIPTION
## Summary

- `WebullHttpClient` was passing `resolvedUrl.pathname + resolvedUrl.search` into `WebullAuth.createHeaders`, so `account_id` ended up in the canonical string twice (once embedded in the path prefix, once in the sorted header+query pairs).
- Webull rejected the resulting signature as `401 UNAUTHORIZED` — staging `/webull/order/place` was failing with `broker_request_error` / Worker-side 502 for every order attempt.
- Change `path` to `resolvedUrl.pathname` only; the composer already merges `query` into the sorted pairs.

## Why it was untested

The existing `WebullHttpClient` tests only assert on the outgoing `fetch` URL. The canonical `path` that gets signed was never inspected. Added a regression test that spies on `WebullAuth.createHeaders` and asserts `{ path: '/openapi/account/orders/place', query: { account_id: 'acct-1' } }`.

## Test plan

- [x] `pnpm vitest run test/infrastructure/webull/` — passes (14 → 15 tests)
- [ ] After merge + staging deploy: rerun `curl /webull/order/place` against sandbox and confirm 200 / order-id instead of 401

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 認証プロセスにおけるシグネチャ生成の精度を向上させました。クエリパラメータの処理方法を最適化し、認証の信頼性を高めました。

* **テスト**
  * 認証ヘッダー生成ロジックの正確性を検証する新しい回帰テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->