### PR TITLE
fix(quotes): use v1 /market-data/snapshot (matches openapi-java-sdk)

### DIFF
--- a/src/infrastructure/quotes/WebullQuoteClient.ts
+++ b/src/infrastructure/quotes/WebullQuoteClient.ts
@@ -62,7 +62,12 @@ interface RawSnapshotEntry {
   ap?: number | string
 }
 
-const DEFAULT_QUOTE_PATH = '/openapi/market-data/stock/snapshot'
+// openapi-java-sdk's HttpQuotesApiClient (v1) hits `/openapi/market-data/snapshot`
+// with x-version: v1 and only `symbols` + `category`. developer.webull.com also
+// documents a v2 variant at `/openapi/market-data/stock/snapshot`, but the v2
+// endpoint returns 417 on our sandbox credentials, whereas v1 is the path the
+// SDK has shipped in production. Stay on v1 for now.
+const DEFAULT_QUOTE_PATH = '/openapi/market-data/snapshot'
 
 /**
  * Minimal Webull market-data snapshot client. Signs requests with the same
@@ -92,14 +97,9 @@ export class WebullQuoteClient {
 
     // Webull SDK wire format is space-separated: "US STOCK" / "US ETF".
     // Using the underscore identifiers as-is yields 417/500.
-    // extend_hour_required + overnight_required are documented as optional but
-    // are always present in the developer.webull.com example, and omitting
-    // them yields 417 Expectation Failed on v2 snapshot.
     const query = {
       symbols: symbols.join(','),
       category: WEBULL_CATEGORY_WIRE[category],
-      extend_hour_required: 'false',
-      overnight_required: 'false',
     }
     const url = new URL(this.quotePath, `${this.baseUrl}/`)
     for (const [key, value] of Object.entries(query)) {
@@ -115,8 +115,8 @@ export class WebullQuoteClient {
         path: url.pathname,
         query,
         host: url.host,
-        // Market-data snapshot requires x-version: v2 (per developer.webull.com).
-        version: 'v2',
+        // v1 matches HttpQuotesApiClient in openapi-java-sdk.
+        version: 'v1',
       })
     } catch (error) {
       throw new BrokerRequestError(

--- a/test/infrastructure/quotes/webullQuoteClient.test.ts
+++ b/test/infrastructure/quotes/webullQuoteClient.test.ts
@@ -31,6 +31,46 @@ describe('groupSymbolsByCategory', () => {
 })
 
 describe('WebullQuoteClient.getSnapshots', () => {
+  // Regression for #84/#85/#86/#87/#88: the combination of path + x-version is
+  // fragile against developer.webull.com's v2 docs vs what the SDK actually
+  // ships. Lock both so any future drift is caught here instead of at runtime.
+  it('defaults to v1 /openapi/market-data/snapshot with x-version: v1 header', async () => {
+    let capturedUrl: URL | undefined
+    let capturedHeaders: Headers | undefined
+    const fetchFn = vi.fn(async (input: Request | string | URL, init?: RequestInit) => {
+      const urlStr = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      capturedUrl = new URL(urlStr)
+      capturedHeaders = new Headers(init?.headers)
+      return new Response(JSON.stringify({ data: [] }), { status: 200 })
+    }) as unknown as typeof fetch
+    const client = new WebullQuoteClient({ auth: baseAuth, fetchFn })
+    await client.getSnapshots(['SOXL'], 'US_ETF')
+    expect(capturedUrl?.pathname).toBe('/openapi/market-data/snapshot')
+    expect(capturedHeaders?.get('x-version')).toBe('v1')
+  })
+
+  // Negative: show the assertions above are not trivially satisfied — if the
+  // default path were accidentally changed (e.g. back to the v2 stock variant
+  // docs), overriding quotePath produces a different pathname. This guards
+  // against a regression where DEFAULT_QUOTE_PATH drifts silently.
+  it('honours quotePath override (proves the default assertion is meaningful)', async () => {
+    let capturedUrl: URL | undefined
+    const fetchFn = vi.fn(async (input: Request | string | URL) => {
+      const urlStr = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      capturedUrl = new URL(urlStr)
+      return new Response(JSON.stringify({ data: [] }), { status: 200 })
+    }) as unknown as typeof fetch
+    const overridePath = '/openapi/market-data/stock/snapshot'
+    const client = new WebullQuoteClient({
+      auth: baseAuth,
+      fetchFn,
+      quotePath: overridePath,
+    })
+    await client.getSnapshots(['SOXL'], 'US_ETF')
+    expect(capturedUrl?.pathname).toBe(overridePath)
+    expect(capturedUrl?.pathname).not.toBe('/openapi/market-data/snapshot')
+  })
+
   it('sends category as space-separated wire form (US STOCK / US ETF), not underscore', async () => {
     // Regression: underscored categories (US_STOCK / US_ETF) yielded 417/500
     // from the Webull snapshot endpoint.


### PR DESCRIPTION
## Summary

After #85, #86, #87 the quote feed was still returning `417 Expectation Failed` on `US_ETF`. None of the fixes we inferred from developer.webull.com's v2 docs (path, version, category wire format, extend/overnight params) resolved it.

Pivoted to the openapi-java-sdk — specifically `HttpQuotesApiClient.getSnapshots` — which is the source of truth for what actually works in production. It hits:

```
GET /openapi/market-data/snapshot     x-version: v1
    ?symbols=<csv>&category=<wire>
```

No `stock/` in the path, no v2, no `extend_hour_required`, no `overnight_required`. developer.webull.com documents a v2 variant at `/openapi/market-data/stock/snapshot`, but the sandbox we're pointed at doesn't accept it.

## Change

- Path: `/openapi/market-data/stock/snapshot` → `/openapi/market-data/snapshot`
- `x-version`: `v2` → `v1`
- Remove `extend_hour_required` / `overnight_required`
- Keep space-separated category wire format from #86 (the Java SDK uses the same enum)

## Test plan

- [x] `pnpm vitest run test/infrastructure/quotes/` — passes
- [ ] After deploy: `pnpm wrangler tail ... --search quote_feed` should finally show `fetched: 2, persisted: 2, skipped: [7267,6752,285A], errors: []`

Sources
- [openapi-java-sdk HttpQuotesApiClient.java](https://github.com/webull-inc/openapi-java-sdk/blob/main/webull-java-sdk-quotes/src/main/java/com/webull/openapi/quotes/internal/http/HttpQuotesApiClient.java)

Refs #84


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * Webullのクォート取得で使用するデフォルトAPIパスを更新し、リクエストヘッダーのバージョンを調整して取得の安定性を向上しました。
  * 不要なクエリパラメータを削除し、リクエストを簡素化しました。

* **テスト**
  * デフォルト経路とヘッダ振る舞い、および経路のオーバーライド動作を検証する自動テストを追加しました。

* **チア（保守）**
  * APIエンドポイント設定の整理を行いました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->