### PR TITLE
feat(dashboard): render timestamps in JST

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -96,6 +96,31 @@ function fmtNumber(n: number | null | undefined, digits = 2): string {
   return n.toFixed(digits)
 }
 
+const JST_FORMATTER = new Intl.DateTimeFormat('en-CA', {
+  timeZone: 'Asia/Tokyo',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  hour12: false,
+})
+
+/**
+ * Render an ISO/Date value in JST (YYYY-MM-DD HH:mm:ss JST). Returns the
+ * raw string unchanged on parse failure so operators can still grep for the
+ * original even if upstream emits a weird format.
+ */
+function fmtJst(value: string | Date | null | undefined): string {
+  if (value === null || value === undefined) return '-'
+  const d = value instanceof Date ? value : new Date(value)
+  if (!Number.isFinite(d.getTime())) return typeof value === 'string' ? value : '-'
+  const parts = JST_FORMATTER.formatToParts(d)
+  const pick = (type: string) => parts.find((p) => p.type === type)?.value ?? ''
+  return `${pick('year')}-${pick('month')}-${pick('day')} ${pick('hour')}:${pick('minute')}:${pick('second')} JST`
+}
+
 const STYLE = `
   body{font-family:-apple-system,system-ui,sans-serif;margin:0;padding:20px;background:#f5f5f7;color:#1d1d1f}
   h1{margin:0 0 16px;font-size:22px}
@@ -134,7 +159,7 @@ function layout(title: string, body: string): string {
   <a href="/dashboard/config">Config</a>
 </nav>
 ${body}
-<div class="footer">rendered at ${esc(new Date().toISOString())}</div>
+<div class="footer">rendered at ${esc(fmtJst(new Date()))}</div>
 </body>
 </html>`
 }
@@ -178,8 +203,8 @@ function positionsBody(
         <td>${quote ? fmtNumber(quote.price, 2) : '<span class="muted">-</span>'}</td>
         <td class="${pnlClass}">${pnlPct === null ? '-' : fmtNumber(pnlPct, 2) + '%'}</td>
         <td>${pendingSide ? esc(pendingSide) : '<span class="muted">-</span>'}</td>
-        <td>${s.cooldownUntil ? esc(s.cooldownUntil) : '<span class="muted">-</span>'}</td>
-        <td class="muted">${esc(s.updatedAt)}</td>
+        <td>${s.cooldownUntil ? esc(fmtJst(s.cooldownUntil)) : '<span class="muted">-</span>'}</td>
+        <td class="muted">${esc(fmtJst(s.updatedAt))}</td>
       </tr>`
     })
     .join('')
@@ -207,8 +232,8 @@ function portfolioBody(p: {
       <tr><th>dailyStartEquity</th><td>${fmtNumber(p.dailyStartEquity, 2)}</td></tr>
       <tr><th>dailyRealizedPnl</th><td class="${ddClass}">${fmtNumber(p.dailyRealizedPnl, 2)}</td></tr>
       <tr><th>drawdown</th><td class="${ddClass}">${drawdownPct === null ? '-' : fmtNumber(drawdownPct, 2) + '%'}</td></tr>
-      <tr><th>tradingDisabledUntil</th><td>${kill ? `<span class="warn">${esc(kill)}</span>` : '<span class="ok">active</span>'}</td></tr>
-      <tr><th>updatedAt</th><td class="muted">${esc(p.updatedAt)}</td></tr>
+      <tr><th>tradingDisabledUntil</th><td>${kill ? `<span class="warn">${esc(fmtJst(kill))}</span>` : '<span class="ok">active</span>'}</td></tr>
+      <tr><th>updatedAt</th><td class="muted">${esc(fmtJst(p.updatedAt))}</td></tr>
     </tbody>
   </table>`
 }
@@ -247,7 +272,7 @@ function tradesBody(
         r.errorMessage ? `ERR: ${r.errorMessage}` : r.brokerStatus ?? r.tradeEventType
       return `<tr>
         <td>${r.id}</td>
-        <td class="muted">${esc(r.timestamp)}</td>
+        <td class="muted">${esc(fmtJst(r.timestamp))}</td>
         <td>${esc(r.tradeEventType)}</td>
         <td><strong>${esc(r.symbol ?? '-')}</strong></td>
         <td>${esc(r.side ?? '-')}</td>

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -119,6 +119,8 @@ describe('dashboard', () => {
     const body = await res.text()
     expect(body).toContain('dailyStartEquity')
     expect(body).toContain('-1.50%')
+    // 2026-04-23T00:00:00Z → 2026-04-23 09:00:00 JST
+    expect(body).toContain('2026-04-23 09:00:00 JST')
   })
 
   it('renders config page with global_config + symbol table', async () => {


### PR DESCRIPTION
## Summary

Dashboard 全ページの timestamp を JST 表記 (\`YYYY-MM-DD HH:mm:ss JST\`) に変更。#122 の follow-up。

### 変更

- 共通 \`fmtJst\` を追加 (Intl.DateTimeFormat + Asia/Tokyo)
- parse 失敗時は原文字列をそのまま返し grep 可能性を維持
- 適用箇所:
  - footer (rendered at)
  - positions: updatedAt / cooldownUntil
  - portfolio: updatedAt / tradingDisabledUntil
  - trades: timestamp

## Test plan

- [x] \`pnpm test\` — 301 passed (portfolio の JST アサーション追加)
- [x] \`pnpm typecheck\` — clean
- [ ] staging deploy 後ブラウザで JST 表示確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ダッシュボードの日付・時刻表示をJST形式（YYYY-MM-DD HH:mm:ss JST）に統一しました。

* **テスト**
  * JST形式の日付・時刻表示の動作確認テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->