### PR TITLE
fix(risk): 未 seed portfolio で戦略が全 halt する回帰を修正

### DIFF
--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -130,7 +130,20 @@ export async function runStrategyCron(
   // when realized PnL is underwater but not yet at drawdown_kill threshold.
   // Emits a journal-visible log so the operator can tell a quiet day from
   // a halved one.
-  const ddScale = computeDrawdownRiskScale(portfolioSnapshot, {
+  const { portfolio: portfolioForScale, usedFallback } = resolvePortfolioForRiskScale(
+    portfolioSnapshot,
+    global.totalCapitalUsd,
+  )
+  if (usedFallback) {
+    console.log(
+      JSON.stringify({
+        event: 'portfolio_unseeded_fallback',
+        requestId: options.requestId,
+        fallbackEquity: portfolioForScale.dailyStartEquity,
+      }),
+    )
+  }
+  const ddScale = computeDrawdownRiskScale(portfolioForScale, {
     baseRiskPct: global.riskBasePerTradePct,
     halfThreshold: global.riskDdHalfThreshold,
     haltThreshold: global.riskDdHaltThreshold,
@@ -236,4 +249,43 @@ function sanitizeEquity(value: number | null | undefined, fallback: number): num
   if (value === null || value === undefined) return fallback
   if (!Number.isFinite(value) || value <= 0) return fallback
   return value
+}
+
+/**
+ * 「未 seed」portfolio (dailyStartEquity <= 0) と「壊れた値」(NaN / 負値) を
+ * 区別する pure helper。未 seed かつ global.totalCapitalUsd が正値なら、
+ * その baseline で dailyStartEquity を埋めた snapshot を返す。これで
+ * `/admin/portfolio/roll-daily` 未実行の初日 / 日跨ぎでも drawdownRiskScale
+ * が halt ではなく normal で動く。
+ *
+ * 壊れた値 (NaN など) は fallback せず元の snapshot を返し、
+ * drawdownRiskScale 側の fail-closed (halt) に任せる。
+ * CodeRabbit review #125 の fail-closed 意図を崩さない。
+ */
+export function resolvePortfolioForRiskScale<
+  P extends { dailyStartEquity: number; dailyRealizedPnl: number },
+>(
+  portfolio: P,
+  totalCapitalUsd: number | null | undefined,
+): { portfolio: P; usedFallback: boolean } {
+  // start > 0 ならそのまま
+  if (portfolio.dailyStartEquity > 0) return { portfolio, usedFallback: false }
+  // NaN / 負値など壊れている場合は fallback しない (halt を期待)
+  if (!Number.isFinite(portfolio.dailyStartEquity)) return { portfolio, usedFallback: false }
+  if (
+    totalCapitalUsd === null ||
+    totalCapitalUsd === undefined ||
+    !Number.isFinite(totalCapitalUsd) ||
+    totalCapitalUsd <= 0
+  ) {
+    return { portfolio, usedFallback: false }
+  }
+  return {
+    portfolio: {
+      ...portfolio,
+      dailyStartEquity: totalCapitalUsd,
+      dailyRealizedPnl: 0, // 未 seed = 未実現損益もゼロ扱い
+    },
+    usedFallback: true,
+  }
 }

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -252,15 +252,21 @@ function sanitizeEquity(value: number | null | undefined, fallback: number): num
 }
 
 /**
- * 「未 seed」portfolio (dailyStartEquity <= 0) と「壊れた値」(NaN / 負値) を
- * 区別する pure helper。未 seed かつ global.totalCapitalUsd が正値なら、
- * その baseline で dailyStartEquity を埋めた snapshot を返す。これで
- * `/admin/portfolio/roll-daily` 未実行の初日 / 日跨ぎでも drawdownRiskScale
- * が halt ではなく normal で動く。
+ * 「未 seed」portfolio と「壊れた値」の portfolio を区別する pure helper。
  *
- * 壊れた値 (NaN など) は fallback せず元の snapshot を返し、
- * drawdownRiskScale 側の fail-closed (halt) に任せる。
- * CodeRabbit review #125 の fail-closed 意図を崩さない。
+ * 分類:
+ *   - `dailyStartEquity > 0`: seed 済、そのまま使う (fallback なし)
+ *   - `dailyStartEquity <= 0` かつ **有限値** (0 / 負値): 未 seed 扱い。
+ *     `global.totalCapitalUsd` が正値なら baseline として fallback。負値も
+ *     同じく未 seed 判定 (tests 参照) で、broken data ではない。
+ *   - `dailyStartEquity` が **非有限** (NaN / Infinity): 壊れ値 → fallback
+ *     しない。後段 `drawdownRiskScale` の fail-closed (step: 'halt') に任せる。
+ *   - `dailyRealizedPnl` が非有限: 同上、fallback 経路で 0 に上書きして
+ *     fail-closed を迂回しないよう早期 return (CodeRabbit review #131)。
+ *
+ * 狙い: `/admin/portfolio/roll-daily` 未実行の初日 / 日跨ぎでも
+ * `drawdownRiskScale` が halt ではなく normal で動き、BUY 機会を逃さない。
+ * 同時に CodeRabbit review #125 の fail-closed 意図 (壊れ値は halt) は維持。
  */
 export function resolvePortfolioForRiskScale<
   P extends { dailyStartEquity: number; dailyRealizedPnl: number },

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -270,8 +270,12 @@ export function resolvePortfolioForRiskScale<
 ): { portfolio: P; usedFallback: boolean } {
   // start > 0 ならそのまま
   if (portfolio.dailyStartEquity > 0) return { portfolio, usedFallback: false }
-  // NaN / 負値など壊れている場合は fallback しない (halt を期待)
+  // dailyStartEquity が NaN / Infinity → fallback しない (halt を期待)
   if (!Number.isFinite(portfolio.dailyStartEquity)) return { portfolio, usedFallback: false }
+  // dailyRealizedPnl が壊れている (NaN / Infinity) なら fallback しない。
+  // fallback 経路で勝手に 0 へ上書きすると壊れ値を fail-closed で捕まえ損ねる
+  // (CodeRabbit review #131)。
+  if (!Number.isFinite(portfolio.dailyRealizedPnl)) return { portfolio, usedFallback: false }
   if (
     totalCapitalUsd === null ||
     totalCapitalUsd === undefined ||

--- a/test/trading/strategy/runStrategyCron.test.ts
+++ b/test/trading/strategy/runStrategyCron.test.ts
@@ -171,14 +171,23 @@ describe('resolvePortfolioForRiskScale', () => {
     expect(resolvePortfolioForRiskScale(p, Number.NaN).usedFallback).toBe(false)
   })
 
-  it('does NOT fallback when dailyStartEquity is negative', () => {
-    // Negative is treated as unseeded, and fallback activates — but the
-    // intent here is: any non-positive finite value is "not yet initialized"
-    // (differs from NaN which means corrupt).
+  it('treats negative dailyStartEquity as unseeded and falls back', () => {
+    // Negative finite value is treated as unseeded (not yet initialized),
+    // distinct from NaN which means corrupt.
     const r = resolvePortfolioForRiskScale(
       { dailyStartEquity: -1, dailyRealizedPnl: 0 },
       3333,
     )
     expect(r.usedFallback).toBe(true)
+  })
+
+  it('does NOT fallback when dailyRealizedPnl is non-finite (corrupt)', () => {
+    // CodeRabbit #131 review: if realizedPnl is NaN / Infinity, the portfolio
+    // snapshot is corrupt and must trigger fail-closed via drawdownRiskScale,
+    // not get silently zeroed by the fallback path.
+    const p = { dailyStartEquity: 0, dailyRealizedPnl: Number.NaN }
+    const r = resolvePortfolioForRiskScale(p, 3333)
+    expect(r.usedFallback).toBe(false)
+    expect(r.portfolio).toBe(p)
   })
 })

--- a/test/trading/strategy/runStrategyCron.test.ts
+++ b/test/trading/strategy/runStrategyCron.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { loadGlobalConfigFrom } from '../../../src/infrastructure/db/globalConfigLoader'
 import { loadSymbolUniverse } from '../../../src/infrastructure/db/symbolUniverse'
-import { runStrategyCron } from '../../../src/trading/strategy/runStrategyCron'
+import { resolvePortfolioForRiskScale, runStrategyCron } from '../../../src/trading/strategy/runStrategyCron'
 import { makeGlobalConfigSnapshot, makeSymbolUniverse } from '../../helpers/configFixtures'
 
 vi.mock('../../../src/infrastructure/db/globalConfigLoader', () => ({
@@ -133,5 +133,52 @@ describe('runStrategyCron', () => {
     } as unknown as Parameters<typeof runStrategyCron>[0]
     const result = await runStrategyCron(envWithBrokenPortfolio)
     expect(result.skipReason).toBe('portfolio_halted')
+  })
+
+})
+
+describe('resolvePortfolioForRiskScale', () => {
+  it('returns the portfolio unchanged when dailyStartEquity > 0', () => {
+    const p = { dailyStartEquity: 10_000, dailyRealizedPnl: -100 }
+    const r = resolvePortfolioForRiskScale(p, 3333)
+    expect(r.usedFallback).toBe(false)
+    expect(r.portfolio).toBe(p)
+  })
+
+  it('substitutes totalCapitalUsd when dailyStartEquity is 0 (unseeded)', () => {
+    const r = resolvePortfolioForRiskScale(
+      { dailyStartEquity: 0, dailyRealizedPnl: 0 },
+      3333,
+    )
+    expect(r.usedFallback).toBe(true)
+    expect(r.portfolio.dailyStartEquity).toBe(3333)
+    expect(r.portfolio.dailyRealizedPnl).toBe(0)
+  })
+
+  it('does NOT fallback when dailyStartEquity is NaN (truly broken)', () => {
+    const p = { dailyStartEquity: Number.NaN, dailyRealizedPnl: 0 }
+    const r = resolvePortfolioForRiskScale(p, 3333)
+    expect(r.usedFallback).toBe(false)
+    expect(r.portfolio).toBe(p)
+  })
+
+  it('does NOT fallback when totalCapitalUsd is null / 0 / negative', () => {
+    const p = { dailyStartEquity: 0, dailyRealizedPnl: 0 }
+    expect(resolvePortfolioForRiskScale(p, null).usedFallback).toBe(false)
+    expect(resolvePortfolioForRiskScale(p, undefined).usedFallback).toBe(false)
+    expect(resolvePortfolioForRiskScale(p, 0).usedFallback).toBe(false)
+    expect(resolvePortfolioForRiskScale(p, -100).usedFallback).toBe(false)
+    expect(resolvePortfolioForRiskScale(p, Number.NaN).usedFallback).toBe(false)
+  })
+
+  it('does NOT fallback when dailyStartEquity is negative', () => {
+    // Negative is treated as unseeded, and fallback activates — but the
+    // intent here is: any non-positive finite value is "not yet initialized"
+    // (differs from NaN which means corrupt).
+    const r = resolvePortfolioForRiskScale(
+      { dailyStartEquity: -1, dailyRealizedPnl: 0 },
+      3333,
+    )
+    expect(r.usedFallback).toBe(true)
   })
 })


### PR DESCRIPTION
## 背景

#125 で \`computeDrawdownRiskScale\` を fail-closed 化 (portfolio 値が不正なら scale:0, step:'halt'、CodeRabbit 指摘対応) したが、これが **日跨ぎ後の \"未 seed\" 状態でも発動** し、\`/admin/portfolio/roll-daily\` を毎朝手動実行しないと BUY が一切出ない回帰を生んだ。

staging 4/24 01:15 UTC の tail 観測:

\`\`\`json
{"event":"drawdown_risk_scale","step":"halt","scale":0,"drawdown":0}
{"event":"strategy_cron_run","rejected":[
  {"symbol":"SOXL","reason":"sizing rejected: insufficient-risk-budget"},...]}
\`\`\`

## 変更

「未 seed」(\`dailyStartEquity <= 0\` かつ有限値) と「壊れた値」(\`NaN\` / \`-Infinity\` 等) は意味が違う。

- 未 seed: \`global_config.totalCapitalUsd\` が seed 済ならそれを baseline に一時 fallback、\`dailyRealizedPnl\` は 0 扱いで normal 動作
- 壊れ値: 従来通り \`drawdownRiskScale\` の fail-closed で halt

実装:

- \`resolvePortfolioForRiskScale\` という pure 関数を \`runStrategyCron.ts\` に追加
- cron 本体でこれを呼び、fallback 発生時は \`portfolio_unseeded_fallback\` を log emit (\`requestId\` 付きで dashboard 等から追跡可能)
- \`drawdownRiskScale\` 側は無変更 — fail-closed 契約は維持

## 動作マトリクス

| \`dailyStartEquity\` | \`totalCapitalUsd\` | 挙動 |
|---|---|---|
| > 0 | any | そのまま使う (従来通り) |
| 0 | > 0 | **NEW: totalCapitalUsd を baseline に fallback (normal)** |
| 0 | null / <= 0 | halt (従来通り、真に seed 不能) |
| NaN | any | halt (壊れ値、従来通り) |

## Test plan

- [x] \`pnpm test\` — 327 passed (+5 \`resolvePortfolioForRiskScale\` pure tests)
- [x] \`pnpm typecheck\` — clean
- [ ] staging deploy 後、次 */15 cron で \`portfolio_unseeded_fallback\` log + BUY 判定に進むこと確認

## 関連

- #125 (merged): drawdownRiskScale の fail-closed 強化 (本 fix の直接原因)
- 本 PR は fail-closed 意図を維持したまま「未 seed」ケースだけ救う最小差分

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * ポートフォリオのリスクスケーリングに未シードや不正値のエッジケース用フォールバックを追加し、計算の堅牢性を向上しました。フォールバック発動時はフォールバック適用後のエクイティ情報とともにイベントがログ記録されます（requestId 等の参照可能な識別情報を含む）。

* **テスト**
  * フォールバック動作と各種不正入力（ゼロ・負値・NaN・非有限値・totalCapitalUsd の無効値等）に対する挙動を検証する包括的なテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->