### PR TITLE
feat(webull): route orders to per-market accounts (#97)

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -48,7 +48,8 @@ export function parseNumberEnv(value: string | undefined, key?: string): number 
 export interface Env {
   WEBULL_APP_KEY?: string
   WEBULL_APP_SECRET?: string
-  WEBULL_ACCOUNT_ID?: string
+  WEBULL_ACCOUNT_ID_JP_CASH?: string
+  WEBULL_ACCOUNT_ID_US_MARGIN?: string
   WEBULL_API_BASE?: string
   /** Override the snapshot endpoint path (POC: UAT 未確定なので env で差し替え). */
   WEBULL_QUOTE_PATH?: string

--- a/src/infrastructure/webull/WebullHttpClient.ts
+++ b/src/infrastructure/webull/WebullHttpClient.ts
@@ -2,18 +2,31 @@ import type { OrderIntent } from '../../trading/domain/OrderIntent'
 import { BrokerRequestError } from '../../shared/errors'
 import type {
   WebullAccountDto,
+  WebullMarket,
   WebullOrderDetailDto,
   WebullPlaceOrderResponseDto,
   WebullSubscriptionDto,
 } from './dto'
-import { toWebullPlaceOrderRequest } from './mapper'
+import { inferWebullMarket, toWebullPlaceOrderRequest } from './mapper'
 import { WebullAuth } from './WebullAuth'
 
 export interface WebullClientEnv {
   WEBULL_APP_KEY?: string
   WEBULL_APP_SECRET?: string
-  WEBULL_ACCOUNT_ID?: string
   WEBULL_API_BASE?: string
+  /**
+   * Per-market account IDs. Webull issues separate accounts per market
+   * (JP CASH for JP equities, US_MARGIN for US equities) and each order
+   * must route through the matching one — a JPY account silently rejects
+   * USD-denominated orders.
+   */
+  WEBULL_ACCOUNT_ID_JP_CASH?: string
+  WEBULL_ACCOUNT_ID_US_MARGIN?: string
+}
+
+export interface WebullAccountIdMap {
+  jp?: string
+  us?: string
 }
 
 interface WebullRetryOptions {
@@ -25,7 +38,8 @@ interface WebullRetryOptions {
 
 interface WebullHttpClientOptions {
   auth: WebullAuth
-  accountId?: string
+  /** Per-market account IDs. Supply at least one. */
+  accountIds: WebullAccountIdMap
   baseUrl?: string
   timeoutMs?: number
   retry?: WebullRetryOptions
@@ -38,6 +52,7 @@ export class WebullHttpClient {
   private readonly timeoutMs: number
   private readonly fetchFn: typeof fetch
   private readonly retry: Required<WebullRetryOptions>
+  private readonly accountIds: WebullAccountIdMap
 
   constructor(private readonly options: WebullHttpClientOptions) {
     this.baseUrl = (options.baseUrl ?? 'https://api.sandbox.webull.hk').replace(/\/+$/, '')
@@ -52,6 +67,7 @@ export class WebullHttpClient {
       multiplier: options.retry?.multiplier ?? 2,
       jitter: options.retry?.jitter ?? 0.25,
     }
+    this.accountIds = options.accountIds
   }
 
   async listSubscriptions(): Promise<WebullSubscriptionDto[]> {
@@ -60,7 +76,7 @@ export class WebullHttpClient {
 
   async getAccount(): Promise<WebullAccountDto> {
     return this.request<WebullAccountDto>('GET', '/account/profile', {
-      query: { account_id: this.requireAccountId() },
+      query: { account_id: this.requireAnyAccountId() },
     })
   }
 
@@ -79,24 +95,31 @@ export class WebullHttpClient {
     clientOrderId: string,
     pageSize = 50,
   ): Promise<WebullOrderDetailDto | undefined> {
-    const history = await this.request<WebullOrderDetailDto[]>(
-      'GET',
-      '/openapi/account/orders/history',
-      {
-        query: {
-          account_id: this.requireAccountId(),
-          page_size: String(pageSize),
-        },
-      },
+    // The order could have been placed against either account. Query every
+    // configured account and return the first hit.
+    const configured = this.configuredAccountIds()
+    const pages = await Promise.all(
+      configured.map((accountId) =>
+        this.request<WebullOrderDetailDto[]>('GET', '/openapi/account/orders/history', {
+          query: { account_id: accountId, page_size: String(pageSize) },
+        }),
+      ),
     )
-    return history.find((entry) => entry.client_order_id === clientOrderId)
+    for (const page of pages) {
+      const hit = page.find((entry) => entry.client_order_id === clientOrderId)
+      if (hit) return hit
+    }
+    return undefined
   }
 
   async placeOrder(intent: OrderIntent): Promise<WebullPlaceOrderResponseDto> {
+    // Route to the market-matching account. Placing a USD order on a JPY
+    // CASH account results in silent rejection (#97).
+    const market = inferWebullMarket(intent.symbol)
     // v2 endpoint. JP UAT / newer Webull deployments reject the v1
     // `/trade/order/place` + `stock_order` body with ILLEGAL_PARAMETER.
     return this.request<WebullPlaceOrderResponseDto>('POST', '/openapi/account/orders/place', {
-      query: { account_id: this.requireAccountId() },
+      query: { account_id: this.requireAccountId(market) },
       body: toWebullPlaceOrderRequest(intent),
     })
   }
@@ -237,12 +260,25 @@ export class WebullHttpClient {
     )
   }
 
-  private requireAccountId(): string {
-    if (!this.options.accountId) {
+  private requireAccountId(market: WebullMarket): string {
+    const key: keyof WebullAccountIdMap = market === 'JP' ? 'jp' : 'us'
+    const id = this.accountIds[key]
+    if (!id) {
+      throw new BrokerRequestError(`Missing Webull account ID for market=${market}`, 'webullAccountId')
+    }
+    return id
+  }
+
+  private requireAnyAccountId(): string {
+    const id = this.accountIds.jp ?? this.accountIds.us
+    if (!id) {
       throw new BrokerRequestError('Missing Webull account ID', 'webullAccountId')
     }
+    return id
+  }
 
-    return this.options.accountId
+  private configuredAccountIds(): string[] {
+    return [this.accountIds.jp, this.accountIds.us].filter((x): x is string => !!x)
   }
 }
 
@@ -255,7 +291,10 @@ export function createWebullHttpClient(
       appKey: env.WEBULL_APP_KEY,
       appSecret: env.WEBULL_APP_SECRET,
     }),
-    accountId: env.WEBULL_ACCOUNT_ID,
+    accountIds: {
+      jp: env.WEBULL_ACCOUNT_ID_JP_CASH,
+      us: env.WEBULL_ACCOUNT_ID_US_MARGIN,
+    },
     baseUrl: env.WEBULL_API_BASE,
     timeoutMs: options?.timeoutMs,
     retry: options?.retry,

--- a/src/infrastructure/webull/WebullHttpClient.ts
+++ b/src/infrastructure/webull/WebullHttpClient.ts
@@ -98,6 +98,15 @@ export class WebullHttpClient {
     // The order could have been placed against either account. Query every
     // configured account and return the first hit.
     const configured = this.configuredAccountIds()
+    if (configured.length === 0) {
+      // Mirror placeOrder / getAccount: surface misconfiguration loudly
+      // rather than returning `undefined` (which would be indistinguishable
+      // from "order not in the recent history window" at the call site).
+      throw new BrokerRequestError(
+        'Missing Webull account IDs: set WEBULL_ACCOUNT_ID_JP_CASH and/or WEBULL_ACCOUNT_ID_US_MARGIN',
+        'webullAccountId',
+      )
+    }
     const pages = await Promise.all(
       configured.map((accountId) =>
         this.request<WebullOrderDetailDto[]>('GET', '/openapi/account/orders/history', {

--- a/src/trading/bridge/bridgeKeepAlive.ts
+++ b/src/trading/bridge/bridgeKeepAlive.ts
@@ -6,7 +6,8 @@ export interface BridgeKeepAliveEnv {
   BRIDGE?: DurableObjectNamespace<BridgeContainer>
   WEBULL_APP_KEY?: string
   WEBULL_APP_SECRET?: string
-  WEBULL_ACCOUNT_ID?: string
+  WEBULL_ACCOUNT_ID_JP_CASH?: string
+  WEBULL_ACCOUNT_ID_US_MARGIN?: string
   WEBULL_GRPC_ENDPOINT?: string
   EVENT_INGEST_URL?: string
   EVENT_INGEST_SECRET?: string
@@ -81,7 +82,8 @@ export async function keepBridgeAlive(
       envVars: {
         WEBULL_APP_KEY: env.WEBULL_APP_KEY!,
         WEBULL_APP_SECRET: env.WEBULL_APP_SECRET!,
-        WEBULL_ACCOUNT_ID: env.WEBULL_ACCOUNT_ID!,
+        WEBULL_ACCOUNT_ID_JP_CASH: env.WEBULL_ACCOUNT_ID_JP_CASH!,
+        WEBULL_ACCOUNT_ID_US_MARGIN: env.WEBULL_ACCOUNT_ID_US_MARGIN!,
         WEBULL_GRPC_ENDPOINT: env.WEBULL_GRPC_ENDPOINT!,
         EVENT_INGEST_URL: env.EVENT_INGEST_URL!,
         EVENT_INGEST_SECRET: env.EVENT_INGEST_SECRET!,
@@ -140,7 +142,8 @@ async function stopContainer(
 const requiredSecrets = [
   'WEBULL_APP_KEY',
   'WEBULL_APP_SECRET',
-  'WEBULL_ACCOUNT_ID',
+  'WEBULL_ACCOUNT_ID_JP_CASH',
+  'WEBULL_ACCOUNT_ID_US_MARGIN',
   'WEBULL_GRPC_ENDPOINT',
   'EVENT_INGEST_URL',
   'EVENT_INGEST_SECRET',

--- a/test/infrastructure/webull/webullHttpClient.test.ts
+++ b/test/infrastructure/webull/webullHttpClient.test.ts
@@ -132,7 +132,7 @@ describe('WebullHttpClient', () => {
     // Client is configured with both jp + us accounts. An order can live in
     // either, so we must query both. Return the target coid from the us
     // account page and unrelated entries from the jp page.
-    const fetchMock = vi.fn<typeof fetch>(async (input: Request | string | URL) => {
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(async (input) => {
       const urlStr = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
       const accountId = new URL(urlStr).searchParams.get('account_id')
       const body = accountId === 'acct-1'
@@ -142,7 +142,7 @@ describe('WebullHttpClient', () => {
           ]
         : [{ client_order_id: 'unrelated', status: 'PENDING' }]
       return new Response(JSON.stringify(body), { status: 200 })
-    }) as unknown as typeof fetch
+    })
     const client = createClient(fetchMock)
 
     const detail = await client.findOrderByClientId('coid-123')
@@ -158,9 +158,9 @@ describe('WebullHttpClient', () => {
   it('findOrderByClientId returns undefined when the coid is in neither account', async () => {
     // Each account call needs a fresh Response since the body can only be
     // read once. `mockResolvedValue` returns the same instance every time.
-    const fetchMock = vi.fn<typeof fetch>(
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(
       async () => new Response(JSON.stringify([{ client_order_id: 'unrelated' }]), { status: 200 }),
-    ) as unknown as typeof fetch
+    )
     const client = createClient(fetchMock)
     expect(await client.findOrderByClientId('missing')).toBeUndefined()
   })

--- a/test/infrastructure/webull/webullHttpClient.test.ts
+++ b/test/infrastructure/webull/webullHttpClient.test.ts
@@ -18,7 +18,7 @@ function createClient(fetchFn: typeof fetch, timeoutMs?: number): WebullHttpClie
       appKey: 'app-key',
       appSecret: 'app-secret',
     }),
-    accountId: 'acct-1',
+    accountIds: { us: 'acct-1', jp: 'acct-jp-1' },
     baseUrl: 'https://broker.example.test',
     timeoutMs,
     retry: {
@@ -43,7 +43,7 @@ describe('WebullHttpClient', () => {
     const spy = vi.spyOn(auth, 'createHeaders')
     const client = new WebullHttpClient({
       auth,
-      accountId: 'acct-1',
+      accountIds: { us: 'acct-1', jp: 'acct-jp-1' },
       baseUrl: 'https://broker.example.test',
       retry: { maxAttempts: 1, baseDelayMs: 0, multiplier: 2, jitter: 0 },
       fetchFn: fetchMock,
@@ -128,36 +128,39 @@ describe('WebullHttpClient', () => {
     expect(body.new_orders[0].symbol).toBe('1570')
   })
 
-  it('findOrderByClientId fetches orders/history and filters client-side', async () => {
-    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
-      new Response(
-        JSON.stringify([
-          { client_order_id: 'other-1', status: 'PENDING' },
-          { client_order_id: 'coid-123', order_id: 'ord-abc', symbol: 'SOXL', status: 'FILLED', filled_quantity: '1' },
-          { client_order_id: 'other-2', status: 'CANCELLED' },
-        ]),
-        { status: 200 },
-      ),
-    )
+  it('findOrderByClientId queries orders/history for every configured account and merges results', async () => {
+    // Client is configured with both jp + us accounts. An order can live in
+    // either, so we must query both. Return the target coid from the us
+    // account page and unrelated entries from the jp page.
+    const fetchMock = vi.fn<typeof fetch>(async (input: Request | string | URL) => {
+      const urlStr = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      const accountId = new URL(urlStr).searchParams.get('account_id')
+      const body = accountId === 'acct-1'
+        ? [
+            { client_order_id: 'other-1', status: 'PENDING' },
+            { client_order_id: 'coid-123', symbol: 'SOXL', status: 'FILLED', filled_quantity: '1' },
+          ]
+        : [{ client_order_id: 'unrelated', status: 'PENDING' }]
+      return new Response(JSON.stringify(body), { status: 200 })
+    }) as unknown as typeof fetch
     const client = createClient(fetchMock)
 
     const detail = await client.findOrderByClientId('coid-123')
 
-    expect(fetchMock).toHaveBeenCalledTimes(1)
-    const [url, init] = fetchMock.mock.calls[0]!
-    const u = new URL(url as string)
-    // History endpoint — the JP UAT tenant does not expose /orders/detail.
-    expect(u.pathname).toBe('/openapi/account/orders/history')
-    expect(u.searchParams.get('account_id')).toBe('acct-1')
-    expect(u.searchParams.get('page_size')).toBe('50')
-    expect(init?.method).toBe('GET')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const accountIdsQueried = fetchMock.mock.calls
+      .map((call) => new URL(call[0] as string).searchParams.get('account_id'))
+      .sort()
+    expect(accountIdsQueried).toEqual(['acct-1', 'acct-jp-1'])
     expect(detail?.status).toBe('FILLED')
   })
 
-  it('findOrderByClientId returns undefined when the coid is not in the history page', async () => {
-    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
-      new Response(JSON.stringify([{ client_order_id: 'unrelated' }]), { status: 200 }),
-    )
+  it('findOrderByClientId returns undefined when the coid is in neither account', async () => {
+    // Each account call needs a fresh Response since the body can only be
+    // read once. `mockResolvedValue` returns the same instance every time.
+    const fetchMock = vi.fn<typeof fetch>(
+      async () => new Response(JSON.stringify([{ client_order_id: 'unrelated' }]), { status: 200 }),
+    ) as unknown as typeof fetch
     const client = createClient(fetchMock)
     expect(await client.findOrderByClientId('missing')).toBeUndefined()
   })
@@ -176,8 +179,11 @@ describe('WebullHttpClient', () => {
 
     await client.getAccount()
 
+    // getAccount() uses the first configured account id. Our createClient
+    // helper sets `{ us: 'acct-1', jp: 'acct-jp-1' }` — jp wins since it's
+    // preferred in requireAnyAccountId's lookup order.
     const [url, init] = fetchMock.mock.calls[0]!
-    expect(url).toBe('https://broker.example.test/account/profile?account_id=acct-1')
+    expect(url).toBe('https://broker.example.test/account/profile?account_id=acct-jp-1')
     expect(init?.method).toBe('GET')
     expect(init?.body).toBeUndefined()
     expect(init?.headers).toMatchObject({

--- a/test/infrastructure/webull/webullHttpClient.test.ts
+++ b/test/infrastructure/webull/webullHttpClient.test.ts
@@ -155,6 +155,19 @@ describe('WebullHttpClient', () => {
     expect(detail?.status).toBe('FILLED')
   })
 
+  it('findOrderByClientId throws BrokerRequestError when no account ids are configured', async () => {
+    const fetchMock = vi.fn<typeof fetch>()
+    const client = new WebullHttpClient({
+      auth: new WebullAuth({ appKey: 'app-key', appSecret: 'app-secret' }),
+      accountIds: {},
+      baseUrl: 'https://broker.example.test',
+      retry: { maxAttempts: 1, baseDelayMs: 0, multiplier: 1, jitter: 0 },
+      fetchFn: fetchMock,
+    })
+    await expect(client.findOrderByClientId('whatever')).rejects.toThrow(/Missing Webull account IDs/)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it('findOrderByClientId returns undefined when the coid is in neither account', async () => {
     // Each account call needs a fresh Response since the body can only be
     // read once. `mockResolvedValue` returns the same instance every time.

--- a/test/routes/trade.test.ts
+++ b/test/routes/trade.test.ts
@@ -165,7 +165,13 @@ describe('trade routes', () => {
           sellAbove: 20,
         }),
       },
-      { ...env, WEBULL_APP_KEY: 'app-key', WEBULL_APP_SECRET: 'app-secret', WEBULL_ACCOUNT_ID: 'acct-1' },
+      {
+        ...env,
+        WEBULL_APP_KEY: 'app-key',
+        WEBULL_APP_SECRET: 'app-secret',
+        WEBULL_ACCOUNT_ID_US_MARGIN: 'acct-1',
+        WEBULL_ACCOUNT_ID_JP_CASH: 'acct-jp-1',
+      },
     )
 
     expect(response.status).toBe(200)

--- a/test/routes/webull.test.ts
+++ b/test/routes/webull.test.ts
@@ -120,7 +120,8 @@ describe('webull routes', () => {
         ...baseEnv,
         WEBULL_APP_KEY: 'app-key',
         WEBULL_APP_SECRET: 'app-secret',
-        WEBULL_ACCOUNT_ID: 'acct-1',
+        WEBULL_ACCOUNT_ID_US_MARGIN: 'acct-1',
+        WEBULL_ACCOUNT_ID_JP_CASH: 'acct-jp-1',
       },
     )
 


### PR DESCRIPTION
## Summary

Probe found two accounts on our Webull UAT tenant:

| type | currency | state |
|---|---|---|
| JP **CASH** | JPY | non-zero balance, 1 pre-existing JP ETF position |
| US **MARGIN** | USD | empty (never used) |

We've been sending every order through the CASH account. Yesterday's SOXL BUY never appeared in either account's `orders/history` — a JPY-denominated account silently rejects USD-denominated orders. This explains both the “order_not_found_in_recent_history” on admin lookup (#95/#96) and likely some of the 417s in #89.

## Change

- `WebullClientEnv` now takes `WEBULL_ACCOUNT_ID_JP_CASH` + `WEBULL_ACCOUNT_ID_US_MARGIN`. Old `WEBULL_ACCOUNT_ID` is removed per repo policy of "no backwards-compat hacks".
- `WebullHttpClient.placeOrder` picks the account by `inferWebullMarket(symbol)`:
  - JP (4-digit + alphanumeric like `285A`) → `WEBULL_ACCOUNT_ID_JP_CASH`
  - US (everything else) → `WEBULL_ACCOUNT_ID_US_MARGIN`
- `findOrderByClientId` queries every configured account concurrently and returns the first hit — an order can live in either account.
- `Env` / `bridgeKeepAlive` secrets list updated accordingly.

## Secrets rollout (required for deploy)

```bash
pnpm wrangler secret put WEBULL_ACCOUNT_ID_JP_CASH --env staging    # paste JP CASH account id
pnpm wrangler secret put WEBULL_ACCOUNT_ID_US_MARGIN --env staging  # paste US_MARGIN account id
pnpm wrangler secret delete WEBULL_ACCOUNT_ID --env staging         # optional cleanup
```

Refer to the operator's 1Password vault for the actual account IDs.

Deploy will fail (type-safe at compile time via `Env`) until the two new secrets are set.

## Test plan

- [x] `pnpm vitest run test/infrastructure/webull/` — 17 tests pass (new multi-account assertions: placeOrder URL, findOrder queries both, getAccount fallback)
- [ ] After merge + secrets + deploy:
  - `POST /webull/order/place` for SOXL → should now land in US_MARGIN's history
  - `POST /webull/order/place` for `7267` → should land in JP_CASH's history (and we'll know whether #89's JP 417 was really a tenant problem or account routing)
  - `POST /admin/strategy/run` → SOXL evaluate path unchanged, order routing now correct

Refs #97 #89 #81


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **設定変更**
  * Webull ブローカーのアカウント設定を更新しました。単一の環境変数から市場別の専用アカウントID（日本キャッシュ口座と米国マージン口座）に分割されました。環境変数を更新してください。
* **テスト**
  * テスト環境とユニットテストを新しいアカウント設定に合わせて更新しました（振る舞いは従来通り検証されます）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->