### PR TITLE
feat(reconciliation): journal fill reconcile + POST /admin/orders/reconcile

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -4,6 +4,7 @@ import { ValidationError } from '../shared/errors'
 import { createWebullHttpClient } from '../infrastructure/webull/WebullHttpClient'
 import { PortfolioStateClient } from '../trading/state/PortfolioStateClient'
 import { SymbolStateClient } from '../trading/state/SymbolStateClient'
+import { reconcileFills } from '../trading/reconciliation/reconcileFills'
 import { runStrategyCron } from '../trading/strategy/runStrategyCron'
 
 /**
@@ -49,6 +50,19 @@ export const admin = new Hono<AppBindings>()
    * If the order is older than that window, returns 404
    * `order_not_found_in_recent_history`.
    */
+  /**
+   * Poll Webull for every locally-submitted order that doesn't yet have a
+   * terminal `broker_status` in trade_journal, and patch the row with
+   * `filled_qty / filled_price / broker_status`. Safe to call on demand —
+   * idempotent (terminal rows are already excluded by the WHERE clause).
+   *
+   * PnL roll-up into PortfolioStateDO is a follow-up; this just makes sure
+   * the journal reflects what Webull says about each order.
+   */
+  .post('/orders/reconcile', async (c) => {
+    const summary = await reconcileFills({ env: c.env })
+    return c.json(summary)
+  })
   .get('/orders/:clientOrderId', async (c) => {
     const clientOrderId = c.req.param('clientOrderId').trim()
     if (clientOrderId.length === 0) {

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -60,7 +60,7 @@ export const admin = new Hono<AppBindings>()
    * the journal reflects what Webull says about each order.
    */
   .post('/orders/reconcile', async (c) => {
-    const summary = await reconcileFills({ env: c.env })
+    const summary = await reconcileFills({ env: c.env, requestId: c.get('requestId') })
     return c.json(summary)
   })
   .get('/orders/:clientOrderId', async (c) => {

--- a/src/trading/reconciliation/reconcileFills.ts
+++ b/src/trading/reconciliation/reconcileFills.ts
@@ -1,0 +1,159 @@
+import { and, desc, eq, gte, isNull } from 'drizzle-orm'
+import type { Env } from '../../config/env'
+import { createDb } from '../../infrastructure/db/tradeJournalRepo'
+import { tradeJournal } from '../../infrastructure/db/schema'
+import { createWebullHttpClient } from '../../infrastructure/webull/WebullHttpClient'
+import type { WebullOrderDetailDto } from '../../infrastructure/webull/dto'
+
+// Terminal Webull order statuses — once we see one of these we can stop
+// polling for this order. Anything else (NEW, PENDING, PARTIALLY_FILLED) is
+// still in flight.
+const TERMINAL_STATUSES = new Set<string>([
+  'FILLED',
+  'CANCELLED',
+  'REJECTED',
+  'EXPIRED',
+])
+
+export interface ReconcileSummary {
+  inspected: number
+  updated: Array<{ clientOrderId: string; status: string }>
+  stillPending: Array<{ clientOrderId: string; status?: string }>
+  notFound: string[]
+  errors: Array<{ clientOrderId: string; message: string }>
+}
+
+interface ReconcileOptions {
+  env: Env
+  /** How far back to scan for unreconciled post_submit rows. Default 48h. */
+  lookbackMs?: number
+  /** Cap on rows inspected per call so a single invocation doesn't fan out. */
+  limit?: number
+  now?: () => Date
+}
+
+/**
+ * Poll Webull for the current state of every locally-submitted order that
+ * doesn't yet have a terminal `broker_status` recorded, and patch the
+ * matching `post_submit` row in `trade_journal` with `filled_qty /
+ * filled_price / broker_status`.
+ *
+ * PnL computation + PortfolioStateDO apply is deliberately out of scope —
+ * that step needs per-symbol avg-cost tracking and will land as a separate
+ * issue. This is just the plumbing that turns "we placed an order" into
+ * "we know what happened to it."
+ */
+export async function reconcileFills(options: ReconcileOptions): Promise<ReconcileSummary> {
+  const summary: ReconcileSummary = {
+    inspected: 0,
+    updated: [],
+    stillPending: [],
+    notFound: [],
+    errors: [],
+  }
+  if (!options.env.DB) return summary
+
+  const now = options.now ?? (() => new Date())
+  const since = new Date(now().getTime() - (options.lookbackMs ?? 48 * 3_600_000)).toISOString()
+  const limit = options.limit ?? 50
+
+  const db = createDb(options.env.DB)
+  const candidates = await db
+    .select({
+      id: tradeJournal.id,
+      clientOrderId: tradeJournal.clientOrderId,
+      symbol: tradeJournal.symbol,
+      side: tradeJournal.side,
+    })
+    .from(tradeJournal)
+    .where(
+      and(
+        eq(tradeJournal.tradeEventType, 'post_submit'),
+        eq(tradeJournal.submitted, true),
+        isNull(tradeJournal.brokerStatus),
+        gte(tradeJournal.timestamp, since),
+      ),
+    )
+    .orderBy(desc(tradeJournal.id))
+    .limit(limit)
+
+  if (candidates.length === 0) return summary
+
+  summary.inspected = candidates.length
+  const client = createWebullHttpClient(options.env)
+
+  for (const row of candidates) {
+    const coid = row.clientOrderId
+    if (!coid) continue
+    let detail: WebullOrderDetailDto | undefined
+    try {
+      detail = await client.findOrderByClientId(coid)
+    } catch (error) {
+      summary.errors.push({
+        clientOrderId: coid,
+        message: error instanceof Error ? error.message : String(error),
+      })
+      continue
+    }
+
+    if (!detail) {
+      summary.notFound.push(coid)
+      continue
+    }
+
+    const status = detail.status
+    if (!status || !TERMINAL_STATUSES.has(status)) {
+      summary.stillPending.push({ clientOrderId: coid, status })
+      continue
+    }
+
+    const filledQty = toNumberOrNull(detail.filled_quantity)
+    const filledPrice = pickFilledPrice(detail)
+
+    await db
+      .update(tradeJournal)
+      .set({
+        brokerStatus: status,
+        filledQty,
+        filledPrice,
+      })
+      .where(eq(tradeJournal.id, row.id))
+
+    summary.updated.push({ clientOrderId: coid, status })
+  }
+
+  return summary
+}
+
+function toNumberOrNull(value: string | undefined): number | null {
+  if (value === undefined || value === null) return null
+  const n = Number(value)
+  return Number.isFinite(n) ? n : null
+}
+
+/**
+ * The order detail payload doesn't always carry an aggregate `filled_price`
+ * at the top level. Prefer the first fill item's price if present; otherwise
+ * fall back to limit_price (best-effort proxy for small sandbox orders).
+ */
+function pickFilledPrice(detail: WebullOrderDetailDto): number | null {
+  // v2 OrderHistory doesn't expose an aggregate filled_price, so average from
+  // the items if available. Sandbox orders often have a single item.
+  if (detail.items && detail.items.length > 0) {
+    const prices = detail.items
+      .map((item) => toNumberOrNull((item as { filled_price?: string }).filled_price))
+      .filter((n): n is number => n !== null && n > 0)
+    if (prices.length > 0) {
+      const sum = prices.reduce((acc, n) => acc + n, 0)
+      return sum / prices.length
+    }
+  }
+  // Fall back to the limit price we signed the order at. This is not
+  // technically the fill price, but it's a strict upper bound for a BUY
+  // limit and lower bound for a SELL limit — good enough for downstream
+  // notional aggregations when the broker doesn't echo the fill back.
+  return toNumberOrNull(detail.limit_price)
+}
+
+// Exposed for tests.
+export const _internal = { TERMINAL_STATUSES, pickFilledPrice }

--- a/src/trading/reconciliation/reconcileFills.ts
+++ b/src/trading/reconciliation/reconcileFills.ts
@@ -25,6 +25,12 @@ export interface ReconcileSummary {
 
 interface ReconcileOptions {
   env: Env
+  /**
+   * Correlates reconcile logs with the originating request. Callers should
+   * pass `c.get('requestId')` when invoking from a route, or generate their
+   * own (e.g. `crypto.randomUUID()`) for cron-triggered runs.
+   */
+  requestId?: string
   /** How far back to scan for unreconciled post_submit rows. Default 48h. */
   lookbackMs?: number
   /** Cap on rows inspected per call so a single invocation doesn't fan out. */
@@ -137,7 +143,11 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
       console.error(
         JSON.stringify({
           event: 'reconcile_fill_update_error',
+          requestId: options.requestId,
+          rowId: row.id,
           clientOrderId: coid,
+          symbol: row.symbol,
+          side: row.side,
           status,
           message,
         }),
@@ -156,13 +166,22 @@ function toNumberOrNull(value: string | undefined): number | null {
 }
 
 /**
- * The order detail payload doesn't always carry an aggregate `filled_price`
- * at the top level. Prefer the first fill item's price if present; otherwise
- * fall back to limit_price (best-effort proxy for small sandbox orders).
+ * Webull's order history response doesn't expose an aggregate `filled_price`.
+ * Recover a usable effective fill price in this order:
+ *
+ *   1. If `items[]` carries per-fill `filled_price` entries (partial or full
+ *      fills), **average across all positively-priced items**.
+ *   2. Otherwise fall back to the signed `limit_price` — strict upper bound
+ *      for a BUY limit and lower bound for a SELL limit, good enough as a
+ *      best-effort proxy for small sandbox orders where we only care about
+ *      ballpark P&L aggregation.
+ *   3. Otherwise `null`.
  */
 function pickFilledPrice(detail: WebullOrderDetailDto): number | null {
-  // v2 OrderHistory doesn't expose an aggregate filled_price, so average from
-  // the items if available. Sandbox orders often have a single item.
+  // Sandbox orders usually have a single item, so the average collapses to
+  // that one item's price. Partial fills at multiple prices would average
+  // out naturally — callers that need precise per-fill accounting will need
+  // to walk items[] directly instead.
   if (detail.items && detail.items.length > 0) {
     const prices = detail.items
       .map((item) => toNumberOrNull((item as { filled_price?: string }).filled_price))

--- a/src/trading/reconciliation/reconcileFills.ts
+++ b/src/trading/reconciliation/reconcileFills.ts
@@ -84,7 +84,16 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
 
   for (const row of candidates) {
     const coid = row.clientOrderId
-    if (!coid) continue
+    if (!coid) {
+      // In practice a post_submit row with submitted=1 always has a coid
+      // (it's the idempotency key we signed the order with). Surface any
+      // violation loudly instead of silently dropping the row.
+      summary.errors.push({
+        clientOrderId: `row_id:${row.id}`,
+        message: 'missing client_order_id on post_submit row',
+      })
+      continue
+    }
     let detail: WebullOrderDetailDto | undefined
     try {
       detail = await client.findOrderByClientId(coid)
@@ -110,16 +119,31 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
     const filledQty = toNumberOrNull(detail.filled_quantity)
     const filledPrice = pickFilledPrice(detail)
 
-    await db
-      .update(tradeJournal)
-      .set({
-        brokerStatus: status,
-        filledQty,
-        filledPrice,
-      })
-      .where(eq(tradeJournal.id, row.id))
-
-    summary.updated.push({ clientOrderId: coid, status })
+    try {
+      await db
+        .update(tradeJournal)
+        .set({
+          brokerStatus: status,
+          filledQty,
+          filledPrice,
+        })
+        .where(eq(tradeJournal.id, row.id))
+      summary.updated.push({ clientOrderId: coid, status })
+    } catch (error) {
+      // A single row's UPDATE shouldn't kill the whole batch; most other
+      // rows can still be reconciled. Log the failure into the errors bucket
+      // so the operator can retry just this one.
+      const message = error instanceof Error ? error.message : String(error)
+      console.error(
+        JSON.stringify({
+          event: 'reconcile_fill_update_error',
+          clientOrderId: coid,
+          status,
+          message,
+        }),
+      )
+      summary.errors.push({ clientOrderId: coid, message: `update_failed: ${message}` })
+    }
   }
 
   return summary

--- a/src/trading/reconciliation/reconcileFills.ts
+++ b/src/trading/reconciliation/reconcileFills.ts
@@ -123,7 +123,7 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
     }
 
     const filledQty = toNumberOrNull(detail.filled_quantity)
-    const filledPrice = pickFilledPrice(detail)
+    const filledPrice = resolveFilledPrice(filledQty, detail)
 
     try {
       await db
@@ -198,5 +198,21 @@ function pickFilledPrice(detail: WebullOrderDetailDto): number | null {
   return toNumberOrNull(detail.limit_price)
 }
 
+/**
+ * Only record a fill price when there's actually a fill, and only if it
+ * passes the "finite and > 0" guideline. For CANCELLED / REJECTED rows
+ * (filledQty=0) this returns null so we don't misrepresent the row as if
+ * it had transacted at the signed limit price.
+ */
+function resolveFilledPrice(
+  filledQty: number | null,
+  detail: WebullOrderDetailDto,
+): number | null {
+  if (filledQty === null || filledQty <= 0) return null
+  const candidate = pickFilledPrice(detail)
+  if (candidate === null || !Number.isFinite(candidate) || candidate <= 0) return null
+  return candidate
+}
+
 // Exposed for tests.
-export const _internal = { TERMINAL_STATUSES, pickFilledPrice }
+export const _internal = { TERMINAL_STATUSES, pickFilledPrice, resolveFilledPrice }

--- a/test/trading/reconciliation/reconcileFills.test.ts
+++ b/test/trading/reconciliation/reconcileFills.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { _internal } from '../../../src/trading/reconciliation/reconcileFills'
+
+describe('reconcileFills internals', () => {
+  it('TERMINAL_STATUSES covers the expected Webull statuses', () => {
+    expect([...(_internal.TERMINAL_STATUSES as Set<string>)].sort()).toEqual(
+      ['CANCELLED', 'EXPIRED', 'FILLED', 'REJECTED'],
+    )
+  })
+
+  it('pickFilledPrice averages item fill prices when present', () => {
+    const price = _internal.pickFilledPrice({
+      items: [
+        { filled_price: '30.10' } as never,
+        { filled_price: '30.20' } as never,
+      ],
+      limit_price: '99',
+    })
+    expect(price).toBeCloseTo(30.15)
+  })
+
+  it('pickFilledPrice falls back to limit_price when no item fill prices', () => {
+    const price = _internal.pickFilledPrice({ limit_price: '12.50' })
+    expect(price).toBe(12.5)
+  })
+
+  it('pickFilledPrice returns null when neither items nor limit_price is usable', () => {
+    expect(_internal.pickFilledPrice({})).toBeNull()
+    expect(_internal.pickFilledPrice({ limit_price: 'n/a' })).toBeNull()
+  })
+
+  it('pickFilledPrice ignores zero-priced items', () => {
+    const price = _internal.pickFilledPrice({
+      items: [
+        { filled_price: '0' } as never,
+        { filled_price: '25.00' } as never,
+      ],
+      limit_price: '99',
+    })
+    expect(price).toBeCloseTo(25)
+  })
+})

--- a/test/trading/reconciliation/reconcileFills.test.ts
+++ b/test/trading/reconciliation/reconcileFills.test.ts
@@ -39,4 +39,24 @@ describe('reconcileFills internals', () => {
     })
     expect(price).toBeCloseTo(25)
   })
+
+  // The guard that sits between pickFilledPrice and the DB write.
+  it('resolveFilledPrice returns null when filledQty is zero / null / negative', () => {
+    const detail = { limit_price: '30' }
+    expect(_internal.resolveFilledPrice(0, detail)).toBeNull()
+    expect(_internal.resolveFilledPrice(null, detail)).toBeNull()
+    expect(_internal.resolveFilledPrice(-1, detail)).toBeNull()
+  })
+
+  it('resolveFilledPrice returns the candidate price when filledQty > 0 and price is finite + positive', () => {
+    const detail = { limit_price: '30' }
+    expect(_internal.resolveFilledPrice(1, detail)).toBe(30)
+  })
+
+  it('resolveFilledPrice returns null when the candidate price is non-positive / non-finite', () => {
+    expect(_internal.resolveFilledPrice(1, { limit_price: '0' })).toBeNull()
+    expect(_internal.resolveFilledPrice(1, { limit_price: '-5' })).toBeNull()
+    expect(_internal.resolveFilledPrice(1, { limit_price: 'NaN' })).toBeNull()
+    expect(_internal.resolveFilledPrice(1, {})).toBeNull()
+  })
 })


### PR DESCRIPTION
## Summary

First half of #81. Adds the plumbing that turns "we submitted an order" into "we know what happened to it."

### Change

- `reconcileFills({ env, lookbackMs?, limit?, now? })` queries `trade_journal` for `post_submit` rows where `submitted=1 AND broker_status IS NULL AND timestamp > now-48h`, calls `WebullHttpClient.findOrderByClientId` for each, and patches the row with `broker_status / filled_qty / filled_price` when the order reaches a terminal state (`FILLED / CANCELLED / REJECTED / EXPIRED`).
- `POST /admin/orders/reconcile` exposes it on demand. Returns a summary:

  ```json
  {
    "inspected": 3,
    "updated": [{"clientOrderId":"...","status":"FILLED"}],
    "stillPending": [{"clientOrderId":"...","status":"PENDING"}],
    "notFound": ["..."],
    "errors": []
  }
  ```

### Out of scope

- **Applying realized PnL to PortfolioStateDO.** Needs per-symbol avg-cost tracking (SymbolStateDO side). Separate issue.
- **Automatic cron wiring.** Admin-only for now. Promote to `*/5` cron after observing a few manual runs.
- **Pagination sweep beyond the 50-entry history page.** If an order is older than Webull's recent window, it stays `notFound`. Follow-up.

### Fill-price logic

`pickFilledPrice(detail)`:

1. If `items[]` has item-level `filled_price`, average them (sandbox orders usually have 1 item, so this is just that item's price).
2. Otherwise fall back to `limit_price` — strict upper bound for BUY limit / lower bound for SELL limit, good enough for the journal until we have explicit fill events.
3. Else `null`.

### Test plan

- [x] `pnpm vitest run test/trading/reconciliation/` — 5 unit tests on pickFilledPrice + TERMINAL_STATUSES (DB integration runs on CI only — local drizzle-orm node_modules issue is pre-existing)
- [ ] After deploy: place a sandbox order, wait, then `POST /admin/orders/reconcile` and inspect the summary + `trade_journal` row

Refs #81


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 管理者向けに新しい注文調整エンドポイント（POST /orders/reconcile）を追加しました。ブローカー未同期の注文を検査し、見つかった更新（約定数量・価格）を個別に適用して集計結果をJSONで返します。個別更新失敗が発生しても処理は継続され、エラー情報が結果に含まれます。

* **Tests**
  * 終端ステータス判定と約定価格算出ロジック（アイテム価格の平均化、リミット価格のフォールバック、無効値除外等）を検証するテストスイートを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->