### PR TITLE
feat(errors): split BrokerRequestError into auth/rate-limit/client/server (#82)

### DIFF
--- a/src/infrastructure/quotes/BarClient.ts
+++ b/src/infrastructure/quotes/BarClient.ts
@@ -1,5 +1,5 @@
 import type { DailyBar } from '../../trading/strategy/indicators'
-import { BrokerRequestError } from '../../shared/errors'
+import { BrokerRequestError, brokerErrorForStatus } from '../../shared/errors'
 import { WebullAuth } from '../webull/WebullAuth'
 import { inferWebullMarket } from '../webull/mapper'
 
@@ -117,7 +117,8 @@ export class WebullBarClient implements BarClient {
     }
 
     if (!response.ok) {
-      throw new BrokerRequestError(
+      throw brokerErrorForStatus(
+        response.status,
         `Webull bar request failed with status ${response.status}`,
         `GET ${this.barsPath}`,
       )

--- a/src/infrastructure/quotes/WebullQuoteClient.ts
+++ b/src/infrastructure/quotes/WebullQuoteClient.ts
@@ -1,4 +1,4 @@
-import { BrokerRequestError } from '../../shared/errors'
+import { BrokerRequestError, brokerErrorForStatus } from '../../shared/errors'
 import { WebullAuth } from '../webull/WebullAuth'
 import { inferWebullMarket } from '../webull/mapper'
 
@@ -146,7 +146,8 @@ export class WebullQuoteClient {
     }
 
     if (!response.ok) {
-      throw new BrokerRequestError(
+      throw brokerErrorForStatus(
+        response.status,
         `Webull quote request failed with status ${response.status}`,
         `GET ${this.quotePath}`,
       )

--- a/src/infrastructure/webull/WebullHttpClient.ts
+++ b/src/infrastructure/webull/WebullHttpClient.ts
@@ -1,5 +1,5 @@
 import type { OrderIntent } from '../../trading/domain/OrderIntent'
-import { BrokerRequestError } from '../../shared/errors'
+import { BrokerRequestError, brokerErrorForStatus } from '../../shared/errors'
 import type {
   WebullAccountDto,
   WebullMarket,
@@ -227,7 +227,11 @@ export class WebullHttpClient {
       lastFailure = new Error(`Webull request failed with status ${response.status}`)
 
       if (response.status >= 400 && response.status < 500) {
-        throw new BrokerRequestError(
+        // 4xx is the caller's fault or an auth/rate-limit problem — do not
+        // retry. Map to the narrowest error subclass so downstream handlers
+        // can treat 401/429 differently from 400.
+        throw brokerErrorForStatus(
+          response.status,
           `Webull request failed permanently with status ${response.status}`,
           `${method} ${path}`,
           { cause: lastFailure },
@@ -248,7 +252,10 @@ export class WebullHttpClient {
     }
 
     if (lastStatus !== undefined) {
-      throw new BrokerRequestError(
+      // Retries exhausted on a 5xx. Surface as a server-class error so alerts
+      // can distinguish "Webull is down" from "we sent a bad request".
+      throw brokerErrorForStatus(
+        lastStatus,
         `Webull request failed after ${this.retry.maxAttempts} attempts with last status ${lastStatus}`,
         `${method} ${path}`,
         { cause: lastFailure },

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -24,21 +24,108 @@ export class ValidationError extends TradingError {
   }
 }
 
+/**
+ * Base class for all broker-layer errors. Subclasses narrow the failure
+ * into "retry" vs "give up" vs "alert loudly" categories so call sites and
+ * cron log filters don't have to re-parse status codes from the message.
+ *
+ * Keep existing call sites (`throw new BrokerRequestError(...)`) working —
+ * it still represents "broker layer request failed, caller probably shouldn't
+ * retry". Subclasses exist on top.
+ */
 export class BrokerRequestError extends TradingError {
-  readonly code = 'broker_request_error'
-  readonly status = 502
+  readonly code: string = 'broker_request_error'
+  readonly status: ContentfulStatusCode = 502
   readonly broker = 'webull'
   override readonly cause?: unknown
+  /** Upstream Webull HTTP status when known. */
+  readonly brokerStatus?: number
 
   constructor(
     message: string,
     readonly operation: string,
-    options?: { cause?: unknown },
+    options?: { cause?: unknown; brokerStatus?: number },
   ) {
     super(message)
     this.name = 'BrokerRequestError'
     this.cause = options?.cause
+    this.brokerStatus = options?.brokerStatus
   }
+}
+
+/** Webull returned 401/403 — credential / signing issue. Do not retry. */
+export class BrokerAuthError extends BrokerRequestError {
+  override readonly code = 'broker_auth_error'
+
+  constructor(
+    message: string,
+    operation: string,
+    options?: { cause?: unknown; brokerStatus?: number },
+  ) {
+    super(message, operation, options)
+    this.name = 'BrokerAuthError'
+  }
+}
+
+/** Webull returned 429 — slow down, back off longer before retry. */
+export class BrokerRateLimitError extends BrokerRequestError {
+  override readonly code = 'broker_rate_limit_error'
+
+  constructor(
+    message: string,
+    operation: string,
+    options?: { cause?: unknown; brokerStatus?: number },
+  ) {
+    super(message, operation, options)
+    this.name = 'BrokerRateLimitError'
+  }
+}
+
+/** Webull returned a non-auth/non-rate-limit 4xx — caller's request was bad. Do not retry. */
+export class BrokerClientError extends BrokerRequestError {
+  override readonly code = 'broker_client_error'
+
+  constructor(
+    message: string,
+    operation: string,
+    options?: { cause?: unknown; brokerStatus?: number },
+  ) {
+    super(message, operation, options)
+    this.name = 'BrokerClientError'
+  }
+}
+
+/** Webull returned 5xx — transient server-side failure, retry with backoff. */
+export class BrokerServerError extends BrokerRequestError {
+  override readonly code = 'broker_server_error'
+
+  constructor(
+    message: string,
+    operation: string,
+    options?: { cause?: unknown; brokerStatus?: number },
+  ) {
+    super(message, operation, options)
+    this.name = 'BrokerServerError'
+  }
+}
+
+/**
+ * Pick the narrowest BrokerRequestError subclass for an upstream HTTP status.
+ * Callers that don't care about the distinction can still catch the base
+ * `BrokerRequestError`.
+ */
+export function brokerErrorForStatus(
+  status: number,
+  message: string,
+  operation: string,
+  options?: { cause?: unknown },
+): BrokerRequestError {
+  const opts = { ...options, brokerStatus: status }
+  if (status === 401 || status === 403) return new BrokerAuthError(message, operation, opts)
+  if (status === 429) return new BrokerRateLimitError(message, operation, opts)
+  if (status >= 400 && status < 500) return new BrokerClientError(message, operation, opts)
+  if (status >= 500 && status < 600) return new BrokerServerError(message, operation, opts)
+  return new BrokerRequestError(message, operation, opts)
 }
 
 // Planned but deferred per issue #1 §13:

--- a/test/infrastructure/webull/webullHttpClient.test.ts
+++ b/test/infrastructure/webull/webullHttpClient.test.ts
@@ -1,4 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
+import {
+  BrokerAuthError,
+  BrokerClientError,
+  BrokerRateLimitError,
+  BrokerServerError,
+} from '../../../src/shared/errors'
 import { WebullAuth } from '../../../src/infrastructure/webull/WebullAuth'
 import { WebullHttpClient } from '../../../src/infrastructure/webull/WebullHttpClient'
 import type { OrderIntent } from '../../../src/trading/domain/OrderIntent'
@@ -255,6 +261,37 @@ describe('WebullHttpClient', () => {
       'Webull request failed permanently with status 400',
     )
     expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('maps 401 to BrokerAuthError (and does not retry)', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response('unauth', { status: 401 }))
+    const client = createClient(fetchMock)
+    await expect(client.placeOrder(intent)).rejects.toBeInstanceOf(BrokerAuthError)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('maps 429 to BrokerRateLimitError (and does not retry inside the 4xx branch)', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response('slow down', { status: 429 }))
+    const client = createClient(fetchMock)
+    await expect(client.placeOrder(intent)).rejects.toBeInstanceOf(BrokerRateLimitError)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('maps a non-auth 4xx to BrokerClientError', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response('nope', { status: 400 }))
+    const client = createClient(fetchMock)
+    await expect(client.placeOrder(intent)).rejects.toBeInstanceOf(BrokerClientError)
+  })
+
+  it('maps a retried-out 5xx to BrokerServerError with brokerStatus set', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response('boom', { status: 503 }))
+    const client = createClient(fetchMock)
+    const err = await client.placeOrder(intent).catch((e: unknown) => e)
+    expect(err).toBeInstanceOf(BrokerServerError)
+    expect((err as BrokerServerError).brokerStatus).toBe(503)
+    expect(fetchMock).toHaveBeenCalledTimes(3)
   })
 
   it('retries AbortError failures', async () => {


### PR DESCRIPTION
## Summary

Closes #82. The `BrokerRequestError` previously collapsed every non-2xx Webull response into a single class with the status code only readable from the message string. Journal readers and alert rules had to regex it out to tell "our signing broke" from "Webull is down" from "rate-limited".

## Change

Introduce subclasses that extend `BrokerRequestError` so all existing `catch (e: BrokerRequestError)` blocks keep working:

| Class | Maps to | Semantics |
|---|---|---|
| `BrokerAuthError` | 401 / 403 | signing or credential problem — do NOT retry, alert |
| `BrokerRateLimitError` | 429 | back off longer before any retry |
| `BrokerClientError` | other 4xx | caller's request is bad — do NOT retry |
| `BrokerServerError` | 5xx | transient, retry OK |

`brokerErrorForStatus(status, message, operation, options)` picks the narrowest class. Wired into:

- `WebullHttpClient.request` — both the immediate 4xx branch and the retries-exhausted final throw
- `BarClient.getDailyBars`
- `WebullQuoteClient.getSnapshots`

`brokerStatus` is also stored on the error instance for downstream code that wants the raw number.

## trade_journal

No logger change needed — the existing sink writes `error.constructor.name` into `error_class`, so post_submit entries now automatically read `BrokerAuthError` / `BrokerRateLimitError` / etc. instead of the generic `BrokerRequestError`.

## Out of scope

- Longer backoff on `BrokerRateLimitError` (today it just doesn't retry — a proper exponential backoff with honor-Retry-After is a separate change).
- Alert rules / observability hookup — picks up the new class names for free, but nothing is wired yet.

## Test plan

- [x] `pnpm vitest run test/infrastructure/webull/ test/infrastructure/quotes/` — 39 tests pass (4 new: 401 → Auth, 429 → RateLimit, 400 → Client, retried 503 → Server with `brokerStatus=503`)
- [x] Existing `BrokerRequestError` assertions still hit via `instanceof` chain
- [ ] After deploy: a forced 401 (e.g. wrong secret) should show `error_class: BrokerAuthError` in trade_journal instead of just `BrokerRequestError`

Refs #82


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ブローカーAPI通信エラーのハンドリングを改善し、HTTP ステータスコードに基づいた詳細なエラー情報を提供するようになりました。認証エラー、レート制限エラー、クライアントエラー、サーバーエラーなど、より正確なエラー分類が可能になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->