### PR TITLE
feat(cron): JP 銘柄を Pullback cron に統合 (currency-aware + 100-lot round) (#119)

### DIFF
--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -37,6 +37,12 @@ export interface PullbackSchedulerOptions {
   barLookback?: number
   riskPerTradePct?: number
   pendingLockTtlMs?: number
+  /**
+   * Exchange lot size for this run (e.g. 100 for TSE). Default 1. Applied
+   * uniformly to all symbols in this invocation — callers running mixed
+   * markets should invoke the scheduler once per lot-size.
+   */
+  lotSize?: number
   now?: () => Date
 }
 
@@ -128,6 +134,7 @@ export async function runPullbackScheduler(
         baselineAtr20: indicators.baselineAtr20,
         symbolCap: options.symbolCapMap?.[upper],
         riskPerTradePct: options.riskPerTradePct,
+        lotSize: options.lotSize,
       })
       if (sizing.quantity <= 0) {
         summary.rejected.push({

--- a/src/trading/strategy/pullbackSizing.ts
+++ b/src/trading/strategy/pullbackSizing.ts
@@ -12,13 +12,23 @@ export interface PullbackSizingInput {
   riskPerTradePct?: number
   /** ATR floor ratio. If atr20 < baselineAtr20 * this, size is halved. Default 0.5. */
   atrFloorRatio?: number
+  /**
+   * Exchange lot size. Final quantity is floored to a multiple of this
+   * (e.g. 100 for TSE equities). Default 1 (no rounding).
+   */
+  lotSize?: number
 }
 
 export interface PullbackSizingResult {
   quantity: number
   notional: number
   capped: boolean
-  capReason?: 'atr-floor' | 'symbol-cap' | 'invalid-stop' | 'insufficient-risk-budget'
+  capReason?:
+    | 'atr-floor'
+    | 'symbol-cap'
+    | 'invalid-stop'
+    | 'insufficient-risk-budget'
+    | 'lot-size-round'
 }
 
 /**
@@ -58,6 +68,21 @@ export function computePullbackSizing(input: PullbackSizingInput): PullbackSizin
     notional = quantity * input.entryPrice
     capped = true
     capReason = 'symbol-cap'
+  }
+
+  // Exchange lot-size rounding (e.g. TSE 100-share lots). Must run AFTER all
+  // other caps so we don't round up back over symbolCap. If the round-down
+  // zeroes the qty, surface it explicitly so caller can reject rather than
+  // silently skip.
+  const lotSize = input.lotSize ?? 1
+  if (lotSize > 1) {
+    const rounded = Math.floor(quantity / lotSize) * lotSize
+    if (rounded !== quantity) {
+      quantity = rounded
+      notional = quantity * input.entryPrice
+      capped = true
+      capReason = rounded === 0 ? 'lot-size-round' : capReason ?? 'lot-size-round'
+    }
   }
 
   return { quantity, notional, capped, capReason }

--- a/src/trading/strategy/pullbackSizing.ts
+++ b/src/trading/strategy/pullbackSizing.ts
@@ -74,12 +74,20 @@ export function computePullbackSizing(input: PullbackSizingInput): PullbackSizin
   // other caps so we don't round up back over symbolCap. If the round-down
   // zeroes the qty, surface it explicitly so caller can reject rather than
   // silently skip.
-  const lotSize = input.lotSize ?? 1
+  // Validate and normalize lotSize to a positive finite integer.
+  let lotSize = input.lotSize ?? 1
+  if (!Number.isFinite(lotSize) || !Number.isInteger(lotSize) || lotSize <= 0) {
+    lotSize = 1
+  }
   if (lotSize > 1) {
     const rounded = Math.floor(quantity / lotSize) * lotSize
     if (rounded !== quantity) {
       quantity = rounded
       notional = quantity * input.entryPrice
+      // Guard that quantity and notional are finite after rounding.
+      if (!Number.isFinite(quantity) || !Number.isFinite(notional)) {
+        return { quantity: 0, notional: 0, capped: true, capReason: 'lot-size-round' }
+      }
       capped = true
       capReason = rounded === 0 ? 'lot-size-round' : capReason ?? 'lot-size-round'
     }

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -2,6 +2,7 @@ import type { Env } from '../../config/env'
 import { YahooBarClient } from '../../infrastructure/quotes/YahooBarClient'
 import { loadGlobalConfigFrom } from '../../infrastructure/db/globalConfigLoader'
 import { loadSymbolUniverse } from '../../infrastructure/db/symbolUniverse'
+import type { SymbolCurrency } from '../../infrastructure/db/symbolConfigRepo'
 import { createWebullHttpClient } from '../../infrastructure/webull/WebullHttpClient'
 import { MockExecution } from '../execution/MockExecution'
 import { WebullExecution } from '../execution/WebullExecution'
@@ -10,13 +11,15 @@ import { SymbolStateClient } from '../state/SymbolStateClient'
 import { runPullbackScheduler, type PullbackRunSummary } from './pullbackScheduler'
 
 const DEFAULT_EQUITY_USD = 10_000
+const DEFAULT_EQUITY_JPY = 1_500_000
+const JP_LOT_SIZE = 100
 
 export interface StrategyCronResult {
   summary: PullbackRunSummary
   symbols: string[]
   skipReason?:
     | 'trading_disabled'
-    | 'no_us_symbols'
+    | 'no_tradable_symbols'
     | 'no_bridge_state'
     | 'portfolio_halted'
     | 'drawdown_kill'
@@ -25,27 +28,27 @@ export interface StrategyCronResult {
 /**
  * Cron-driven Pullback strategy entry。呼び出し側 (`src/index.ts`) は:
  *   1. global_config + symbol_universe を D1 から読む
- *   2. trading_enabled=0 / JP-only / SYMBOL_STATE 未 bind なら skip
+ *   2. trading_enabled=0 / symbol 不在 / SYMBOL_STATE 未 bind なら skip
  *   3. PortfolioStateDO の kill-switch / drawdown を確認 (fail-closed)
- *   4. US symbols に絞って runPullbackScheduler を起動
+ *   4. currency 毎に runPullbackScheduler を起動し summary を合算
  *
  * Risk gate のうち **portfolio-wide な pre-flight 判定** (tradingDisabledUntil
  * と drawdown_kill) は本関数で適用する。per-symbol gate (spread / halt / gap /
  * JP band / inverse_pair / settled_cash) は TradingService 側が持っており、
  * 本 cron 経路では未統合 — follow-up で gate parity を取る予定。
  *
- * JP 銘柄は Webull JP UAT で market-data bar が 404 なので本 cron では除外。
- * JP は手動 /trade/execute 運用 (#32 live 疎通後に解禁)。
+ * JP 銘柄は 100 株ロットで round-down される。bar 取得は Yahoo Finance の
+ * `<code>.T` サフィックス (YahooBarClient 内で自動付与)。
  */
 export async function runStrategyCron(env: Env): Promise<StrategyCronResult> {
-  const emptySummary: PullbackRunSummary = {
+  const emptySummary = (): PullbackRunSummary => ({
     evaluated: 0,
     buys: 0,
     sells: 0,
     holds: 0,
     rejected: [],
     errors: [],
-  }
+  })
 
   const [global, universe] = await Promise.all([
     loadGlobalConfigFrom(env),
@@ -53,18 +56,19 @@ export async function runStrategyCron(env: Env): Promise<StrategyCronResult> {
   ])
 
   if (!global.tradingEnabled) {
-    return { summary: emptySummary, symbols: [], skipReason: 'trading_disabled' }
+    return { summary: emptySummary(), symbols: [], skipReason: 'trading_disabled' }
   }
 
-  const usSymbols = universe.allowedSymbols.filter(
-    (sym) => (universe.symbolCurrency[sym] ?? 'USD') === 'USD',
-  )
-  if (usSymbols.length === 0) {
-    return { summary: emptySummary, symbols: [], skipReason: 'no_us_symbols' }
+  if (universe.allowedSymbols.length === 0) {
+    return { summary: emptySummary(), symbols: [], skipReason: 'no_tradable_symbols' }
   }
 
   if (!env.SYMBOL_STATE) {
-    return { summary: emptySummary, symbols: usSymbols, skipReason: 'no_bridge_state' }
+    return {
+      summary: emptySummary(),
+      symbols: universe.allowedSymbols,
+      skipReason: 'no_bridge_state',
+    }
   }
 
   // Portfolio-level pre-flight (fail-closed):
@@ -74,7 +78,11 @@ export async function runStrategyCron(env: Env): Promise<StrategyCronResult> {
   // - tradingDisabledUntil が有効 & 未来 → halt
   // - drawdown 閾値超過 → halt
   if (!env.PORTFOLIO_STATE) {
-    return { summary: emptySummary, symbols: usSymbols, skipReason: 'portfolio_halted' }
+    return {
+      summary: emptySummary(),
+      symbols: universe.allowedSymbols,
+      skipReason: 'portfolio_halted',
+    }
   }
   const portfolioStore = new PortfolioStateClient(env.PORTFOLIO_STATE)
   try {
@@ -83,17 +91,29 @@ export async function runStrategyCron(env: Env): Promise<StrategyCronResult> {
     if (portfolio.tradingDisabledUntil) {
       const disabledUntilMs = new Date(portfolio.tradingDisabledUntil).getTime()
       if (!Number.isFinite(disabledUntilMs) || disabledUntilMs > now) {
-        return { summary: emptySummary, symbols: usSymbols, skipReason: 'portfolio_halted' }
+        return {
+          summary: emptySummary(),
+          symbols: universe.allowedSymbols,
+          skipReason: 'portfolio_halted',
+        }
       }
     }
     if (portfolio.dailyStartEquity > 0) {
       const ratio = portfolio.dailyRealizedPnl / portfolio.dailyStartEquity
       if (ratio <= global.drawdownKillThreshold) {
-        return { summary: emptySummary, symbols: usSymbols, skipReason: 'drawdown_kill' }
+        return {
+          summary: emptySummary(),
+          symbols: universe.allowedSymbols,
+          skipReason: 'drawdown_kill',
+        }
       }
     }
   } catch {
-    return { summary: emptySummary, symbols: usSymbols, skipReason: 'portfolio_halted' }
+    return {
+      summary: emptySummary(),
+      symbols: universe.allowedSymbols,
+      skipReason: 'portfolio_halted',
+    }
   }
 
   const positionStore = new SymbolStateClient(env.SYMBOL_STATE)
@@ -104,10 +124,6 @@ export async function runStrategyCron(env: Env): Promise<StrategyCronResult> {
   // style) in one endpoint — chosen over Webull's JP-subscription-gated
   // market-data API (see #84). Webull is still the order-execution path.
   const barClient = new YahooBarClient()
-
-  // sizing に流す equity は正の有限値のみ許可 (0 / 負 / NaN / Infinity を弾く)。
-  // D1 から読んだ値が壊れていたら default に落とす。
-  const equity = sanitizeEquity(global.totalCapitalUsd)
 
   // Pullback デフォルト rule は D1 global_config に寄せた (#118)。
   // 実運用中の tuning は `UPDATE global_config SET ...` で即反映可能。
@@ -121,21 +137,55 @@ export async function runStrategyCron(env: Env): Promise<StrategyCronResult> {
     requireAboveSma50: global.pullbackDefaultRequireAboveSma50,
   }
 
-  const summary = await runPullbackScheduler({
-    symbols: usSymbols,
-    equity,
-    barClient,
-    positionStore,
-    execution,
-    symbolCapMap: universe.symbolMaxNotional,
-    defaultRule,
-  })
+  const byCurrency: Record<SymbolCurrency, string[]> = { USD: [], JPY: [] }
+  for (const sym of universe.allowedSymbols) {
+    const cur = universe.symbolCurrency[sym] ?? 'USD'
+    byCurrency[cur].push(sym)
+  }
 
-  return { summary, symbols: usSymbols }
+  const summary = emptySummary()
+  const runs: Array<{ currency: SymbolCurrency; equity: number; lotSize: number; symbols: string[] }> = []
+  if (byCurrency.USD.length > 0) {
+    runs.push({
+      currency: 'USD',
+      equity: sanitizeEquity(global.totalCapitalUsd, DEFAULT_EQUITY_USD),
+      lotSize: 1,
+      symbols: byCurrency.USD,
+    })
+  }
+  if (byCurrency.JPY.length > 0) {
+    runs.push({
+      currency: 'JPY',
+      equity: sanitizeEquity(global.totalCapitalJpy, DEFAULT_EQUITY_JPY),
+      lotSize: JP_LOT_SIZE,
+      symbols: byCurrency.JPY,
+    })
+  }
+
+  for (const run of runs) {
+    const sub = await runPullbackScheduler({
+      symbols: run.symbols,
+      equity: run.equity,
+      lotSize: run.lotSize,
+      barClient,
+      positionStore,
+      execution,
+      symbolCapMap: universe.symbolMaxNotional,
+      defaultRule,
+    })
+    summary.evaluated += sub.evaluated
+    summary.buys += sub.buys
+    summary.sells += sub.sells
+    summary.holds += sub.holds
+    summary.rejected.push(...sub.rejected)
+    summary.errors.push(...sub.errors)
+  }
+
+  return { summary, symbols: universe.allowedSymbols }
 }
 
-function sanitizeEquity(value: number | null | undefined): number {
-  if (value === null || value === undefined) return DEFAULT_EQUITY_USD
-  if (!Number.isFinite(value) || value <= 0) return DEFAULT_EQUITY_USD
+function sanitizeEquity(value: number | null | undefined, fallback: number): number {
+  if (value === null || value === undefined) return fallback
+  if (!Number.isFinite(value) || value <= 0) return fallback
   return value
 }

--- a/test/strategy/pullbackSizing.test.ts
+++ b/test/strategy/pullbackSizing.test.ts
@@ -71,4 +71,48 @@ describe('computePullbackSizing', () => {
       computePullbackSizing({ equity: 100_000, entryPrice: 100, stopPct: 0, atr20: 2, baselineAtr20: 2 }),
     ).toMatchObject({ quantity: 0, capReason: 'invalid-stop' })
   })
+
+  it('rounds down to lotSize multiples (TSE 100-share lot)', () => {
+    // equity 1.5M JPY, risk 0.4% = 6_000 JPY budget. Entry 1500, stop -4% =
+    // 60 JPY risk/share. Raw qty = floor(6000 / 60) = 100. Already a
+    // 100-lot multiple so no change.
+    const exact = computePullbackSizing({
+      equity: 1_500_000,
+      entryPrice: 1500,
+      stopPct: -0.04,
+      atr20: 10,
+      baselineAtr20: 10,
+      lotSize: 100,
+    })
+    expect(exact.quantity).toBe(100)
+
+    // symbolCap forces qty below a lot boundary: cap 250_000 at 1500 →
+    // floor(250000/1500) = 166 → round down to 100.
+    const rounded = computePullbackSizing({
+      equity: 100_000_000,
+      entryPrice: 1500,
+      stopPct: -0.04,
+      atr20: 10,
+      baselineAtr20: 10,
+      symbolCap: 250_000,
+      lotSize: 100,
+    })
+    expect(rounded.quantity).toBe(100)
+    expect(rounded.notional).toBe(150_000)
+    expect(rounded.capped).toBe(true)
+  })
+
+  it('returns qty=0 with lot-size-round when raw qty is below one lot', () => {
+    // Budget too small to afford 100 shares → round down to 0.
+    const result = computePullbackSizing({
+      equity: 100_000,
+      entryPrice: 5000,
+      stopPct: -0.04,
+      atr20: 10,
+      baselineAtr20: 10,
+      lotSize: 100,
+    })
+    expect(result.quantity).toBe(0)
+    expect(result.capReason).toBe('lot-size-round')
+  })
 })

--- a/test/trading/strategy/runStrategyCron.test.ts
+++ b/test/trading/strategy/runStrategyCron.test.ts
@@ -35,15 +35,15 @@ describe('runStrategyCron', () => {
     expect(result.summary.evaluated).toBe(0)
   })
 
-  it('skips with no_us_symbols when universe is JP-only', async () => {
+  it('skips with no_tradable_symbols when universe is empty', async () => {
     vi.mocked(loadSymbolUniverse).mockResolvedValue(
       makeSymbolUniverse({
-        allowedSymbols: ['6301', '4502'],
-        symbolCurrency: { '6301': 'JPY', '4502': 'JPY' },
+        allowedSymbols: [],
+        symbolCurrency: {},
       }),
     )
     const result = await runStrategyCron(env)
-    expect(result.skipReason).toBe('no_us_symbols')
+    expect(result.skipReason).toBe('no_tradable_symbols')
   })
 
   it('skips with no_bridge_state when SYMBOL_STATE binding is missing', async () => {


### PR DESCRIPTION
## Summary

#119 の実装。従来は `runStrategyCron` が USD-only filter で JP 銘柄を cron から除外していたが、currency-aware sizing + 100-lot 丸めを入れて JP も同じ cron パスで評価する。

### 主な変更

- `computePullbackSizing` に `lotSize?: number` (default 1) を追加。全 cap 後に `floor(qty/lotSize)*lotSize` で丸め、1 lot 未満は `quantity=0, capReason='lot-size-round'` で reject (pullbackScheduler 側が `rejected` に記録)。
- `PullbackSchedulerOptions.lotSize` を追加。scheduler は単一 lot-size 前提 (mixed market は cron 側で currency 毎に呼び分け)。
- `runStrategyCron`:
  - `allowedSymbols` を `symbolCurrency` で USD/JPY に仕分け。
  - USD: `totalCapitalUsd ?? 10_000`, lotSize=1
  - JPY: `totalCapitalJpy ?? 1_500_000`, lotSize=100
  - currency 毎に scheduler を呼び、summary を合算。
  - `skipReason` 一覧: `no_us_symbols` → `no_tradable_symbols` に汎化 (universe 全体空のみ skip)。
- bar client: `YahooBarClient` が既に `.T` suffix を自動付与しているので追加変更なし。

### 非対象 (#119 follow-up 扱い)

- JP market hours gate (既存 `halt` / `JP band` 側の話)
- JP settled_cash gate / PDT 等の per-symbol risk gate の cron 統合
- 税区分 / NISA routing

## Test plan

- [x] `pnpm test` — 294 passed (lot-round 2 ケース追加)
- [x] `pnpm typecheck` — clean
- [ ] staging で JP 銘柄 (7267 / 6752 / 285A) を active=1 にして次 cron で sizing が 100 株丸めになるか観察
- [ ] JP BUY が Webull JP UAT に到達し FILLED になるか確認

## 関連

- Closes #119
- 前提: #118 (Pullback default rule を D1 化) — merged
- 参照: #89 (JP sandbox tenant blocker — infra 側)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 取引戦略で取引単位（ロット）を指定可能にし、ロット単位で数量を切り下げる処理を導入しました（切り下げにより数量が0になる場合あり）。
  * 複数通貨（例：USD、JPY）ごとに戦略を実行し、通貨別の資本とロットを扱えるようになりました。
  * シンボル選定のスキップ理由を「取引可能なシンボルがない」へ汎用化しました。

* **Tests**
  * ロット丸め挙動と数量切り下げのテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->