### PR TITLE
feat(admin): POST /admin/strategy/run for on-demand strategy cron debug

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -3,6 +3,7 @@ import type { AppBindings } from '../app'
 import { ValidationError } from '../shared/errors'
 import { PortfolioStateClient } from '../trading/state/PortfolioStateClient'
 import { SymbolStateClient } from '../trading/state/SymbolStateClient'
+import { runStrategyCron } from '../trading/strategy/runStrategyCron'
 
 /**
  * Operator-only endpoints. Basic-auth-protected by the same middleware as
@@ -25,6 +26,18 @@ export const admin = new Hono<AppBindings>()
     const client = new SymbolStateClient(c.env.SYMBOL_STATE)
     const state = await client.seedSettledCash(symbol, amount)
     return c.json({ symbol, settledCash: state.settledCash, updatedAt: state.updatedAt })
+  })
+  /**
+   * Manual trigger for `runStrategyCron`. Returns the same `StrategyCronResult`
+   * the hourly scheduled handler would console.log. Useful for debugging bar
+   * fetch failures / skip reasons without waiting for :15 of the hour.
+   *
+   * Honours `global_config.dry_run` via runStrategyCron itself — does NOT
+   * bypass. Protected by the same basic-auth as the rest of /admin/*.
+   */
+  .post('/strategy/run', async (c) => {
+    const result = await runStrategyCron(c.env)
+    return c.json(result)
   })
   .post('/portfolio/seed-equity', async (c) => {
     if (!c.env.PORTFOLIO_STATE) {


### PR DESCRIPTION
## Summary

The Pullback cron's diagnostic output is a single \`console.log(strategy_cron_run)\` line — captured by \`wrangler tail\` but not persisted to D1 / \`trade_journal\`. That's fine for a live observer, but when the cron runs at :15 of the hour and produces nothing in \`trade_journal\`, there's no way after the fact to tell between:

- \`skipReason: 'trading_disabled' | 'no_us_symbols' | 'no_bridge_state' | 'portfolio_halted' | 'drawdown_kill'\`
- Bar fetch failed → \`summary.errors: [{ symbol, message }]\`, cron returned without submitting
- All symbols HOLD → nothing to submit, also no journal entry

Add a manual trigger so we can re-run on demand and inspect \`StrategyCronResult\` directly:

\`\`\`
POST /admin/strategy/run
→ 200 { summary, symbols, skipReason? }
\`\`\`

## Behaviour

- Invokes \`runStrategyCron(env)\` — same path the hourly scheduled handler uses. No scope change to the strategy logic itself.
- Honours \`global_config.dry_run\`. If dry_run=1, MockExecution still runs; no real orders get placed.
- Protected by the existing basic-auth middleware already mounted on \`/admin/*\`.

## Motivation

Current session has had two consecutive :15 cron fires produce zero journal entries (11:15 and 12:15 JST) after #90 merged — either bar endpoint is still returning a 4xx (#84 / #89 class issue) or all signals are HOLD. An hour-long feedback loop per iteration is too slow; this route drops it to ~2s.

## Test plan

- [x] \`pnpm vitest run\` — existing routes/admin tests still pass (the new handler has no custom logic, just forwards to runStrategyCron which has its own test suite in test/trading/strategy/runStrategyCron.test.ts)
- [ ] After merge + deploy: \`curl -u admin:\$PW -X POST .../admin/strategy/run | jq\` should return the full StrategyCronResult including errors[] / rejected[] arrays if bars failed.

Refs #84 #89

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 管理者向けに戦略実行の手動トリガー機能を追加しました。既存の認証保護と同じセキュリティレベルを備えた新しいエンドポイントにより、スケジュール外での戦略実行が可能になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->