### PR TITLE
feat(cron): auto-reconcile fills on the */5 cadence (#81)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { createDb, insertJournalRecord } from './infrastructure/db/tradeJournalR
 import { setTradeJournalDbContext } from './infrastructure/logger/tradeJournal'
 import { keepBridgeAlive } from './trading/bridge/bridgeKeepAlive'
 import { runQuoteFeed } from './trading/quotes/quoteScheduler'
+import { reconcileFills } from './trading/reconciliation/reconcileFills'
 import { runStrategyCron } from './trading/strategy/runStrategyCron'
 
 // 5 分毎の quote feed + bridge keep-alive cron
@@ -90,6 +91,38 @@ export default {
           console.error(
             JSON.stringify({
               event: 'quote_feed_error',
+              requestId,
+              message: error instanceof Error ? error.message : String(error),
+            }),
+          )
+        },
+      ),
+    )
+    // Fill reconciliation piggybacks on the 5-minute cadence. The SELECT
+    // filters out terminal rows so if nothing is in flight this is a single
+    // zero-row query. Per-order Webull GET only fires for unreconciled coids.
+    ctx.waitUntil(
+      reconcileFills({ env, requestId }).then(
+        (summary) => {
+          // Skip the log line entirely when there was nothing to do — the
+          // feed runs every 5 minutes and most intervals are idle.
+          if (summary.inspected === 0) return
+          console.log(
+            JSON.stringify({
+              event: 'reconcile_fills_run',
+              requestId,
+              inspected: summary.inspected,
+              updated: summary.updated,
+              stillPending: summary.stillPending.length,
+              notFound: summary.notFound.length,
+              errorCount: summary.errors.length,
+            }),
+          )
+        },
+        (error) => {
+          console.error(
+            JSON.stringify({
+              event: 'reconcile_fills_error',
               requestId,
               message: error instanceof Error ? error.message : String(error),
             }),

--- a/src/trading/reconciliation/reconcileFills.ts
+++ b/src/trading/reconciliation/reconcileFills.ts
@@ -50,6 +50,12 @@ interface ReconcileOptions {
  * "we know what happened to it."
  */
 export async function reconcileFills(options: ReconcileOptions): Promise<ReconcileSummary> {
+  // Fail-closed on a missing DB binding to match loadGlobalConfigFrom /
+  // loadSymbolUniverse. A silent empty summary would be indistinguishable
+  // from "nothing to reconcile" and hide a misconfiguration.
+  if (!options.env.DB) {
+    throw new Error('reconcileFills requires env.DB binding (D1 not configured)')
+  }
   const summary: ReconcileSummary = {
     inspected: 0,
     updated: [],
@@ -57,7 +63,6 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
     notFound: [],
     errors: [],
   }
-  if (!options.env.DB) return summary
 
   const now = options.now ?? (() => new Date())
   const since = new Date(now().getTime() - (options.lookbackMs ?? 48 * 3_600_000)).toISOString()


### PR DESCRIPTION
## Summary

Wire `reconcileFills` (from #100) into the existing `*/5 * * * *` scheduled handler alongside `runQuoteFeed` and `keepBridgeAlive`. The underlying SELECT filters on `broker_status IS NULL`, so an idle tick is a single empty-result query with no Webull fan-out.

### Logging

- `reconcile_fills_run` is emitted only when `inspected > 0` — keeps the 288-per-day idle ticks quiet.
- `reconcile_fills_error` covers outer promise failures (DB binding missing, uncaught throw, etc.).
- Per-row update failures still land in `summary.errors` (handled inside `reconcileFills`, unchanged from #100).

### Cadence choice

Going with `*/5` rather than hourly because:

- Strategy cron at `:15` places orders; 5-min cadence means a fill reconciles within 5 min of the broker accepting it rather than up to 60 min.
- Webull's `/orders/history` page_size cap is 100 — long polling intervals risk the coid falling off the window if order volume picks up.
- The DB filter makes idle ticks cheap.

## Out of scope

- PortfolioStateDO PnL application — still deferred.
- Per-fill events (vs. aggregate). Current resolver averages items when Webull returns multiple fills.
- Exponential backoff on repeated `BrokerRateLimitError` — the error-class split from #82 means we can special-case 429 later without touching this cron.

## Test plan

- [x] Existing `reconcileFills` unit tests (pickFilledPrice / resolveFilledPrice / TERMINAL_STATUSES) still pass.
- [ ] After merge + deploy: `wrangler tail --search reconcile` should be silent until a Pullback order is placed at `:15`, then log `reconcile_fills_run` on the next `*/5` tick after the broker transitions to FILLED / CANCELLED.

Refs #81 #100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 定期実行される取引結果の調整機能を追加しました。調整処理が正常に完了し、処理対象がある場合に実行ログを記録します。エラーが発生した場合は、詳細なエラーログを出力して問題追跡を支援します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->