### PR TITLE
fix(orders): use /orders/history for lookup (JP UAT lacks /orders/detail)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"69c90f65-a8b9-467f-9798-eb99abc5b9e3","pid":99086,"acquiredAt":1776649332725}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"69c90f65-a8b9-467f-9798-eb99abc5b9e3","pid":99086,"acquiredAt":1776649332725}

--- a/src/infrastructure/webull/WebullHttpClient.ts
+++ b/src/infrastructure/webull/WebullHttpClient.ts
@@ -66,15 +66,30 @@ export class WebullHttpClient {
 
   /**
    * Fetch the current status of a previously-placed order by its client-side
-   * idempotency key. Mirrors openapi-java-sdk's TradeHttpApiV2Service.
+   * idempotency key.
+   *
+   * `/openapi/account/orders/detail` returns 404 on the JP UAT tenant our
+   * `WEBULL_API_BASE` resolves to; `/openapi/account/orders/history` is the
+   * only working lookup. It returns a paginated array — we fetch the first
+   * page (default 10) and filter client-side. If the order is older than the
+   * last page, the caller gets `undefined` and should fall back to a wider
+   * pagination sweep (out of scope for the MVP admin endpoint).
    */
-  async getOrderDetail(clientOrderId: string): Promise<WebullOrderDetailDto> {
-    return this.request<WebullOrderDetailDto>('GET', '/openapi/account/orders/detail', {
-      query: {
-        account_id: this.requireAccountId(),
-        client_order_id: clientOrderId,
+  async findOrderByClientId(
+    clientOrderId: string,
+    pageSize = 50,
+  ): Promise<WebullOrderDetailDto | undefined> {
+    const history = await this.request<WebullOrderDetailDto[]>(
+      'GET',
+      '/openapi/account/orders/history',
+      {
+        query: {
+          account_id: this.requireAccountId(),
+          page_size: String(pageSize),
+        },
       },
-    })
+    )
+    return history.find((entry) => entry.client_order_id === clientOrderId)
   }
 
   async placeOrder(intent: OrderIntent): Promise<WebullPlaceOrderResponseDto> {

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -41,12 +41,13 @@ export const admin = new Hono<AppBindings>()
     return c.json(result)
   })
   /**
-   * Lookup the Webull-side status of an order by client_order_id. Primary use
-   * is checking whether an auto-placed order filled / was cancelled, ahead of
-   * wiring fill-tracking into PortfolioStateDO (#81).
+   * Lookup the Webull-side status of an order by client_order_id.
    *
-   * `client_order_id` is the uuid we pass into `toWebullPlaceOrderRequest` and
-   * the same id that's stored in `trade_journal.client_order_id`.
+   * The JP UAT tenant does not expose `/openapi/account/orders/detail` (404
+   * on both v1 and v2), so we fetch the first page of
+   * `/openapi/account/orders/history` (50 entries) and filter client-side.
+   * If the order is older than that window, returns 404
+   * `order_not_found_in_recent_history`.
    */
   .get('/orders/:clientOrderId', async (c) => {
     const clientOrderId = c.req.param('clientOrderId').trim()
@@ -54,7 +55,10 @@ export const admin = new Hono<AppBindings>()
       throw new ValidationError('clientOrderId must be non-empty', { field: 'clientOrderId' })
     }
     const client = createWebullHttpClient(c.env)
-    const detail = await client.getOrderDetail(clientOrderId)
+    const detail = await client.findOrderByClientId(clientOrderId)
+    if (!detail) {
+      return c.json({ error: 'order_not_found_in_recent_history', clientOrderId }, 404)
+    }
     return c.json(detail)
   })
   .post('/portfolio/seed-equity', async (c) => {

--- a/test/infrastructure/webull/webullHttpClient.test.ts
+++ b/test/infrastructure/webull/webullHttpClient.test.ts
@@ -128,32 +128,38 @@ describe('WebullHttpClient', () => {
     expect(body.new_orders[0].symbol).toBe('1570')
   })
 
-  it('fetches order detail via GET /openapi/account/orders/detail with client_order_id', async () => {
+  it('findOrderByClientId fetches orders/history and filters client-side', async () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(
-        JSON.stringify({
-          client_order_id: 'coid-123',
-          order_id: 'ord-abc',
-          symbol: 'SOXL',
-          status: 'FILLED',
-          quantity: '1',
-          filled_quantity: '1',
-        }),
+        JSON.stringify([
+          { client_order_id: 'other-1', status: 'PENDING' },
+          { client_order_id: 'coid-123', order_id: 'ord-abc', symbol: 'SOXL', status: 'FILLED', filled_quantity: '1' },
+          { client_order_id: 'other-2', status: 'CANCELLED' },
+        ]),
         { status: 200 },
       ),
     )
     const client = createClient(fetchMock)
 
-    const detail = await client.getOrderDetail('coid-123')
+    const detail = await client.findOrderByClientId('coid-123')
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
     const [url, init] = fetchMock.mock.calls[0]!
     const u = new URL(url as string)
-    expect(u.pathname).toBe('/openapi/account/orders/detail')
+    // History endpoint — the JP UAT tenant does not expose /orders/detail.
+    expect(u.pathname).toBe('/openapi/account/orders/history')
     expect(u.searchParams.get('account_id')).toBe('acct-1')
-    expect(u.searchParams.get('client_order_id')).toBe('coid-123')
+    expect(u.searchParams.get('page_size')).toBe('50')
     expect(init?.method).toBe('GET')
-    expect(detail.status).toBe('FILLED')
+    expect(detail?.status).toBe('FILLED')
+  })
+
+  it('findOrderByClientId returns undefined when the coid is not in the history page', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify([{ client_order_id: 'unrelated' }]), { status: 200 }),
+    )
+    const client = createClient(fetchMock)
+    expect(await client.findOrderByClientId('missing')).toBeUndefined()
   })
 
   it('requests account details from the documented profile endpoint', async () => {


### PR DESCRIPTION
## Summary

Follow-up to #95. After deploy, hitting `GET /admin/orders/<coid>` returned 502 `broker_request_error`. Probe showed the actual Webull response:

```
[404] /openapi/account/orders/detail v1 → "404 Route Not Found"
[404] /openapi/account/orders/detail v2 → "404 Route Not Found"
[200] /openapi/account/orders/history v1 → real list
[200] /openapi/account/list v1 → 2 accounts (CASH + US_MARGIN)
```

`/orders/detail` does not exist on the JP UAT tenant. Only `/orders/history` is exposed.

### Change

- Rename `WebullHttpClient.getOrderDetail(clientOrderId)` → `findOrderByClientId(clientOrderId)`.
- Under the hood: fetch `/openapi/account/orders/history?account_id=...&page_size=50` and filter by `client_order_id` client-side.
- Admin route `GET /admin/orders/:clientOrderId` now returns:
  - `200 <entry>` when the coid is in the recent history page
  - `404 { error: 'order_not_found_in_recent_history', clientOrderId }` when it's beyond the window

### Out of scope

- **Multi-account routing.** The probe incidentally surfaced that our tenant has two accounts — `CJP0064548` CASH and `CJP0064560` US_MARGIN. `WEBULL_ACCOUNT_ID` currently points at the CASH account. It's plausible that US orders should route through `US_MARGIN` (and that this explains some of the JP 417s in #89). Separate investigation.
- **Pagination sweep.** If a coid is older than the 50-entry page, we 404. Adding a `last_client_order_id` cursor loop is a follow-up.

## Test plan

- [x] `pnpm vitest run test/infrastructure/webull/` — 2 new tests (history path + query shape; 404 path)
- [ ] After deploy: `GET /admin/orders/248d73ddd9a040be95387e34ef1cd188` (yesterday's SOXL test order) should return its actual status + filled_quantity. If older than 50 entries, the 404 response proves the fallback path.

Refs #81


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 注文情報の取得方法を改善し、最近の注文履歴から検索するように変更しました
  * 指定された注文が見つからない場合、適切なエラーメッセージを返すようになりました
  
* **テスト**
  * 注文検索機能の新しい動作に対応したテストケースを追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->