### PR TITLE
feat(quotes): YahooBarClient for US + JP market data

### DIFF
--- a/src/infrastructure/quotes/YahooBarClient.ts
+++ b/src/infrastructure/quotes/YahooBarClient.ts
@@ -1,0 +1,174 @@
+import type { DailyBar } from '../../trading/strategy/indicators'
+import { BrokerRequestError, brokerErrorForStatus } from '../../shared/errors'
+import { inferWebullMarket } from '../webull/mapper'
+import type { BarClient } from './BarClient'
+
+const DEFAULT_BASE_URL = 'https://query1.finance.yahoo.com'
+const DEFAULT_TIMEOUT_MS = 5_000
+// Yahoo `/v8/finance/chart` blocks requests without a browser-like UA with
+// "Edge: Too Many Requests" at the first call. Match the yfinance library's
+// convention of sending a minimal Mozilla UA — no API key involved.
+const DEFAULT_USER_AGENT = 'Mozilla/5.0'
+
+export interface YahooBarClientOptions {
+  baseUrl?: string
+  timeoutMs?: number
+  fetchFn?: typeof fetch
+  userAgent?: string
+}
+
+interface YahooChartResponse {
+  chart?: {
+    result?: Array<{
+      meta?: {
+        currency?: string
+        regularMarketPrice?: number
+      }
+      timestamp?: number[]
+      indicators?: {
+        quote?: Array<{
+          open?: Array<number | null>
+          high?: Array<number | null>
+          low?: Array<number | null>
+          close?: Array<number | null>
+        }>
+      }
+    }>
+    error?: {
+      code?: string
+      description?: string
+    } | null
+  }
+}
+
+/**
+ * Daily-bar client backed by Yahoo Finance's undocumented but stable
+ * `query1.finance.yahoo.com/v8/finance/chart` endpoint.
+ *
+ * Works for both US (`SOXL`, `AAPL`) and JP (`7267.T`, `285A.T`) symbols
+ * without authentication. A browser-like User-Agent is required; the
+ * endpoint short-circuits anonymous requests with 429.
+ *
+ * Symbol convention:
+ *   - JP symbols (4 char TSE code per `inferWebullMarket`) are suffixed
+ *     with `.T` automatically. Callers pass the bare code.
+ *   - Everything else is sent as-is.
+ */
+export class YahooBarClient implements BarClient {
+  private readonly baseUrl: string
+  private readonly timeoutMs: number
+  private readonly fetchFn: typeof fetch
+  private readonly userAgent: string
+
+  constructor(options: YahooBarClientOptions = {}) {
+    this.baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '')
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+    // Workers' global `fetch` must be bound to globalThis or it explodes with
+    // "Illegal invocation" — mirrors WebullHttpClient.
+    this.fetchFn = options.fetchFn ?? fetch.bind(globalThis)
+    this.userAgent = options.userAgent ?? DEFAULT_USER_AGENT
+  }
+
+  async getDailyBars(symbol: string, lookback: number): Promise<DailyBar[]> {
+    const yahooSymbol = toYahooSymbol(symbol)
+    const url = new URL(`/v8/finance/chart/${encodeURIComponent(yahooSymbol)}`, this.baseUrl)
+    url.searchParams.set('interval', '1d')
+    url.searchParams.set('range', rangeForLookback(lookback))
+
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs)
+    let response: Response
+    try {
+      response = await this.fetchFn(url.href, {
+        method: 'GET',
+        headers: {
+          Accept: 'application/json',
+          'User-Agent': this.userAgent,
+        },
+        signal: controller.signal,
+      })
+    } catch (error) {
+      throw new BrokerRequestError(
+        `Yahoo bar fetch failed: ${error instanceof Error ? error.message : String(error)}`,
+        `GET /v8/finance/chart/${yahooSymbol}`,
+        { cause: error instanceof Error ? error : undefined },
+      )
+    } finally {
+      clearTimeout(timeoutId)
+    }
+
+    if (!response.ok) {
+      throw brokerErrorForStatus(
+        response.status,
+        `Yahoo bar request failed with status ${response.status}`,
+        `GET /v8/finance/chart/${yahooSymbol}`,
+      )
+    }
+
+    const json = (await response.json()) as YahooChartResponse
+    const bars = normalizeYahooChart(json, lookback)
+    return bars
+  }
+}
+
+/**
+ * Convert a caller-side symbol into the Yahoo convention. JP TSE codes
+ * need a `.T` suffix; everything else is unchanged.
+ */
+export function toYahooSymbol(symbol: string): string {
+  if (symbol.includes('.')) return symbol // already qualified (e.g. 7267.T)
+  if (inferWebullMarket(symbol) === 'JP') return `${symbol}.T`
+  return symbol
+}
+
+/**
+ * Yahoo `range` enum uses coarse bucket strings (`5d`, `1mo`, `3mo`, ...)
+ * rather than an exact N-bar count. Pick the smallest bucket that covers
+ * the requested lookback — downstream callers slice to exactly `lookback`.
+ */
+function rangeForLookback(lookback: number): string {
+  if (lookback <= 5) return '5d'
+  if (lookback <= 22) return '1mo'
+  if (lookback <= 66) return '3mo'
+  if (lookback <= 132) return '6mo'
+  if (lookback <= 264) return '1y'
+  if (lookback <= 528) return '2y'
+  return '5y'
+}
+
+/**
+ * Map Yahoo's columnar response into our row-based `DailyBar[]`. Yahoo
+ * returns Unix-second timestamps and parallel OHLC arrays; skip any row
+ * where one of the OHLC values is null (holidays, dividend adjustments).
+ * Output is oldest-first, already the order Yahoo emits, to match the
+ * downstream indicator expectations.
+ */
+function normalizeYahooChart(json: YahooChartResponse, lookback: number): DailyBar[] {
+  const result = json.chart?.result?.[0]
+  const timestamps = result?.timestamp
+  const q = result?.indicators?.quote?.[0]
+  if (!timestamps || !q) return []
+
+  const opens = q.open ?? []
+  const highs = q.high ?? []
+  const lows = q.low ?? []
+  const closes = q.close ?? []
+
+  const bars: DailyBar[] = []
+  for (let i = 0; i < timestamps.length; i += 1) {
+    const open = opens[i]
+    const high = highs[i]
+    const low = lows[i]
+    const close = closes[i]
+    if (open == null || high == null || low == null || close == null) continue
+    const ts = timestamps[i]
+    if (typeof ts !== 'number') continue
+    const date = new Date(ts * 1000).toISOString().slice(0, 10)
+    bars.push({ date, open, high, low, close })
+  }
+
+  // Yahoo returns oldest-first; enforce the invariant and cap to lookback
+  // so callers get the shape they asked for.
+  bars.sort((a, b) => a.date.localeCompare(b.date))
+  return bars.slice(-lookback)
+}

