### PR TITLE
feat(strategy): loosen Pullback entry gates

### DIFF
--- a/src/trading/strategy/strategies/PullbackUptrendStrategy.ts
+++ b/src/trading/strategy/strategies/PullbackUptrendStrategy.ts
@@ -37,9 +37,14 @@ export const DEFAULT_RULE: SymbolRule = Object.freeze({
   stopPct: -0.04,
   takeProfitPct: 0.07,
   timeStopDays: 10,
-  pullbackMax: -0.03,
+  // Looser pullback band: accept shallow dips too. Original -0.03 → -0.06
+  // rarely fired (weekly-at-most signal rate). -0.01 → -0.06 expects a
+  // few signals per week in normal market conditions.
+  pullbackMax: -0.01,
   pullbackMin: -0.06,
-  minReturn50d: 0.08,
+  // Drop trend threshold from +8% → +3%. The 8% filter was tuned for
+  // steep trends; +3% captures mild uptrends which are far more common.
+  minReturn50d: 0.03,
   requireAboveSma50: true,
 })
 


### PR DESCRIPTION
## Summary

DEMO_MODE 撤去後、Pullback の厳しめ gate (50日リターン +8% 以上 + 押し目 -3% 〜 -6%) では 4 銘柄全 HOLD が続いて cron 発注 0 件。sandbox 観察のためには週 1-2 回は signal 出る設定に緩める必要がある。

## 変更

DEFAULT_RULE のみ調整:

| param | before | after | 狙い |
|---|---|---|---|
| `minReturn50d` | 0.08 (+8%) | **0.03 (+3%)** | 軽度の上昇トレンドでも entry 許可 |
| `pullbackMax` | -0.03 | **-0.01** | 浅い押し目も許容 |
| `pullbackMin` | -0.06 | -0.06 | 据え置き |
| `stopPct` / `takeProfitPct` / `timeStopDays` | 同左 | 同左 | exit 条件は本来形を維持 |

## 想定発火頻度

- 通常相場で **週数回** → 1 週間で pipeline の BUY → FILL → (TP/SL/time-stop) SELL → reconcile の全サイクル観察可
- SYMBOL_RULES env で per-symbol override は引き続き可能

## Test plan

- [x] \`pnpm vitest run test/trading/strategy/\` — 16 tests pass (DEFAULT_RULE 値変更のみ、既存 assertion とも互換)
- [ ] merge + deploy 後、次の :15 cron で \`buys > 0\` が 1 日のうちに観察されるか

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **設定変更**
  * トレーディング戦略のデフォルト設定パラメータを調整し、より浅いプルバック条件を受け入れるよう変更しました。
  * アップトレンド判定の要件を緩和し、より多くの取引機会をキャッチしやすくしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->