### PR TITLE
chore: remove DEMO_MODE flag (sandbox already risk-free)

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -297,13 +297,3 @@ export interface Env {
    */
   DB?: D1Database
 }
-// DEMO_MODE: pipeline observation helper, frequent BUY/SELL cycles (#113).
-export interface Env {
-  /**
-   * When `'true'`, runStrategyCron replaces DEFAULT_RULE with
-   * DEMO_FREQUENT_RULE for every US symbol — loose entry gates + tight
-   * TP/SL + 1-day time stop. Pipeline observation only; never enable
-   * in real-money deployments.
-   */
-  DEMO_MODE?: string
-}

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -7,7 +7,6 @@ import { MockExecution } from '../execution/MockExecution'
 import { WebullExecution } from '../execution/WebullExecution'
 import { PortfolioStateClient } from '../state/PortfolioStateClient'
 import { SymbolStateClient } from '../state/SymbolStateClient'
-import { DEMO_FREQUENT_RULE, type SymbolRule } from './strategies/PullbackUptrendStrategy'
 import { runPullbackScheduler, type PullbackRunSummary } from './pullbackScheduler'
 
 const DEFAULT_EQUITY_USD = 10_000
@@ -110,14 +109,6 @@ export async function runStrategyCron(env: Env): Promise<StrategyCronResult> {
   // D1 から読んだ値が壊れていたら default に落とす。
   const equity = sanitizeEquity(global.totalCapitalUsd)
 
-  // DEMO_MODE=true で Pullback の全 gate を緩め、毎日複数回 fire する
-  // 設定 (DEMO_FREQUENT_RULE) を全 US symbol に適用。pipeline の実観察
-  // のために置いてある一時モード、実運用では env を外す。
-  const demoMode = env.DEMO_MODE === 'true'
-  const rulesMap: Record<string, SymbolRule> | undefined = demoMode
-    ? Object.fromEntries(usSymbols.map((s) => [s.toUpperCase(), DEMO_FREQUENT_RULE]))
-    : undefined
-
   const summary = await runPullbackScheduler({
     symbols: usSymbols,
     equity,
@@ -125,7 +116,6 @@ export async function runStrategyCron(env: Env): Promise<StrategyCronResult> {
     positionStore,
     execution,
     symbolCapMap: universe.symbolMaxNotional,
-    rulesMap,
   })
 
   return { summary, symbols: usSymbols }

--- a/src/trading/strategy/strategies/PullbackUptrendStrategy.ts
+++ b/src/trading/strategy/strategies/PullbackUptrendStrategy.ts
@@ -57,22 +57,6 @@ export const LEVERAGED_RULE: SymbolRule = Object.freeze({
   requireAboveSma50: true,
 })
 
-/**
- * Demo / pipeline-observation rule: deliberately easy to trigger so the
- * place → fill → reconcile → exit → fill loop cycles multiple times per
- * trading day. All trend / direction gates disabled; tiny TP/SL so exits
- * fire intraday on normal volatility. NOT for real-money trading.
- */
-export const DEMO_FREQUENT_RULE: SymbolRule = Object.freeze({
-  stopPct: -0.005,       // 0.5% drop → SELL
-  takeProfitPct: 0.005,  // 0.5% rise → SELL
-  timeStopDays: 1,       // 1 business day max hold
-  pullbackMax: -0.0001,  // any pullback from 20d high qualifies
-  pullbackMin: -0.50,    // no meaningful lower bound
-  minReturn50d: -1.0,    // disable 50d trend filter
-  requireAboveSma50: false,
-})
-
 export interface PullbackInput {
   symbol: string
   indicators: PullbackIndicators


### PR DESCRIPTION
## Summary

DEMO_MODE was added in #113 to "loosen Pullback gates so the cron fires multiple times per day for pipeline observation". User pointed out the rationale was circular — sandbox already means virtual funds, so letting normal Pullback trade freely is zero-risk. The flag is extra mental load without a real need.

## Drops

- \`Env.DEMO_MODE\` interface field
- \`DEMO_FREQUENT_RULE\` constant (loose params unsuitable for real money anyway)
- \`runStrategyCron\`'s \`env.DEMO_MODE === 'true'\` branch + the rulesMap override

## Keeps

- \`SymbolRule.minReturn50d\` + \`SymbolRule.requireAboveSma50\` — these fields were added to make DEMO_MODE possible, but they're also useful per-symbol tuning knobs via the existing SYMBOL_RULES env. Removing them would force hardcoded gate values back.
- \`parseSymbolRulesMap\` / \`SymbolRuleShape\` / \`coerceRule\` handling of the new fields — same justification.

## Out of band

Staging secret already deleted (\`wrangler secret delete DEMO_MODE\`). Nothing further needed post-merge.

## Test plan

- [x] \`pnpm vitest run test/trading/strategy/\` — 16 tests pass with the fields still in place but DEMO_FREQUENT_RULE gone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * デモモード関連の設定およびトレード戦略の制御フローを削除しました。本番運用のための環境構成が簡潔になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->