### PR TITLE
feat(orders): switch order_type from LIMIT to MARKET

### DIFF
--- a/src/infrastructure/webull/dto.ts
+++ b/src/infrastructure/webull/dto.ts
@@ -20,7 +20,8 @@ export interface WebullV2OrderEntry {
   symbol: string
   instrument_type: 'EQUITY'
   market: WebullMarket
-  order_type: 'LIMIT'
+  order_type: 'LIMIT' | 'MARKET'
+  /** MARKET orders still carry limit_price as a safety cap (Webull schema). */
   limit_price: string
   quantity: string
   support_trading_session: 'N'

--- a/src/infrastructure/webull/mapper.ts
+++ b/src/infrastructure/webull/mapper.ts
@@ -11,7 +11,10 @@ export function toWebullPlaceOrderRequest(intent: OrderIntent): WebullPlaceOrder
         symbol,
         instrument_type: 'EQUITY',
         market: inferWebullMarket(symbol),
-        order_type: 'LIMIT',
+        // MARKET: sandbox の fill simulator は limit 注文を通さないので、
+        // POC 検証用に成行で発注する。Webull schema は MARKET でも
+        // limit_price を safety cap として必須にしている。
+        order_type: 'MARKET',
         limit_price: intent.price.toFixed(3),
         quantity: String(intent.quantity),
         support_trading_session: 'N',

--- a/test/infrastructure/webull/webullHttpClient.test.ts
+++ b/test/infrastructure/webull/webullHttpClient.test.ts
@@ -89,7 +89,7 @@ describe('WebullHttpClient', () => {
           symbol: 'SOXL',
           instrument_type: 'EQUITY',
           market: 'US',
-          order_type: 'LIMIT',
+          order_type: 'MARKET',
           limit_price: '9.500',
           quantity: '2',
           support_trading_session: 'N',


### PR DESCRIPTION
## 背景

ずっと指値 (LIMIT) で発注していたが、Webull sandbox は fill simulator を持っておらず、limit 注文は market 価格以上でも EOD で CANCELED になっていた。結果:

- 我々が cron から出した注文はすべて不成立
- \"買えた後\" の処理 (recordFill / PortfolioStateDO 反映 / Pullback exit / cooldown) が一度も動作していない
- 自動売買ツールの後半半分が未検証状態

## 対策

発注を成行 (MARKET) に切り替える。Webull の schema 上 \`limit_price\` は成行でも必須なので safety cap として残す (Java SDK example と同じ形)。

## 本番切替時の注意

成行はスリッページを受け入れる発注方式。実マネー運用では環境変数や銘柄ルールで LIMIT / MARKET を切替可能にすべき。今は sandbox で fill を発生させるためだけの設定。

## Test plan

- [x] \`pnpm vitest run test/infrastructure/webull/\` — 22 tests pass
- [ ] merge 後: \`/admin/strategy/run\` → signal が出た symbol で即 FILLED が返るか確認
- [ ] fill したら 5 分後の reconcile で PortfolioStateDO に反映されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * マーケットオーダーの機能をサポートしました。リミットオーダーに加えてマーケットオーダーが利用できるようになります。

* **その他**
  * マーケットオーダーの場合も、安全弁として制限価格が含まれます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->