--- a/src/infrastructure/quotes/YahooBarClient.ts
+++ b/src/infrastructure/quotes/YahooBarClient.ts
@@ -70,6 +70,15 @@ export class YahooBarClient implements BarClient {
   }
 
   async getDailyBars(symbol: string, lookback: number): Promise<DailyBar[]> {
+    if (!Number.isInteger(lookback) || lookback <= 0) {
+      // rangeForLookback assumes a positive bucket, and `slice(-0)` /
+      // `slice(-NaN)` both silently return the full array rather than the
+      // requested window. Fail fast with a descriptive error so callers can't
+      // accidentally ask for "all bars".
+      throw new RangeError(
+        `YahooBarClient.getDailyBars: lookback must be a positive integer, got ${lookback}`,
+      )
+    }
     const yahooSymbol = toYahooSymbol(symbol)
     const url = new URL(`/v8/finance/chart/${encodeURIComponent(yahooSymbol)}`, this.baseUrl)
     url.searchParams.set('interval', '1d')
@@ -160,9 +169,17 @@ function normalizeYahooChart(json: YahooChartResponse, lookback: number): DailyB
     const high = highs[i]
     const low = lows[i]
     const close = closes[i]
-    if (open == null || high == null || low == null || close == null) continue
+    // Drop any row that fails the repo-wide "price > 0 and finite" guarantee
+    // (rejects null, NaN, Infinity, zero, and negatives in one guard).
+    if (!isPositiveFinite(open) || !isPositiveFinite(high) || !isPositiveFinite(low) || !isPositiveFinite(close)) {
+      continue
+    }
+    // Sanity check: Yahoo occasionally ships adjusted rows where `low > high`
+    // around dividend events. A bar with that invariant broken is unreliable
+    // for downstream indicators (ATR, etc.), so skip it.
+    if (low > high) continue
     const ts = timestamps[i]
-    if (typeof ts !== 'number') continue
+    if (typeof ts !== 'number' || !Number.isFinite(ts)) continue
     const date = new Date(ts * 1000).toISOString().slice(0, 10)
     bars.push({ date, open, high, low, close })
   }
