### PR TITLE
fix(reconciliation): treat Webull 'CANCELED' as terminal (spelling)

### DIFF
--- a/src/trading/reconciliation/reconcileFills.ts
+++ b/src/trading/reconciliation/reconcileFills.ts
@@ -11,9 +11,15 @@ import { SymbolStateClient } from '../state/SymbolStateClient'
 // Terminal Webull order statuses — once we see one of these we can stop
 // polling for this order. Anything else (NEW, PENDING, PARTIALLY_FILLED) is
 // still in flight.
+//
+// Include both `CANCELLED` (British, expected from the SDK enum) and
+// `CANCELED` (American, actually observed on the JP UAT tenant's
+// orders/history response for a day-expired limit). Matching only one
+// spelling left a 15-hour "stillPending" gap on a real SOXL order.
 const TERMINAL_STATUSES = new Set<string>([
   'FILLED',
   'CANCELLED',
+  'CANCELED',
   'REJECTED',
   'EXPIRED',
 ])

--- a/test/trading/reconciliation/reconcileFills.test.ts
+++ b/test/trading/reconciliation/reconcileFills.test.ts
@@ -4,7 +4,7 @@ import { _internal } from '../../../src/trading/reconciliation/reconcileFills'
 describe('reconcileFills internals', () => {
   it('TERMINAL_STATUSES covers the expected Webull statuses', () => {
     expect([...(_internal.TERMINAL_STATUSES as Set<string>)].sort()).toEqual(
-      ['CANCELLED', 'EXPIRED', 'FILLED', 'REJECTED'],
+      ['CANCELED', 'CANCELLED', 'EXPIRED', 'FILLED', 'REJECTED'],
     )
   })
 


### PR DESCRIPTION
## Summary

A real SOXL day-order placed yesterday (\`limit \$100\`, submitted 11:42 UTC) expired overnight. Webull's JP UAT tenant returned the terminal status as \`CANCELED\` (American, single L) on \`orders/history\`. Our \`TERMINAL_STATUSES\` set only had \`CANCELLED\` (British, double L), so \`reconcileFills\` kept sticking the row into \`stillPending\` for 15 hours — \`broker_status\` stayed null, pending-lock release never fired.

Add \`CANCELED\` to the set. Keep \`CANCELLED\` for whichever tenant / version returns the British variant (the Webull Java SDK enum uses it).

## Verification after deploy

\`POST /admin/orders/reconcile\` should transition the existing SOXL row to \`broker_status: CANCELED\` on the next run, and \`clearPendingLockIfMatches\` would then release the lock (matched by coid, so safe).

## Test plan

- [x] Updated \`reconcileFills.test.ts\` TERMINAL_STATUSES assertion includes both spellings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 注文の調整処理で、アメリカ英語のスペル「CANCELED」とイギリス英語のスペル「CANCELLED」の両方の取消ステータスを正しく認識できるようにしました。これにより、Webull からのすべての取消通知が適切に処理されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->