### PR TITLE
fix(bars): parse v2 stock/bars `time` field (insufficient-bars root cause)

### DIFF
--- a/src/infrastructure/quotes/BarClient.ts
+++ b/src/infrastructure/quotes/BarClient.ts
@@ -144,6 +144,10 @@ export function createWebullBarClient(
 }
 
 interface RawBar {
+  // v2 stock/bars returns `time` as ISO-with-offset, e.g.
+  // "2026-04-17T04:00:00.000+0000". v1 and other surfaces use `date` or
+  // `trade_time`. Accept all three.
+  time?: string
   date?: string
   trade_time?: string
   open?: number | string
@@ -156,7 +160,7 @@ function normalizeBars(json: unknown): DailyBar[] {
   const rawList = extractList(json)
   const bars: DailyBar[] = []
   for (const raw of rawList) {
-    const date = typeof raw.date === 'string' ? raw.date : typeof raw.trade_time === 'string' ? raw.trade_time.slice(0, 10) : ''
+    const date = extractDate(raw)
     const open = toNumber(raw.open)
     const high = toNumber(raw.high)
     const low = toNumber(raw.low)
@@ -167,6 +171,16 @@ function normalizeBars(json: unknown): DailyBar[] {
   // Ensure oldest-first for downstream indicators.
   bars.sort((a, b) => a.date.localeCompare(b.date))
   return bars
+}
+
+function extractDate(raw: RawBar): string {
+  // Prefer a full `date` string when present, else derive YYYY-MM-DD from
+  // `time` / `trade_time` by taking the leading 10 chars. All three shapes
+  // have been observed in the wild depending on the endpoint version.
+  if (typeof raw.date === 'string' && raw.date.length >= 10) return raw.date
+  if (typeof raw.time === 'string' && raw.time.length >= 10) return raw.time.slice(0, 10)
+  if (typeof raw.trade_time === 'string' && raw.trade_time.length >= 10) return raw.trade_time.slice(0, 10)
+  return ''
 }
 
 function extractList(json: unknown): RawBar[] {

--- a/test/infrastructure/quotes/webullBarClient.test.ts
+++ b/test/infrastructure/quotes/webullBarClient.test.ts
@@ -12,6 +12,45 @@ function mockJsonResponse(body: unknown, status = 200) {
 }
 
 describe('WebullBarClient.getDailyBars', () => {
+  // Regression: v2 /market-data/stock/bars returns `time` as
+  // "2026-04-17T04:00:00.000+0000"; a prior normalizer only looked at
+  // `date` / `trade_time`, so every bar was dropped and Pullback saw
+  // "insufficient bars for indicators" even on 200 OK.
+  it('parses v2 `time` field (ISO w/ offset) as a YYYY-MM-DD date', async () => {
+    const fetchFn = vi.fn(async () =>
+      mockJsonResponse([
+        {
+          tickerId: '913244722',
+          symbol: 'SOXL',
+          time: '2026-04-17T04:00:00.000+0000',
+          open: '93.195000',
+          high: '94.750000',
+          low: '90.660000',
+          close: '94.680000',
+          volume: '67081435',
+        },
+        {
+          symbol: 'SOXL',
+          time: '2026-04-16T04:00:00.000+0000',
+          open: '85.010000',
+          high: '90.0',
+          low: '84.0',
+          close: '88.37',
+        },
+      ]),
+    ) as unknown as typeof fetch
+
+    const client = new WebullBarClient({ auth: baseAuth, fetchFn })
+    const bars = await client.getDailyBars('SOXL', 2)
+
+    expect(bars).toHaveLength(2)
+    // Oldest first by date
+    expect(bars[0]?.date).toBe('2026-04-16')
+    expect(bars[1]?.date).toBe('2026-04-17')
+    expect(bars[1]?.close).toBeCloseTo(94.68)
+  })
+
+
   // Regression for #84-style drift: default endpoint + Java-SDK-matching
   // query field names (`timespan` + `count`, NOT `period` + `limit`).
   // Historical default `/market-data/candles` + `period/limit` silently


### PR DESCRIPTION
## Summary

After #92 the bar endpoint finally returned 200 OK for SOXL, but Pullback still rejected it with `insufficient bars for indicators`. The probe body showed why:

```json
{
  "tickerId": "913244722",
  "symbol": "SOXL",
  "time": "2026-04-17T04:00:00.000+0000",
  "open": "93.195000",
  "close": "94.680000"
}
```

v2 `/openapi/market-data/stock/bars` uses a `time` key (ISO with offset), not `date` or `trade_time`. The old normalizer only looked at the latter two, so every bar was silently dropped after a 200 OK and Pullback saw zero bars.

Add `time` to the recognised shapes and derive `YYYY-MM-DD` from its leading 10 chars.

## Out of scope: SOXS

Separately, SOXS still hits a vendor-side 417 `INVALID_SYMBOL` ("More than one symbol was found in the category, size: 2") on both `US_ETF` and `US_STOCK` categories — that's a data disambiguation issue at Webull's end, tracked in #93. The DB-level `active=0` for SOXS has been applied out of band so the next cron run only evaluates SOXL.

## Test plan

- [x] `pnpm vitest run test/infrastructure/quotes/` — 4 BarClient tests (new `time`-field test + existing defaults / category-routing / override-sanity)
- [ ] After deploy: `POST /admin/strategy/run` should return `evaluated: 1, errors: [], rejected: []` for SOXL, with either `buys: 1` (signal) or `holds: 1` (HOLD).

Refs #84 #93
