### PR TITLE
feat(strategy): DEMO_MODE env toggle for frequent BUY→SELL cycles

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -215,6 +215,13 @@ import type { PortfolioStateDO } from '../trading/state/PortfolioStateDO'
 
 export interface Env {
   PORTFOLIO_STATE?: DurableObjectNamespace<PortfolioStateDO>
+  /**
+   * When `'true'`, runStrategyCron replaces DEFAULT_RULE with
+   * DEMO_FREQUENT_RULE for every US symbol — loose entry gates + tight
+   * TP/SL + 1-day time stop. Used purely for pipeline observation; never
+   * enable in real-money deployments.
+   */
+  DEMO_MODE?: string
 }
 
 /**

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -139,6 +139,8 @@ interface SymbolRuleShape {
   timeStopDays: number
   pullbackMax: number
   pullbackMin: number
+  minReturn50d: number
+  requireAboveSma50: boolean
 }
 
 function coerceRule(raw: Record<string, unknown>, symbol: string): Partial<SymbolRuleShape> {
@@ -149,6 +151,7 @@ function coerceRule(raw: Record<string, unknown>, symbol: string): Partial<Symbo
     'timeStopDays',
     'pullbackMax',
     'pullbackMin',
+    'minReturn50d',
   ]
   for (const key of numberKeys) {
     if (raw[key] !== undefined) {
@@ -156,9 +159,19 @@ function coerceRule(raw: Record<string, unknown>, symbol: string): Partial<Symbo
       if (typeof value !== 'number' || !Number.isFinite(value)) {
         throw new Error(`'${symbol}.${key}' must be a finite number`)
       }
-      out[key] = value
+      ;(out[key] as number) = value
     }
   }
+
+  // Parse requireAboveSma50 as boolean
+  if (raw.requireAboveSma50 !== undefined) {
+    const value = raw.requireAboveSma50
+    if (typeof value !== 'boolean') {
+      throw new Error(`'${symbol}.requireAboveSma50' must be a boolean`)
+    }
+    out.requireAboveSma50 = value
+  }
+
   return out
 }
 
@@ -215,13 +228,6 @@ import type { PortfolioStateDO } from '../trading/state/PortfolioStateDO'
 
 export interface Env {
   PORTFOLIO_STATE?: DurableObjectNamespace<PortfolioStateDO>
-  /**
-   * When `'true'`, runStrategyCron replaces DEFAULT_RULE with
-   * DEMO_FREQUENT_RULE for every US symbol — loose entry gates + tight
-   * TP/SL + 1-day time stop. Used purely for pipeline observation; never
-   * enable in real-money deployments.
-   */
-  DEMO_MODE?: string
 }
 
 /**
@@ -292,4 +298,14 @@ export interface Env {
    * Optional so existing tests / legacy deploys without D1 keep working.
    */
   DB?: D1Database
+}
+
+/**
+ * When `'true'`, runStrategyCron replaces DEFAULT_RULE with
+ * DEMO_FREQUENT_RULE for every US symbol — loose entry gates + tight
+ * TP/SL + 1-day time stop. Used purely for pipeline observation; never
+ * enable in real-money deployments.
+ */
+export interface Env {
+  DEMO_MODE?: string
 }

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -7,6 +7,7 @@ import { MockExecution } from '../execution/MockExecution'
 import { WebullExecution } from '../execution/WebullExecution'
 import { PortfolioStateClient } from '../state/PortfolioStateClient'
 import { SymbolStateClient } from '../state/SymbolStateClient'
+import { DEMO_FREQUENT_RULE, type SymbolRule } from './strategies/PullbackUptrendStrategy'
 import { runPullbackScheduler, type PullbackRunSummary } from './pullbackScheduler'
 
 const DEFAULT_EQUITY_USD = 10_000
