### PR TITLE
fix(orders): add margin_type=INDEFINITE for US orders

### DIFF
--- a/src/infrastructure/webull/dto.ts
+++ b/src/infrastructure/webull/dto.ts
@@ -28,6 +28,13 @@ export interface WebullV2OrderEntry {
   time_in_force: 'DAY'
   entrust_type: 'QTY'
   account_tax_type: 'GENERAL'
+  /**
+   * Required by Webull's JP UAT tenant for US orders (placed through the
+   * US_MARGIN account). `ONE_DAY` = intraday, closes same session.
+   * `INDEFINITE` = can be held overnight. Omit for JP orders — JP_CASH
+   * account is non-margin and rejects this field.
+   */
+  margin_type?: 'ONE_DAY' | 'INDEFINITE'
 }
 
 export interface WebullPlaceOrderRequestDto {

--- a/src/infrastructure/webull/mapper.ts
+++ b/src/infrastructure/webull/mapper.ts
@@ -4,13 +4,14 @@ import type { WebullMarket, WebullPlaceOrderRequestDto, WebullPlaceOrderResponse
 
 export function toWebullPlaceOrderRequest(intent: OrderIntent): WebullPlaceOrderRequestDto {
   const symbol = intent.symbol.toUpperCase()
+  const market = inferWebullMarket(symbol)
   return {
     new_orders: [
       {
         client_order_id: intent.clientOrderId,
         symbol,
         instrument_type: 'EQUITY',
-        market: inferWebullMarket(symbol),
+        market,
         order_type: 'LIMIT',
         limit_price: intent.price.toFixed(3),
         quantity: String(intent.quantity),
@@ -19,6 +20,16 @@ export function toWebullPlaceOrderRequest(intent: OrderIntent): WebullPlaceOrder
         time_in_force: 'DAY',
         entrust_type: 'QTY',
         account_tax_type: 'GENERAL',
+        // US orders on the JP UAT tenant's US_MARGIN account require a
+        // margin_type. The Webull enum exposes ONE_DAY (intraday) and
+        // INDEFINITE (can hold overnight). Pullback is a swing strategy →
+        // INDEFINITE. Leveraged securities (SOXL / SOXS) are rejected with
+        // OPENAPI_SECURITY_NOT_SUPPORT_MARGIN_TRADE regardless of value;
+        // exclude them from the cron universe rather than trying to work
+        // around it here.
+        // JP orders go through the CASH account (JPY, non-margin) and must
+        // NOT carry margin_type.
+        ...(market === 'US' ? { margin_type: 'INDEFINITE' } : {}),
       },
     ],
   }

--- a/test/infrastructure/webull/webullHttpClient.test.ts
+++ b/test/infrastructure/webull/webullHttpClient.test.ts
@@ -97,6 +97,7 @@ describe('WebullHttpClient', () => {
           time_in_force: 'DAY',
           entrust_type: 'QTY',
           account_tax_type: 'GENERAL',
+          margin_type: 'INDEFINITE',
         },
       ],
     })
@@ -132,6 +133,9 @@ describe('WebullHttpClient', () => {
     const body = JSON.parse(fetchMock.mock.calls[0]![1]!.body as string)
     expect(body.new_orders[0].market).toBe('JP')
     expect(body.new_orders[0].symbol).toBe('1570')
+    // JP CASH account is non-margin — margin_type would be rejected by
+    // Webull. The mapper must omit the field for JP orders.
+    expect(body.new_orders[0].margin_type).toBeUndefined()
   })
 
   it('findOrderByClientId queries orders/history for every configured account and merges results', async () => {


### PR DESCRIPTION
## Summary

Probe against the JP UAT tenant (hidden behind our \`WEBULL_API_BASE\`) revealed that US orders posted to the \`US_MARGIN\` account are rejected without a \`margin_type\` field:

\`\`\`json
{ "error_code": "OPENAPI_ORDER_MARGIN_TYPE_ILLEGAL", "message": "Margin type parameter error." }
\`\`\`

Adding \`margin_type: "INDEFINITE"\` unblocks the path — AAPL BUY @ \$300 just returned 200 with \`order_id: 037DAFFTF66DT0KF4N1S000000\`, now visible in the account's \`orders/history\` as \`SUBMITTED\` (first real order ever to reach the broker from this POC).

## Change

- \`WebullV2OrderEntry.margin_type?: 'ONE_DAY' | 'INDEFINITE'\`
- \`toWebullPlaceOrderRequest\` sets it **only for US** orders:
  - US → \`INDEFINITE\` (can hold overnight — Pullback is swing)
  - JP → omitted (JP CASH account is non-margin and rejects the field)
- Tests: existing SOXL (US) assertion now expects \`margin_type: 'INDEFINITE'\`; the JP (\`1570\`) test asserts the field is \`undefined\`.

## Separate restriction, not fixed here

SOXL / SOXS return \`OPENAPI_SECURITY_NOT_SUPPORT_MARGIN_TRADE\` regardless of \`margin_type\` value (Webull sandbox blocks 3x-leveraged ETFs on the margin account). Follow-up: swap the Pullback universe to plain US equities / non-leveraged ETFs so the cron can actually transact.

## Test plan

- [x] \`pnpm vitest run test/infrastructure/webull/\` — 22 tests pass (US asserts new field, JP asserts omitted)
- [x] Manual probe: AAPL order 200 OK, visible in history as SUBMITTED
- [ ] After merge + deploy: \`POST /webull/order/place\` with an AAPL-class symbol should succeed via the Worker path too

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 米国市場での取引注文リクエストにマージン期間タイプの指定オプションを追加し、より柔軟な注文処理に対応しました。

* **テスト**
  * 複数市場における注文マッピングのテストを拡充し、各市場での正確な処理を確認しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->