### PR TITLE
fix(quotes): align with Webull /market-data/stock/snapshot v2 spec (#84)

### DIFF
--- a/src/infrastructure/quotes/WebullQuoteClient.ts
+++ b/src/infrastructure/quotes/WebullQuoteClient.ts
@@ -2,7 +2,14 @@ import { BrokerRequestError } from '../../shared/errors'
 import { WebullAuth } from '../webull/WebullAuth'
 import { inferWebullMarket } from '../webull/mapper'
 
-export type WebullQuoteCategory = 'US_STOCK' | 'JP_STOCK'
+// Webull market-data snapshot endpoint only accepts equity/ETF categories.
+// JP_STOCK is NOT supported here — JP quotes require a separate API path we
+// haven't wired yet. See #84.
+export type WebullQuoteCategory = 'US_STOCK' | 'US_ETF'
+
+// Minimal US ETF allowlist for the POC universe. Expand or move to
+// symbol_config.category when universe grows.
+const US_ETF_SYMBOLS = new Set<string>(['SOXL', 'SOXS'])
 
 export interface QuoteResult {
   symbol: string
@@ -48,7 +55,7 @@ interface RawSnapshotEntry {
   ap?: number | string
 }
 
-const DEFAULT_QUOTE_PATH = '/openapi/market/snapshot'
+const DEFAULT_QUOTE_PATH = '/openapi/market-data/stock/snapshot'
 
 /**
  * Minimal Webull market-data snapshot client. Signs requests with the same
@@ -86,10 +93,13 @@ export class WebullQuoteClient {
     try {
       authHeaders = await this.options.auth.createHeaders({
         method: 'GET',
-        path: url.pathname + url.search,
+        // Signing is path-only; query is merged into canonical sorted pairs.
+        // Passing `pathname + search` would duplicate query params (see #80).
+        path: url.pathname,
         query,
         host: url.host,
-        version: 'v1',
+        // Market-data snapshot requires x-version: v2 (per developer.webull.com).
+        version: 'v2',
       })
     } catch (error) {
       throw new BrokerRequestError(
@@ -155,13 +165,25 @@ export function createWebullQuoteClient(
   })
 }
 
-export function groupSymbolsByCategory(symbols: string[]): Record<WebullQuoteCategory, string[]> {
-  const grouped: Record<WebullQuoteCategory, string[]> = { US_STOCK: [], JP_STOCK: [] }
+export interface SymbolGrouping {
+  grouped: Record<WebullQuoteCategory, string[]>
+  // Symbols that cannot be routed through the US snapshot endpoint
+  // (currently JP — tracked separately so callers can log / skip).
+  unsupported: string[]
+}
+
+export function groupSymbolsByCategory(symbols: string[]): SymbolGrouping {
+  const grouped: Record<WebullQuoteCategory, string[]> = { US_STOCK: [], US_ETF: [] }
+  const unsupported: string[] = []
   for (const symbol of symbols) {
-    const category: WebullQuoteCategory = inferWebullMarket(symbol) === 'JP' ? 'JP_STOCK' : 'US_STOCK'
+    if (inferWebullMarket(symbol) === 'JP') {
+      unsupported.push(symbol)
+      continue
+    }
+    const category: WebullQuoteCategory = US_ETF_SYMBOLS.has(symbol) ? 'US_ETF' : 'US_STOCK'
     grouped[category].push(symbol)
   }
-  return grouped
+  return { grouped, unsupported }
 }
 
 function normalizeSnapshots(json: unknown, fallbackAsOf: string): QuoteResult[] {

--- a/src/trading/quotes/quoteScheduler.ts
+++ b/src/trading/quotes/quoteScheduler.ts
@@ -40,10 +40,14 @@ export async function runQuoteFeed(options: RunQuoteFeedOptions): Promise<QuoteR
   if (symbols.length === 0) return summary
 
   const client = options.client ?? createWebullQuoteClient(env, { now })
-  const groups = groupSymbolsByCategory(symbols)
+  const { grouped, unsupported } = groupSymbolsByCategory(symbols)
   const fetchedAt = now().toISOString()
 
-  for (const [category, group] of Object.entries(groups) as Array<[WebullQuoteCategory, string[]]>) {
+  // JP symbols have no working snapshot endpoint yet — mark as skipped so the
+  // summary reflects "known unfetchable" rather than a silent drop.
+  for (const symbol of unsupported) summary.skipped.push(symbol)
+
+  for (const [category, group] of Object.entries(grouped) as Array<[WebullQuoteCategory, string[]]>) {
     if (group.length === 0) continue
     let results: QuoteResult[]
     try {

--- a/test/infrastructure/quotes/webullQuoteClient.test.ts
+++ b/test/infrastructure/quotes/webullQuoteClient.test.ts
@@ -15,10 +15,11 @@ function mockFetch(responseBody: unknown, init: ResponseInit = { status: 200 }):
 }
 
 describe('groupSymbolsByCategory', () => {
-  it('routes 4-digit codes to JP_STOCK and others to US_STOCK', () => {
-    const grouped = groupSymbolsByCategory(['SOXL', '7203', 'AAPL', '9984'])
-    expect(grouped.US_STOCK).toEqual(['SOXL', 'AAPL'])
-    expect(grouped.JP_STOCK).toEqual(['7203', '9984'])
+  it('splits US symbols into US_ETF (allowlist) vs US_STOCK, and surfaces JP as unsupported', () => {
+    const { grouped, unsupported } = groupSymbolsByCategory(['SOXL', '7203', 'AAPL', '9984', 'SOXS'])
+    expect(grouped.US_ETF).toEqual(['SOXL', 'SOXS'])
+    expect(grouped.US_STOCK).toEqual(['AAPL'])
+    expect(unsupported).toEqual(['7203', '9984'])
   })
 })
 


### PR DESCRIPTION
## Summary

Quote feed cron has been 404ing continuously because of three mismatches with the actual Webull OpenAPI Data API:

1. **Wrong path** — default was `/openapi/market/snapshot`; the documented endpoint is `/openapi/market-data/stock/snapshot`.
2. **Wrong `x-version`** — we were signing with `v1`; the market-data snapshot requires `v2`.
3. **Wrong categories** — API accepts `US_STOCK` / `US_ETF`. `JP_STOCK` is not a valid value there (JP requires a separate endpoint we haven't wired).

Also applies the same signing path dedup as #80 (pathname only, query stays in sorted pairs).

## Behavior change

- `groupSymbolsByCategory` now returns `{ grouped: { US_STOCK, US_ETF }, unsupported }` where `unsupported` holds JP symbols.
- `runQuoteFeed` pushes JP symbols onto `summary.skipped` instead of calling the endpoint with `JP_STOCK` and failing.
- Minimal US ETF allowlist (`SOXL`, `SOXS`) seeded inline. Expand or lift to `symbol_config.category` when universe grows.

## Out of scope

- JP quote source (separate follow-up — documented in #84)
- Bar / candle endpoint path — different client, same shape; may also need updating but not touched here.

## Test plan

- [x] `pnpm vitest run test/infrastructure/quotes/` — passes (10 tests)
- [ ] After merge + staging deploy: `pnpm wrangler tail ... --search quote_feed` — expect `fetched > 0` for SOXL/SOXS and `7267/6752/285A` on `skipped`.

Refs #84
