### PR TITLE
fix(quotes): bar endpoint alignment + revert mistaken space-wire category

### DIFF
--- a/src/infrastructure/quotes/BarClient.ts
+++ b/src/infrastructure/quotes/BarClient.ts
@@ -3,7 +3,19 @@ import { BrokerRequestError } from '../../shared/errors'
 import { WebullAuth } from '../webull/WebullAuth'
 import { inferWebullMarket } from '../webull/mapper'
 
-export type BarCategory = 'US_STOCK' | 'JP_STOCK'
+// developer.webull.com shows `category=US_STOCK` on the wire (underscore).
+// Python SDK's EasyEnum.__str__ returns `self.name` (the underscored
+// identifier), and Java SDK passes `Category.US_STOCK.name()` the same way.
+// JP_STOCK has no working HK-sandbox path — JP bars need a JP tenant (#89).
+export type BarCategory = 'US_STOCK' | 'US_ETF' | 'JP_STOCK'
+
+// Mirrors WebullQuoteClient's US ETF allowlist.
+const US_ETF_SYMBOLS = new Set<string>(['SOXL', 'SOXS'])
+
+function resolveBarCategory(symbol: string): BarCategory {
+  if (inferWebullMarket(symbol) === 'JP') return 'JP_STOCK'
+  return US_ETF_SYMBOLS.has(symbol) ? 'US_ETF' : 'US_STOCK'
+}
 
 export interface BarClient {
   getDailyBars(symbol: string, lookback: number): Promise<DailyBar[]>
@@ -39,7 +51,11 @@ export class WebullBarClient implements BarClient {
 
   constructor(private readonly options: WebullBarClientOptions) {
     this.baseUrl = (options.baseUrl ?? 'https://api.sandbox.webull.hk').replace(/\/+$/, '')
-    this.barsPath = options.barsPath ?? '/market-data/candles'
+    // openapi-java-sdk's HttpQuotesApiClient.getBars uses
+    // `/openapi/market-data/bars` with v1. Historical default here was
+    // `/market-data/candles` which has no /openapi prefix and the wrong
+    // resource name (`candles`). Update to SDK-accurate default.
+    this.barsPath = options.barsPath ?? '/openapi/market-data/bars'
     this.timeoutMs = options.timeoutMs ?? 5_000
     // Workers の global `fetch` はメソッド呼び出し扱いで `this` を globalThis
     // にひも付けないと "Illegal invocation" で落ちる。明示的に bind しておく。
@@ -47,8 +63,16 @@ export class WebullBarClient implements BarClient {
   }
 
   async getDailyBars(symbol: string, lookback: number): Promise<DailyBar[]> {
-    const category: BarCategory = inferWebullMarket(symbol) === 'JP' ? 'JP_STOCK' : 'US_STOCK'
-    const query = { symbol, category, period: '1d', limit: String(lookback) }
+    const category = resolveBarCategory(symbol)
+    // Java SDK (HttpQuotesApiClient.getBars) uses `timespan` + `count`, not
+    // `period` + `limit`. The category goes on the wire as the underscored
+    // identifier per developer.webull.com example + Python SDK __str__.
+    const query = {
+      symbol,
+      category,
+      timespan: 'd1',
+      count: String(lookback),
+    }
 
     const url = new URL(this.barsPath, `${this.baseUrl}/`)
     for (const [k, v] of Object.entries(query)) url.searchParams.set(k, v)
@@ -57,7 +81,9 @@ export class WebullBarClient implements BarClient {
     try {
       headers = await this.options.auth.createHeaders({
         method: 'GET',
-        path: url.pathname + url.search,
+        // Signing is path-only; query is merged into the canonical sorted pairs.
+        // Passing `pathname + search` duplicates query params (same bug as #80).
+        path: url.pathname,
         query,
         host: url.host,
         version: 'v1',

--- a/src/infrastructure/quotes/WebullQuoteClient.ts
+++ b/src/infrastructure/quotes/WebullQuoteClient.ts
@@ -11,12 +11,6 @@ export type WebullQuoteCategory = 'US_STOCK' | 'US_ETF'
 // symbol_config.category when universe grows.
 const US_ETF_SYMBOLS = new Set<string>(['SOXL', 'SOXS'])
 
-// Wire format on the API is space-separated, not underscore.
-// ref https://github.com/webull-inc/openapi-python-sdk/blob/main/webull-python-sdk-mdata/webullsdkmdata/common/category.py
-const WEBULL_CATEGORY_WIRE: Record<WebullQuoteCategory, string> = {
-  US_STOCK: 'US STOCK',
-  US_ETF: 'US ETF',
-}
 
 export interface QuoteResult {
   symbol: string
@@ -95,12 +89,12 @@ export class WebullQuoteClient {
   async getSnapshots(symbols: string[], category: WebullQuoteCategory): Promise<QuoteResult[]> {
     if (symbols.length === 0) return []
 
-    // Webull SDK wire format is space-separated: "US STOCK" / "US ETF".
-    // Using the underscore identifiers as-is yields 417/500.
-    const query = {
-      symbols: symbols.join(','),
-      category: WEBULL_CATEGORY_WIRE[category],
-    }
+    // Category goes on the wire as the underscored identifier
+    // (developer.webull.com example + Python/Java SDK convention). An earlier
+    // hypothesis that the wire format was "US STOCK" / "US ETF" (space) was
+    // wrong — Python's EasyEnum.__str__ returns `self.name`, and the docs
+    // example is literally `category=US_STOCK`.
+    const query = { symbols: symbols.join(','), category }
     const url = new URL(this.quotePath, `${this.baseUrl}/`)
     for (const [key, value] of Object.entries(query)) {
       url.searchParams.set(key, value)

--- a/test/infrastructure/quotes/webullBarClient.test.ts
+++ b/test/infrastructure/quotes/webullBarClient.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest'
+import { WebullBarClient } from '../../../src/infrastructure/quotes/BarClient'
+import { WebullAuth } from '../../../src/infrastructure/webull/WebullAuth'
+
+const baseAuth = new WebullAuth({ appKey: 'ak', appSecret: 'sk' })
+
+function mockJsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('WebullBarClient.getDailyBars', () => {
+  // Regression for #84-style drift: default endpoint + Java-SDK-matching
+  // query field names (`timespan` + `count`, NOT `period` + `limit`).
+  // Historical default `/market-data/candles` + `period/limit` silently
+  // drops every bar request because it has the wrong path AND wrong params.
+  it('defaults to /openapi/market-data/bars with timespan=d1 + count + x-version: v1', async () => {
+    let capturedUrl: URL | undefined
+    let capturedHeaders: Headers | undefined
+    const fetchFn = vi.fn(async (input: Request | string | URL, init?: RequestInit) => {
+      const urlStr = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      capturedUrl = new URL(urlStr)
+      capturedHeaders = new Headers(init?.headers)
+      return mockJsonResponse({ data: [] })
+    }) as unknown as typeof fetch
+
+    const client = new WebullBarClient({ auth: baseAuth, fetchFn })
+    await client.getDailyBars('SOXL', 30)
+
+    expect(capturedUrl?.pathname).toBe('/openapi/market-data/bars')
+    expect(capturedUrl?.searchParams.get('symbol')).toBe('SOXL')
+    expect(capturedUrl?.searchParams.get('timespan')).toBe('d1')
+    expect(capturedUrl?.searchParams.get('count')).toBe('30')
+    expect(capturedUrl?.searchParams.get('period')).toBeNull()
+    expect(capturedUrl?.searchParams.get('limit')).toBeNull()
+    expect(capturedHeaders?.get('x-version')).toBe('v1')
+  })
+
+  // Category routing mirrors WebullQuoteClient: SOXL/SOXS are ETFs, 4-digit
+  // (7203) and alphanumeric (285A) TSE codes are JP.
+  it('routes SOXL→US_ETF, AAPL→US_STOCK, 285A→JP_STOCK on the wire', async () => {
+    const captured: string[] = []
+    const fetchFn = vi.fn(async (input: Request | string | URL) => {
+      const urlStr = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      captured.push(new URL(urlStr).searchParams.get('category') ?? '')
+      return mockJsonResponse({ data: [] })
+    }) as unknown as typeof fetch
+
+    const client = new WebullBarClient({ auth: baseAuth, fetchFn })
+    await client.getDailyBars('SOXL', 1)
+    await client.getDailyBars('AAPL', 1)
+    await client.getDailyBars('285A', 1)
+
+    expect(captured).toEqual(['US_ETF', 'US_STOCK', 'JP_STOCK'])
+  })
+
+  // Negative: honouring `barsPath` override proves the default assertion above
+  // would actually catch a drift of DEFAULT barsPath back to `/market-data/candles`.
+  it('honours barsPath override (default-assertion sanity)', async () => {
+    let capturedPath: string | undefined
+    const fetchFn = vi.fn(async (input: Request | string | URL) => {
+      const urlStr = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      capturedPath = new URL(urlStr).pathname
+      return mockJsonResponse({ data: [] })
+    }) as unknown as typeof fetch
+
+    const client = new WebullBarClient({
+      auth: baseAuth,
+      fetchFn,
+      barsPath: '/market-data/candles',
+    })
+    await client.getDailyBars('SOXL', 1)
+
+    expect(capturedPath).toBe('/market-data/candles')
+    expect(capturedPath).not.toBe('/openapi/market-data/bars')
+  })
+})

--- a/test/infrastructure/quotes/webullQuoteClient.test.ts
+++ b/test/infrastructure/quotes/webullQuoteClient.test.ts
@@ -71,13 +71,14 @@ describe('WebullQuoteClient.getSnapshots', () => {
     expect(capturedUrl?.pathname).not.toBe('/openapi/market-data/snapshot')
   })
 
-  it('sends category as space-separated wire form (US STOCK / US ETF), not underscore', async () => {
-    // Regression: underscored categories (US_STOCK / US_ETF) yielded 417/500
-    // from the Webull snapshot endpoint.
+  it('sends category as the underscored identifier (US_STOCK / US_ETF)', async () => {
+    // Wire format confirmed by developer.webull.com example
+    // (`category=US_STOCK`) and Python SDK EasyEnum.__str__ = self.name.
+    // An earlier hypothesis of space-separated wire format was incorrect.
     const fetchFn = vi.fn(async (input: Request | string | URL) => {
       const urlStr = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
       const url = new URL(urlStr)
-      expect(url.searchParams.get('category')).toBe('US ETF')
+      expect(url.searchParams.get('category')).toBe('US_ETF')
       return new Response(JSON.stringify({ data: [] }), { status: 200 })
     }) as unknown as typeof fetch
     const client = new WebullQuoteClient({ auth: baseAuth, fetchFn })


### PR DESCRIPTION
## Summary

`BarClient` was broken against `api.sandbox.webull.hk` for the same class of reasons `WebullQuoteClient` was (#84 → #85/#86/#87/#88). The Pullback cron's US lane never produced a `pre_submit` at 11:15 JST because `getDailyBars` was 404ing silently (surfaced through `summary.errors`, not `trade_journal`).

Two changes shipped together:

### BarClient — align to openapi-java-sdk HttpQuotesApiClient.getBars

| | before | after |
|---|---|---|
| path | `/market-data/candles` | `/openapi/market-data/bars` |
| query field names | `period` + `limit` | `timespan` + `count` |
| signing path | `pathname + search` | `pathname` only (dedup, same bug class as #80) |
| category routing | US_STOCK / JP_STOCK (3 values only) | US_STOCK / US_ETF / JP_STOCK, with `SOXL`/`SOXS` → US_ETF |

### WebullQuoteClient — revert the space-wire category from #86

#86 changed the category on the wire to `"US STOCK"` / `"US ETF"` (space-separated). That hypothesis was wrong:

- [developer.webull.com's snapshot example](https://developer.webull.com/apis/docs/market-data-api/data-api/) shows `category=US_STOCK` literally (underscore).
- Python SDK's `EasyEnum.__str__` returns `self.name` — the underscored identifier.
- Java SDK passes `Category.US_STOCK.name()`, same underscore.

So the wire format is the underscored identifier. Reverted.

## Out of scope

- The endpoint may still 417 / 404 on `api.sandbox.webull.hk` for tenant/feature reasons (#84, #89) — this PR fixes the client-side mismatches so that if/when the tenant issue is resolved, the request shape will be correct.
- Neither BarClient nor QuoteClient speak JP through this base URL; JP remains parked until a JP sandbox tenant is available (#89).

## Test plan

- [x] `pnpm vitest run test/infrastructure/quotes/` — 3 files, 16 tests pass
- [x] New `webullBarClient.test.ts` locks default path + headers + field names + category routing
- [x] `webullQuoteClient.test.ts` updated to `expect(category).toBe('US_ETF')`
- [ ] After deploy: `pnpm wrangler tail ... --search strategy_cron` at the next :15 should either surface a new Webull status code from `/openapi/market-data/bars` (progress) or start emitting real signals for SOXL/SOXS.

Sources
- [openapi-java-sdk HttpQuotesApiClient.java](https://github.com/webull-inc/openapi-java-sdk/blob/main/webull-java-sdk-quotes/src/main/java/com/webull/openapi/quotes/internal/http/HttpQuotesApiClient.java)
- [openapi-python-sdk EasyEnum](https://github.com/webull-inc/openapi-python-sdk/blob/main/webull-python-sdk-core/webullsdkcore/common/easy_enum.py)
- [openapi-python-sdk category.py](https://github.com/webull-inc/openapi-python-sdk/blob/main/webull-python-sdk-mdata/webullsdkmdata/common/category.py)

Refs #84


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * US ETFのマーケットデータ対応を拡張しました。日本株式およびUS株式に加えて、US上場投資信託の価格データ取得が可能になります。

* **テスト**
  * マーケットデータ取得の信頼性向上のため、包括的なテストスイートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->