### PR TITLE
feat(quotes): route JP symbols through JP_STOCK category (subscription pending)

### DIFF
--- a/src/infrastructure/quotes/BarClient.ts
+++ b/src/infrastructure/quotes/BarClient.ts
@@ -6,7 +6,11 @@ import { inferWebullMarket } from '../webull/mapper'
 // developer.webull.com shows `category=US_STOCK` on the wire (underscore).
 // Python SDK's EasyEnum.__str__ returns `self.name` (the underscored
 // identifier), and Java SDK passes `Category.US_STOCK.name()` the same way.
-// JP_STOCK has no working HK-sandbox path — JP bars need a JP tenant (#89).
+// JP_STOCK is accepted on this JP UAT tenant's /stock/bars endpoint, but the
+// app key needs a JP stock-quotes subscription enabled (Webull support). Until
+// then JP requests return 401 "Insufficient permission, please subscribe to
+// stock quotes." We route JP symbols through the normal category so the cron
+// starts succeeding the moment the subscription lands.
 export type BarCategory = 'US_STOCK' | 'US_ETF' | 'JP_STOCK'
 
 // Mirrors WebullQuoteClient's US ETF allowlist.

--- a/src/infrastructure/quotes/WebullQuoteClient.ts
+++ b/src/infrastructure/quotes/WebullQuoteClient.ts
@@ -2,10 +2,14 @@ import { BrokerRequestError, brokerErrorForStatus } from '../../shared/errors'
 import { WebullAuth } from '../webull/WebullAuth'
 import { inferWebullMarket } from '../webull/mapper'
 
-// Webull market-data snapshot endpoint only accepts equity/ETF categories.
-// JP_STOCK is NOT supported here — JP quotes require a separate API path we
-// haven't wired yet. See #84.
-export type WebullQuoteCategory = 'US_STOCK' | 'US_ETF'
+// Webull /openapi/market-data/stock/snapshot (v2) accepts US_STOCK / US_ETF
+// and ALSO JP_STOCK on the JP UAT tenant — the endpoint/category are valid,
+// but the app key needs a JP quotes subscription enabled (today Webull
+// support has to flip it; no self-serve portal). Until then JP requests
+// return 401 "Insufficient permission, please subscribe to stock quotes."
+// We still route JP through the same path so the moment subscription lands,
+// the cron starts feeding JP quotes with no code change.
+export type WebullQuoteCategory = 'US_STOCK' | 'US_ETF' | 'JP_STOCK'
 
 // Minimal US ETF allowlist for the POC universe. Expand or move to
 // symbol_config.category when universe grows.
@@ -185,17 +189,18 @@ export function createWebullQuoteClient(
 
 export interface SymbolGrouping {
   grouped: Record<WebullQuoteCategory, string[]>
-  // Symbols that cannot be routed through the US snapshot endpoint
-  // (currently JP — tracked separately so callers can log / skip).
+  // Reserved for symbols that can't be routed (none today — kept so callers
+  // and tests don't regress if a new market shows up that the endpoint
+  // genuinely doesn't handle).
   unsupported: string[]
 }
 
 export function groupSymbolsByCategory(symbols: string[]): SymbolGrouping {
-  const grouped: Record<WebullQuoteCategory, string[]> = { US_STOCK: [], US_ETF: [] }
+  const grouped: Record<WebullQuoteCategory, string[]> = { US_STOCK: [], US_ETF: [], JP_STOCK: [] }
   const unsupported: string[] = []
   for (const symbol of symbols) {
     if (inferWebullMarket(symbol) === 'JP') {
-      unsupported.push(symbol)
+      grouped.JP_STOCK.push(symbol)
       continue
     }
     const category: WebullQuoteCategory = US_ETF_SYMBOLS.has(symbol) ? 'US_ETF' : 'US_STOCK'

--- a/test/infrastructure/quotes/webullQuoteClient.test.ts
+++ b/test/infrastructure/quotes/webullQuoteClient.test.ts
@@ -15,7 +15,7 @@ function mockFetch(responseBody: unknown, init: ResponseInit = { status: 200 }):
 }
 
 describe('groupSymbolsByCategory', () => {
-  it('splits US symbols into US_ETF (allowlist) vs US_STOCK, and surfaces JP as unsupported', () => {
+  it('routes SOXL/SOXS → US_ETF, other US → US_STOCK, 4-digit/alphanumeric TSE → JP_STOCK', () => {
     const { grouped, unsupported } = groupSymbolsByCategory([
       'SOXL',
       '7203',
@@ -26,7 +26,8 @@ describe('groupSymbolsByCategory', () => {
     ])
     expect(grouped.US_ETF).toEqual(['SOXL', 'SOXS'])
     expect(grouped.US_STOCK).toEqual(['AAPL'])
-    expect(unsupported).toEqual(['7203', '9984', '285A'])
+    expect(grouped.JP_STOCK).toEqual(['7203', '9984', '285A'])
+    expect(unsupported).toEqual([])
   })
 })
 


### PR DESCRIPTION
> **DRAFT (2026-04-20): Webull サポート確認により merge 保留中。経緯は末尾「Update」参照。**

## Summary

Probe against the JP UAT tenant revealed that `/openapi/market-data/stock/snapshot` with `category=JP_STOCK` returns a very specific 401:

```json
{
  "error_code": "Unauthorized",
  "message": "Insufficient permission, please subscribe to stock quotes.",
  "status": 401
}
```

Not a 404 Route Not Found — the endpoint and category are both valid. The app key just needs a JP stock-quotes subscription enabled.

Plain numeric tickers (`7267`, `6752`, `285A`) are the correct symbol format. `TSE:7267` and `7267.T` both return `INVALID_SYMBOL`.

## Change

- `WebullQuoteCategory` now includes `JP_STOCK`.
- `groupSymbolsByCategory` routes JP symbols into `JP_STOCK` instead of the `unsupported` bucket.
- `BarClient` comment updated (same subscription story).
- Tests assert JP symbols land in `grouped.JP_STOCK` with `unsupported` empty.

## Cron effect

The moment Webull's JP market-data subscription goes live, the `*/5` quote feed will start populating `SymbolStateDO.quote` for JP symbols with no further code change.

## Explicitly out of scope

- `runStrategyCron` still filters to USD symbols only. Wiring JP into the Pullback loop needs currency-aware sizing + budget split and is a separate change.
- SymbolStateDO spread / stale gates using JP snapshot data — unlocked by this PR but not yet consumed by the cron path.

---

## Update (2026-04-20) — Webull サポートからの回答を踏まえ DRAFT 化

サポートに問い合わせた結果:

> ①大変申し訳ございませんが、現在マーケットデータの提供は行ておりません。
> なお、近日中にご提供をさせていただく予定でございますのでもうしばらくお待ちいただきますようお願い申し上げます。

**JP マーケットデータは現時点で未提供 / 近日リリース予定**ということが判明。

この PR を今 merge すると cron が 5 分ごとに 401 `"Insufficient permission"` を JP 銘柄 × 3 symbols 分出し続ける (288 回/日) ため、サブスクリプションが正式に開始されるまで merge を見送る。

その間の運用:

- JP 銘柄は DB レベルで `active=0` に停止 (ノイズ排除)
- 本 PR はコードは正しく、Webull のアナウンス (ホームページ / アプリ push) が出たタイミングで re-review → merge

### 関連

- ② (US_MARGIN sandbox 仮想資金) は同時に対応いただき、`buying_power: $40,000` 付与済 → US cron は実際に発注可能な状態
- #104 merge のタイミング: Webull から JP market-data 開始通知を受領した後

Refs #84