@@ -171,4 +188,8 @@ function normalizeYahooChart(json: YahooChartResponse, lookback: number): DailyB
   // so callers get the shape they asked for.
   bars.sort((a, b) => a.date.localeCompare(b.date))
   return bars.slice(-lookback)
+}
+
+function isPositiveFinite(value: number | null | undefined): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
 }

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -1,5 +1,5 @@
 import type { Env } from '../../config/env'
-import { createWebullBarClient } from '../../infrastructure/quotes/BarClient'
+import { YahooBarClient } from '../../infrastructure/quotes/YahooBarClient'
 import { loadGlobalConfigFrom } from '../../infrastructure/db/globalConfigLoader'
 import { loadSymbolUniverse } from '../../infrastructure/db/symbolUniverse'
 import { createWebullHttpClient } from '../../infrastructure/webull/WebullHttpClient'
@@ -100,7 +100,10 @@ export async function runStrategyCron(env: Env): Promise<StrategyCronResult> {
   const execution = global.dryRun
     ? new MockExecution()
     : new WebullExecution(createWebullHttpClient(env))
-  const barClient = createWebullBarClient(env)
+  // Yahoo Finance /v8/finance/chart is free, no auth, covers US + JP (7267.T
+  // style) in one endpoint — chosen over Webull's JP-subscription-gated
+  // market-data API (see #84). Webull is still the order-execution path.
+  const barClient = new YahooBarClient()
 
   // sizing に流す equity は正の有限値のみ許可 (0 / 負 / NaN / Infinity を弾く)。
   // D1 から読んだ値が壊れていたら default に落とす。

--- a/test/infrastructure/quotes/yahooBarClient.test.ts
+++ b/test/infrastructure/quotes/yahooBarClient.test.ts
@@ -110,6 +110,46 @@ describe('YahooBarClient.getDailyBars', () => {
     expect(bars.at(-1)?.close).toBe(closes[21])
   })
 
+  it.each([0, -1, 1.5, NaN, Number.POSITIVE_INFINITY])(
+    'throws RangeError for non-positive-integer lookback=%s',
+    async (bad) => {
+      const fetchFn = vi.fn<typeof fetch>()
+      const client = new YahooBarClient({ fetchFn })
+      await expect(client.getDailyBars('SOXL', bad)).rejects.toBeInstanceOf(RangeError)
+      expect(fetchFn).not.toHaveBeenCalled()
+    },
+  )
+
+  it('drops bars with non-positive / non-finite prices and low>high inversions', async () => {
+    const ts = [1745539200, 1745625600, 1745712000, 1745798400, 1745884800]
+    const fetchFn = vi.fn<typeof fetch>().mockImplementation(async () =>
+      mockJsonResponse({
+        chart: {
+          result: [
+            {
+              meta: { currency: 'USD', regularMarketPrice: 94.68 },
+              timestamp: ts,
+              indicators: {
+                quote: [
+                  {
+                    open: [94, 0, 95, 96, 97], // zero at idx 1
+                    high: [95, 95, 95, 90, 98], // low>high at idx 3
+                    low: [93, 94, 94, 95, 96],
+                    close: [94.5, 94.5, Number.NaN, 95.5, 97.5], // NaN at idx 2
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    )
+    const client = new YahooBarClient({ fetchFn })
+    const bars = await client.getDailyBars('SOXL', 5)
+    // Rows 0 and 4 survive; 1 (open=0), 2 (close=NaN), 3 (low>high) dropped.
+    expect(bars.map((b) => b.close)).toEqual([94.5, 97.5])
+  })
+
   it('throws BrokerRequestError on non-2xx (mapped via brokerErrorForStatus)', async () => {
     const fetchFn = vi.fn<typeof fetch>().mockImplementation(async () =>
       new Response('Too Many Requests', { status: 429 }),

--- a/test/infrastructure/quotes/yahooBarClient.test.ts
+++ b/test/infrastructure/quotes/yahooBarClient.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest'
+import { YahooBarClient, toYahooSymbol } from '../../../src/infrastructure/quotes/YahooBarClient'
+
+function mockJsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function sampleChart(opts: { timestamps: number[]; closes: Array<number | null> }) {
+  return {
+    chart: {
+      result: [
+        {
+          meta: { currency: 'USD', regularMarketPrice: 94.68 },
+          timestamp: opts.timestamps,
+          indicators: {
+            quote: [
+              {
+                open: opts.closes.map((c) => (c == null ? null : c * 0.99)),
+                high: opts.closes.map((c) => (c == null ? null : c * 1.01)),
+                low: opts.closes.map((c) => (c == null ? null : c * 0.98)),
+                close: opts.closes,
+              },
+            ],
+          },
+        },
+      ],
+    },
+  }
+}
+
+describe('toYahooSymbol', () => {
+  it('leaves US equities and ETFs as-is', () => {
+    expect(toYahooSymbol('SOXL')).toBe('SOXL')
+    expect(toYahooSymbol('AAPL')).toBe('AAPL')
+  })
+
+  it('adds .T suffix for 4-digit JP codes and alphanumeric TSE codes', () => {
+    expect(toYahooSymbol('7267')).toBe('7267.T')
+    expect(toYahooSymbol('285A')).toBe('285A.T')
+  })
+
+  it('leaves already-qualified symbols unchanged', () => {
+    expect(toYahooSymbol('7267.T')).toBe('7267.T')
+    expect(toYahooSymbol('BRK.A')).toBe('BRK.A')
+  })
+})
+
+describe('YahooBarClient.getDailyBars', () => {
+  it('calls /v8/finance/chart/<symbol> with interval=1d and a browser-like UA', async () => {
+    let capturedUrl: URL | undefined
+    let capturedHeaders: Headers | undefined
+    const fetchFn = vi.fn<typeof fetch>().mockImplementation(async (input, init) => {
+      const urlStr = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      capturedUrl = new URL(urlStr)
+      capturedHeaders = new Headers(init?.headers)
+      return mockJsonResponse(sampleChart({ timestamps: [1745539200], closes: [94.68] }))
+    })
+
+    const client = new YahooBarClient({ fetchFn })
+    const bars = await client.getDailyBars('SOXL', 5)
+
+    expect(capturedUrl?.hostname).toBe('query1.finance.yahoo.com')
+    expect(capturedUrl?.pathname).toBe('/v8/finance/chart/SOXL')
+    expect(capturedUrl?.searchParams.get('interval')).toBe('1d')
+    expect(capturedUrl?.searchParams.get('range')).toBe('5d')
+    expect(capturedHeaders?.get('User-Agent')).toMatch(/Mozilla/)
+    expect(bars).toHaveLength(1)
+    expect(bars[0]?.close).toBe(94.68)
+  })
+
+  it('adds .T suffix for JP TSE codes in the URL path', async () => {
+    let capturedUrl: URL | undefined
+    const fetchFn = vi.fn<typeof fetch>().mockImplementation(async (input) => {
+      const urlStr = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      capturedUrl = new URL(urlStr)
+      return mockJsonResponse(sampleChart({ timestamps: [1745539200], closes: [1341] }))
+    })
+    const client = new YahooBarClient({ fetchFn })
+    await client.getDailyBars('7267', 5)
+    expect(capturedUrl?.pathname).toBe('/v8/finance/chart/7267.T')
+  })
+
+  it('drops rows where any OHLC field is null', async () => {
+    const fetchFn = vi.fn<typeof fetch>().mockImplementation(async () =>
+      mockJsonResponse(
+        sampleChart({
+          timestamps: [1745539200, 1745625600, 1745712000],
+          closes: [94.68, null, 97.12],
+        }),
+      ),
+    )
+    const client = new YahooBarClient({ fetchFn })
+    const bars = await client.getDailyBars('SOXL', 5)
+    expect(bars.map((b) => b.close)).toEqual([94.68, 97.12])
+  })
+
+  it('caps output to the requested lookback even when Yahoo returns more', async () => {
+    const ts = Array.from({ length: 22 }, (_, i) => 1745539200 + i * 86400)
+    const closes = Array.from({ length: 22 }, (_, i) => 90 + i * 0.5)
+    const fetchFn = vi.fn<typeof fetch>().mockImplementation(async () =>
+      mockJsonResponse(sampleChart({ timestamps: ts, closes })),
+    )
+    const client = new YahooBarClient({ fetchFn })
+    const bars = await client.getDailyBars('SOXL', 10)
+    expect(bars).toHaveLength(10)
+    // Oldest-first → closest to `lookback` most recent days.
+    expect(bars.at(-1)?.close).toBe(closes[21])
+  })
+
+  it('throws BrokerRequestError on non-2xx (mapped via brokerErrorForStatus)', async () => {
+    const fetchFn = vi.fn<typeof fetch>().mockImplementation(async () =>
+      new Response('Too Many Requests', { status: 429 }),
+    )
+    const client = new YahooBarClient({ fetchFn })
+    await expect(client.getDailyBars('SOXL', 5)).rejects.toThrow(/status 429/)
+  })
+})


### PR DESCRIPTION
## Summary

Webull's market-data API is gated behind a JP-stock subscription that their support confirmed is not yet available (per 2026-04-20 vendor response; "近日中に提供予定"). On the US side, `SOXS` also hits `INVALID_SYMBOL` on Webull's `/stock/bars` (#93), further limiting the usable universe.

Yahoo Finance's `query1.finance.yahoo.com/v8/finance/chart/<symbol>` endpoint — the same one `yfinance` wraps — covers both markets in one place with no auth, no key, and resolves `SOXS` cleanly. Switch the Pullback cron's bar source over.

## Quick verification (from probe)

| symbol | Yahoo price | currency | bars returned |
|---|---|---|---|
| SOXL | $94.68 | USD | 22 |
| SOXS | $18.87 | USD | 22 |
| AAPL | $270.23 | USD | 22 |
| 7267.T | ¥1,341 | JPY | 22 |
| 6752.T | ¥2,982 | JPY | 22 |
| 285A.T | ¥30,510 | JPY | 22 |

(285A's price looks surprisingly high — needs a separate sanity check against Webull's symbol listing before we re-enable JP in the cron. Out of scope for this PR.)

## Change

- `YahooBarClient` implements the existing `BarClient` interface so Pullback consumes it unchanged.
- `toYahooSymbol()` adds `.T` for TSE codes (4-digit `7267` or alphanumeric `285A`). US equities and already-qualified symbols (`BRK.A`, `7267.T`) pass through.
- Browser-like `User-Agent: Mozilla/5.0` — Yahoo's endpoint 429s anonymous requests.
- Errors flow through `brokerErrorForStatus` (#82) so downstream catch blocks don't need to special-case.
- `runStrategyCron` swaps `createWebullBarClient(env)` → `new YahooBarClient()`.

## Out of scope

- **YahooQuoteClient (snapshot)** — Pullback is bar-only today. Needed only if/when we wire spread/stale gates into the cron.
- **Removing the Webull quote/bar clients** — still reachable from manual `/trade/execute` callers; prune once nothing imports them.
- **JP-inclusive Pullback cron** — `runStrategyCron` still filters to USD symbols because the `equity` parameter is USD and sizing needs currency-aware splitting before JP is safe to include.
- **285A price disambiguation** — `.T` suffix on Yahoo may be pointing at a different instrument than Webull's `285A`. Worth confirming before JP goes into the cron.

## Test plan

- [x] `pnpm vitest run test/infrastructure/quotes/` — 25 tests pass (8 new Yahoo, 17 existing Webull/Bar)
- [ ] After deploy: `POST /admin/strategy/run` should return the same shape as before, just with bars sourced from Yahoo. `errors[]` should be empty for SOXL (was 404 on Webull bar pre-#92).

Refs #84 #93


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * マーケットデータ取得を Yahoo Finance に切替え、国内（TSE）銘柄の表記自動補完や日次データ取得に対応しました。
  * 取得データの妥当性チェックを強化し、欠損・不正値や価格の逆転などを除外するようになりました。

* **テスト**
  * シンボル正規化・日次データ取得・エラー処理・ルックバック制限などを網羅する包括的なテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->