### PR TITLE
feat(admin): POST /admin/portfolio/roll-daily (EOD rollover)

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -89,9 +89,7 @@ export const admin = new Hono<AppBindings>()
       throw new ValidationError('PORTFOLIO_STATE binding is not configured', { field: 'env' })
     }
     const client = new PortfolioStateClient(c.env.PORTFOLIO_STATE)
-    const before = await client.getPortfolio()
-    const nextStart = before.dailyStartEquity + before.dailyRealizedPnl
-    const after = await client.seedDailyStartEquity(nextStart)
+    const { before, after } = await client.rollDaily()
     return c.json({
       rolledAt: after.updatedAt,
       rolledDelta: before.dailyRealizedPnl,

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -75,6 +75,36 @@ export const admin = new Hono<AppBindings>()
     }
     return c.json(detail)
   })
+  /**
+   * EOD-ish rollover: snapshot `dailyStartEquity + dailyRealizedPnl` as the
+   * new day's opening equity and zero out `dailyRealizedPnl`. Intended as a
+   * manual / cron-triggered "close the day" step so the drawdown-kill gate
+   * re-anchors against today's session rather than cumulative lifetime PnL.
+   *
+   * Returns both the before / after snapshot so an operator (or the eventual
+   * EOD cron) can log the exact dollar delta that was rolled.
+   */
+  .post('/portfolio/roll-daily', async (c) => {
+    if (!c.env.PORTFOLIO_STATE) {
+      throw new ValidationError('PORTFOLIO_STATE binding is not configured', { field: 'env' })
+    }
+    const client = new PortfolioStateClient(c.env.PORTFOLIO_STATE)
+    const before = await client.getPortfolio()
+    const nextStart = before.dailyStartEquity + before.dailyRealizedPnl
+    const after = await client.seedDailyStartEquity(nextStart)
+    return c.json({
+      rolledAt: after.updatedAt,
+      rolledDelta: before.dailyRealizedPnl,
+      before: {
+        dailyStartEquity: before.dailyStartEquity,
+        dailyRealizedPnl: before.dailyRealizedPnl,
+      },
+      after: {
+        dailyStartEquity: after.dailyStartEquity,
+        dailyRealizedPnl: after.dailyRealizedPnl,
+      },
+    })
+  })
   .post('/portfolio/seed-equity', async (c) => {
     if (!c.env.PORTFOLIO_STATE) {
       throw new ValidationError('PORTFOLIO_STATE binding is not configured', { field: 'env' })

--- a/src/trading/state/PortfolioStateClient.ts
+++ b/src/trading/state/PortfolioStateClient.ts
@@ -31,4 +31,8 @@ export class PortfolioStateClient implements PortfolioStore {
   setTradingDisabledUntil(iso: string | null): Promise<PortfolioState> {
     return this.stub().setTradingDisabledUntil(iso)
   }
+
+  rollDaily(): Promise<{ before: PortfolioState; after: PortfolioState }> {
+    return this.stub().rollDaily()
+  }
 }

--- a/src/trading/state/PortfolioStateDO.ts
+++ b/src/trading/state/PortfolioStateDO.ts
@@ -1,6 +1,7 @@
 import { DurableObject } from 'cloudflare:workers'
 import {
   applyRealizedPnl,
+  rollDaily,
   seedDailyStartEquity,
   setTradingDisabledUntil,
   type PortfolioTransitionContext,
@@ -40,6 +41,13 @@ export class PortfolioStateDO extends DurableObject<object> {
     const next = setTradingDisabledUntil(state, iso, this.transitionCtx)
     await this.save(next)
     return next
+  }
+
+  async rollDaily(): Promise<{ before: PortfolioState; after: PortfolioState }> {
+    const state = await this.load()
+    const { before, after } = rollDaily(state, this.transitionCtx)
+    await this.save(after)
+    return { before, after }
   }
 
   private async load(): Promise<PortfolioState> {

--- a/src/trading/state/PortfolioStore.ts
+++ b/src/trading/state/PortfolioStore.ts
@@ -10,4 +10,5 @@ export interface PortfolioStore {
   seedDailyStartEquity(amount: number): Promise<PortfolioState>
   applyRealizedPnl(delta: number): Promise<PortfolioState>
   setTradingDisabledUntil(iso: string | null): Promise<PortfolioState>
+  rollDaily(): Promise<{ before: PortfolioState; after: PortfolioState }>
 }

--- a/src/trading/state/portfolioStateTransitions.ts
+++ b/src/trading/state/portfolioStateTransitions.ts
@@ -72,3 +72,23 @@ export function setTradingDisabledUntil(
     updatedAt: ctx.now().toISOString(),
   }
 }
+
+/**
+ * EOD rollover: computes `nextStart = dailyStartEquity + dailyRealizedPnl`,
+ * resets `dailyRealizedPnl` to 0, and returns both the before and after states.
+ * This is the atomic version that prevents races with `applyRealizedPnl`.
+ */
+export function rollDaily(
+  state: PortfolioState,
+  ctx: PortfolioTransitionContext = defaultCtx,
+): { before: PortfolioState; after: PortfolioState } {
+  const before = state
+  const nextStart = state.dailyStartEquity + state.dailyRealizedPnl
+  const after: PortfolioState = {
+    ...state,
+    dailyStartEquity: nextStart,
+    dailyRealizedPnl: 0,
+    updatedAt: ctx.now().toISOString(),
+  }
+  return { before, after }
+}

--- a/test/trading/application/tradingServiceDrawdown.test.ts
+++ b/test/trading/application/tradingServiceDrawdown.test.ts
@@ -80,6 +80,11 @@ function makePortfolioStore(initial: PortfolioState): {
       current = { ...current, tradingDisabledUntil: iso }
       return current
     },
+    async rollDaily() {
+      const before = current
+      current = { ...current, dailyStartEquity: 0, dailyRealizedPnl: 0 }
+      return { before, after: current }
+    },
   }
   return { store, captured, current: () => current }
 }

--- a/test/trading/application/tradingServiceDrawdown.test.ts
+++ b/test/trading/application/tradingServiceDrawdown.test.ts
@@ -82,7 +82,8 @@ function makePortfolioStore(initial: PortfolioState): {
     },
     async rollDaily() {
       const before = current
-      current = { ...current, dailyStartEquity: 0, dailyRealizedPnl: 0 }
+      const nextStart = current.dailyStartEquity + current.dailyRealizedPnl
+      current = { ...current, dailyStartEquity: nextStart, dailyRealizedPnl: 0 }
       return { before, after: current }
     },
   }


### PR DESCRIPTION
## Summary

\`dailyRealizedPnl\` accumulates monotonically today — after the first profitable SELL it stays positive forever, and eventually the drawdown-kill gate would misfire against a historic window rather than today's session. Add a manual rollover step so the operator (and, later, an EOD cron) can close the day cleanly.

### Behavior

\`\`\`
POST /admin/portfolio/roll-daily   (basic-auth)

nextStart = before.dailyStartEquity + before.dailyRealizedPnl
seedDailyStartEquity(nextStart)   // also zeros dailyRealizedPnl
\`\`\`

Returns both snapshots plus the rolled delta:

\`\`\`json
{
  "rolledAt": "2026-04-20T...",
  "rolledDelta": 12.34,
  "before": { "dailyStartEquity": 3333, "dailyRealizedPnl": 12.34 },
  "after":  { "dailyStartEquity": 3345.34, "dailyRealizedPnl": 0 }
}
\`\`\`

## Out of scope

- **Auto EOD cron.** Adding a \"0 0 * * *\" (JST midnight) trigger in \`wrangler.jsonc\` + an \`index.ts\` handler branch is the obvious follow-up, but I want to see a couple of manual runs first and pick a time that doesn't clip in-flight reconciles.
- **Market-close-aware timing.** Today the POC is single-symbol US (SOXL); a real version would roll per-market at each market's close. Once JP comes online (pending #104 + Webull subscription) we'd want that split.

## Test plan

- [x] \`pnpm vitest run test/trading/state/\` — 45 tests pass (existing \`seedDailyStartEquity\` transition)
- [ ] After deploy: run \`curl -X POST /admin/portfolio/roll-daily\`, verify the returned \`before/after\` + that \`GET /admin/...\` follow-up shows \`dailyRealizedPnl = 0\` and \`dailyStartEquity\` bumped by the rolled delta.

Refs #81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 管理者限定の新しいエンドポイント POST /portfolio/roll-daily を追加しました。日次ロール処理を実行し、rolledAt/rolledDelta と処理前後のスナップショットをJSONで返します。
* **バグ修正 / 挙動**
  * 日次開始残高を更新し、当日実現損益をリセットするロール処理を追加・整合化しました。
* **テスト**
  * テスト用モックに日次ロール動作の対応を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->