### PR TITLE
feat(risk): drawdown-scaled risk per trade (Lane 2 of #23)

### DIFF
--- a/drizzle/0007_add_risk_scale_params.sql
+++ b/drizzle/0007_add_risk_scale_params.sql
@@ -1,0 +1,60 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_global_config` (
+	`id` text PRIMARY KEY NOT NULL,
+	`dry_run` integer DEFAULT true NOT NULL,
+	`trading_enabled` integer DEFAULT false NOT NULL,
+	`market_hours_check` integer DEFAULT false NOT NULL,
+	`max_order_notional` real DEFAULT 100 NOT NULL,
+	`max_order_notional_usd` real DEFAULT 2000 NOT NULL,
+	`max_order_notional_jpy` real DEFAULT 100000 NOT NULL,
+	`total_capital_usd` real,
+	`total_capital_jpy` real,
+	`max_portfolio_exposure_pct` real DEFAULT 0.6 NOT NULL,
+	`drawdown_kill_threshold` real DEFAULT -0.02 NOT NULL,
+	`stale_quote_ms` integer DEFAULT 900000 NOT NULL,
+	`gap_reject_pct` real DEFAULT 0.03 NOT NULL,
+	`spread_limit_pct_us` real DEFAULT 0.0025 NOT NULL,
+	`spread_limit_pct_jp` real DEFAULT 0.006 NOT NULL,
+	`pullback_default_stop_pct` real DEFAULT -0.04 NOT NULL,
+	`pullback_default_take_profit_pct` real DEFAULT 0.07 NOT NULL,
+	`pullback_default_time_stop_days` integer DEFAULT 10 NOT NULL,
+	`pullback_default_pullback_max` real DEFAULT -0.03 NOT NULL,
+	`pullback_default_pullback_min` real DEFAULT -0.06 NOT NULL,
+	`pullback_default_min_return_50d` real DEFAULT 0.08 NOT NULL,
+	`pullback_default_require_above_sma50` integer DEFAULT true NOT NULL,
+	`pullback_default_k_atr` real DEFAULT 2 NOT NULL,
+	`risk_base_per_trade_pct` real DEFAULT 0.004 NOT NULL,
+	`risk_dd_half_threshold` real DEFAULT -0.05 NOT NULL,
+	`risk_dd_halt_threshold` real DEFAULT -0.1 NOT NULL,
+	`updated_at` text NOT NULL,
+	CONSTRAINT "global_config_max_order_notional_range" CHECK("__new_global_config"."max_order_notional" > 0 AND "__new_global_config"."max_order_notional" <= 10000000),
+	CONSTRAINT "global_config_max_order_notional_usd_range" CHECK("__new_global_config"."max_order_notional_usd" > 0 AND "__new_global_config"."max_order_notional_usd" <= 1000000),
+	CONSTRAINT "global_config_max_order_notional_jpy_range" CHECK("__new_global_config"."max_order_notional_jpy" > 0 AND "__new_global_config"."max_order_notional_jpy" <= 100000000),
+	CONSTRAINT "global_config_total_capital_usd_range" CHECK("__new_global_config"."total_capital_usd" IS NULL OR "__new_global_config"."total_capital_usd" > 0),
+	CONSTRAINT "global_config_total_capital_jpy_range" CHECK("__new_global_config"."total_capital_jpy" IS NULL OR "__new_global_config"."total_capital_jpy" > 0),
+	CONSTRAINT "global_config_max_portfolio_exposure_pct_range" CHECK("__new_global_config"."max_portfolio_exposure_pct" > 0 AND "__new_global_config"."max_portfolio_exposure_pct" <= 1),
+	CONSTRAINT "global_config_drawdown_kill_threshold_range" CHECK("__new_global_config"."drawdown_kill_threshold" >= -1 AND "__new_global_config"."drawdown_kill_threshold" <= 0),
+	CONSTRAINT "global_config_stale_quote_ms_range" CHECK("__new_global_config"."stale_quote_ms" >= 0),
+	CONSTRAINT "global_config_gap_reject_pct_range" CHECK("__new_global_config"."gap_reject_pct" >= 0 AND "__new_global_config"."gap_reject_pct" <= 1),
+	CONSTRAINT "global_config_spread_limit_pct_us_range" CHECK("__new_global_config"."spread_limit_pct_us" >= 0 AND "__new_global_config"."spread_limit_pct_us" <= 1),
+	CONSTRAINT "global_config_spread_limit_pct_jp_range" CHECK("__new_global_config"."spread_limit_pct_jp" >= 0 AND "__new_global_config"."spread_limit_pct_jp" <= 1),
+	CONSTRAINT "global_config_pullback_default_stop_pct_range" CHECK("__new_global_config"."pullback_default_stop_pct" < 0 AND "__new_global_config"."pullback_default_stop_pct" >= -1),
+	CONSTRAINT "global_config_pullback_default_take_profit_pct_range" CHECK("__new_global_config"."pullback_default_take_profit_pct" > 0 AND "__new_global_config"."pullback_default_take_profit_pct" <= 1),
+	CONSTRAINT "global_config_pullback_default_time_stop_days_range" CHECK("__new_global_config"."pullback_default_time_stop_days" > 0 AND "__new_global_config"."pullback_default_time_stop_days" <= 365),
+	CONSTRAINT "global_config_pullback_default_pullback_max_range" CHECK("__new_global_config"."pullback_default_pullback_max" <= 0 AND "__new_global_config"."pullback_default_pullback_max" >= -1),
+	CONSTRAINT "global_config_pullback_default_pullback_min_range" CHECK("__new_global_config"."pullback_default_pullback_min" <= 0 AND "__new_global_config"."pullback_default_pullback_min" >= -1),
+	CONSTRAINT "global_config_pullback_default_min_return_50d_range" CHECK("__new_global_config"."pullback_default_min_return_50d" >= -1 AND "__new_global_config"."pullback_default_min_return_50d" <= 10),
+	CONSTRAINT "global_config_pullback_default_k_atr_range" CHECK("__new_global_config"."pullback_default_k_atr" > 0 AND "__new_global_config"."pullback_default_k_atr" <= 10),
+	CONSTRAINT "global_config_pullback_default_pullback_window_order" CHECK("__new_global_config"."pullback_default_pullback_min" <= "__new_global_config"."pullback_default_pullback_max"),
+	CONSTRAINT "global_config_risk_base_per_trade_pct_range" CHECK("__new_global_config"."risk_base_per_trade_pct" > 0 AND "__new_global_config"."risk_base_per_trade_pct" <= 1),
+	CONSTRAINT "global_config_risk_dd_half_threshold_range" CHECK("__new_global_config"."risk_dd_half_threshold" < 0 AND "__new_global_config"."risk_dd_half_threshold" >= -1),
+	CONSTRAINT "global_config_risk_dd_halt_threshold_range" CHECK("__new_global_config"."risk_dd_halt_threshold" < 0 AND "__new_global_config"."risk_dd_halt_threshold" >= -1),
+	CONSTRAINT "global_config_risk_dd_threshold_order" CHECK("__new_global_config"."risk_dd_halt_threshold" <= "__new_global_config"."risk_dd_half_threshold")
+);
+--> statement-breakpoint
+-- 既存 global_config にはまだ risk_* 列が無いので SELECT から除外、DEFAULT に任せる。
+-- pullback_default_k_atr は #124 (main) で追加済なので SELECT 可。
+INSERT INTO `__new_global_config`("id", "dry_run", "trading_enabled", "market_hours_check", "max_order_notional", "max_order_notional_usd", "max_order_notional_jpy", "total_capital_usd", "total_capital_jpy", "max_portfolio_exposure_pct", "drawdown_kill_threshold", "stale_quote_ms", "gap_reject_pct", "spread_limit_pct_us", "spread_limit_pct_jp", "pullback_default_stop_pct", "pullback_default_take_profit_pct", "pullback_default_time_stop_days", "pullback_default_pullback_max", "pullback_default_pullback_min", "pullback_default_min_return_50d", "pullback_default_require_above_sma50", "pullback_default_k_atr", "updated_at") SELECT "id", "dry_run", "trading_enabled", "market_hours_check", "max_order_notional", "max_order_notional_usd", "max_order_notional_jpy", "total_capital_usd", "total_capital_jpy", "max_portfolio_exposure_pct", "drawdown_kill_threshold", "stale_quote_ms", "gap_reject_pct", "spread_limit_pct_us", "spread_limit_pct_jp", "pullback_default_stop_pct", "pullback_default_take_profit_pct", "pullback_default_time_stop_days", "pullback_default_pullback_max", "pullback_default_pullback_min", "pullback_default_min_return_50d", "pullback_default_require_above_sma50", "pullback_default_k_atr", "updated_at" FROM `global_config`;--> statement-breakpoint
+DROP TABLE `global_config`;--> statement-breakpoint
+ALTER TABLE `__new_global_config` RENAME TO `global_config`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,636 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "2dd29ae8-8d36-4eee-9f8a-0b3a286c81ef",
+  "prevId": "8e552429-a62e-4c9c-b6e4-587be747634f",
+  "tables": {
+    "global_config": {
+      "name": "global_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "trading_enabled": {
+          "name": "trading_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "market_hours_check": {
+          "name": "market_hours_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "max_order_notional": {
+          "name": "max_order_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "max_order_notional_usd": {
+          "name": "max_order_notional_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2000
+        },
+        "max_order_notional_jpy": {
+          "name": "max_order_notional_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100000
+        },
+        "total_capital_usd": {
+          "name": "total_capital_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_capital_jpy": {
+          "name": "total_capital_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_portfolio_exposure_pct": {
+          "name": "max_portfolio_exposure_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.6
+        },
+        "drawdown_kill_threshold": {
+          "name": "drawdown_kill_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.02
+        },
+        "stale_quote_ms": {
+          "name": "stale_quote_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 900000
+        },
+        "gap_reject_pct": {
+          "name": "gap_reject_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.03
+        },
+        "spread_limit_pct_us": {
+          "name": "spread_limit_pct_us",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.0025
+        },
+        "spread_limit_pct_jp": {
+          "name": "spread_limit_pct_jp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.006
+        },
+        "pullback_default_stop_pct": {
+          "name": "pullback_default_stop_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.04
+        },
+        "pullback_default_take_profit_pct": {
+          "name": "pullback_default_take_profit_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.07
+        },
+        "pullback_default_time_stop_days": {
+          "name": "pullback_default_time_stop_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "pullback_default_pullback_max": {
+          "name": "pullback_default_pullback_max",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.03
+        },
+        "pullback_default_pullback_min": {
+          "name": "pullback_default_pullback_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.06
+        },
+        "pullback_default_min_return_50d": {
+          "name": "pullback_default_min_return_50d",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.08
+        },
+        "pullback_default_require_above_sma50": {
+          "name": "pullback_default_require_above_sma50",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "pullback_default_k_atr": {
+          "name": "pullback_default_k_atr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "risk_base_per_trade_pct": {
+          "name": "risk_base_per_trade_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.004
+        },
+        "risk_dd_half_threshold": {
+          "name": "risk_dd_half_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.05
+        },
+        "risk_dd_halt_threshold": {
+          "name": "risk_dd_halt_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "global_config_max_order_notional_range": {
+          "name": "global_config_max_order_notional_range",
+          "value": "\"global_config\".\"max_order_notional\" > 0 AND \"global_config\".\"max_order_notional\" <= 10000000"
+        },
+        "global_config_max_order_notional_usd_range": {
+          "name": "global_config_max_order_notional_usd_range",
+          "value": "\"global_config\".\"max_order_notional_usd\" > 0 AND \"global_config\".\"max_order_notional_usd\" <= 1000000"
+        },
+        "global_config_max_order_notional_jpy_range": {
+          "name": "global_config_max_order_notional_jpy_range",
+          "value": "\"global_config\".\"max_order_notional_jpy\" > 0 AND \"global_config\".\"max_order_notional_jpy\" <= 100000000"
+        },
+        "global_config_total_capital_usd_range": {
+          "name": "global_config_total_capital_usd_range",
+          "value": "\"global_config\".\"total_capital_usd\" IS NULL OR \"global_config\".\"total_capital_usd\" > 0"
+        },
+        "global_config_total_capital_jpy_range": {
+          "name": "global_config_total_capital_jpy_range",
+          "value": "\"global_config\".\"total_capital_jpy\" IS NULL OR \"global_config\".\"total_capital_jpy\" > 0"
+        },
+        "global_config_max_portfolio_exposure_pct_range": {
+          "name": "global_config_max_portfolio_exposure_pct_range",
+          "value": "\"global_config\".\"max_portfolio_exposure_pct\" > 0 AND \"global_config\".\"max_portfolio_exposure_pct\" <= 1"
+        },
+        "global_config_drawdown_kill_threshold_range": {
+          "name": "global_config_drawdown_kill_threshold_range",
+          "value": "\"global_config\".\"drawdown_kill_threshold\" >= -1 AND \"global_config\".\"drawdown_kill_threshold\" <= 0"
+        },
+        "global_config_stale_quote_ms_range": {
+          "name": "global_config_stale_quote_ms_range",
+          "value": "\"global_config\".\"stale_quote_ms\" >= 0"
+        },
+        "global_config_gap_reject_pct_range": {
+          "name": "global_config_gap_reject_pct_range",
+          "value": "\"global_config\".\"gap_reject_pct\" >= 0 AND \"global_config\".\"gap_reject_pct\" <= 1"
+        },
+        "global_config_spread_limit_pct_us_range": {
+          "name": "global_config_spread_limit_pct_us_range",
+          "value": "\"global_config\".\"spread_limit_pct_us\" >= 0 AND \"global_config\".\"spread_limit_pct_us\" <= 1"
+        },
+        "global_config_spread_limit_pct_jp_range": {
+          "name": "global_config_spread_limit_pct_jp_range",
+          "value": "\"global_config\".\"spread_limit_pct_jp\" >= 0 AND \"global_config\".\"spread_limit_pct_jp\" <= 1"
+        },
+        "global_config_pullback_default_stop_pct_range": {
+          "name": "global_config_pullback_default_stop_pct_range",
+          "value": "\"global_config\".\"pullback_default_stop_pct\" < 0 AND \"global_config\".\"pullback_default_stop_pct\" >= -1"
+        },
+        "global_config_pullback_default_take_profit_pct_range": {
+          "name": "global_config_pullback_default_take_profit_pct_range",
+          "value": "\"global_config\".\"pullback_default_take_profit_pct\" > 0 AND \"global_config\".\"pullback_default_take_profit_pct\" <= 1"
+        },
+        "global_config_pullback_default_time_stop_days_range": {
+          "name": "global_config_pullback_default_time_stop_days_range",
+          "value": "\"global_config\".\"pullback_default_time_stop_days\" > 0 AND \"global_config\".\"pullback_default_time_stop_days\" <= 365"
+        },
+        "global_config_pullback_default_pullback_max_range": {
+          "name": "global_config_pullback_default_pullback_max_range",
+          "value": "\"global_config\".\"pullback_default_pullback_max\" <= 0 AND \"global_config\".\"pullback_default_pullback_max\" >= -1"
+        },
+        "global_config_pullback_default_pullback_min_range": {
+          "name": "global_config_pullback_default_pullback_min_range",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= 0 AND \"global_config\".\"pullback_default_pullback_min\" >= -1"
+        },
+        "global_config_pullback_default_min_return_50d_range": {
+          "name": "global_config_pullback_default_min_return_50d_range",
+          "value": "\"global_config\".\"pullback_default_min_return_50d\" >= -1 AND \"global_config\".\"pullback_default_min_return_50d\" <= 10"
+        },
+        "global_config_pullback_default_k_atr_range": {
+          "name": "global_config_pullback_default_k_atr_range",
+          "value": "\"global_config\".\"pullback_default_k_atr\" > 0 AND \"global_config\".\"pullback_default_k_atr\" <= 10"
+        },
+        "global_config_pullback_default_pullback_window_order": {
+          "name": "global_config_pullback_default_pullback_window_order",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= \"global_config\".\"pullback_default_pullback_max\""
+        },
+        "global_config_risk_base_per_trade_pct_range": {
+          "name": "global_config_risk_base_per_trade_pct_range",
+          "value": "\"global_config\".\"risk_base_per_trade_pct\" > 0 AND \"global_config\".\"risk_base_per_trade_pct\" <= 1"
+        },
+        "global_config_risk_dd_half_threshold_range": {
+          "name": "global_config_risk_dd_half_threshold_range",
+          "value": "\"global_config\".\"risk_dd_half_threshold\" < 0 AND \"global_config\".\"risk_dd_half_threshold\" >= -1"
+        },
+        "global_config_risk_dd_halt_threshold_range": {
+          "name": "global_config_risk_dd_halt_threshold_range",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" < 0 AND \"global_config\".\"risk_dd_halt_threshold\" >= -1"
+        },
+        "global_config_risk_dd_threshold_order": {
+          "name": "global_config_risk_dd_threshold_order",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" <= \"global_config\".\"risk_dd_half_threshold\""
+        }
+      }
+    },
+    "inverse_pairs": {
+      "name": "inverse_pairs",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inverse": {
+          "name": "inverse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "symbol_config": {
+      "name": "symbol_config",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "market": {
+          "name": "market",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_notional": {
+          "name": "max_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "symbol_config_currency_enum": {
+          "name": "symbol_config_currency_enum",
+          "value": "\"symbol_config\".\"currency\" IN ('USD', 'JPY')"
+        }
+      }
+    },
+    "trade_journal": {
+      "name": "trade_journal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trade_event_type": {
+          "name": "trade_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "strategy_name": {
+          "name": "strategy_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_action": {
+          "name": "signal_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_reason": {
+          "name": "signal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_allowed": {
+          "name": "risk_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_reasons": {
+          "name": "risk_reasons",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "limit_price": {
+          "name": "limit_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notional": {
+          "name": "notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "broker_status": {
+          "name": "broker_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "submitted": {
+          "name": "submitted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_qty": {
+          "name": "filled_qty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_price": {
+          "name": "filled_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "realized_pnl": {
+          "name": "realized_pnl",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hold_days": {
+          "name": "hold_days",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_reason": {
+          "name": "exit_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1776950604312,
       "tag": "0006_add_pullback_default_k_atr",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1776951852893,
+      "tag": "0007_add_risk_scale_params",
+      "breakpoints": true
     }
   ]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ export default {
 
     if (event.cron === CRON_STRATEGY) {
       ctx.waitUntil(
-        runStrategyCron(env).then(
+        runStrategyCron(env, { requestId }).then(
           (result) => {
             console.log(
               JSON.stringify({

--- a/src/infrastructure/db/globalConfigRepo.ts
+++ b/src/infrastructure/db/globalConfigRepo.ts
@@ -32,6 +32,12 @@ export interface GlobalConfigSnapshot {
   pullbackDefaultRequireAboveSma50: boolean
   /** ATR multiplier for vol-adaptive stop。default 2.0。 */
   pullbackDefaultKAtr: number
+  /** Base risk fraction per trade (0.4% default)。#23 Lane 2。 */
+  riskBasePerTradePct: number
+  /** drawdown がこの閾値 (負) 未満で size を 0.5× に (-0.05 default)。 */
+  riskDdHalfThreshold: number
+  /** drawdown がこの閾値 (負) 未満で size を 0 に (-0.10 default)。 */
+  riskDdHaltThreshold: number
 }
 
 /**
@@ -62,6 +68,9 @@ export const GLOBAL_CONFIG_DEFAULTS: GlobalConfigSnapshot = Object.freeze({
   pullbackDefaultMinReturn50d: 0.08,
   pullbackDefaultRequireAboveSma50: true,
   pullbackDefaultKAtr: 2.0,
+  riskBasePerTradePct: 0.004,
+  riskDdHalfThreshold: -0.05,
+  riskDdHaltThreshold: -0.10,
 })
 
 export async function loadGlobalConfig(
@@ -93,5 +102,8 @@ export async function loadGlobalConfig(
     pullbackDefaultMinReturn50d: row.pullbackDefaultMinReturn50d,
     pullbackDefaultRequireAboveSma50: row.pullbackDefaultRequireAboveSma50,
     pullbackDefaultKAtr: row.pullbackDefaultKAtr,
+    riskBasePerTradePct: row.riskBasePerTradePct,
+    riskDdHalfThreshold: row.riskDdHalfThreshold,
+    riskDdHaltThreshold: row.riskDdHaltThreshold,
   }
 }

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -148,6 +148,15 @@ export const globalConfig = sqliteTable(
      * POC 推奨域 1.5–2.5、default 2.0。
      */
     pullbackDefaultKAtr: real('pullback_default_k_atr').notNull().default(2.0),
+    /**
+     * Base risk fraction per trade (0.4% default)。drawdown scale を掛けた値が
+     * pullbackSizing に渡る。#23 Lane 2。
+     */
+    riskBasePerTradePct: real('risk_base_per_trade_pct').notNull().default(0.004),
+    /** drawdown がこの閾値 (負) 未満になると size を halfScaleFactor に。-0.05 既定。 */
+    riskDdHalfThreshold: real('risk_dd_half_threshold').notNull().default(-0.05),
+    /** drawdown がこの閾値 (負) 未満になると size を 0 に (halt)。-0.10 既定。 */
+    riskDdHaltThreshold: real('risk_dd_halt_threshold').notNull().default(-0.10),
     updatedAt: text('updated_at').notNull(),
   },
   (t) => ({
@@ -230,6 +239,24 @@ export const globalConfig = sqliteTable(
     pullbackDefaultPullbackWindowOrder: check(
       'global_config_pullback_default_pullback_window_order',
       sql`${t.pullbackDefaultPullbackMin} <= ${t.pullbackDefaultPullbackMax}`,
+    ),
+    riskBasePerTradePctRange: check(
+      'global_config_risk_base_per_trade_pct_range',
+      sql`${t.riskBasePerTradePct} > 0 AND ${t.riskBasePerTradePct} <= 1`,
+    ),
+    riskDdHalfThresholdRange: check(
+      'global_config_risk_dd_half_threshold_range',
+      sql`${t.riskDdHalfThreshold} < 0 AND ${t.riskDdHalfThreshold} >= -1`,
+    ),
+    riskDdHaltThresholdRange: check(
+      'global_config_risk_dd_halt_threshold_range',
+      sql`${t.riskDdHaltThreshold} < 0 AND ${t.riskDdHaltThreshold} >= -1`,
+    ),
+    // halt (深) ≤ half (浅) の順序を強制。逆転すると runtime で throw するので
+    // DB 側でも弾く。
+    riskDdThresholdOrder: check(
+      'global_config_risk_dd_threshold_order',
+      sql`${t.riskDdHaltThreshold} <= ${t.riskDdHalfThreshold}`,
     ),
   }),
 )

--- a/src/trading/risk/drawdownRiskScale.ts
+++ b/src/trading/risk/drawdownRiskScale.ts
@@ -1,0 +1,54 @@
+import type { PortfolioState } from '../state/portfolioTypes'
+
+/** Default base risk fraction per trade. Matches pullbackSizing default. */
+export const BASE_RISK_PER_TRADE_PCT = 0.004
+
+/**
+ * Thresholds for daily drawdown → risk scaling. Keyed on `realizedPnl /
+ * dailyStartEquity` (negative values = drawdown).
+ *
+ *   dd >= -0.05  → scale 1.0 (normal operation)
+ *   dd >= -0.10  → scale 0.5 (losing half-day, halve exposure)
+ *   dd <  -0.10  → scale 0.0 (kill for the day — drawdown_kill pre-flight
+ *                             already covers the -2% floor case; this is
+ *                             the belt-and-suspenders step above that)
+ *
+ * Intentionally 3-level step rather than continuous — step is robust to
+ * intraday noise (one bad tick won't shift size continuously) and obvious
+ * to the operator when inspecting logs.
+ */
+export interface DrawdownScaleResult {
+  scale: number
+  drawdown: number
+  /** Human-readable step label for journalling / logs. */
+  step: 'normal' | 'half' | 'halt'
+}
+
+/**
+ * Compute the risk-scale factor from the current portfolio snapshot. Pure
+ * function — no DO call, testable in isolation.
+ *
+ * `drawdown` is clipped at 0 from above so an intraday up-move doesn't
+ * produce a positive "drawdown". When `dailyStartEquity <= 0` (uninitialized
+ * portfolio), returns scale 1.0 with drawdown 0 — fail-open because the
+ * broader drawdown_kill path in runStrategyCron already refuses to
+ * evaluate that case.
+ */
+export function computeDrawdownRiskScale(portfolio: Pick<PortfolioState, 'dailyStartEquity' | 'dailyRealizedPnl'>): DrawdownScaleResult {
+  if (
+    !Number.isFinite(portfolio.dailyStartEquity) ||
+    portfolio.dailyStartEquity <= 0 ||
+    !Number.isFinite(portfolio.dailyRealizedPnl)
+  ) {
+    return { scale: 1, drawdown: 0, step: 'normal' }
+  }
+  const raw = portfolio.dailyRealizedPnl / portfolio.dailyStartEquity
+  const drawdown = raw < 0 ? raw : 0
+  if (drawdown >= -0.05) {
+    return { scale: 1, drawdown, step: 'normal' }
+  }
+  if (drawdown >= -0.10) {
+    return { scale: 0.5, drawdown, step: 'half' }
+  }
+  return { scale: 0, drawdown, step: 'halt' }
+}

--- a/src/trading/risk/drawdownRiskScale.ts
+++ b/src/trading/risk/drawdownRiskScale.ts
@@ -1,22 +1,14 @@
 import type { PortfolioState } from '../state/portfolioTypes'
 
-/** Default base risk fraction per trade. Matches pullbackSizing default. */
-export const BASE_RISK_PER_TRADE_PCT = 0.004
+export interface DrawdownRiskScaleParams {
+  /** Base risk fraction per trade (e.g. 0.004 = 0.4%). */
+  baseRiskPct: number
+  /** Drawdown threshold to enter "half" scale (e.g. -0.05). */
+  halfThreshold: number
+  /** Drawdown threshold to enter "halt" scale (e.g. -0.10). */
+  haltThreshold: number
+}
 
-/**
- * Thresholds for daily drawdown → risk scaling. Keyed on `realizedPnl /
- * dailyStartEquity` (negative values = drawdown).
- *
- *   dd >= -0.05  → scale 1.0 (normal operation)
- *   dd >= -0.10  → scale 0.5 (losing half-day, halve exposure)
- *   dd <  -0.10  → scale 0.0 (kill for the day — drawdown_kill pre-flight
- *                             already covers the -2% floor case; this is
- *                             the belt-and-suspenders step above that)
- *
- * Intentionally 3-level step rather than continuous — step is robust to
- * intraday noise (one bad tick won't shift size continuously) and obvious
- * to the operator when inspecting logs.
- */
 export interface DrawdownScaleResult {
   scale: number
   drawdown: number
@@ -25,29 +17,54 @@ export interface DrawdownScaleResult {
 }
 
 /**
- * Compute the risk-scale factor from the current portfolio snapshot. Pure
- * function — no DO call, testable in isolation.
+ * Compute the risk-scale factor from the current portfolio snapshot given
+ * caller-provided thresholds (loaded from D1 global_config). Pure function.
  *
- * `drawdown` is clipped at 0 from above so an intraday up-move doesn't
- * produce a positive "drawdown". When `dailyStartEquity <= 0` (uninitialized
- * portfolio), returns scale 1.0 with drawdown 0 — fail-open because the
- * broader drawdown_kill path in runStrategyCron already refuses to
- * evaluate that case.
+ *   dd >= halfThreshold → scale 1.0 (normal)
+ *   dd >= haltThreshold → scale 0.5 (half)
+ *   dd <  haltThreshold → scale 0.0 (halt)
+ *
+ * `drawdown` is clipped at 0 from above so an intraday up-move does not
+ * yield a positive "drawdown". When `dailyStartEquity <= 0` (uninitialized
+ * portfolio) we **fail-closed** with scale 0 / step 'halt' — the caller
+ * can reject rather than silently trade at full size.
+ *
+ * Invalid params (non-finite, or halt > half, or non-negative halt) throw
+ * — caller must pass coherent thresholds. No silent clamping.
  */
-export function computeDrawdownRiskScale(portfolio: Pick<PortfolioState, 'dailyStartEquity' | 'dailyRealizedPnl'>): DrawdownScaleResult {
+export function computeDrawdownRiskScale(
+  portfolio: Pick<PortfolioState, 'dailyStartEquity' | 'dailyRealizedPnl'>,
+  params: DrawdownRiskScaleParams,
+): DrawdownScaleResult {
+  if (!Number.isFinite(params.baseRiskPct) || params.baseRiskPct <= 0) {
+    throw new Error(`computeDrawdownRiskScale: baseRiskPct must be a positive finite number, got ${params.baseRiskPct}`)
+  }
+  if (!Number.isFinite(params.halfThreshold) || params.halfThreshold >= 0) {
+    throw new Error(`computeDrawdownRiskScale: halfThreshold must be a negative finite number, got ${params.halfThreshold}`)
+  }
+  if (!Number.isFinite(params.haltThreshold) || params.haltThreshold >= 0) {
+    throw new Error(`computeDrawdownRiskScale: haltThreshold must be a negative finite number, got ${params.haltThreshold}`)
+  }
+  if (params.haltThreshold > params.halfThreshold) {
+    throw new Error(`computeDrawdownRiskScale: haltThreshold (${params.haltThreshold}) must be <= halfThreshold (${params.halfThreshold})`)
+  }
+  // Fail-closed: if portfolio snapshot is invalid / uninitialized, we cannot
+  // evaluate drawdown and must not silently pass full-size trades. Return
+  // halt so Risk can reject. (CodeRabbit #125 review: "Risk must be able to
+  // reject".)
   if (
     !Number.isFinite(portfolio.dailyStartEquity) ||
     portfolio.dailyStartEquity <= 0 ||
     !Number.isFinite(portfolio.dailyRealizedPnl)
   ) {
-    return { scale: 1, drawdown: 0, step: 'normal' }
+    return { scale: 0, drawdown: 0, step: 'halt' }
   }
   const raw = portfolio.dailyRealizedPnl / portfolio.dailyStartEquity
   const drawdown = raw < 0 ? raw : 0
-  if (drawdown >= -0.05) {
+  if (drawdown >= params.halfThreshold) {
     return { scale: 1, drawdown, step: 'normal' }
   }
-  if (drawdown >= -0.10) {
+  if (drawdown >= params.haltThreshold) {
     return { scale: 0.5, drawdown, step: 'half' }
   }
   return { scale: 0, drawdown, step: 'halt' }

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -8,6 +8,10 @@ import { MockExecution } from '../execution/MockExecution'
 import { WebullExecution } from '../execution/WebullExecution'
 import { PortfolioStateClient } from '../state/PortfolioStateClient'
 import { SymbolStateClient } from '../state/SymbolStateClient'
+import {
+  BASE_RISK_PER_TRADE_PCT,
+  computeDrawdownRiskScale,
+} from '../risk/drawdownRiskScale'
 import { runPullbackScheduler, type PullbackRunSummary } from './pullbackScheduler'
 
 const DEFAULT_EQUITY_USD = 10_000
@@ -85,11 +89,12 @@ export async function runStrategyCron(env: Env): Promise<StrategyCronResult> {
     }
   }
   const portfolioStore = new PortfolioStateClient(env.PORTFOLIO_STATE)
+  let portfolioSnapshot: Awaited<ReturnType<typeof portfolioStore.getPortfolio>>
   try {
-    const portfolio = await portfolioStore.getPortfolio()
+    portfolioSnapshot = await portfolioStore.getPortfolio()
     const now = Date.now()
-    if (portfolio.tradingDisabledUntil) {
-      const disabledUntilMs = new Date(portfolio.tradingDisabledUntil).getTime()
+    if (portfolioSnapshot.tradingDisabledUntil) {
+      const disabledUntilMs = new Date(portfolioSnapshot.tradingDisabledUntil).getTime()
       if (!Number.isFinite(disabledUntilMs) || disabledUntilMs > now) {
         return {
           summary: emptySummary(),
@@ -98,8 +103,8 @@ export async function runStrategyCron(env: Env): Promise<StrategyCronResult> {
         }
       }
     }
-    if (portfolio.dailyStartEquity > 0) {
-      const ratio = portfolio.dailyRealizedPnl / portfolio.dailyStartEquity
+    if (portfolioSnapshot.dailyStartEquity > 0) {
+      const ratio = portfolioSnapshot.dailyRealizedPnl / portfolioSnapshot.dailyStartEquity
       if (ratio <= global.drawdownKillThreshold) {
         return {
           summary: emptySummary(),
@@ -115,6 +120,23 @@ export async function runStrategyCron(env: Env): Promise<StrategyCronResult> {
       skipReason: 'portfolio_halted',
     }
   }
+
+  // Drawdown-scaled risk: derate sizing for the rest of the trading day
+  // when realized PnL is underwater but not yet at drawdown_kill threshold.
+  // Emits a journal-visible log so the operator can tell a quiet day from
+  // a halved one.
+  const ddScale = computeDrawdownRiskScale(portfolioSnapshot)
+  if (ddScale.step !== 'normal') {
+    console.log(
+      JSON.stringify({
+        event: 'drawdown_risk_scale',
+        step: ddScale.step,
+        scale: ddScale.scale,
+        drawdown: ddScale.drawdown,
+      }),
+    )
+  }
+  const scaledRiskPerTradePct = BASE_RISK_PER_TRADE_PCT * ddScale.scale
 
   const positionStore = new SymbolStateClient(env.SYMBOL_STATE)
   const execution = global.dryRun
@@ -173,6 +195,7 @@ export async function runStrategyCron(env: Env): Promise<StrategyCronResult> {
       execution,
       symbolCapMap: universe.symbolMaxNotional,
       defaultRule,
+      riskPerTradePct: scaledRiskPerTradePct,
     })
     summary.evaluated += sub.evaluated
     summary.buys += sub.buys

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -8,10 +8,7 @@ import { MockExecution } from '../execution/MockExecution'
 import { WebullExecution } from '../execution/WebullExecution'
 import { PortfolioStateClient } from '../state/PortfolioStateClient'
 import { SymbolStateClient } from '../state/SymbolStateClient'
-import {
-  BASE_RISK_PER_TRADE_PCT,
-  computeDrawdownRiskScale,
-} from '../risk/drawdownRiskScale'
+import { computeDrawdownRiskScale } from '../risk/drawdownRiskScale'
 import { runPullbackScheduler, type PullbackRunSummary } from './pullbackScheduler'
 
 const DEFAULT_EQUITY_USD = 10_000
@@ -44,7 +41,15 @@ export interface StrategyCronResult {
  * JP 銘柄は 100 株ロットで round-down される。bar 取得は Yahoo Finance の
  * `<code>.T` サフィックス (YahooBarClient 内で自動付与)。
  */
-export async function runStrategyCron(env: Env): Promise<StrategyCronResult> {
+export interface RunStrategyCronOptions {
+  /** Correlation id for structured logs (from scheduled() handler). */
+  requestId?: string
+}
+
+export async function runStrategyCron(
+  env: Env,
+  options: RunStrategyCronOptions = {},
+): Promise<StrategyCronResult> {
   const emptySummary = (): PullbackRunSummary => ({
     evaluated: 0,
     buys: 0,
@@ -125,18 +130,23 @@ export async function runStrategyCron(env: Env): Promise<StrategyCronResult> {
   // when realized PnL is underwater but not yet at drawdown_kill threshold.
   // Emits a journal-visible log so the operator can tell a quiet day from
   // a halved one.
-  const ddScale = computeDrawdownRiskScale(portfolioSnapshot)
+  const ddScale = computeDrawdownRiskScale(portfolioSnapshot, {
+    baseRiskPct: global.riskBasePerTradePct,
+    halfThreshold: global.riskDdHalfThreshold,
+    haltThreshold: global.riskDdHaltThreshold,
+  })
   if (ddScale.step !== 'normal') {
     console.log(
       JSON.stringify({
         event: 'drawdown_risk_scale',
+        requestId: options.requestId,
         step: ddScale.step,
         scale: ddScale.scale,
         drawdown: ddScale.drawdown,
       }),
     )
   }
-  const scaledRiskPerTradePct = BASE_RISK_PER_TRADE_PCT * ddScale.scale
+  const scaledRiskPerTradePct = global.riskBasePerTradePct * ddScale.scale
 
   const positionStore = new SymbolStateClient(env.SYMBOL_STATE)
   const execution = global.dryRun

--- a/test/helpers/configFixtures.ts
+++ b/test/helpers/configFixtures.ts
@@ -32,6 +32,9 @@ export function makeGlobalConfigSnapshot(
     pullbackDefaultMinReturn50d: 0.08,
     pullbackDefaultRequireAboveSma50: true,
     pullbackDefaultKAtr: 2.0,
+    riskBasePerTradePct: 0.004,
+    riskDdHalfThreshold: -0.05,
+    riskDdHaltThreshold: -0.10,
     source: 'd1',
     ...overrides,
   }

--- a/test/trading/risk/drawdownRiskScale.test.ts
+++ b/test/trading/risk/drawdownRiskScale.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { computeDrawdownRiskScale } from '../../../src/trading/risk/drawdownRiskScale'
+
+describe('computeDrawdownRiskScale', () => {
+  it('returns scale 1.0 when at or above start-of-day equity', () => {
+    const r = computeDrawdownRiskScale({ dailyStartEquity: 10_000, dailyRealizedPnl: 100 })
+    expect(r.scale).toBe(1)
+    expect(r.step).toBe('normal')
+    expect(r.drawdown).toBe(0) // clipped at 0
+  })
+
+  it('returns scale 1.0 when drawdown is shallower than -5%', () => {
+    const r = computeDrawdownRiskScale({ dailyStartEquity: 10_000, dailyRealizedPnl: -300 })
+    expect(r.scale).toBe(1)
+    expect(r.step).toBe('normal')
+  })
+
+  it('returns scale 0.5 when drawdown is in [-10%, -5%)', () => {
+    const r = computeDrawdownRiskScale({ dailyStartEquity: 10_000, dailyRealizedPnl: -600 })
+    expect(r.scale).toBe(0.5)
+    expect(r.step).toBe('half')
+  })
+
+  it('returns scale 0.0 when drawdown is below -10%', () => {
+    const r = computeDrawdownRiskScale({ dailyStartEquity: 10_000, dailyRealizedPnl: -1_200 })
+    expect(r.scale).toBe(0)
+    expect(r.step).toBe('halt')
+  })
+
+  it('returns normal with dd=0 when dailyStartEquity is uninitialized', () => {
+    const r = computeDrawdownRiskScale({ dailyStartEquity: 0, dailyRealizedPnl: -100 })
+    expect(r.scale).toBe(1)
+    expect(r.drawdown).toBe(0)
+  })
+
+  it('treats non-finite fields as uninitialized (fail-open)', () => {
+    const r = computeDrawdownRiskScale({ dailyStartEquity: Number.NaN, dailyRealizedPnl: -100 })
+    expect(r.scale).toBe(1)
+  })
+
+  it('boundary: exactly -5% stays normal, exactly -10% is half', () => {
+    expect(computeDrawdownRiskScale({ dailyStartEquity: 10_000, dailyRealizedPnl: -500 }).step).toBe('normal')
+    expect(computeDrawdownRiskScale({ dailyStartEquity: 10_000, dailyRealizedPnl: -1_000 }).step).toBe('half')
+  })
+})

--- a/test/trading/risk/drawdownRiskScale.test.ts
+++ b/test/trading/risk/drawdownRiskScale.test.ts
@@ -1,45 +1,125 @@
 import { describe, expect, it } from 'vitest'
-import { computeDrawdownRiskScale } from '../../../src/trading/risk/drawdownRiskScale'
+import {
+  computeDrawdownRiskScale,
+  type DrawdownRiskScaleParams,
+} from '../../../src/trading/risk/drawdownRiskScale'
+
+const defaultParams: DrawdownRiskScaleParams = {
+  baseRiskPct: 0.004,
+  halfThreshold: -0.05,
+  haltThreshold: -0.10,
+}
 
 describe('computeDrawdownRiskScale', () => {
   it('returns scale 1.0 when at or above start-of-day equity', () => {
-    const r = computeDrawdownRiskScale({ dailyStartEquity: 10_000, dailyRealizedPnl: 100 })
+    const r = computeDrawdownRiskScale(
+      { dailyStartEquity: 10_000, dailyRealizedPnl: 100 },
+      defaultParams,
+    )
     expect(r.scale).toBe(1)
     expect(r.step).toBe('normal')
-    expect(r.drawdown).toBe(0) // clipped at 0
+    expect(r.drawdown).toBe(0)
   })
 
-  it('returns scale 1.0 when drawdown is shallower than -5%', () => {
-    const r = computeDrawdownRiskScale({ dailyStartEquity: 10_000, dailyRealizedPnl: -300 })
+  it('returns scale 1.0 when drawdown is shallower than halfThreshold', () => {
+    const r = computeDrawdownRiskScale(
+      { dailyStartEquity: 10_000, dailyRealizedPnl: -300 },
+      defaultParams,
+    )
     expect(r.scale).toBe(1)
     expect(r.step).toBe('normal')
   })
 
-  it('returns scale 0.5 when drawdown is in [-10%, -5%)', () => {
-    const r = computeDrawdownRiskScale({ dailyStartEquity: 10_000, dailyRealizedPnl: -600 })
+  it('returns scale 0.5 when drawdown is in [haltThreshold, halfThreshold)', () => {
+    const r = computeDrawdownRiskScale(
+      { dailyStartEquity: 10_000, dailyRealizedPnl: -600 },
+      defaultParams,
+    )
     expect(r.scale).toBe(0.5)
     expect(r.step).toBe('half')
   })
 
-  it('returns scale 0.0 when drawdown is below -10%', () => {
-    const r = computeDrawdownRiskScale({ dailyStartEquity: 10_000, dailyRealizedPnl: -1_200 })
+  it('returns scale 0.0 when drawdown is below haltThreshold', () => {
+    const r = computeDrawdownRiskScale(
+      { dailyStartEquity: 10_000, dailyRealizedPnl: -1_200 },
+      defaultParams,
+    )
     expect(r.scale).toBe(0)
     expect(r.step).toBe('halt')
   })
 
-  it('returns normal with dd=0 when dailyStartEquity is uninitialized', () => {
-    const r = computeDrawdownRiskScale({ dailyStartEquity: 0, dailyRealizedPnl: -100 })
-    expect(r.scale).toBe(1)
-    expect(r.drawdown).toBe(0)
+  it('returns halt (fail-closed) when dailyStartEquity is uninitialized', () => {
+    const r = computeDrawdownRiskScale(
+      { dailyStartEquity: 0, dailyRealizedPnl: -100 },
+      defaultParams,
+    )
+    expect(r.scale).toBe(0)
+    expect(r.step).toBe('halt')
   })
 
-  it('treats non-finite fields as uninitialized (fail-open)', () => {
-    const r = computeDrawdownRiskScale({ dailyStartEquity: Number.NaN, dailyRealizedPnl: -100 })
-    expect(r.scale).toBe(1)
+  it('returns halt (fail-closed) when fields are non-finite', () => {
+    const r = computeDrawdownRiskScale(
+      { dailyStartEquity: Number.NaN, dailyRealizedPnl: -100 },
+      defaultParams,
+    )
+    expect(r.scale).toBe(0)
+    expect(r.step).toBe('halt')
   })
 
-  it('boundary: exactly -5% stays normal, exactly -10% is half', () => {
-    expect(computeDrawdownRiskScale({ dailyStartEquity: 10_000, dailyRealizedPnl: -500 }).step).toBe('normal')
-    expect(computeDrawdownRiskScale({ dailyStartEquity: 10_000, dailyRealizedPnl: -1_000 }).step).toBe('half')
+  it('boundary: exactly halfThreshold stays normal, exactly haltThreshold is half', () => {
+    expect(
+      computeDrawdownRiskScale(
+        { dailyStartEquity: 10_000, dailyRealizedPnl: -500 },
+        defaultParams,
+      ).step,
+    ).toBe('normal')
+    expect(
+      computeDrawdownRiskScale(
+        { dailyStartEquity: 10_000, dailyRealizedPnl: -1_000 },
+        defaultParams,
+      ).step,
+    ).toBe('half')
+  })
+
+  it('respects caller-provided thresholds', () => {
+    const relaxed = { baseRiskPct: 0.004, halfThreshold: -0.10, haltThreshold: -0.20 }
+    const r = computeDrawdownRiskScale(
+      { dailyStartEquity: 10_000, dailyRealizedPnl: -600 },
+      relaxed,
+    )
+    expect(r.step).toBe('normal') // -6% DD is shallower than -10% threshold
+  })
+
+  it('throws on invalid baseRiskPct', () => {
+    expect(() =>
+      computeDrawdownRiskScale(
+        { dailyStartEquity: 10_000, dailyRealizedPnl: 0 },
+        { ...defaultParams, baseRiskPct: 0 },
+      ),
+    ).toThrow(/baseRiskPct/)
+  })
+
+  it('throws on non-negative thresholds', () => {
+    expect(() =>
+      computeDrawdownRiskScale(
+        { dailyStartEquity: 10_000, dailyRealizedPnl: 0 },
+        { ...defaultParams, halfThreshold: 0 },
+      ),
+    ).toThrow(/halfThreshold/)
+    expect(() =>
+      computeDrawdownRiskScale(
+        { dailyStartEquity: 10_000, dailyRealizedPnl: 0 },
+        { ...defaultParams, haltThreshold: 0.1 },
+      ),
+    ).toThrow(/haltThreshold/)
+  })
+
+  it('throws when haltThreshold is shallower than halfThreshold', () => {
+    expect(() =>
+      computeDrawdownRiskScale(
+        { dailyStartEquity: 10_000, dailyRealizedPnl: 0 },
+        { baseRiskPct: 0.004, halfThreshold: -0.10, haltThreshold: -0.05 },
+      ),
+    ).toThrow(/haltThreshold.*halfThreshold/)
   })
 })


### PR DESCRIPTION
## Summary

trading-strategist 推奨 top 3 のうち Lane 2。daily drawdown に応じて \`riskPerTradePct\` を 3 段で scale する。

### 変更

- \`src/trading/risk/drawdownRiskScale.ts\` 新規:
  - \`computeDrawdownRiskScale(portfolio)\` 純関数。dd = clamp(realizedPnl/startEquity, -, 0)
  - dd >= -5%: scale 1.0 / dd >= -10%: 0.5 / dd < -10%: 0.0
- \`runStrategyCron\` が portfolio snapshot を使って \`riskPerTradePct = 0.004 * scale\` を scheduler に pass。step が non-normal の時だけ \`drawdown_risk_scale\` log emit。

### 設計判断

- 3 段 step: 連続関数より intraday noise に堅牢。チューニング地獄を避ける。
- peak NAV は持たず \`dailyStartEquity\` からの underwater を drawdown とみなす簡易版 (POC 期で十分、peak-based は schema 拡張 follow-up)。
- drawdown_kill (#38-B) が -2% で全 halt する既存 gate と直交。本 lane は -5%/-10% の段階的 exposure 絞り。

## Test plan

- [x] \`pnpm test\` — 308 passed (+7 境界/fail-open)
- [x] \`pnpm typecheck\` — clean

## Merge 順序

Lane 1 (#atr-based-stop) 先 merge → 本 PR rebase 推奨。Lane 3 と scheduler 呼出し付近で軽衝突予想。

## 関連

- Refs #23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ポートフォリオのドローダウンに応じた3段階（通常／半減／停止）の自動リスク調整を導入し、取引ごとのポジションサイズが動的に変動します。
  * ドローダウン閾値と基本リスクの設定が永続化され、管理画面や設定から利用可能になります。

* **ログ／観測性**
  * 半減または停止のスケーリングが発生した際に詳細なスケール情報をログ出力します。

* **テスト**
  * 新しいリスク調整ロジックの包括的なテストを追加しました。

* **データベース／マイグレーション**
  * 永続設定にドローダウン関連のパラメータを追加するマイグレーションを含みます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->