### PR TITLE
feat(sizing): ATR-based adaptive stop distance (Lane 1 of #23)

### DIFF
--- a/drizzle/0006_add_pullback_default_k_atr.sql
+++ b/drizzle/0006_add_pullback_default_k_atr.sql
@@ -22,7 +22,7 @@ CREATE TABLE `__new_global_config` (
 	`pullback_default_pullback_min` real DEFAULT -0.06 NOT NULL,
 	`pullback_default_min_return_50d` real DEFAULT 0.08 NOT NULL,
 	`pullback_default_require_above_sma50` integer DEFAULT true NOT NULL,
-	`pullback_default_k_atr` real,
+	`pullback_default_k_atr` real DEFAULT 2.0 NOT NULL,
 	`updated_at` text NOT NULL,
 	CONSTRAINT "global_config_max_order_notional_range" CHECK("__new_global_config"."max_order_notional" > 0 AND "__new_global_config"."max_order_notional" <= 10000000),
 	CONSTRAINT "global_config_max_order_notional_usd_range" CHECK("__new_global_config"."max_order_notional_usd" > 0 AND "__new_global_config"."max_order_notional_usd" <= 1000000),
@@ -41,12 +41,12 @@ CREATE TABLE `__new_global_config` (
 	CONSTRAINT "global_config_pullback_default_pullback_max_range" CHECK("__new_global_config"."pullback_default_pullback_max" <= 0 AND "__new_global_config"."pullback_default_pullback_max" >= -1),
 	CONSTRAINT "global_config_pullback_default_pullback_min_range" CHECK("__new_global_config"."pullback_default_pullback_min" <= 0 AND "__new_global_config"."pullback_default_pullback_min" >= -1),
 	CONSTRAINT "global_config_pullback_default_min_return_50d_range" CHECK("__new_global_config"."pullback_default_min_return_50d" >= -1 AND "__new_global_config"."pullback_default_min_return_50d" <= 10),
-	CONSTRAINT "global_config_pullback_default_k_atr_range" CHECK("__new_global_config"."pullback_default_k_atr" IS NULL OR ("__new_global_config"."pullback_default_k_atr" > 0 AND "__new_global_config"."pullback_default_k_atr" <= 10)),
+	CONSTRAINT "global_config_pullback_default_k_atr_range" CHECK("__new_global_config"."pullback_default_k_atr" > 0 AND "__new_global_config"."pullback_default_k_atr" <= 10),
 	CONSTRAINT "global_config_pullback_default_pullback_window_order" CHECK("__new_global_config"."pullback_default_pullback_min" <= "__new_global_config"."pullback_default_pullback_max")
 );
 --> statement-breakpoint
 -- Existing global_config にはまだ pullback_default_k_atr が無いので
--- SELECT から除外、DEFAULT (NULL) に任せる。
+-- SELECT から除外、DEFAULT (2.0) に任せる。
 INSERT INTO `__new_global_config`("id", "dry_run", "trading_enabled", "market_hours_check", "max_order_notional", "max_order_notional_usd", "max_order_notional_jpy", "total_capital_usd", "total_capital_jpy", "max_portfolio_exposure_pct", "drawdown_kill_threshold", "stale_quote_ms", "gap_reject_pct", "spread_limit_pct_us", "spread_limit_pct_jp", "pullback_default_stop_pct", "pullback_default_take_profit_pct", "pullback_default_time_stop_days", "pullback_default_pullback_max", "pullback_default_pullback_min", "pullback_default_min_return_50d", "pullback_default_require_above_sma50", "updated_at") SELECT "id", "dry_run", "trading_enabled", "market_hours_check", "max_order_notional", "max_order_notional_usd", "max_order_notional_jpy", "total_capital_usd", "total_capital_jpy", "max_portfolio_exposure_pct", "drawdown_kill_threshold", "stale_quote_ms", "gap_reject_pct", "spread_limit_pct_us", "spread_limit_pct_jp", "pullback_default_stop_pct", "pullback_default_take_profit_pct", "pullback_default_time_stop_days", "pullback_default_pullback_max", "pullback_default_pullback_min", "pullback_default_min_return_50d", "pullback_default_require_above_sma50", "updated_at" FROM `global_config`;--> statement-breakpoint
 DROP TABLE `global_config`;--> statement-breakpoint
 ALTER TABLE `__new_global_config` RENAME TO `global_config`;--> statement-breakpoint

--- a/drizzle/0006_add_pullback_default_k_atr.sql
+++ b/drizzle/0006_add_pullback_default_k_atr.sql
@@ -1,0 +1,53 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_global_config` (
+	`id` text PRIMARY KEY NOT NULL,
+	`dry_run` integer DEFAULT true NOT NULL,
+	`trading_enabled` integer DEFAULT false NOT NULL,
+	`market_hours_check` integer DEFAULT false NOT NULL,
+	`max_order_notional` real DEFAULT 100 NOT NULL,
+	`max_order_notional_usd` real DEFAULT 2000 NOT NULL,
+	`max_order_notional_jpy` real DEFAULT 100000 NOT NULL,
+	`total_capital_usd` real,
+	`total_capital_jpy` real,
+	`max_portfolio_exposure_pct` real DEFAULT 0.6 NOT NULL,
+	`drawdown_kill_threshold` real DEFAULT -0.02 NOT NULL,
+	`stale_quote_ms` integer DEFAULT 900000 NOT NULL,
+	`gap_reject_pct` real DEFAULT 0.03 NOT NULL,
+	`spread_limit_pct_us` real DEFAULT 0.0025 NOT NULL,
+	`spread_limit_pct_jp` real DEFAULT 0.006 NOT NULL,
+	`pullback_default_stop_pct` real DEFAULT -0.04 NOT NULL,
+	`pullback_default_take_profit_pct` real DEFAULT 0.07 NOT NULL,
+	`pullback_default_time_stop_days` integer DEFAULT 10 NOT NULL,
+	`pullback_default_pullback_max` real DEFAULT -0.03 NOT NULL,
+	`pullback_default_pullback_min` real DEFAULT -0.06 NOT NULL,
+	`pullback_default_min_return_50d` real DEFAULT 0.08 NOT NULL,
+	`pullback_default_require_above_sma50` integer DEFAULT true NOT NULL,
+	`pullback_default_k_atr` real,
+	`updated_at` text NOT NULL,
+	CONSTRAINT "global_config_max_order_notional_range" CHECK("__new_global_config"."max_order_notional" > 0 AND "__new_global_config"."max_order_notional" <= 10000000),
+	CONSTRAINT "global_config_max_order_notional_usd_range" CHECK("__new_global_config"."max_order_notional_usd" > 0 AND "__new_global_config"."max_order_notional_usd" <= 1000000),
+	CONSTRAINT "global_config_max_order_notional_jpy_range" CHECK("__new_global_config"."max_order_notional_jpy" > 0 AND "__new_global_config"."max_order_notional_jpy" <= 100000000),
+	CONSTRAINT "global_config_total_capital_usd_range" CHECK("__new_global_config"."total_capital_usd" IS NULL OR "__new_global_config"."total_capital_usd" > 0),
+	CONSTRAINT "global_config_total_capital_jpy_range" CHECK("__new_global_config"."total_capital_jpy" IS NULL OR "__new_global_config"."total_capital_jpy" > 0),
+	CONSTRAINT "global_config_max_portfolio_exposure_pct_range" CHECK("__new_global_config"."max_portfolio_exposure_pct" > 0 AND "__new_global_config"."max_portfolio_exposure_pct" <= 1),
+	CONSTRAINT "global_config_drawdown_kill_threshold_range" CHECK("__new_global_config"."drawdown_kill_threshold" >= -1 AND "__new_global_config"."drawdown_kill_threshold" <= 0),
+	CONSTRAINT "global_config_stale_quote_ms_range" CHECK("__new_global_config"."stale_quote_ms" >= 0),
+	CONSTRAINT "global_config_gap_reject_pct_range" CHECK("__new_global_config"."gap_reject_pct" >= 0 AND "__new_global_config"."gap_reject_pct" <= 1),
+	CONSTRAINT "global_config_spread_limit_pct_us_range" CHECK("__new_global_config"."spread_limit_pct_us" >= 0 AND "__new_global_config"."spread_limit_pct_us" <= 1),
+	CONSTRAINT "global_config_spread_limit_pct_jp_range" CHECK("__new_global_config"."spread_limit_pct_jp" >= 0 AND "__new_global_config"."spread_limit_pct_jp" <= 1),
+	CONSTRAINT "global_config_pullback_default_stop_pct_range" CHECK("__new_global_config"."pullback_default_stop_pct" < 0 AND "__new_global_config"."pullback_default_stop_pct" >= -1),
+	CONSTRAINT "global_config_pullback_default_take_profit_pct_range" CHECK("__new_global_config"."pullback_default_take_profit_pct" > 0 AND "__new_global_config"."pullback_default_take_profit_pct" <= 1),
+	CONSTRAINT "global_config_pullback_default_time_stop_days_range" CHECK("__new_global_config"."pullback_default_time_stop_days" > 0 AND "__new_global_config"."pullback_default_time_stop_days" <= 365),
+	CONSTRAINT "global_config_pullback_default_pullback_max_range" CHECK("__new_global_config"."pullback_default_pullback_max" <= 0 AND "__new_global_config"."pullback_default_pullback_max" >= -1),
+	CONSTRAINT "global_config_pullback_default_pullback_min_range" CHECK("__new_global_config"."pullback_default_pullback_min" <= 0 AND "__new_global_config"."pullback_default_pullback_min" >= -1),
+	CONSTRAINT "global_config_pullback_default_min_return_50d_range" CHECK("__new_global_config"."pullback_default_min_return_50d" >= -1 AND "__new_global_config"."pullback_default_min_return_50d" <= 10),
+	CONSTRAINT "global_config_pullback_default_k_atr_range" CHECK("__new_global_config"."pullback_default_k_atr" IS NULL OR ("__new_global_config"."pullback_default_k_atr" > 0 AND "__new_global_config"."pullback_default_k_atr" <= 10)),
+	CONSTRAINT "global_config_pullback_default_pullback_window_order" CHECK("__new_global_config"."pullback_default_pullback_min" <= "__new_global_config"."pullback_default_pullback_max")
+);
+--> statement-breakpoint
+-- Existing global_config にはまだ pullback_default_k_atr が無いので
+-- SELECT から除外、DEFAULT (NULL) に任せる。
+INSERT INTO `__new_global_config`("id", "dry_run", "trading_enabled", "market_hours_check", "max_order_notional", "max_order_notional_usd", "max_order_notional_jpy", "total_capital_usd", "total_capital_jpy", "max_portfolio_exposure_pct", "drawdown_kill_threshold", "stale_quote_ms", "gap_reject_pct", "spread_limit_pct_us", "spread_limit_pct_jp", "pullback_default_stop_pct", "pullback_default_take_profit_pct", "pullback_default_time_stop_days", "pullback_default_pullback_max", "pullback_default_pullback_min", "pullback_default_min_return_50d", "pullback_default_require_above_sma50", "updated_at") SELECT "id", "dry_run", "trading_enabled", "market_hours_check", "max_order_notional", "max_order_notional_usd", "max_order_notional_jpy", "total_capital_usd", "total_capital_jpy", "max_portfolio_exposure_pct", "drawdown_kill_threshold", "stale_quote_ms", "gap_reject_pct", "spread_limit_pct_us", "spread_limit_pct_jp", "pullback_default_stop_pct", "pullback_default_take_profit_pct", "pullback_default_time_stop_days", "pullback_default_pullback_max", "pullback_default_pullback_min", "pullback_default_min_return_50d", "pullback_default_require_above_sma50", "updated_at" FROM `global_config`;--> statement-breakpoint
+DROP TABLE `global_config`;--> statement-breakpoint
+ALTER TABLE `__new_global_config` RENAME TO `global_config`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,595 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "873cb7aa-a7c8-4d84-98a7-0d349531fb04",
+  "prevId": "8e552429-a62e-4c9c-b6e4-587be747634f",
+  "tables": {
+    "global_config": {
+      "name": "global_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "trading_enabled": {
+          "name": "trading_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "market_hours_check": {
+          "name": "market_hours_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "max_order_notional": {
+          "name": "max_order_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "max_order_notional_usd": {
+          "name": "max_order_notional_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2000
+        },
+        "max_order_notional_jpy": {
+          "name": "max_order_notional_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100000
+        },
+        "total_capital_usd": {
+          "name": "total_capital_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_capital_jpy": {
+          "name": "total_capital_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_portfolio_exposure_pct": {
+          "name": "max_portfolio_exposure_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.6
+        },
+        "drawdown_kill_threshold": {
+          "name": "drawdown_kill_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.02
+        },
+        "stale_quote_ms": {
+          "name": "stale_quote_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 900000
+        },
+        "gap_reject_pct": {
+          "name": "gap_reject_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.03
+        },
+        "spread_limit_pct_us": {
+          "name": "spread_limit_pct_us",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.0025
+        },
+        "spread_limit_pct_jp": {
+          "name": "spread_limit_pct_jp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.006
+        },
+        "pullback_default_stop_pct": {
+          "name": "pullback_default_stop_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.04
+        },
+        "pullback_default_take_profit_pct": {
+          "name": "pullback_default_take_profit_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.07
+        },
+        "pullback_default_time_stop_days": {
+          "name": "pullback_default_time_stop_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "pullback_default_pullback_max": {
+          "name": "pullback_default_pullback_max",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.03
+        },
+        "pullback_default_pullback_min": {
+          "name": "pullback_default_pullback_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.06
+        },
+        "pullback_default_min_return_50d": {
+          "name": "pullback_default_min_return_50d",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.08
+        },
+        "pullback_default_require_above_sma50": {
+          "name": "pullback_default_require_above_sma50",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "pullback_default_k_atr": {
+          "name": "pullback_default_k_atr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "global_config_max_order_notional_range": {
+          "name": "global_config_max_order_notional_range",
+          "value": "\"global_config\".\"max_order_notional\" > 0 AND \"global_config\".\"max_order_notional\" <= 10000000"
+        },
+        "global_config_max_order_notional_usd_range": {
+          "name": "global_config_max_order_notional_usd_range",
+          "value": "\"global_config\".\"max_order_notional_usd\" > 0 AND \"global_config\".\"max_order_notional_usd\" <= 1000000"
+        },
+        "global_config_max_order_notional_jpy_range": {
+          "name": "global_config_max_order_notional_jpy_range",
+          "value": "\"global_config\".\"max_order_notional_jpy\" > 0 AND \"global_config\".\"max_order_notional_jpy\" <= 100000000"
+        },
+        "global_config_total_capital_usd_range": {
+          "name": "global_config_total_capital_usd_range",
+          "value": "\"global_config\".\"total_capital_usd\" IS NULL OR \"global_config\".\"total_capital_usd\" > 0"
+        },
+        "global_config_total_capital_jpy_range": {
+          "name": "global_config_total_capital_jpy_range",
+          "value": "\"global_config\".\"total_capital_jpy\" IS NULL OR \"global_config\".\"total_capital_jpy\" > 0"
+        },
+        "global_config_max_portfolio_exposure_pct_range": {
+          "name": "global_config_max_portfolio_exposure_pct_range",
+          "value": "\"global_config\".\"max_portfolio_exposure_pct\" > 0 AND \"global_config\".\"max_portfolio_exposure_pct\" <= 1"
+        },
+        "global_config_drawdown_kill_threshold_range": {
+          "name": "global_config_drawdown_kill_threshold_range",
+          "value": "\"global_config\".\"drawdown_kill_threshold\" >= -1 AND \"global_config\".\"drawdown_kill_threshold\" <= 0"
+        },
+        "global_config_stale_quote_ms_range": {
+          "name": "global_config_stale_quote_ms_range",
+          "value": "\"global_config\".\"stale_quote_ms\" >= 0"
+        },
+        "global_config_gap_reject_pct_range": {
+          "name": "global_config_gap_reject_pct_range",
+          "value": "\"global_config\".\"gap_reject_pct\" >= 0 AND \"global_config\".\"gap_reject_pct\" <= 1"
+        },
+        "global_config_spread_limit_pct_us_range": {
+          "name": "global_config_spread_limit_pct_us_range",
+          "value": "\"global_config\".\"spread_limit_pct_us\" >= 0 AND \"global_config\".\"spread_limit_pct_us\" <= 1"
+        },
+        "global_config_spread_limit_pct_jp_range": {
+          "name": "global_config_spread_limit_pct_jp_range",
+          "value": "\"global_config\".\"spread_limit_pct_jp\" >= 0 AND \"global_config\".\"spread_limit_pct_jp\" <= 1"
+        },
+        "global_config_pullback_default_stop_pct_range": {
+          "name": "global_config_pullback_default_stop_pct_range",
+          "value": "\"global_config\".\"pullback_default_stop_pct\" < 0 AND \"global_config\".\"pullback_default_stop_pct\" >= -1"
+        },
+        "global_config_pullback_default_take_profit_pct_range": {
+          "name": "global_config_pullback_default_take_profit_pct_range",
+          "value": "\"global_config\".\"pullback_default_take_profit_pct\" > 0 AND \"global_config\".\"pullback_default_take_profit_pct\" <= 1"
+        },
+        "global_config_pullback_default_time_stop_days_range": {
+          "name": "global_config_pullback_default_time_stop_days_range",
+          "value": "\"global_config\".\"pullback_default_time_stop_days\" > 0 AND \"global_config\".\"pullback_default_time_stop_days\" <= 365"
+        },
+        "global_config_pullback_default_pullback_max_range": {
+          "name": "global_config_pullback_default_pullback_max_range",
+          "value": "\"global_config\".\"pullback_default_pullback_max\" <= 0 AND \"global_config\".\"pullback_default_pullback_max\" >= -1"
+        },
+        "global_config_pullback_default_pullback_min_range": {
+          "name": "global_config_pullback_default_pullback_min_range",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= 0 AND \"global_config\".\"pullback_default_pullback_min\" >= -1"
+        },
+        "global_config_pullback_default_min_return_50d_range": {
+          "name": "global_config_pullback_default_min_return_50d_range",
+          "value": "\"global_config\".\"pullback_default_min_return_50d\" >= -1 AND \"global_config\".\"pullback_default_min_return_50d\" <= 10"
+        },
+        "global_config_pullback_default_k_atr_range": {
+          "name": "global_config_pullback_default_k_atr_range",
+          "value": "\"global_config\".\"pullback_default_k_atr\" IS NULL OR (\"global_config\".\"pullback_default_k_atr\" > 0 AND \"global_config\".\"pullback_default_k_atr\" <= 10)"
+        },
+        "global_config_pullback_default_pullback_window_order": {
+          "name": "global_config_pullback_default_pullback_window_order",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= \"global_config\".\"pullback_default_pullback_max\""
+        }
+      }
+    },
+    "inverse_pairs": {
+      "name": "inverse_pairs",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inverse": {
+          "name": "inverse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "symbol_config": {
+      "name": "symbol_config",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "market": {
+          "name": "market",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_notional": {
+          "name": "max_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "symbol_config_currency_enum": {
+          "name": "symbol_config_currency_enum",
+          "value": "\"symbol_config\".\"currency\" IN ('USD', 'JPY')"
+        }
+      }
+    },
+    "trade_journal": {
+      "name": "trade_journal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trade_event_type": {
+          "name": "trade_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "strategy_name": {
+          "name": "strategy_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_action": {
+          "name": "signal_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_reason": {
+          "name": "signal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_allowed": {
+          "name": "risk_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_reasons": {
+          "name": "risk_reasons",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "limit_price": {
+          "name": "limit_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notional": {
+          "name": "notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "broker_status": {
+          "name": "broker_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "submitted": {
+          "name": "submitted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_qty": {
+          "name": "filled_qty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_price": {
+          "name": "filled_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "realized_pnl": {
+          "name": "realized_pnl",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hold_days": {
+          "name": "hold_days",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_reason": {
+          "name": "exit_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -184,8 +184,9 @@
           "name": "pullback_default_k_atr",
           "type": "real",
           "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
         },
         "updated_at": {
           "name": "updated_at",
@@ -270,7 +271,7 @@
         },
         "global_config_pullback_default_k_atr_range": {
           "name": "global_config_pullback_default_k_atr_range",
-          "value": "\"global_config\".\"pullback_default_k_atr\" IS NULL OR (\"global_config\".\"pullback_default_k_atr\" > 0 AND \"global_config\".\"pullback_default_k_atr\" <= 10)"
+          "value": "\"global_config\".\"pullback_default_k_atr\" > 0 AND \"global_config\".\"pullback_default_k_atr\" <= 10"
         },
         "global_config_pullback_default_pullback_window_order": {
           "name": "global_config_pullback_default_pullback_window_order",

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1776868121048,
       "tag": "0005_add_pullback_default_rule",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1776950604312,
+      "tag": "0006_add_pullback_default_k_atr",
+      "breakpoints": true
     }
   ]
 }

--- a/src/infrastructure/db/globalConfigRepo.ts
+++ b/src/infrastructure/db/globalConfigRepo.ts
@@ -30,8 +30,8 @@ export interface GlobalConfigSnapshot {
   pullbackDefaultPullbackMin: number
   pullbackDefaultMinReturn50d: number
   pullbackDefaultRequireAboveSma50: boolean
-  /** ATR multiplier for vol-adaptive stop。null = disabled (legacy pct-only)。 */
-  pullbackDefaultKAtr: number | null
+  /** ATR multiplier for vol-adaptive stop。default 2.0。 */
+  pullbackDefaultKAtr: number
 }
 
 /**
@@ -61,7 +61,7 @@ export const GLOBAL_CONFIG_DEFAULTS: GlobalConfigSnapshot = Object.freeze({
   pullbackDefaultPullbackMin: -0.06,
   pullbackDefaultMinReturn50d: 0.08,
   pullbackDefaultRequireAboveSma50: true,
-  pullbackDefaultKAtr: null,
+  pullbackDefaultKAtr: 2.0,
 })
 
 export async function loadGlobalConfig(

--- a/src/infrastructure/db/globalConfigRepo.ts
+++ b/src/infrastructure/db/globalConfigRepo.ts
@@ -30,6 +30,8 @@ export interface GlobalConfigSnapshot {
   pullbackDefaultPullbackMin: number
   pullbackDefaultMinReturn50d: number
   pullbackDefaultRequireAboveSma50: boolean
+  /** ATR multiplier for vol-adaptive stop。null = disabled (legacy pct-only)。 */
+  pullbackDefaultKAtr: number | null
 }
 
 /**
@@ -59,6 +61,7 @@ export const GLOBAL_CONFIG_DEFAULTS: GlobalConfigSnapshot = Object.freeze({
   pullbackDefaultPullbackMin: -0.06,
   pullbackDefaultMinReturn50d: 0.08,
   pullbackDefaultRequireAboveSma50: true,
+  pullbackDefaultKAtr: null,
 })
 
 export async function loadGlobalConfig(
@@ -89,5 +92,6 @@ export async function loadGlobalConfig(
     pullbackDefaultPullbackMin: row.pullbackDefaultPullbackMin,
     pullbackDefaultMinReturn50d: row.pullbackDefaultMinReturn50d,
     pullbackDefaultRequireAboveSma50: row.pullbackDefaultRequireAboveSma50,
+    pullbackDefaultKAtr: row.pullbackDefaultKAtr,
   }
 }

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -142,6 +142,13 @@ export const globalConfig = sqliteTable(
     pullbackDefaultPullbackMin: real('pullback_default_pullback_min').notNull().default(-0.06),
     pullbackDefaultMinReturn50d: real('pullback_default_min_return_50d').notNull().default(0.08),
     pullbackDefaultRequireAboveSma50: integer('pullback_default_require_above_sma50', { mode: 'boolean' }).notNull().default(true),
+    /**
+     * Optional ATR multiplier for vol-adaptive stop sizing. NULL = disabled
+     * (legacy pct-only stop)。set 時は
+     *   stopDistance = max(k_atr * atr20, |entry * stop_pct|)
+     * POC 推奨域 1.5–2.5。
+     */
+    pullbackDefaultKAtr: real('pullback_default_k_atr'),
     updatedAt: text('updated_at').notNull(),
   },
   (t) => ({
@@ -214,6 +221,10 @@ export const globalConfig = sqliteTable(
     pullbackDefaultMinReturn50dRange: check(
       'global_config_pullback_default_min_return_50d_range',
       sql`${t.pullbackDefaultMinReturn50d} >= -1 AND ${t.pullbackDefaultMinReturn50d} <= 10`,
+    ),
+    pullbackDefaultKAtrRange: check(
+      'global_config_pullback_default_k_atr_range',
+      sql`${t.pullbackDefaultKAtr} IS NULL OR (${t.pullbackDefaultKAtr} > 0 AND ${t.pullbackDefaultKAtr} <= 10)`,
     ),
     // 相対関係を DB で縛る: min > max だと BUY 条件を満たす pullback 幅が
     // 空集合になり戦略が静かに停止する。runtime UPDATE の typo 防止。

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -143,12 +143,11 @@ export const globalConfig = sqliteTable(
     pullbackDefaultMinReturn50d: real('pullback_default_min_return_50d').notNull().default(0.08),
     pullbackDefaultRequireAboveSma50: integer('pullback_default_require_above_sma50', { mode: 'boolean' }).notNull().default(true),
     /**
-     * Optional ATR multiplier for vol-adaptive stop sizing. NULL = disabled
-     * (legacy pct-only stop)。set 時は
+     * ATR multiplier for vol-adaptive stop sizing。
      *   stopDistance = max(k_atr * atr20, |entry * stop_pct|)
-     * POC 推奨域 1.5–2.5。
+     * POC 推奨域 1.5–2.5、default 2.0。
      */
-    pullbackDefaultKAtr: real('pullback_default_k_atr'),
+    pullbackDefaultKAtr: real('pullback_default_k_atr').notNull().default(2.0),
     updatedAt: text('updated_at').notNull(),
   },
   (t) => ({
@@ -224,7 +223,7 @@ export const globalConfig = sqliteTable(
     ),
     pullbackDefaultKAtrRange: check(
       'global_config_pullback_default_k_atr_range',
-      sql`${t.pullbackDefaultKAtr} IS NULL OR (${t.pullbackDefaultKAtr} > 0 AND ${t.pullbackDefaultKAtr} <= 10)`,
+      sql`${t.pullbackDefaultKAtr} > 0 AND ${t.pullbackDefaultKAtr} <= 10`,
     ),
     // 相対関係を DB で縛る: min > max だと BUY 条件を満たす pullback 幅が
     // 空集合になり戦略が静かに停止する。runtime UPDATE の typo 防止。

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -135,6 +135,7 @@ export async function runPullbackScheduler(
         symbolCap: options.symbolCapMap?.[upper],
         riskPerTradePct: options.riskPerTradePct,
         lotSize: options.lotSize,
+        kAtr: rule.kAtr,
       })
       if (sizing.quantity <= 0) {
         summary.rejected.push({

--- a/src/trading/strategy/pullbackSizing.ts
+++ b/src/trading/strategy/pullbackSizing.ts
@@ -18,12 +18,12 @@ export interface PullbackSizingInput {
    */
   lotSize?: number
   /**
-   * ATR multiplier for the stop distance. When set, the effective stop is
+   * ATR multiplier for the stop distance. Effective stop becomes
    * `max(kAtr * atr20, |entryPrice * stopPct|)` — vol-adaptive normally,
-   * pct-based as a floor guard for post-halt / post-gap periods where
-   * ATR can collapse. Undefined = disabled (legacy pct-only behaviour).
+   * pct-based as a floor guard when ATR is 0 (post-halt / post-gap).
+   * Required; invalid (<=0 or non-finite) throws.
    */
-  kAtr?: number
+  kAtr: number
 }
 
 export interface PullbackSizingResult {
@@ -48,15 +48,12 @@ export interface PullbackSizingResult {
 export function computePullbackSizing(input: PullbackSizingInput): PullbackSizingResult {
   const riskPct = input.riskPerTradePct ?? 0.004
   const atrFloor = input.atrFloorRatio ?? 0.5
+  if (!Number.isFinite(input.kAtr) || input.kAtr <= 0) {
+    throw new Error(`computePullbackSizing: kAtr must be a positive finite number, got ${input.kAtr}`)
+  }
   const pctStop = Math.abs(input.entryPrice * input.stopPct)
-  // kAtr: vol-adaptive stop. Take max with pct-based so ATR collapse
-  // (halts, gaps) doesn't produce a dangerously tight stop. Undefined =
-  // legacy behaviour.
-  const kAtr = input.kAtr
-  const atrStop =
-    kAtr !== undefined && Number.isFinite(kAtr) && kAtr > 0 && input.atr20 > 0
-      ? kAtr * input.atr20
-      : 0
+  // vol-adaptive: kAtr * atr20。atr20=0 (post-halt/gap) は pct stop が floor。
+  const atrStop = input.atr20 > 0 ? input.kAtr * input.atr20 : 0
   const stopDistance = atrStop > pctStop ? atrStop : pctStop
 
   if (!Number.isFinite(stopDistance) || stopDistance <= 0) {

--- a/src/trading/strategy/pullbackSizing.ts
+++ b/src/trading/strategy/pullbackSizing.ts
@@ -17,6 +17,13 @@ export interface PullbackSizingInput {
    * (e.g. 100 for TSE equities). Default 1 (no rounding).
    */
   lotSize?: number
+  /**
+   * ATR multiplier for the stop distance. When set, the effective stop is
+   * `max(kAtr * atr20, |entryPrice * stopPct|)` — vol-adaptive normally,
+   * pct-based as a floor guard for post-halt / post-gap periods where
+   * ATR can collapse. Undefined = disabled (legacy pct-only behaviour).
+   */
+  kAtr?: number
 }
 
 export interface PullbackSizingResult {
@@ -41,7 +48,16 @@ export interface PullbackSizingResult {
 export function computePullbackSizing(input: PullbackSizingInput): PullbackSizingResult {
   const riskPct = input.riskPerTradePct ?? 0.004
   const atrFloor = input.atrFloorRatio ?? 0.5
-  const stopDistance = Math.abs(input.entryPrice * input.stopPct)
+  const pctStop = Math.abs(input.entryPrice * input.stopPct)
+  // kAtr: vol-adaptive stop. Take max with pct-based so ATR collapse
+  // (halts, gaps) doesn't produce a dangerously tight stop. Undefined =
+  // legacy behaviour.
+  const kAtr = input.kAtr
+  const atrStop =
+    kAtr !== undefined && Number.isFinite(kAtr) && kAtr > 0 && input.atr20 > 0
+      ? kAtr * input.atr20
+      : 0
+  const stopDistance = atrStop > pctStop ? atrStop : pctStop
 
   if (!Number.isFinite(stopDistance) || stopDistance <= 0) {
     return { quantity: 0, notional: 0, capped: true, capReason: 'invalid-stop' }

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -135,8 +135,7 @@ export async function runStrategyCron(env: Env): Promise<StrategyCronResult> {
     pullbackMin: global.pullbackDefaultPullbackMin,
     minReturn50d: global.pullbackDefaultMinReturn50d,
     requireAboveSma50: global.pullbackDefaultRequireAboveSma50,
-    // null → undefined で opt-out (legacy pct-only stop) を表現。
-    kAtr: global.pullbackDefaultKAtr ?? undefined,
+    kAtr: global.pullbackDefaultKAtr,
   }
 
   const byCurrency: Record<SymbolCurrency, string[]> = { USD: [], JPY: [] }

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -135,6 +135,8 @@ export async function runStrategyCron(env: Env): Promise<StrategyCronResult> {
     pullbackMin: global.pullbackDefaultPullbackMin,
     minReturn50d: global.pullbackDefaultMinReturn50d,
     requireAboveSma50: global.pullbackDefaultRequireAboveSma50,
+    // null → undefined で opt-out (legacy pct-only stop) を表現。
+    kAtr: global.pullbackDefaultKAtr ?? undefined,
   }
 
   const byCurrency: Record<SymbolCurrency, string[]> = { USD: [], JPY: [] }

--- a/src/trading/strategy/strategies/PullbackUptrendStrategy.ts
+++ b/src/trading/strategy/strategies/PullbackUptrendStrategy.ts
@@ -32,11 +32,11 @@ export interface SymbolRule {
    */
   requireAboveSma50: boolean
   /**
-   * Optional ATR multiplier for vol-adaptive stop sizing. When set the
-   * sizing stop distance becomes `max(kAtr * atr20, |entry * stopPct|)`.
-   * Undefined (default) = legacy pct-only stop.
+   * ATR multiplier for vol-adaptive stop sizing。
+   *   stopDistance = max(kAtr * atr20, |entry * stopPct|)
+   * POC 推奨域 1.5–2.5。
    */
-  kAtr?: number
+  kAtr: number
 }
 
 /**
@@ -52,6 +52,7 @@ export const TEST_DEFAULT_RULE: SymbolRule = Object.freeze({
   pullbackMin: -0.06,
   minReturn50d: 0.08,
   requireAboveSma50: true,
+  kAtr: 2.0,
 })
 
 export interface PullbackInput {

--- a/src/trading/strategy/strategies/PullbackUptrendStrategy.ts
+++ b/src/trading/strategy/strategies/PullbackUptrendStrategy.ts
@@ -31,6 +31,12 @@ export interface SymbolRule {
    * demo / frequent-cycle mode so entry doesn't depend on trend direction.
    */
   requireAboveSma50: boolean
+  /**
+   * Optional ATR multiplier for vol-adaptive stop sizing. When set the
+   * sizing stop distance becomes `max(kAtr * atr20, |entry * stopPct|)`.
+   * Undefined (default) = legacy pct-only stop.
+   */
+  kAtr?: number
 }
 
 /**

--- a/test/helpers/configFixtures.ts
+++ b/test/helpers/configFixtures.ts
@@ -31,7 +31,7 @@ export function makeGlobalConfigSnapshot(
     pullbackDefaultPullbackMin: -0.06,
     pullbackDefaultMinReturn50d: 0.08,
     pullbackDefaultRequireAboveSma50: true,
-    pullbackDefaultKAtr: null,
+    pullbackDefaultKAtr: 2.0,
     source: 'd1',
     ...overrides,
   }

--- a/test/helpers/configFixtures.ts
+++ b/test/helpers/configFixtures.ts
@@ -31,6 +31,7 @@ export function makeGlobalConfigSnapshot(
     pullbackDefaultPullbackMin: -0.06,
     pullbackDefaultMinReturn50d: 0.08,
     pullbackDefaultRequireAboveSma50: true,
+    pullbackDefaultKAtr: null,
     source: 'd1',
     ...overrides,
   }

--- a/test/strategy/pullbackSizing.test.ts
+++ b/test/strategy/pullbackSizing.test.ts
@@ -1,17 +1,28 @@
 import { describe, expect, it } from 'vitest'
-import { computePullbackSizing } from '../../src/trading/strategy/pullbackSizing'
+import { computePullbackSizing, type PullbackSizingInput } from '../../src/trading/strategy/pullbackSizing'
+
+/**
+ * kAtr is required (#23 Lane 1, no-backward-compat). This helper injects
+ * kAtr=2 by default; individual tests override to exercise ATR-dominant
+ * paths. Chosen so `kAtr * atr20 <= |entry * stopPct|` in the baseline case,
+ * preserving the pct-bound expectations of legacy tests.
+ */
+const baseInput = (
+  overrides: Partial<PullbackSizingInput> = {},
+): PullbackSizingInput => ({
+  equity: 100_000,
+  entryPrice: 100,
+  stopPct: -0.04,
+  atr20: 2,
+  baselineAtr20: 2,
+  kAtr: 2,
+  ...overrides,
+})
 
 describe('computePullbackSizing', () => {
   it('sizes to 0.4% NAV risk divided by stop distance', () => {
-    // $100k equity, 0.4% risk = $400 budget. Entry $100, stop -4% = $4 risk/share.
-    // qty = floor(400 / 4) = 100. notional = 100 * 100 = 10_000.
-    const result = computePullbackSizing({
-      equity: 100_000,
-      entryPrice: 100,
-      stopPct: -0.04,
-      atr20: 2,
-      baselineAtr20: 2,
-    })
+    // max(pct=4, atr=4) = 4. qty = floor(400 / 4) = 100.
+    const result = computePullbackSizing(baseInput())
     expect(result.quantity).toBe(100)
     expect(result.notional).toBe(10_000)
     expect(result.capped).toBe(false)
@@ -19,137 +30,104 @@ describe('computePullbackSizing', () => {
 
   it('implied $ risk never exceeds equity * riskPerTradePct', () => {
     const equity = 50_000
-    const result = computePullbackSizing({
-      equity,
-      entryPrice: 55,
-      stopPct: -0.05,
-      atr20: 1,
-      baselineAtr20: 1,
-      riskPerTradePct: 0.004,
-    })
+    const result = computePullbackSizing(
+      baseInput({
+        equity,
+        entryPrice: 55,
+        stopPct: -0.05,
+        atr20: 1,
+        baselineAtr20: 1,
+        riskPerTradePct: 0.004,
+      }),
+    )
     const maxRisk = equity * 0.004
     const realizedRisk = result.quantity * Math.abs(55 * -0.05)
     expect(realizedRisk).toBeLessThanOrEqual(maxRisk)
   })
 
   it('halves the size when ATR(20) collapses below half the baseline', () => {
-    const base = computePullbackSizing({
-      equity: 100_000,
-      entryPrice: 100,
-      stopPct: -0.04,
-      atr20: 2,
-      baselineAtr20: 2,
-    })
-    const floored = computePullbackSizing({
-      equity: 100_000,
-      entryPrice: 100,
-      stopPct: -0.04,
-      atr20: 0.5,
-      baselineAtr20: 2,
-    })
+    const base = computePullbackSizing(baseInput())
+    const floored = computePullbackSizing(baseInput({ atr20: 0.5, baselineAtr20: 2 }))
     expect(floored.quantity).toBe(Math.floor(base.quantity / 2))
     expect(floored.capped).toBe(true)
     expect(floored.capReason).toBe('atr-floor')
   })
 
   it('clamps to symbolCap when unrestricted notional would exceed it', () => {
-    const result = computePullbackSizing({
-      equity: 1_000_000,
-      entryPrice: 100,
-      stopPct: -0.04,
-      atr20: 2,
-      baselineAtr20: 2,
-      symbolCap: 5_000,
-    })
+    const result = computePullbackSizing(baseInput({ equity: 1_000_000, symbolCap: 5_000 }))
     expect(result.notional).toBeLessThanOrEqual(5_000)
     expect(result.capped).toBe(true)
     expect(result.capReason).toBe('symbol-cap')
   })
 
-  it('rejects a non-positive stop distance', () => {
+  it('rejects when both ATR and pct stop distances are 0', () => {
+    // pctStop=0 (stopPct=0) AND atrStop=0 (atr20=0) → stopDistance=0 → invalid
     expect(
-      computePullbackSizing({ equity: 100_000, entryPrice: 100, stopPct: 0, atr20: 2, baselineAtr20: 2 }),
+      computePullbackSizing(baseInput({ stopPct: 0, atr20: 0, baselineAtr20: 2 })),
     ).toMatchObject({ quantity: 0, capReason: 'invalid-stop' })
   })
 
   it('rounds down to lotSize multiples (TSE 100-share lot)', () => {
-    // equity 1.5M JPY, risk 0.4% = 6_000 JPY budget. Entry 1500, stop -4% =
-    // 60 JPY risk/share. Raw qty = floor(6000 / 60) = 100. Already a
-    // 100-lot multiple so no change.
-    const exact = computePullbackSizing({
-      equity: 1_500_000,
-      entryPrice: 1500,
-      stopPct: -0.04,
-      atr20: 10,
-      baselineAtr20: 10,
-      lotSize: 100,
-    })
+    const exact = computePullbackSizing(
+      baseInput({
+        equity: 1_500_000,
+        entryPrice: 1500,
+        atr20: 10,
+        baselineAtr20: 10,
+        lotSize: 100,
+      }),
+    )
     expect(exact.quantity).toBe(100)
 
-    // symbolCap forces qty below a lot boundary: cap 250_000 at 1500 →
-    // floor(250000/1500) = 166 → round down to 100.
-    const rounded = computePullbackSizing({
-      equity: 100_000_000,
-      entryPrice: 1500,
-      stopPct: -0.04,
-      atr20: 10,
-      baselineAtr20: 10,
-      symbolCap: 250_000,
-      lotSize: 100,
-    })
+    const rounded = computePullbackSizing(
+      baseInput({
+        equity: 100_000_000,
+        entryPrice: 1500,
+        atr20: 10,
+        baselineAtr20: 10,
+        symbolCap: 250_000,
+        lotSize: 100,
+      }),
+    )
     expect(rounded.quantity).toBe(100)
     expect(rounded.notional).toBe(150_000)
     expect(rounded.capped).toBe(true)
   })
 
   it('returns qty=0 with lot-size-round when raw qty is below one lot', () => {
-    // Budget too small to afford 100 shares → round down to 0.
-    const result = computePullbackSizing({
-      equity: 100_000,
-      entryPrice: 5000,
-      stopPct: -0.04,
-      atr20: 10,
-      baselineAtr20: 10,
-      lotSize: 100,
-    })
+    const result = computePullbackSizing(
+      baseInput({
+        entryPrice: 5000,
+        atr20: 10,
+        baselineAtr20: 10,
+        lotSize: 100,
+      }),
+    )
     expect(result.quantity).toBe(0)
     expect(result.capReason).toBe('lot-size-round')
   })
 
-  it('kAtr takes the ATR-based stop when wider than the pct-based stop', () => {
-    // entry 100, stopPct -4% → pct stop = 4. atr20=3 × kAtr=2 → atr stop = 6.
-    const withAtr = computePullbackSizing({
-      equity: 100_000,
-      entryPrice: 100,
-      stopPct: -0.04,
-      atr20: 3,
-      baselineAtr20: 3,
-      kAtr: 2,
-    })
-    const withoutAtr = computePullbackSizing({
-      equity: 100_000,
-      entryPrice: 100,
-      stopPct: -0.04,
-      atr20: 3,
-      baselineAtr20: 3,
-    })
-    expect(withAtr.quantity).toBeLessThan(withoutAtr.quantity)
-    // 100k * 0.4% = 400 budget. floor(400 / 6) = 66.
-    expect(withAtr.quantity).toBe(66)
+  it('uses the ATR-based stop when wider than the pct-based stop', () => {
+    // atr20=3 × kAtr=2 → atr stop = 6 > pct stop 4. floor(400 / 6) = 66.
+    const result = computePullbackSizing(
+      baseInput({ atr20: 3, baselineAtr20: 3, kAtr: 2 }),
+    )
+    expect(result.quantity).toBe(66)
   })
 
-  it('kAtr falls back to pct stop when atr20 is 0 (post-halt ATR collapse guard)', () => {
-    // atr20=0 → kAtr stop = 0, pct stop = 4 wins. floor(400/4) = 100, then
-    // atr-floor halving kicks in (atr20=0 < baseline*0.5) → 50.
-    const result = computePullbackSizing({
-      equity: 100_000,
-      entryPrice: 100,
-      stopPct: -0.04,
-      atr20: 0,
-      baselineAtr20: 3,
-      kAtr: 2,
-    })
+  it('falls back to pct stop when atr20 is 0 (post-halt ATR collapse guard)', () => {
+    // atr20=0 → atrStop=0, pctStop=4 wins. floor(400/4)=100, then atr-floor
+    // halving (atr20 < baseline*0.5) → 50.
+    const result = computePullbackSizing(
+      baseInput({ atr20: 0, baselineAtr20: 3 }),
+    )
     expect(result.quantity).toBe(50)
     expect(result.capReason).toBe('atr-floor')
+  })
+
+  it('throws when kAtr is non-positive or non-finite', () => {
+    expect(() => computePullbackSizing(baseInput({ kAtr: 0 }))).toThrow(/kAtr/)
+    expect(() => computePullbackSizing(baseInput({ kAtr: -1 }))).toThrow(/kAtr/)
+    expect(() => computePullbackSizing(baseInput({ kAtr: Number.NaN }))).toThrow(/kAtr/)
   })
 })

--- a/test/strategy/pullbackSizing.test.ts
+++ b/test/strategy/pullbackSizing.test.ts
@@ -115,4 +115,41 @@ describe('computePullbackSizing', () => {
     expect(result.quantity).toBe(0)
     expect(result.capReason).toBe('lot-size-round')
   })
+
+  it('kAtr takes the ATR-based stop when wider than the pct-based stop', () => {
+    // entry 100, stopPct -4% → pct stop = 4. atr20=3 × kAtr=2 → atr stop = 6.
+    const withAtr = computePullbackSizing({
+      equity: 100_000,
+      entryPrice: 100,
+      stopPct: -0.04,
+      atr20: 3,
+      baselineAtr20: 3,
+      kAtr: 2,
+    })
+    const withoutAtr = computePullbackSizing({
+      equity: 100_000,
+      entryPrice: 100,
+      stopPct: -0.04,
+      atr20: 3,
+      baselineAtr20: 3,
+    })
+    expect(withAtr.quantity).toBeLessThan(withoutAtr.quantity)
+    // 100k * 0.4% = 400 budget. floor(400 / 6) = 66.
+    expect(withAtr.quantity).toBe(66)
+  })
+
+  it('kAtr falls back to pct stop when atr20 is 0 (post-halt ATR collapse guard)', () => {
+    // atr20=0 → kAtr stop = 0, pct stop = 4 wins. floor(400/4) = 100, then
+    // atr-floor halving kicks in (atr20=0 < baseline*0.5) → 50.
+    const result = computePullbackSizing({
+      equity: 100_000,
+      entryPrice: 100,
+      stopPct: -0.04,
+      atr20: 0,
+      baselineAtr20: 3,
+      kAtr: 2,
+    })
+    expect(result.quantity).toBe(50)
+    expect(result.capReason).toBe('atr-floor')
+  })
 })

--- a/test/strategy/pullbackUptrendStrategy.test.ts
+++ b/test/strategy/pullbackUptrendStrategy.test.ts
@@ -17,6 +17,7 @@ const LEVERAGED_RULE: SymbolRule = {
   pullbackMin: -0.06,
   minReturn50d: 0.08,
   requireAboveSma50: true,
+  kAtr: 2.5,
 }
 
 /** Build a valid BUY-triggering input; individual tests mutate one field. */


### PR DESCRIPTION
## Summary

trading-strategist 推奨 top 3 のうち Lane 1。固定 pct stop が銘柄/時期で 2-5倍 動く ATR を無視している問題を最小差分で解決。

### 変更

- \`computePullbackSizing\` に \`kAtr?: number\` を追加。
- 有効時: \`stopDistance = max(kAtr × atr20, |entry × stopPct|)\`。pct stop を floor として残すことで halt/gap 後の ATR collapse でも危険な tight stop にならない。
- \`SymbolRule\` に \`kAtr?\` を追加、scheduler が rule 経由で pass through。
- 既定 off (undefined = legacy)。有効化は rulesMap / TEST_DEFAULT_RULE 経由で個別 opt-in。D1 column 化は follow-up。

### 非対象 (follow-up)

- global_config.pullback_default_k_atr D1 化
- per-symbol kAtr チューニング (まずは default 2.0 の妥当性を staging で確認)

## Test plan

- [x] \`pnpm test\` — 303 passed (+2 kAtr)
- [x] \`pnpm typecheck\` — clean

## Merge 順序

Lane 2 (#drawdown-scaled-risk) と Lane 3 (#sector-bucket-cap) と並列開発。競合無し。Lane 1 先 merge → 残り rebase 推奨。

## 関連

- Refs #23 Risk policy 詳細化

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ストップロス算出がATR（kAtr × ATR20）を利用するようになり、シンボル／グローバルでATR倍率を指定可能に。

* **バグ修正 / 挙動**
  * kAtr に無効な値（0、負、NaN）が与えられた場合に明示的に拒否（例外）される入力検証を追加。

* **テスト**
  * ATR優先/パーセント優先の振る舞い、境界条件、検証例外をカバーするテストを追加・更新。

* **Chores**
  * グローバル設定とDBスキーマに pullbackDefaultKAtr（デフォルト2.0）を追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->