### PR TITLE
fix(quotes): v2 stock snapshot + bars (probe-confirmed working combo)

### DIFF
--- a/src/infrastructure/quotes/BarClient.ts
+++ b/src/infrastructure/quotes/BarClient.ts
@@ -51,11 +51,11 @@ export class WebullBarClient implements BarClient {
 
   constructor(private readonly options: WebullBarClientOptions) {
     this.baseUrl = (options.baseUrl ?? 'https://api.sandbox.webull.hk').replace(/\/+$/, '')
-    // openapi-java-sdk's HttpQuotesApiClient.getBars uses
-    // `/openapi/market-data/bars` with v1. Historical default here was
-    // `/market-data/candles` which has no /openapi prefix and the wrong
-    // resource name (`candles`). Update to SDK-accurate default.
-    this.barsPath = options.barsPath ?? '/openapi/market-data/bars'
+    // JP UAT tenant (jp-openapi-alb.uat.webullbroker.com) only exposes the
+    // v2 bars endpoint at `/openapi/market-data/stock/bars`. The Java SDK's
+    // v1 `/openapi/market-data/bars` returns 404 on this tenant. See #84
+    // probe trace.
+    this.barsPath = options.barsPath ?? '/openapi/market-data/stock/bars'
     this.timeoutMs = options.timeoutMs ?? 5_000
     // Workers の global `fetch` はメソッド呼び出し扱いで `this` を globalThis
     // にひも付けないと "Illegal invocation" で落ちる。明示的に bind しておく。
@@ -64,13 +64,13 @@ export class WebullBarClient implements BarClient {
 
   async getDailyBars(symbol: string, lookback: number): Promise<DailyBar[]> {
     const category = resolveBarCategory(symbol)
-    // Java SDK (HttpQuotesApiClient.getBars) uses `timespan` + `count`, not
-    // `period` + `limit`. The category goes on the wire as the underscored
-    // identifier per developer.webull.com example + Python SDK __str__.
+    // v2 stock/bars timespan enum (from probe 417 body):
+    //   M1, M5, M15, M30, M60, M120, M240, D, W, M, Y
+    // Daily = "D" (upper-case). Earlier `d1` yielded UNSUPPORTED_TIMESPAN.
     const query = {
       symbol,
       category,
-      timespan: 'd1',
+      timespan: 'D',
       count: String(lookback),
     }
 
@@ -86,7 +86,8 @@ export class WebullBarClient implements BarClient {
         path: url.pathname,
         query,
         host: url.host,
-        version: 'v1',
+        // v2 — v1 /market-data/bars is 404 on the JP UAT tenant.
+        version: 'v2',
       })
     } catch (error) {
       throw new BrokerRequestError(

--- a/src/infrastructure/quotes/WebullQuoteClient.ts
+++ b/src/infrastructure/quotes/WebullQuoteClient.ts
@@ -56,12 +56,15 @@ interface RawSnapshotEntry {
   ap?: number | string
 }
 
-// openapi-java-sdk's HttpQuotesApiClient (v1) hits `/openapi/market-data/snapshot`
-// with x-version: v1 and only `symbols` + `category`. developer.webull.com also
-// documents a v2 variant at `/openapi/market-data/stock/snapshot`, but the v2
-// endpoint returns 417 on our sandbox credentials, whereas v1 is the path the
-// SDK has shipped in production. Stay on v1 for now.
-const DEFAULT_QUOTE_PATH = '/openapi/market-data/snapshot'
+// Confirmed working combination on the JP UAT tenant (our `WEBULL_API_BASE`
+// resolves to jp-openapi-alb.uat.webullbroker.com — not the generic
+// api.sandbox.webull.hk fallback):
+// - path `/openapi/market-data/stock/snapshot`
+// - x-version: v2
+// - category: US_ETF / US_STOCK (underscore — matches EasyEnum.__str__ = name)
+// - `extend_hour_required=false` + `overnight_required=false` REQUIRED
+//   (omitting them → 417 Expectation Failed; see probe trace in #84)
+const DEFAULT_QUOTE_PATH = '/openapi/market-data/stock/snapshot'
 
 /**
  * Minimal Webull market-data snapshot client. Signs requests with the same
@@ -89,12 +92,15 @@ export class WebullQuoteClient {
   async getSnapshots(symbols: string[], category: WebullQuoteCategory): Promise<QuoteResult[]> {
     if (symbols.length === 0) return []
 
-    // Category goes on the wire as the underscored identifier
-    // (developer.webull.com example + Python/Java SDK convention). An earlier
-    // hypothesis that the wire format was "US STOCK" / "US ETF" (space) was
-    // wrong — Python's EasyEnum.__str__ returns `self.name`, and the docs
-    // example is literally `category=US_STOCK`.
-    const query = { symbols: symbols.join(','), category }
+    // v2 snapshot requires `extend_hour_required` + `overnight_required` —
+    // omitting them returns 417 Expectation Failed. We don't want extended
+    // or overnight data for the Pullback strategy (daytime cash equity only).
+    const query = {
+      symbols: symbols.join(','),
+      category,
+      extend_hour_required: 'false',
+      overnight_required: 'false',
+    }
     const url = new URL(this.quotePath, `${this.baseUrl}/`)
     for (const [key, value] of Object.entries(query)) {
       url.searchParams.set(key, value)
@@ -109,8 +115,8 @@ export class WebullQuoteClient {
         path: url.pathname,
         query,
         host: url.host,
-        // v1 matches HttpQuotesApiClient in openapi-java-sdk.
-        version: 'v1',
+        // JP UAT only exposes the v2 snapshot; v1 /market-data/snapshot → 404.
+        version: 'v2',
       })
     } catch (error) {
       throw new BrokerRequestError(

--- a/test/infrastructure/quotes/webullBarClient.test.ts
+++ b/test/infrastructure/quotes/webullBarClient.test.ts
@@ -16,7 +16,10 @@ describe('WebullBarClient.getDailyBars', () => {
   // query field names (`timespan` + `count`, NOT `period` + `limit`).
   // Historical default `/market-data/candles` + `period/limit` silently
   // drops every bar request because it has the wrong path AND wrong params.
-  it('defaults to /openapi/market-data/bars with timespan=d1 + count + x-version: v1', async () => {
+  it('defaults to v2 /openapi/market-data/stock/bars with timespan=D + count + x-version: v2', async () => {
+    // Confirmed via stdlib probe (#84): v1 `/market-data/bars` → 404,
+    // v2 `/market-data/stock/bars` → 417 UNSUPPORTED_TIMESPAN (path valid).
+    // Accepted timespan set: {M1, M5, M15, M30, M60, M120, M240, D, W, M, Y}.
     let capturedUrl: URL | undefined
     let capturedHeaders: Headers | undefined
     const fetchFn = vi.fn(async (input: Request | string | URL, init?: RequestInit) => {
@@ -29,13 +32,13 @@ describe('WebullBarClient.getDailyBars', () => {
     const client = new WebullBarClient({ auth: baseAuth, fetchFn })
     await client.getDailyBars('SOXL', 30)
 
-    expect(capturedUrl?.pathname).toBe('/openapi/market-data/bars')
+    expect(capturedUrl?.pathname).toBe('/openapi/market-data/stock/bars')
     expect(capturedUrl?.searchParams.get('symbol')).toBe('SOXL')
-    expect(capturedUrl?.searchParams.get('timespan')).toBe('d1')
+    expect(capturedUrl?.searchParams.get('timespan')).toBe('D')
     expect(capturedUrl?.searchParams.get('count')).toBe('30')
     expect(capturedUrl?.searchParams.get('period')).toBeNull()
     expect(capturedUrl?.searchParams.get('limit')).toBeNull()
-    expect(capturedHeaders?.get('x-version')).toBe('v1')
+    expect(capturedHeaders?.get('x-version')).toBe('v2')
   })
 
   // Category routing mirrors WebullQuoteClient: SOXL/SOXS are ETFs, 4-digit
@@ -74,6 +77,6 @@ describe('WebullBarClient.getDailyBars', () => {
     await client.getDailyBars('SOXL', 1)
 
     expect(capturedPath).toBe('/market-data/candles')
-    expect(capturedPath).not.toBe('/openapi/market-data/bars')
+    expect(capturedPath).not.toBe('/openapi/market-data/stock/bars')
   })
 })

--- a/test/infrastructure/quotes/webullQuoteClient.test.ts
+++ b/test/infrastructure/quotes/webullQuoteClient.test.ts
@@ -34,7 +34,10 @@ describe('WebullQuoteClient.getSnapshots', () => {
   // Regression for #84/#85/#86/#87/#88: the combination of path + x-version is
   // fragile against developer.webull.com's v2 docs vs what the SDK actually
   // ships. Lock both so any future drift is caught here instead of at runtime.
-  it('defaults to v1 /openapi/market-data/snapshot with x-version: v1 header', async () => {
+  it('defaults to v2 /openapi/market-data/stock/snapshot with x-version: v2 + extend/overnight params', async () => {
+    // Confirmed against the JP UAT tenant via stdlib probe (#84). v1
+    // `/market-data/snapshot` returns 404; v2 `/market-data/stock/snapshot`
+    // returns 200 with extend_hour_required + overnight_required present.
     let capturedUrl: URL | undefined
     let capturedHeaders: Headers | undefined
     const fetchFn = vi.fn(async (input: Request | string | URL, init?: RequestInit) => {
@@ -45,8 +48,10 @@ describe('WebullQuoteClient.getSnapshots', () => {
     }) as unknown as typeof fetch
     const client = new WebullQuoteClient({ auth: baseAuth, fetchFn })
     await client.getSnapshots(['SOXL'], 'US_ETF')
-    expect(capturedUrl?.pathname).toBe('/openapi/market-data/snapshot')
-    expect(capturedHeaders?.get('x-version')).toBe('v1')
+    expect(capturedUrl?.pathname).toBe('/openapi/market-data/stock/snapshot')
+    expect(capturedUrl?.searchParams.get('extend_hour_required')).toBe('false')
+    expect(capturedUrl?.searchParams.get('overnight_required')).toBe('false')
+    expect(capturedHeaders?.get('x-version')).toBe('v2')
   })
 
   // Negative: show the assertions above are not trivially satisfied — if the
@@ -60,7 +65,7 @@ describe('WebullQuoteClient.getSnapshots', () => {
       capturedUrl = new URL(urlStr)
       return new Response(JSON.stringify({ data: [] }), { status: 200 })
     }) as unknown as typeof fetch
-    const overridePath = '/openapi/market-data/stock/snapshot'
+    const overridePath = '/openapi/market-data/snapshot'
     const client = new WebullQuoteClient({
       auth: baseAuth,
       fetchFn,
@@ -68,7 +73,7 @@ describe('WebullQuoteClient.getSnapshots', () => {
     })
     await client.getSnapshots(['SOXL'], 'US_ETF')
     expect(capturedUrl?.pathname).toBe(overridePath)
-    expect(capturedUrl?.pathname).not.toBe('/openapi/market-data/snapshot')
+    expect(capturedUrl?.pathname).not.toBe('/openapi/market-data/stock/snapshot')
   })
 
   it('sends category as the underscored identifier (US_STOCK / US_ETF)', async () => {


### PR DESCRIPTION
## Summary

Stdlib-only Python probe (`.local/webull-py-probe/probe.py`, unshipped) replicated the openapi-python-sdk signing and tried six path × version × param combinations against our actual `WEBULL_API_BASE` (which resolves to `jp-openapi-alb.uat.webullbroker.com` — not the `api.sandbox.webull.hk` fallback default). Result pinpointed the one working combination for each endpoint:

### Snapshot — 200 OK with full OHLC + bid/ask

```
path     /openapi/market-data/stock/snapshot
version  v2
query    symbols=SOXL&category=US_ETF
         &extend_hour_required=false&overnight_required=false
```

Both `extend_hour_required` and `overnight_required` are **required** (omitting them → 417). `category` is the underscore identifier.

### Bars — path recognised, param value was wrong

```
path     /openapi/market-data/stock/bars
version  v2
timespan enum: M1, M5, M15, M30, M60, M120, M240, D, W, M, Y
```

We were sending `timespan=d1`, which the server rejects with `UNSUPPORTED_TIMESPAN`. Daily is `D` (upper-case).

## Change

| | before (main) | after |
|---|---|---|
| snapshot path | `/openapi/market-data/snapshot` (v1) | `/openapi/market-data/stock/snapshot` (v2) |
| snapshot x-version | `v1` | `v2` |
| snapshot extend/overnight params | absent | `false` / `false` |
| snapshot category | `US_ETF` (correct) | `US_ETF` (unchanged) |
| bars path | `/openapi/market-data/bars` (v1) | `/openapi/market-data/stock/bars` (v2) |
| bars x-version | `v1` | `v2` |
| bars timespan | `d1` | `D` |

Tests updated to assert the confirmed combination; `quotePath` / `barsPath` override tests prove the default assertions would fail if the default drifted.

## Why this took so many PRs

#85 → #86 → #87 → #88 → #90 each churned one axis at a time. Snapshots specifically:

- #87 had the right path/version/extend but the wrong category wire format (space-separated from #86).
- When #87 returned 417, I over-corrected in #88 by reverting to v1 path + dropping extend, thinking "v2 is broken, SDK path is canonical."
- #90 fixed the category wire but stayed on v1 path → 404 everywhere.

The probe made the combination space legible in 6 seconds rather than 4 PR cycles.

## Test plan

- [x] `pnpm vitest run test/infrastructure/quotes/` — 16/16 pass
- [ ] After merge + deploy: `curl -X POST /admin/strategy/run` should now return `summary.errors = []` (bars fetched), and either `buys > 0` (signal fired) or `holds > 0` (all HOLD).
- [ ] `tail --search quote_feed` at the next `*/5` cron should show `fetched: 2, persisted: 2, skipped: [7267,6752,285A]`.

Refs #84


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * Webull API のバージョンを v1 から v2 に更新し、API エンドポイントとリクエストパラメータを最新仕様に対応させました。
  * API 通信の互換性を向上させるため、認証ヘッダーとリクエスト形式を調整しました。

* **テスト**
  * API v2 仕様に対応したテスト項目を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->