### PR TITLE
feat(admin,webull): GET /admin/orders/:clientOrderId (first half of #81)

### DIFF
--- a/src/infrastructure/webull/WebullHttpClient.ts
+++ b/src/infrastructure/webull/WebullHttpClient.ts
@@ -1,6 +1,11 @@
 import type { OrderIntent } from '../../trading/domain/OrderIntent'
 import { BrokerRequestError } from '../../shared/errors'
-import type { WebullAccountDto, WebullPlaceOrderResponseDto, WebullSubscriptionDto } from './dto'
+import type {
+  WebullAccountDto,
+  WebullOrderDetailDto,
+  WebullPlaceOrderResponseDto,
+  WebullSubscriptionDto,
+} from './dto'
 import { toWebullPlaceOrderRequest } from './mapper'
 import { WebullAuth } from './WebullAuth'
 
@@ -56,6 +61,19 @@ export class WebullHttpClient {
   async getAccount(): Promise<WebullAccountDto> {
     return this.request<WebullAccountDto>('GET', '/account/profile', {
       query: { account_id: this.requireAccountId() },
+    })
+  }
+
+  /**
+   * Fetch the current status of a previously-placed order by its client-side
+   * idempotency key. Mirrors openapi-java-sdk's TradeHttpApiV2Service.
+   */
+  async getOrderDetail(clientOrderId: string): Promise<WebullOrderDetailDto> {
+    return this.request<WebullOrderDetailDto>('GET', '/openapi/account/orders/detail', {
+      query: {
+        account_id: this.requireAccountId(),
+        client_order_id: clientOrderId,
+      },
     })
   }
 

--- a/src/infrastructure/webull/dto.ts
+++ b/src/infrastructure/webull/dto.ts
@@ -39,3 +39,31 @@ export interface WebullPlaceOrderResponseDto {
   order_id?: string
   message?: string
 }
+
+/**
+ * Shape returned by GET /openapi/account/orders/detail (v1).
+ * Fields mirror openapi-java-sdk's `v2.OrderHistory`.
+ */
+export interface WebullOrderDetailDto {
+  client_order_id?: string
+  order_id?: string
+  symbol?: string
+  side?: 'BUY' | 'SELL'
+  order_type?: string
+  time_in_force?: string
+  limit_price?: string
+  stop_price?: string
+  quantity?: string
+  filled_quantity?: string
+  // Webull order lifecycle statuses: NEW, PARTIALLY_FILLED, FILLED,
+  // CANCELLED, REJECTED, EXPIRED, etc. Keep as free string for forward-compat.
+  status?: string
+  support_trading_session?: string
+  items?: Array<{
+    order_id?: string
+    symbol?: string
+    quantity?: string
+    filled_quantity?: string
+    status?: string
+  }>
+}

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import type { AppBindings } from '../app'
 import { ValidationError } from '../shared/errors'
+import { createWebullHttpClient } from '../infrastructure/webull/WebullHttpClient'
 import { PortfolioStateClient } from '../trading/state/PortfolioStateClient'
 import { SymbolStateClient } from '../trading/state/SymbolStateClient'
 import { runStrategyCron } from '../trading/strategy/runStrategyCron'
@@ -38,6 +39,23 @@ export const admin = new Hono<AppBindings>()
   .post('/strategy/run', async (c) => {
     const result = await runStrategyCron(c.env)
     return c.json(result)
+  })
+  /**
+   * Lookup the Webull-side status of an order by client_order_id. Primary use
+   * is checking whether an auto-placed order filled / was cancelled, ahead of
+   * wiring fill-tracking into PortfolioStateDO (#81).
+   *
+   * `client_order_id` is the uuid we pass into `toWebullPlaceOrderRequest` and
+   * the same id that's stored in `trade_journal.client_order_id`.
+   */
+  .get('/orders/:clientOrderId', async (c) => {
+    const clientOrderId = c.req.param('clientOrderId').trim()
+    if (clientOrderId.length === 0) {
+      throw new ValidationError('clientOrderId must be non-empty', { field: 'clientOrderId' })
+    }
+    const client = createWebullHttpClient(c.env)
+    const detail = await client.getOrderDetail(clientOrderId)
+    return c.json(detail)
   })
   .post('/portfolio/seed-equity', async (c) => {
     if (!c.env.PORTFOLIO_STATE) {

--- a/test/infrastructure/webull/webullHttpClient.test.ts
+++ b/test/infrastructure/webull/webullHttpClient.test.ts
@@ -128,6 +128,34 @@ describe('WebullHttpClient', () => {
     expect(body.new_orders[0].symbol).toBe('1570')
   })
 
+  it('fetches order detail via GET /openapi/account/orders/detail with client_order_id', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          client_order_id: 'coid-123',
+          order_id: 'ord-abc',
+          symbol: 'SOXL',
+          status: 'FILLED',
+          quantity: '1',
+          filled_quantity: '1',
+        }),
+        { status: 200 },
+      ),
+    )
+    const client = createClient(fetchMock)
+
+    const detail = await client.getOrderDetail('coid-123')
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]!
+    const u = new URL(url as string)
+    expect(u.pathname).toBe('/openapi/account/orders/detail')
+    expect(u.searchParams.get('account_id')).toBe('acct-1')
+    expect(u.searchParams.get('client_order_id')).toBe('coid-123')
+    expect(init?.method).toBe('GET')
+    expect(detail.status).toBe('FILLED')
+  })
+
   it('requests account details from the documented profile endpoint', async () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(


### PR DESCRIPTION
## Summary

First half of #81. Adds read-only infrastructure to look up a placed order's current state on Webull by the client-side idempotency key (`client_order_id`) we already persist in `trade_journal`.

### Change

- `WebullHttpClient.getOrderDetail(clientOrderId)` → `GET /openapi/account/orders/detail` (v1, matches openapi-java-sdk `TradeHttpApiV2Service`)
- `WebullOrderDetailDto` — mirrors `v2.OrderHistory`: status / filled_quantity / limit_price / etc. Kept as strings per Webull's wire format.
- `GET /admin/orders/:clientOrderId` — protected by the existing basic-auth middleware on `/admin/*`.

### Usage

```bash
PW=$(op read op://Personal/beqe7bvw2vwlmnaarvfvxp7vte/Dev/BASIC_AUTH_PASSWORD) && \
curl -s -u "admin:$PW" \
  https://webull-trading-staging.teacatus.workers.dev/admin/orders/<client-order-id> | jq
```

## Out of scope

- Auto polling / fill → PortfolioStateDO wiring. That's the bigger half of #81 and needs a scheduler decision (poll after N seconds? poll on cron boundary? webhook?) plus PortfolioStateDO method additions. Leaving it for a follow-up so this PR stays tight.
- Cancel / replace endpoints — same base class of work, separate PRs.

## Test plan

- [x] `pnpm vitest run test/infrastructure/webull/` — 16/16 pass including the new `getOrderDetail` assertion (path + query params + GET method)
- [ ] After deploy: `GET /admin/orders/248d73ddd9a040be95387e34ef1cd188` (the SOXL test order from yesterday) should return its current status from Webull sandbox.

Refs #81


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 管理者向けに注文詳細を取得できるエンドポイントを追加しました。クライアント注文IDで特定の注文の詳細情報（ステータス、数量、価格など）を照会できるようになりました。

* **テスト**
  * 新しい注文詳細取得機能のユニットテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->