### PR TITLE
fix(quotes): category wire format + 285A-style TSE codes (#84)

### DIFF
--- a/src/infrastructure/quotes/WebullQuoteClient.ts
+++ b/src/infrastructure/quotes/WebullQuoteClient.ts
@@ -11,6 +11,13 @@ export type WebullQuoteCategory = 'US_STOCK' | 'US_ETF'
 // symbol_config.category when universe grows.
 const US_ETF_SYMBOLS = new Set<string>(['SOXL', 'SOXS'])
 
+// Wire format on the API is space-separated, not underscore.
+// ref https://github.com/webull-inc/openapi-python-sdk/blob/main/webull-python-sdk-mdata/webullsdkmdata/common/category.py
+const WEBULL_CATEGORY_WIRE: Record<WebullQuoteCategory, string> = {
+  US_STOCK: 'US STOCK',
+  US_ETF: 'US ETF',
+}
+
 export interface QuoteResult {
   symbol: string
   price: number
@@ -83,7 +90,9 @@ export class WebullQuoteClient {
   async getSnapshots(symbols: string[], category: WebullQuoteCategory): Promise<QuoteResult[]> {
     if (symbols.length === 0) return []
 
-    const query = { symbols: symbols.join(','), category }
+    // Webull SDK wire format is space-separated: "US STOCK" / "US ETF".
+    // Using the underscore identifiers as-is yields 417/500.
+    const query = { symbols: symbols.join(','), category: WEBULL_CATEGORY_WIRE[category] }
     const url = new URL(this.quotePath, `${this.baseUrl}/`)
     for (const [key, value] of Object.entries(query)) {
       url.searchParams.set(key, value)

--- a/src/infrastructure/webull/mapper.ts
+++ b/src/infrastructure/webull/mapper.ts
@@ -35,8 +35,9 @@ export function toExecutionResult(dto: WebullPlaceOrderResponseDto): ExecutionRe
   }
 }
 
-// 4-digit numeric codes are Japanese exchange tickers (TYO / TSE). Anything else
-// is treated as US by default. Extend this when adding other markets.
+// TSE codes are 4 chars. Historically all-numeric (e.g. 7203), but since
+// 2024 TSE issues alphanumeric codes where the 4th character can be a letter
+// (e.g. 285A = Kioxia HD). Match "3 digits + [0-9A-Z]".
 export function inferWebullMarket(symbol: string): WebullMarket {
-  return /^\d{4}$/.test(symbol) ? 'JP' : 'US'
+  return /^\d{3}[0-9A-Z]$/.test(symbol) ? 'JP' : 'US'
 }

--- a/test/infrastructure/quotes/webullQuoteClient.test.ts
+++ b/test/infrastructure/quotes/webullQuoteClient.test.ts
@@ -16,14 +16,35 @@ function mockFetch(responseBody: unknown, init: ResponseInit = { status: 200 }):
 
 describe('groupSymbolsByCategory', () => {
   it('splits US symbols into US_ETF (allowlist) vs US_STOCK, and surfaces JP as unsupported', () => {
-    const { grouped, unsupported } = groupSymbolsByCategory(['SOXL', '7203', 'AAPL', '9984', 'SOXS'])
+    const { grouped, unsupported } = groupSymbolsByCategory([
+      'SOXL',
+      '7203',
+      'AAPL',
+      '9984',
+      'SOXS',
+      '285A', // alphanumeric TSE code (Kioxia HD) — must classify as JP
+    ])
     expect(grouped.US_ETF).toEqual(['SOXL', 'SOXS'])
     expect(grouped.US_STOCK).toEqual(['AAPL'])
-    expect(unsupported).toEqual(['7203', '9984'])
+    expect(unsupported).toEqual(['7203', '9984', '285A'])
   })
 })
 
 describe('WebullQuoteClient.getSnapshots', () => {
+  it('sends category as space-separated wire form (US STOCK / US ETF), not underscore', async () => {
+    // Regression: underscored categories (US_STOCK / US_ETF) yielded 417/500
+    // from the Webull snapshot endpoint.
+    const fetchFn = vi.fn(async (input: Request | string | URL) => {
+      const urlStr = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      const url = new URL(urlStr)
+      expect(url.searchParams.get('category')).toBe('US ETF')
+      return new Response(JSON.stringify({ data: [] }), { status: 200 })
+    }) as unknown as typeof fetch
+    const client = new WebullQuoteClient({ auth: baseAuth, fetchFn })
+    await client.getSnapshots(['SOXL'], 'US_ETF')
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+  })
+
   it('returns an empty array when no symbols are requested', async () => {
     const fetchFn = vi.fn() as unknown as typeof fetch
     const client = new WebullQuoteClient({ auth: baseAuth, fetchFn })


### PR DESCRIPTION
## Summary

Follow-up to #85. After deploying #85, the quote feed got further than 404 but was still failing — `US_STOCK` → 417, `US_ETF` → 500. Two more mismatches with the actual API surface:

1. **Category wire format is space-separated**, not underscored. The Webull SDK enum at [webull-python-sdk-mdata/.../category.py](https://github.com/webull-inc/openapi-python-sdk/blob/main/webull-python-sdk-mdata/webullsdkmdata/common/category.py) defines the strings as `"US STOCK"`, `"US ETF"`, `"HK STOCK"`, etc. Our client sent `US_STOCK` / `US_ETF`, which the server rejected (417 / 500).

   Kept the TS identifier enum (`'US_STOCK' | 'US_ETF'`) for code clarity and added a `WEBULL_CATEGORY_WIRE` map at the edge so the wire format lives in exactly one place.

2. **JP detector was too narrow.** `inferWebullMarket` used `/^\d{4}$/`, but since 2024 TSE issues alphanumeric codes where the 4th char can be a letter (e.g. `285A` = Kioxia HD). `285A` was slipping through as US and being sent to the US snapshot endpoint. Loosened to `/^\d{3}[0-9A-Z]$/`, matches both `7203` and `285A`.

## Behavior change

- All US category requests now carry `category=US STOCK` / `category=US ETF` on the wire.
- `285A` is now grouped with the other JP unsupported symbols (since the JP market-data endpoint still isn't wired — tracked in #84).

## Test plan

- [x] `pnpm vitest run test/infrastructure/quotes/ test/infrastructure/webull/ test/trading/` — 21 files / 152 tests pass
- [x] New regression test verifies `category=US ETF` on the outgoing URL
- [x] `285A` added to the `groupSymbolsByCategory` fixture — must land in `unsupported`
- [ ] After deploy: `pnpm wrangler tail ... --search quote_feed` should show `fetched: 2, persisted: 2, skipped: [7267,6752,285A]`

Refs #84


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Webullからのデータ取得時のクエリ形式を修正しました。
  * 日本株シンボルの認識パターンを改善しました。

* **Tests**
  * クエリパラメータ形式の検証テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->