@@ -109,6 +110,14 @@ export async function runStrategyCron(env: Env): Promise<StrategyCronResult> {
   // D1 から読んだ値が壊れていたら default に落とす。
   const equity = sanitizeEquity(global.totalCapitalUsd)
 
+  // DEMO_MODE=true で Pullback の全 gate を緩め、毎日複数回 fire する
+  // 設定 (DEMO_FREQUENT_RULE) を全 US symbol に適用。pipeline の実観察
+  // のために置いてある一時モード、実運用では env を外す。
+  const demoMode = env.DEMO_MODE === 'true'
+  const rulesMap: Record<string, SymbolRule> | undefined = demoMode
+    ? Object.fromEntries(usSymbols.map((s) => [s.toUpperCase(), DEMO_FREQUENT_RULE]))
+    : undefined
+
   const summary = await runPullbackScheduler({
     symbols: usSymbols,
     equity,
@@ -116,6 +125,7 @@ export async function runStrategyCron(env: Env): Promise<StrategyCronResult> {
     positionStore,
     execution,
     symbolCapMap: universe.symbolMaxNotional,
+    rulesMap,
   })
 
   return { summary, symbols: usSymbols }

--- a/src/trading/strategy/strategies/PullbackUptrendStrategy.ts
+++ b/src/trading/strategy/strategies/PullbackUptrendStrategy.ts
@@ -21,6 +21,16 @@ export interface SymbolRule {
   pullbackMax: number
   /** Pullback range: deeper bound. Default -0.06. */
   pullbackMin: number
+  /**
+   * Minimum 50-day return required to consider the stock in an uptrend.
+   * Default 0.08. Set negative to effectively disable the filter.
+   */
+  minReturn50d: number
+  /**
+   * Require `price > sma50` before entering. Default true. Set false in
+   * demo / frequent-cycle mode so entry doesn't depend on trend direction.
+   */
+  requireAboveSma50: boolean
 }
 
 export const DEFAULT_RULE: SymbolRule = Object.freeze({
@@ -29,6 +39,8 @@ export const DEFAULT_RULE: SymbolRule = Object.freeze({
   timeStopDays: 10,
   pullbackMax: -0.03,
   pullbackMin: -0.06,
+  minReturn50d: 0.08,
+  requireAboveSma50: true,
 })
 
 /**
@@ -41,6 +53,24 @@ export const LEVERAGED_RULE: SymbolRule = Object.freeze({
   timeStopDays: 5,
   pullbackMax: -0.03,
   pullbackMin: -0.06,
+  minReturn50d: 0.08,
+  requireAboveSma50: true,
+})
+
+/**
+ * Demo / pipeline-observation rule: deliberately easy to trigger so the
+ * place → fill → reconcile → exit → fill loop cycles multiple times per
+ * trading day. All trend / direction gates disabled; tiny TP/SL so exits
+ * fire intraday on normal volatility. NOT for real-money trading.
+ */
+export const DEMO_FREQUENT_RULE: SymbolRule = Object.freeze({
+  stopPct: -0.005,       // 0.5% drop → SELL
+  takeProfitPct: 0.005,  // 0.5% rise → SELL
+  timeStopDays: 1,       // 1 business day max hold
+  pullbackMax: -0.0001,  // any pullback from 20d high qualifies
+  pullbackMin: -0.50,    // no meaningful lower bound
+  minReturn50d: -1.0,    // disable 50d trend filter
+  requireAboveSma50: false,
 })
 
 export interface PullbackInput {
@@ -102,10 +132,10 @@ export class PullbackUptrendStrategy {
 
   private entryDecision(input: PullbackInput, rule: SymbolRule): Signal {
     const ind = input.indicators
-    if (ind.return50d <= 0.08) {
-      return hold(input, `50d return ${ind.return50d.toFixed(4)} <= 0.08 trend threshold`)
+    if (ind.return50d <= rule.minReturn50d) {
+      return hold(input, `50d return ${ind.return50d.toFixed(4)} <= ${rule.minReturn50d} trend threshold`)
     }
-    if (ind.price <= ind.sma50) {
+    if (rule.requireAboveSma50 && ind.price <= ind.sma50) {
       return hold(input, `price ${ind.price} <= sma50 ${ind.sma50}`)
     }
     if (ind.high20d <= 0) {


### PR DESCRIPTION
## Summary

POC pipeline observation helper. Normal Pullback fires signals at most a few times per week — useful for real strategy testing, but too sparse for seeing the full \`place → fill → reconcile → exit → fill\` loop in action.

Add a \`DEMO_MODE\` env flag that swaps in \`DEMO_FREQUENT_RULE\` for every US symbol when set to \`'true'\`.

## DEMO_FREQUENT_RULE

| param | default | demo |
|---|---|---|
| minReturn50d (trend filter) | 0.08 | **-1.0** (disabled) |
| requireAboveSma50 | true | **false** |
| pullbackMax / Min (entry band) | -0.03 / -0.06 | **-0.0001 / -0.50** (any dip) |
| takeProfitPct | 0.07 | **0.005** |
| stopPct | -0.04 | **-0.005** |
| timeStopDays | 10 | **1** |

### Intraday cycle expectation

Entry fires for any symbol whose 20d high is above current price (nearly every day). Exit fires whenever the position moves ±0.5% from avg cost, or after 1 business day.

→ Most days should see multiple BUY→SELL cycles per symbol, ideal for validating the journal / reconcile / PortfolioStateDO apply chain with real broker roundtrips.

## Gate parameterization

Two previously-hardcoded entry gates (0.08 trend threshold, \`price > sma50\`) are now driven by \`SymbolRule.minReturn50d\` and \`SymbolRule.requireAboveSma50\` respectively. DEFAULT_RULE and LEVERAGED_RULE keep the original numeric values — production / default behaviour unchanged.

## Enable / disable

\`\`\`bash
# enable
pnpm wrangler secret put DEMO_MODE --env staging   # value: true
# disable
pnpm wrangler secret delete DEMO_MODE --env staging
\`\`\`

Confirmation that demo mode is on: \`/admin/strategy/run\` returns buys > 0 during US market hours when universe has any symbol below its 20d high (almost always).

## Out of scope

- Automatic EOD / weekend skip: demo runs during the cron's normal schedule; signal rate will naturally be lower outside US market hours (no new bars).
- Production safety rails (confirmation dialog, separate env, etc.): this is a POC flag, guard is the explicit opt-in env value.

## Test plan

- [x] \`pnpm vitest run test/trading/strategy/\` — 16 tests pass (existing DEFAULT_RULE assertions unaffected)
- [ ] After merge + deploy + \`wrangler secret put DEMO_MODE\`:
  - Call \`/admin/strategy/run\`, expect \`buys > 0\` for at least one symbol
  - Wait 5 min; \`/admin/orders/reconcile\` should show CANCELED / FILLED for the placed orders
  - Multiple cycles expected through the US trading day

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * デモモードを追加しました。環境設定で有効化すると米国銘柄に対してより頻繁なトレードルールが適用されます（既定ルール→デモ頻繁ルールの切替）。
  * 戦略ルールにトレンド判定用パラメータ（50日リターン閾値、50日移動平均以上要件）を追加し、デフォルト値とデモ用緩和ルールを導入しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->