### PR TITLE
feat(dashboard): per-symbol 判定ログを /dashboard/cron で可視化 (#128)

### DIFF
--- a/drizzle/0009_strategy_decision_log.sql
+++ b/drizzle/0009_strategy_decision_log.sql
@@ -8,3 +8,5 @@ CREATE TABLE `strategy_decision_log` (
 	`price` real,
 	`indicators_json` text
 );
+--> statement-breakpoint
+CREATE INDEX `strategy_decision_log_symbol_id_idx` ON `strategy_decision_log` (`symbol`,`id`);

--- a/drizzle/0009_strategy_decision_log.sql
+++ b/drizzle/0009_strategy_decision_log.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `strategy_decision_log` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`timestamp` text NOT NULL,
+	`request_id` text,
+	`symbol` text NOT NULL,
+	`decision` text NOT NULL,
+	`reason` text,
+	`price` real,
+	`indicators_json` text
+);

--- a/drizzle/meta/0009_snapshot.json
+++ b/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,721 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "64928a04-4d14-47e4-8c0f-0c3f93ea6b6f",
+  "prevId": "39be53f4-2157-4c72-897c-4096ba803e9a",
+  "tables": {
+    "global_config": {
+      "name": "global_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "trading_enabled": {
+          "name": "trading_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "market_hours_check": {
+          "name": "market_hours_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "max_order_notional": {
+          "name": "max_order_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "max_order_notional_usd": {
+          "name": "max_order_notional_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2000
+        },
+        "max_order_notional_jpy": {
+          "name": "max_order_notional_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100000
+        },
+        "total_capital_usd": {
+          "name": "total_capital_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_capital_jpy": {
+          "name": "total_capital_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_portfolio_exposure_pct": {
+          "name": "max_portfolio_exposure_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.6
+        },
+        "drawdown_kill_threshold": {
+          "name": "drawdown_kill_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.02
+        },
+        "stale_quote_ms": {
+          "name": "stale_quote_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 900000
+        },
+        "gap_reject_pct": {
+          "name": "gap_reject_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.03
+        },
+        "spread_limit_pct_us": {
+          "name": "spread_limit_pct_us",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.0025
+        },
+        "spread_limit_pct_jp": {
+          "name": "spread_limit_pct_jp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.006
+        },
+        "pullback_default_stop_pct": {
+          "name": "pullback_default_stop_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.04
+        },
+        "pullback_default_take_profit_pct": {
+          "name": "pullback_default_take_profit_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.07
+        },
+        "pullback_default_time_stop_days": {
+          "name": "pullback_default_time_stop_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "pullback_default_pullback_max": {
+          "name": "pullback_default_pullback_max",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.03
+        },
+        "pullback_default_pullback_min": {
+          "name": "pullback_default_pullback_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.06
+        },
+        "pullback_default_min_return_50d": {
+          "name": "pullback_default_min_return_50d",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.08
+        },
+        "pullback_default_require_above_sma50": {
+          "name": "pullback_default_require_above_sma50",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "pullback_default_k_atr": {
+          "name": "pullback_default_k_atr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "risk_base_per_trade_pct": {
+          "name": "risk_base_per_trade_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.004
+        },
+        "risk_dd_half_threshold": {
+          "name": "risk_dd_half_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.05
+        },
+        "risk_dd_halt_threshold": {
+          "name": "risk_dd_halt_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.1
+        },
+        "bucket_exposure_pct": {
+          "name": "bucket_exposure_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.3
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "global_config_max_order_notional_range": {
+          "name": "global_config_max_order_notional_range",
+          "value": "\"global_config\".\"max_order_notional\" > 0 AND \"global_config\".\"max_order_notional\" <= 10000000"
+        },
+        "global_config_max_order_notional_usd_range": {
+          "name": "global_config_max_order_notional_usd_range",
+          "value": "\"global_config\".\"max_order_notional_usd\" > 0 AND \"global_config\".\"max_order_notional_usd\" <= 1000000"
+        },
+        "global_config_max_order_notional_jpy_range": {
+          "name": "global_config_max_order_notional_jpy_range",
+          "value": "\"global_config\".\"max_order_notional_jpy\" > 0 AND \"global_config\".\"max_order_notional_jpy\" <= 100000000"
+        },
+        "global_config_total_capital_usd_range": {
+          "name": "global_config_total_capital_usd_range",
+          "value": "\"global_config\".\"total_capital_usd\" IS NULL OR \"global_config\".\"total_capital_usd\" > 0"
+        },
+        "global_config_total_capital_jpy_range": {
+          "name": "global_config_total_capital_jpy_range",
+          "value": "\"global_config\".\"total_capital_jpy\" IS NULL OR \"global_config\".\"total_capital_jpy\" > 0"
+        },
+        "global_config_max_portfolio_exposure_pct_range": {
+          "name": "global_config_max_portfolio_exposure_pct_range",
+          "value": "\"global_config\".\"max_portfolio_exposure_pct\" > 0 AND \"global_config\".\"max_portfolio_exposure_pct\" <= 1"
+        },
+        "global_config_drawdown_kill_threshold_range": {
+          "name": "global_config_drawdown_kill_threshold_range",
+          "value": "\"global_config\".\"drawdown_kill_threshold\" >= -1 AND \"global_config\".\"drawdown_kill_threshold\" <= 0"
+        },
+        "global_config_stale_quote_ms_range": {
+          "name": "global_config_stale_quote_ms_range",
+          "value": "\"global_config\".\"stale_quote_ms\" >= 0"
+        },
+        "global_config_gap_reject_pct_range": {
+          "name": "global_config_gap_reject_pct_range",
+          "value": "\"global_config\".\"gap_reject_pct\" >= 0 AND \"global_config\".\"gap_reject_pct\" <= 1"
+        },
+        "global_config_spread_limit_pct_us_range": {
+          "name": "global_config_spread_limit_pct_us_range",
+          "value": "\"global_config\".\"spread_limit_pct_us\" >= 0 AND \"global_config\".\"spread_limit_pct_us\" <= 1"
+        },
+        "global_config_spread_limit_pct_jp_range": {
+          "name": "global_config_spread_limit_pct_jp_range",
+          "value": "\"global_config\".\"spread_limit_pct_jp\" >= 0 AND \"global_config\".\"spread_limit_pct_jp\" <= 1"
+        },
+        "global_config_pullback_default_stop_pct_range": {
+          "name": "global_config_pullback_default_stop_pct_range",
+          "value": "\"global_config\".\"pullback_default_stop_pct\" < 0 AND \"global_config\".\"pullback_default_stop_pct\" >= -1"
+        },
+        "global_config_pullback_default_take_profit_pct_range": {
+          "name": "global_config_pullback_default_take_profit_pct_range",
+          "value": "\"global_config\".\"pullback_default_take_profit_pct\" > 0 AND \"global_config\".\"pullback_default_take_profit_pct\" <= 1"
+        },
+        "global_config_pullback_default_time_stop_days_range": {
+          "name": "global_config_pullback_default_time_stop_days_range",
+          "value": "\"global_config\".\"pullback_default_time_stop_days\" > 0 AND \"global_config\".\"pullback_default_time_stop_days\" <= 365"
+        },
+        "global_config_pullback_default_pullback_max_range": {
+          "name": "global_config_pullback_default_pullback_max_range",
+          "value": "\"global_config\".\"pullback_default_pullback_max\" <= 0 AND \"global_config\".\"pullback_default_pullback_max\" >= -1"
+        },
+        "global_config_pullback_default_pullback_min_range": {
+          "name": "global_config_pullback_default_pullback_min_range",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= 0 AND \"global_config\".\"pullback_default_pullback_min\" >= -1"
+        },
+        "global_config_pullback_default_min_return_50d_range": {
+          "name": "global_config_pullback_default_min_return_50d_range",
+          "value": "\"global_config\".\"pullback_default_min_return_50d\" >= -1 AND \"global_config\".\"pullback_default_min_return_50d\" <= 10"
+        },
+        "global_config_pullback_default_k_atr_range": {
+          "name": "global_config_pullback_default_k_atr_range",
+          "value": "\"global_config\".\"pullback_default_k_atr\" > 0 AND \"global_config\".\"pullback_default_k_atr\" <= 10"
+        },
+        "global_config_pullback_default_pullback_window_order": {
+          "name": "global_config_pullback_default_pullback_window_order",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= \"global_config\".\"pullback_default_pullback_max\""
+        },
+        "global_config_risk_base_per_trade_pct_range": {
+          "name": "global_config_risk_base_per_trade_pct_range",
+          "value": "\"global_config\".\"risk_base_per_trade_pct\" > 0 AND \"global_config\".\"risk_base_per_trade_pct\" <= 1"
+        },
+        "global_config_risk_dd_half_threshold_range": {
+          "name": "global_config_risk_dd_half_threshold_range",
+          "value": "\"global_config\".\"risk_dd_half_threshold\" < 0 AND \"global_config\".\"risk_dd_half_threshold\" >= -1"
+        },
+        "global_config_risk_dd_halt_threshold_range": {
+          "name": "global_config_risk_dd_halt_threshold_range",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" < 0 AND \"global_config\".\"risk_dd_halt_threshold\" >= -1"
+        },
+        "global_config_risk_dd_threshold_order": {
+          "name": "global_config_risk_dd_threshold_order",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" <= \"global_config\".\"risk_dd_half_threshold\""
+        },
+        "global_config_bucket_exposure_pct_range": {
+          "name": "global_config_bucket_exposure_pct_range",
+          "value": "\"global_config\".\"bucket_exposure_pct\" > 0 AND \"global_config\".\"bucket_exposure_pct\" <= 1"
+        }
+      }
+    },
+    "inverse_pairs": {
+      "name": "inverse_pairs",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inverse": {
+          "name": "inverse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "strategy_decision_log": {
+      "name": "strategy_decision_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indicators_json": {
+          "name": "indicators_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "symbol_config": {
+      "name": "symbol_config",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "market": {
+          "name": "market",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_notional": {
+          "name": "max_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "symbol_config_currency_enum": {
+          "name": "symbol_config_currency_enum",
+          "value": "\"symbol_config\".\"currency\" IN ('USD', 'JPY')"
+        }
+      }
+    },
+    "trade_journal": {
+      "name": "trade_journal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trade_event_type": {
+          "name": "trade_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "strategy_name": {
+          "name": "strategy_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_action": {
+          "name": "signal_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_reason": {
+          "name": "signal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_allowed": {
+          "name": "risk_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_reasons": {
+          "name": "risk_reasons",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "limit_price": {
+          "name": "limit_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notional": {
+          "name": "notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "broker_status": {
+          "name": "broker_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "submitted": {
+          "name": "submitted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_qty": {
+          "name": "filled_qty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_price": {
+          "name": "filled_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "realized_pnl": {
+          "name": "realized_pnl",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hold_days": {
+          "name": "hold_days",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_reason": {
+          "name": "exit_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0009_snapshot.json
+++ b/drizzle/meta/0009_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "64928a04-4d14-47e4-8c0f-0c3f93ea6b6f",
+  "id": "725c7835-02e4-42d5-81f4-0e4f08609d10",
   "prevId": "39be53f4-2157-4c72-897c-4096ba803e9a",
   "tables": {
     "global_config": {
@@ -422,7 +422,16 @@
           "autoincrement": false
         }
       },
-      "indexes": {},
+      "indexes": {
+        "strategy_decision_log_symbol_id_idx": {
+          "name": "strategy_decision_log_symbol_id_idx",
+          "columns": [
+            "symbol",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
       "foreignKeys": {},
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1776953017653,
       "tag": "0008_bucket_cap",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1777006563811,
+      "tag": "0009_strategy_decision_log",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -68,7 +68,7 @@
     {
       "idx": 9,
       "version": "6",
-      "when": 1777006563811,
+      "when": 1777007970066,
       "tag": "0009_strategy_decision_log",
       "breakpoints": true
     }

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -1,5 +1,5 @@
 import { sql } from 'drizzle-orm'
-import { check, integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { check, index, integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core'
 
 /**
  * append-only trade decision / order lifecycle log. A single row per logical
@@ -286,19 +286,27 @@ export type GlobalConfigInsert = typeof globalConfig.$inferInsert
  * #128。運用で銘柄単位の診断 (なぜ BUY が出ないのか) に使う。
  * 7 日 TTL で quote feed cron が cleanup 同梱予定。
  */
-export const strategyDecisionLog = sqliteTable('strategy_decision_log', {
-  id: integer('id').primaryKey({ autoIncrement: true }),
-  timestamp: text('timestamp').notNull(),
-  requestId: text('request_id'),
-  symbol: text('symbol').notNull(),
-  /** 'BUY' / 'SELL' / 'HOLD' / 'REJECT' / 'ERROR' */
-  decision: text('decision').notNull(),
-  /** signal.reason (HOLD) / sizing.capReason (REJECT) / error.message (ERROR) */
-  reason: text('reason'),
-  price: real('price'),
-  /** indicators snapshot JSON (debug 用、optional) */
-  indicatorsJson: text('indicators_json'),
-})
+export const strategyDecisionLog = sqliteTable(
+  'strategy_decision_log',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    timestamp: text('timestamp').notNull(),
+    requestId: text('request_id'),
+    symbol: text('symbol').notNull(),
+    /** 'BUY' / 'SELL' / 'HOLD' / 'REJECT' / 'ERROR' */
+    decision: text('decision').notNull(),
+    /** signal.reason (HOLD) / sizing.capReason (REJECT) / error.message (ERROR) */
+    reason: text('reason'),
+    price: real('price'),
+    /** indicators snapshot JSON (debug 用、optional) */
+    indicatorsJson: text('indicators_json'),
+  },
+  (t) => ({
+    // `/dashboard/cron?symbol=X` は WHERE symbol=? ORDER BY id DESC で読む。
+    // (symbol, id) の複合 index で drop-in covering (CodeRabbit #132)。
+    symbolIdIdx: index('strategy_decision_log_symbol_id_idx').on(t.symbol, t.id),
+  }),
+)
 
 export type StrategyDecisionLogRow = typeof strategyDecisionLog.$inferSelect
 export type StrategyDecisionLogInsert = typeof strategyDecisionLog.$inferInsert

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -279,3 +279,26 @@ export const globalConfig = sqliteTable(
 
 export type GlobalConfigRow = typeof globalConfig.$inferSelect
 export type GlobalConfigInsert = typeof globalConfig.$inferInsert
+
+/**
+ * Per-symbol decision log from `runPullbackScheduler`。1 row per
+ * (cron fire × symbol)。HOLD / BUY / SELL / REJECT / ERROR 全ルートを残す。
+ * #128。運用で銘柄単位の診断 (なぜ BUY が出ないのか) に使う。
+ * 7 日 TTL で quote feed cron が cleanup 同梱予定。
+ */
+export const strategyDecisionLog = sqliteTable('strategy_decision_log', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  timestamp: text('timestamp').notNull(),
+  requestId: text('request_id'),
+  symbol: text('symbol').notNull(),
+  /** 'BUY' / 'SELL' / 'HOLD' / 'REJECT' / 'ERROR' */
+  decision: text('decision').notNull(),
+  /** signal.reason (HOLD) / sizing.capReason (REJECT) / error.message (ERROR) */
+  reason: text('reason'),
+  price: real('price'),
+  /** indicators snapshot JSON (debug 用、optional) */
+  indicatorsJson: text('indicators_json'),
+})
+
+export type StrategyDecisionLogRow = typeof strategyDecisionLog.$inferSelect
+export type StrategyDecisionLogInsert = typeof strategyDecisionLog.$inferInsert

--- a/src/infrastructure/logger/strategyDecisionLog.ts
+++ b/src/infrastructure/logger/strategyDecisionLog.ts
@@ -40,6 +40,7 @@ export async function logStrategyDecision(
     console.error(
       JSON.stringify({
         event: 'strategy_decision_log_insert_failed',
+        requestId: record.requestId ?? null,
         symbol: record.symbol,
         decision: record.decision,
         message: error instanceof Error ? error.message : String(error),

--- a/src/infrastructure/logger/strategyDecisionLog.ts
+++ b/src/infrastructure/logger/strategyDecisionLog.ts
@@ -1,0 +1,58 @@
+import type { DrizzleD1Database } from 'drizzle-orm/d1'
+import { strategyDecisionLog } from '../db/schema'
+import { createDb } from '../db/tradeJournalRepo'
+
+export interface StrategyDecisionRecord {
+  timestamp: string
+  requestId?: string
+  symbol: string
+  decision: 'BUY' | 'SELL' | 'HOLD' | 'REJECT' | 'ERROR'
+  reason?: string | null
+  price?: number | null
+  indicatorsJson?: string | null
+}
+
+/**
+ * INSERT one per-symbol decision row. Failure is logged (console.error) and
+ * swallowed — logging must NEVER cause the strategy loop to crash or skip
+ * symbols (logging failure isolation, as already practiced by pullbackScheduler
+ * for tradeJournal entries).
+ *
+ * Callers that don't have DB bound (e.g. unit tests that pass a fake
+ * positionStore) pass `db` as undefined; this function no-ops then.
+ */
+export async function logStrategyDecision(
+  db: DrizzleD1Database | undefined,
+  record: StrategyDecisionRecord,
+): Promise<void> {
+  if (!db) return
+  try {
+    await db.insert(strategyDecisionLog).values({
+      timestamp: record.timestamp,
+      requestId: record.requestId ?? null,
+      symbol: record.symbol,
+      decision: record.decision,
+      reason: record.reason ?? null,
+      price: record.price ?? null,
+      indicatorsJson: record.indicatorsJson ?? null,
+    })
+  } catch (error) {
+    console.error(
+      JSON.stringify({
+        event: 'strategy_decision_log_insert_failed',
+        symbol: record.symbol,
+        decision: record.decision,
+        message: error instanceof Error ? error.message : String(error),
+      }),
+    )
+  }
+}
+
+/**
+ * Factory for a lazy D1 handle used by strategy scheduler. Returns `undefined`
+ * when `env.DB` is unbound so callers can pass a short-circuit value without
+ * branching.
+ */
+export function strategyDecisionDbOrUndefined(env: { DB?: D1Database }): DrizzleD1Database | undefined {
+  return env.DB ? createDb(env.DB) : undefined
+}

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -3,8 +3,8 @@ import type { AppBindings } from '../app'
 import { loadGlobalConfigFrom } from '../infrastructure/db/globalConfigLoader'
 import { loadSymbolUniverse } from '../infrastructure/db/symbolUniverse'
 import { createDb } from '../infrastructure/db/tradeJournalRepo'
-import { tradeJournal } from '../infrastructure/db/schema'
-import { desc } from 'drizzle-orm'
+import { strategyDecisionLog, tradeJournal } from '../infrastructure/db/schema'
+import { desc, eq } from 'drizzle-orm'
 import { PortfolioStateClient } from '../trading/state/PortfolioStateClient'
 import { SymbolStateClient } from '../trading/state/SymbolStateClient'
 import type { SymbolState } from '../trading/state/types'
@@ -64,6 +64,27 @@ export const dashboard = new Hono<AppBindings>()
       loadSymbolUniverse(c.env),
     ])
     return c.html(layout('Config', configBody(global, universe)))
+  })
+  .get('/cron', async (c) => {
+    if (!c.env.DB) {
+      return c.html(layout('Cron Decisions', unavailable('DB not bound')))
+    }
+    const limit = clampLimit(c.req.query('limit'))
+    const symbolFilter = c.req.query('symbol')?.toUpperCase().trim() || undefined
+    const db = createDb(c.env.DB)
+    const rows = symbolFilter
+      ? await db
+          .select()
+          .from(strategyDecisionLog)
+          .where(eq(strategyDecisionLog.symbol, symbolFilter))
+          .orderBy(desc(strategyDecisionLog.id))
+          .limit(limit)
+      : await db
+          .select()
+          .from(strategyDecisionLog)
+          .orderBy(desc(strategyDecisionLog.id))
+          .limit(limit)
+    return c.html(layout('Cron Decisions', cronBody(rows, limit, symbolFilter)))
   })
 
 function messageOf(error: unknown): string {
@@ -157,6 +178,7 @@ function layout(title: string, body: string): string {
   <a href="/dashboard/portfolio">Portfolio</a>
   <a href="/dashboard/trades">Trades</a>
   <a href="/dashboard/config">Config</a>
+  <a href="/dashboard/cron">Cron</a>
 </nav>
 ${body}
 <div class="footer">rendered at ${esc(fmtJst(new Date()))}</div>
@@ -175,6 +197,7 @@ function indexBody(): string {
   <li><a href="/dashboard/portfolio">Portfolio</a> — dailyStartEquity / realized PnL / drawdown / kill-switch</li>
   <li><a href="/dashboard/trades">Trades</a> — trade_journal 直近 (default 50、<code>?limit=N</code> で可変、max 200)</li>
   <li><a href="/dashboard/config">Config</a> — global_config + active symbol_config</li>
+  <li><a href="/dashboard/cron">Cron Decisions</a> — strategy_decision_log 直近 (<code>?symbol=SOXL</code> で絞り込み、日本語 reason)</li>
 </ul>`
 }
 
@@ -331,4 +354,97 @@ function formatConfigValue(v: unknown): string {
   if (v === null || v === undefined) return 'null'
   if (typeof v === 'boolean') return v ? 'true' : 'false'
   return String(v)
+}
+
+/**
+ * Strategy / sizing が出力する英語 reason を日本語に翻訳する display helper。
+ * ログ DB には英語のまま保存し、表示時のみ翻訳 (テスト互換性を崩さない)。
+ * 動的数値はそのまま残すため正規表現で置換。
+ */
+function localizeReason(en: string | null | undefined): string {
+  if (!en) return '-'
+  let s = en
+  // Strategy signal.reason パターン
+  s = s.replace(/^pending order in flight$/, '発注中 (lock 保持)')
+  s = s.replace(/^cooldown active until (.+)$/, 'クールダウン中 ($1 まで)')
+  s = s.replace(/^take-profit hit: pnl (\S+) >= (\S+)$/, '利確到達 (pnl $1 ≥ $2)')
+  s = s.replace(/^stop-loss hit: pnl (\S+) <= (\S+)$/, '損切到達 (pnl $1 ≤ $2)')
+  s = s.replace(/^time-stop hit: held (\S+) >= (\S+)$/, '時間切れ (保有 $1 ≥ $2)')
+  s = s.replace(/^holding: pnl (\S+) within \(([^)]+)\)$/, '保有継続 (pnl $1、範囲 $2)')
+  s = s.replace(/^50d return (\S+) <= (\S+) trend threshold$/, '50日 return $1 が閾値 $2 未満 (uptrend 不成立)')
+  s = s.replace(/^price (\S+) <= sma50 (\S+)$/, '価格 $1 が SMA50 $2 以下 (uptrend 不成立)')
+  s = s.replace(/^invalid 20d high$/, '20日高値が無効')
+  s = s.replace(/^pullback (\S+) > (\S+) \(not deep enough\)$/, '押し目 $1 が浅すぎ (閾値 $2)')
+  s = s.replace(/^pullback (\S+) < (\S+) \(too deep\)$/, '押し目 $1 が深すぎ (閾値 $2)')
+  s = s.replace(/^pullback (\S+) in uptrend \(50d return (\S+)\)$/, '押し目 $1、uptrend 継続 (50日 return $2)')
+  // Sizing capReason
+  s = s.replace(/^sizing rejected: lot-size-round$/, 'サイジング拒否: 100株ロット未満')
+  s = s.replace(/^sizing rejected: insufficient-risk-budget$/, 'サイジング拒否: リスク予算不足')
+  s = s.replace(/^sizing rejected: atr-floor$/, 'サイジング拒否: ATR floor (vol 崩壊)')
+  s = s.replace(/^sizing rejected: symbol-cap$/, 'サイジング拒否: 銘柄別 notional cap 超過')
+  s = s.replace(/^sizing rejected: invalid-stop$/, 'サイジング拒否: stop 距離が無効')
+  s = s.replace(/^sizing rejected: zero qty$/, 'サイジング拒否: qty が 0')
+  // Scheduler inline
+  s = s.replace(/^SELL without position$/, 'SELL 対象ポジションなし')
+  s = s.replace(/^insufficient bars for indicators$/, 'bar 本数不足 (indicator 計算不能)')
+  s = s.replace(/^pending order already in flight$/, '発注中 (pending lock 競合)')
+  s = s.replace(/^invalid price: (\S+)$/, '価格が無効 ($1)')
+  s = s.replace(/^invalid notional:/, 'notional が無効:')
+  s = s.replace(/^invalid position qty: (\S+)$/, 'ポジション qty が無効 ($1)')
+  s = s.replace(/^invalid expiresAt/, 'expiresAt が無効')
+  s = s.replace(/^bar fetch: /, 'bar 取得失敗: ')
+  // Bucket gate
+  s = s.replace(/^bucket cap: (\S+) projected (\S+) > (\S+)$/, 'バケット cap: $1 合計 $2 が上限 $3 を超過')
+  s = s.replace(/^bucket cap: (\S+) cap (\S+) <= 0$/, 'バケット cap: $1 の cap ($2) が 0 以下')
+  s = s.replace(/^bucket cap: (\S+) invalid addNotional (\S+)$/, 'バケット cap: $1 の addNotional ($2) が無効')
+  return s
+}
+
+function cronBody(
+  rows: Array<{
+    id: number
+    timestamp: string
+    requestId: string | null
+    symbol: string
+    decision: string
+    reason: string | null
+    price: number | null
+  }>,
+  limit: number,
+  symbolFilter: string | undefined,
+): string {
+  const header = symbolFilter
+    ? `<p class="muted">Showing ${rows.length} decisions for <strong>${esc(symbolFilter)}</strong> (limit=${limit}, max 200)。<a href="/dashboard/cron">全銘柄へ戻る</a></p>`
+    : `<p class="muted">Showing ${rows.length} decisions (limit=${limit}, max 200)。<code>?symbol=SOXL</code> で絞り込み可能。</p>`
+  if (rows.length === 0) {
+    return `${header}<p class="muted">判定ログがまだありません。</p>`
+  }
+  const tbody = rows
+    .map((r) => {
+      const cls =
+        r.decision === 'BUY'
+          ? 'ok'
+          : r.decision === 'SELL'
+            ? 'warn'
+            : r.decision === 'ERROR'
+              ? 'err'
+              : r.decision === 'REJECT'
+                ? 'warn'
+                : 'muted'
+      return `<tr>
+        <td class="muted">${esc(fmtJst(r.timestamp))}</td>
+        <td><a href="/dashboard/cron?symbol=${esc(r.symbol)}"><strong>${esc(r.symbol)}</strong></a></td>
+        <td class="${cls}">${esc(r.decision)}</td>
+        <td>${esc(localizeReason(r.reason))}</td>
+        <td>${r.price === null ? '-' : fmtNumber(r.price, 2)}</td>
+      </tr>`
+    })
+    .join('')
+  return `${header}
+  <table>
+    <thead><tr>
+      <th>timestamp (JST)</th><th>symbol</th><th>decision</th><th>reason</th><th>price</th>
+    </tr></thead>
+    <tbody>${tbody}</tbody>
+  </table>`
 }

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -72,19 +72,25 @@ export const dashboard = new Hono<AppBindings>()
     const limit = clampLimit(c.req.query('limit'))
     const symbolFilter = c.req.query('symbol')?.toUpperCase().trim() || undefined
     const db = createDb(c.env.DB)
-    const rows = symbolFilter
-      ? await db
-          .select()
-          .from(strategyDecisionLog)
-          .where(eq(strategyDecisionLog.symbol, symbolFilter))
-          .orderBy(desc(strategyDecisionLog.id))
-          .limit(limit)
-      : await db
-          .select()
-          .from(strategyDecisionLog)
-          .orderBy(desc(strategyDecisionLog.id))
-          .limit(limit)
-    return c.html(layout('Cron Decisions', cronBody(rows, limit, symbolFilter)))
+    try {
+      const rows = symbolFilter
+        ? await db
+            .select()
+            .from(strategyDecisionLog)
+            .where(eq(strategyDecisionLog.symbol, symbolFilter))
+            .orderBy(desc(strategyDecisionLog.id))
+            .limit(limit)
+        : await db
+            .select()
+            .from(strategyDecisionLog)
+            .orderBy(desc(strategyDecisionLog.id))
+            .limit(limit)
+      return c.html(layout('Cron Decisions', cronBody(rows, limit, symbolFilter)))
+    } catch (err) {
+      // migration 未適用 / 一時的な D1 エラーで 500 にせず unavailable に落とす
+      // (CodeRabbit #132)。段階的デプロイ時の自己保護。
+      return c.html(layout('Cron Decisions', unavailable(messageOf(err))))
+    }
   })
 
 function messageOf(error: unknown): string {
@@ -378,7 +384,7 @@ function localizeReason(en: string | null | undefined): string {
   s = s.replace(/^pullback (\S+) < (\S+) \(too deep\)$/, '押し目 $1 が深すぎ (閾値 $2)')
   s = s.replace(/^pullback (\S+) in uptrend \(50d return (\S+)\)$/, '押し目 $1、uptrend 継続 (50日 return $2)')
   // Sizing capReason
-  s = s.replace(/^sizing rejected: lot-size-round$/, 'サイジング拒否: 100株ロット未満')
+  s = s.replace(/^sizing rejected: lot-size-round$/, 'サイジング拒否: ロット丸め後に最小取引単位未満')
   s = s.replace(/^sizing rejected: insufficient-risk-budget$/, 'サイジング拒否: リスク予算不足')
   s = s.replace(/^sizing rejected: atr-floor$/, 'サイジング拒否: ATR floor (vol 崩壊)')
   s = s.replace(/^sizing rejected: symbol-cap$/, 'サイジング拒否: 銘柄別 notional cap 超過')
@@ -393,6 +399,7 @@ function localizeReason(en: string | null | undefined): string {
   s = s.replace(/^invalid position qty: (\S+)$/, 'ポジション qty が無効 ($1)')
   s = s.replace(/^invalid expiresAt/, 'expiresAt が無効')
   s = s.replace(/^bar fetch: /, 'bar 取得失敗: ')
+  s = s.replace(/^broker submit error: /, 'broker 送信エラー: ')
   // Bucket gate
   s = s.replace(/^bucket cap: (\S+) projected (\S+) > (\S+)$/, 'バケット cap: $1 合計 $2 が上限 $3 を超過')
   s = s.replace(/^bucket cap: (\S+) cap (\S+) <= 0$/, 'バケット cap: $1 の cap ($2) が 0 以下')
@@ -433,7 +440,7 @@ function cronBody(
                 : 'muted'
       return `<tr>
         <td class="muted">${esc(fmtJst(r.timestamp))}</td>
-        <td><a href="/dashboard/cron?symbol=${esc(r.symbol)}"><strong>${esc(r.symbol)}</strong></a></td>
+        <td><a href="/dashboard/cron?symbol=${encodeURIComponent(r.symbol)}"><strong>${esc(r.symbol)}</strong></a></td>
         <td class="${cls}">${esc(r.decision)}</td>
         <td>${esc(localizeReason(r.reason))}</td>
         <td>${r.price === null ? '-' : fmtNumber(r.price, 2)}</td>

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -334,7 +334,8 @@ export async function runPullbackScheduler(
       await emitDecision({
         symbol: upper,
         decision: 'ERROR',
-        reason: `broker 送信エラー: ${messageOf(error)}`,
+        // DB には英語 canonical で保存。表示層 (localizeReason) で日本語化。
+        reason: `broker submit error: ${messageOf(error)}`,
         price: indicators.price,
       })
       try {

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -66,6 +66,13 @@ export interface PullbackSchedulerOptions {
     price?: number
     indicatorsJson?: string
   }) => Promise<void> | void
+  /**
+   * cron fire 単位の correlation id。emit 失敗時の構造化ログに含めることで
+   * 「どの run で decision sink が落ちたか」を tail から追えるようにする
+   * (CodeRabbit #132 follow-up)。runStrategyCron が scheduled() handler の
+   * `crypto.randomUUID()` を渡す。
+   */
+  requestId?: string
   now?: () => Date
 }
 
@@ -116,6 +123,7 @@ export async function runPullbackScheduler(
       console.error(
         JSON.stringify({
           event: 'on_decision_sink_failed',
+          requestId: options.requestId ?? null,
           symbol: record.symbol,
           decision: record.decision,
           message: err instanceof Error ? err.message : String(err),

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -54,6 +54,18 @@ export interface PullbackSchedulerOptions {
    * (runStrategyCron) が NAV × exposure_pct で算出する。
    */
   bucketCapMap?: Record<string, number>
+  /**
+   * Per-symbol decision sink。HOLD / BUY / SELL / REJECT / ERROR の各 route で
+   * 1 回ずつ呼ばれる。実装は D1 INSERT が典型 (#128)、テストは fake 注入可能。
+   * 呼び出し側が失敗を throw しないのが前提 (logging failure isolation)。
+   */
+  onDecision?: (record: {
+    symbol: string
+    decision: 'BUY' | 'SELL' | 'HOLD' | 'REJECT' | 'ERROR'
+    reason?: string
+    price?: number
+    indicatorsJson?: string
+  }) => Promise<void> | void
   now?: () => Date
 }
 
@@ -95,6 +107,23 @@ export async function runPullbackScheduler(
     errors: [],
   }
 
+  // Logging helper: sink が投げても本体を落とさない (logging failure isolation)。
+  const emitDecision = async (record: Parameters<NonNullable<typeof options.onDecision>>[0]): Promise<void> => {
+    if (!options.onDecision) return
+    try {
+      await options.onDecision(record)
+    } catch (err) {
+      console.error(
+        JSON.stringify({
+          event: 'on_decision_sink_failed',
+          symbol: record.symbol,
+          decision: record.decision,
+          message: err instanceof Error ? err.message : String(err),
+        }),
+      )
+    }
+  }
+
   // Bucket pre-scan: sum the open-position notional per bucket across all
   // symbols in this run so the BUY gate can refuse an entry that would push
   // the bucket over `bucketCapMap[bucket]`. Skipped entirely when no bucket
@@ -130,12 +159,14 @@ export async function runPullbackScheduler(
       bars = await options.barClient.getDailyBars(symbol, lookback)
     } catch (error) {
       summary.errors.push({ symbol: upper, message: messageOf(error) })
+      await emitDecision({ symbol: upper, decision: 'ERROR', reason: `bar fetch: ${messageOf(error)}` })
       continue
     }
 
     const indicators = computePullbackIndicators(bars)
     if (!indicators) {
       summary.rejected.push({ symbol: upper, reason: 'insufficient bars for indicators' })
+      await emitDecision({ symbol: upper, decision: 'REJECT', reason: 'insufficient bars for indicators' })
       continue
     }
 
@@ -158,6 +189,13 @@ export async function runPullbackScheduler(
 
     if (signal.action === 'HOLD') {
       summary.holds += 1
+      await emitDecision({
+        symbol: upper,
+        decision: 'HOLD',
+        reason: signal.reason,
+        price: indicators.price,
+        indicatorsJson: JSON.stringify(indicators),
+      })
       continue
     }
 
@@ -176,19 +214,22 @@ export async function runPullbackScheduler(
         kAtr: rule.kAtr,
       })
       if (sizing.quantity <= 0) {
-        summary.rejected.push({
-          symbol: upper,
-          reason: `sizing rejected: ${sizing.capReason ?? 'zero qty'}`,
-        })
+        const reason = `sizing rejected: ${sizing.capReason ?? 'zero qty'}`
+        summary.rejected.push({ symbol: upper, reason })
+        await emitDecision({ symbol: upper, decision: 'REJECT', reason, price: indicators.price, indicatorsJson: JSON.stringify(indicators) })
         continue
       }
       if (!Number.isFinite(indicators.price) || indicators.price <= 0) {
-        summary.rejected.push({ symbol: upper, reason: `invalid price: ${indicators.price}` })
+        const reason = `invalid price: ${indicators.price}`
+        summary.rejected.push({ symbol: upper, reason })
+        await emitDecision({ symbol: upper, decision: 'REJECT', reason, price: indicators.price })
         continue
       }
       const notional = sizing.quantity * indicators.price
       if (!Number.isFinite(notional) || notional <= 0) {
-        summary.rejected.push({ symbol: upper, reason: `invalid notional: ${notional} (qty=${sizing.quantity}, price=${indicators.price})` })
+        const reason = `invalid notional: ${notional} (qty=${sizing.quantity}, price=${indicators.price})`
+        summary.rejected.push({ symbol: upper, reason })
+        await emitDecision({ symbol: upper, decision: 'REJECT', reason, price: indicators.price })
         continue
       }
       const bucket = options.symbolBucketMap?.[upper]
@@ -199,7 +240,9 @@ export async function runPullbackScheduler(
         cap: bucket ? options.bucketCapMap?.[bucket] : undefined,
       })
       if (!bucketDecision.allowed) {
-        summary.rejected.push({ symbol: upper, reason: bucketDecision.reason ?? 'bucket cap' })
+        const reason = bucketDecision.reason ?? 'bucket cap'
+        summary.rejected.push({ symbol: upper, reason })
+        await emitDecision({ symbol: upper, decision: 'REJECT', reason, price: indicators.price, indicatorsJson: JSON.stringify(indicators) })
         continue
       }
       if (bucket && bucketDecision.newExposure !== undefined) {
@@ -209,20 +252,28 @@ export async function runPullbackScheduler(
     } else {
       // SELL: close the full open position.
       if (state.position === null) {
-        summary.rejected.push({ symbol: upper, reason: 'SELL without position' })
+        const reason = 'SELL without position'
+        summary.rejected.push({ symbol: upper, reason })
+        await emitDecision({ symbol: upper, decision: 'REJECT', reason, price: indicators.price })
         continue
       }
       if (!Number.isFinite(state.position.qty) || state.position.qty <= 0) {
-        summary.rejected.push({ symbol: upper, reason: `invalid position qty: ${state.position.qty}` })
+        const reason = `invalid position qty: ${state.position.qty}`
+        summary.rejected.push({ symbol: upper, reason })
+        await emitDecision({ symbol: upper, decision: 'REJECT', reason, price: indicators.price })
         continue
       }
       if (!Number.isFinite(indicators.price) || indicators.price <= 0) {
-        summary.rejected.push({ symbol: upper, reason: `invalid price: ${indicators.price}` })
+        const reason = `invalid price: ${indicators.price}`
+        summary.rejected.push({ symbol: upper, reason })
+        await emitDecision({ symbol: upper, decision: 'REJECT', reason, price: indicators.price })
         continue
       }
       const notional = state.position.qty * indicators.price
       if (!Number.isFinite(notional) || notional <= 0) {
-        summary.rejected.push({ symbol: upper, reason: `invalid notional: ${notional} (qty=${state.position.qty}, price=${indicators.price})` })
+        const reason = `invalid notional: ${notional} (qty=${state.position.qty}, price=${indicators.price})`
+        summary.rejected.push({ symbol: upper, reason })
+        await emitDecision({ symbol: upper, decision: 'REJECT', reason, price: indicators.price })
         continue
       }
       intent = buildIntent(upper, 'SELL', state.position.qty, indicators.price)
@@ -230,7 +281,9 @@ export async function runPullbackScheduler(
 
     const expiresAtMs = now().getTime() + pendingLockTtlMs
     if (!Number.isFinite(expiresAtMs) || expiresAtMs <= now().getTime()) {
-      summary.rejected.push({ symbol: upper, reason: `invalid expiresAt computed from pendingLockTtlMs: ${pendingLockTtlMs}` })
+      const reason = `invalid expiresAt computed from pendingLockTtlMs: ${pendingLockTtlMs}`
+      summary.rejected.push({ symbol: upper, reason })
+      await emitDecision({ symbol: upper, decision: 'REJECT', reason, price: indicators.price })
       continue
     }
     const lockResult = await options.positionStore.lockPendingOrder(upper, {
@@ -240,7 +293,9 @@ export async function runPullbackScheduler(
       expiresAt: new Date(expiresAtMs).toISOString(),
     })
     if (!lockResult.ok) {
-      summary.rejected.push({ symbol: upper, reason: 'pending order already in flight' })
+      const reason = 'pending order already in flight'
+      summary.rejected.push({ symbol: upper, reason })
+      await emitDecision({ symbol: upper, decision: 'REJECT', reason, price: indicators.price })
       continue
     }
 
@@ -275,6 +330,12 @@ export async function runPullbackScheduler(
       summary.errors.push({
         symbol: upper,
         message: messageOf(error),
+      })
+      await emitDecision({
+        symbol: upper,
+        decision: 'ERROR',
+        reason: `broker 送信エラー: ${messageOf(error)}`,
+        price: indicators.price,
       })
       try {
         logPostSubmit({
@@ -320,6 +381,13 @@ export async function runPullbackScheduler(
     } else {
       summary.sells += 1
     }
+    await emitDecision({
+      symbol: upper,
+      decision: intent.side,
+      reason: signal.reason,
+      price: intent.price,
+      indicatorsJson: JSON.stringify(indicators),
+    })
 
     if (result.mode === 'DRY_RUN') {
       // No broker event will clear the lock; release it eagerly.

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -9,6 +9,10 @@ import { WebullExecution } from '../execution/WebullExecution'
 import { PortfolioStateClient } from '../state/PortfolioStateClient'
 import { SymbolStateClient } from '../state/SymbolStateClient'
 import { computeDrawdownRiskScale } from '../risk/drawdownRiskScale'
+import {
+  logStrategyDecision,
+  strategyDecisionDbOrUndefined,
+} from '../../infrastructure/logger/strategyDecisionLog'
 import { runPullbackScheduler, type PullbackRunSummary } from './pullbackScheduler'
 
 const DEFAULT_EQUITY_USD = 10_000
@@ -221,6 +225,7 @@ export async function runStrategyCron(
     for (const b of buckets) {
       bucketCapMap[b] = run.equity * global.bucketExposurePct
     }
+    const decisionDb = strategyDecisionDbOrUndefined(env)
     const sub = await runPullbackScheduler({
       symbols: run.symbols,
       equity: run.equity,
@@ -233,6 +238,12 @@ export async function runStrategyCron(
       bucketCapMap,
       defaultRule,
       riskPerTradePct: scaledRiskPerTradePct,
+      onDecision: (record) =>
+        logStrategyDecision(decisionDb, {
+          timestamp: new Date().toISOString(),
+          requestId: options.requestId,
+          ...record,
+        }),
     })
     summary.evaluated += sub.evaluated
     summary.buys += sub.buys

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -238,6 +238,7 @@ export async function runStrategyCron(
       bucketCapMap,
       defaultRule,
       riskPerTradePct: scaledRiskPerTradePct,
+      requestId: options.requestId,
       onDecision: (record) =>
         logStrategyDecision(decisionDb, {
           timestamp: new Date().toISOString(),

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -147,4 +147,17 @@ describe('dashboard', () => {
     expect(body).not.toContain('<script>')
     expect(body).toContain('&lt;script&gt;')
   })
+
+  it('renders cron page with "unavailable" when DB is not bound', async () => {
+    const app = createApp()
+    const res = await app.request('/dashboard/cron', { headers: authHeader }, baseEnv)
+    expect(res.status).toBe(200)
+    expect(await res.text()).toContain('unavailable')
+  })
+
+  it('cron page requires basic auth', async () => {
+    const app = createApp()
+    const res = await app.request('/dashboard/cron', {}, baseEnv)
+    expect(res.status).toBe(401)
+  })
 })


### PR DESCRIPTION
## Summary

日常運用で「6752 がなぜずっと BUY 出ないのか (pullback 浅い? sma50 下? sizing で弾かれてる?)」を tail 不要で dashboard から銘柄単位・時系列に追えるようにする。

### Schema (migration 0009)

\`strategy_decision_log\`: 1 row per (cron fire × symbol)、HOLD/BUY/SELL/REJECT/ERROR 全 route を記録。

| column | type |
|---|---|
| id | integer PK |
| timestamp | text NOT NULL (ISO8601) |
| request_id | text (cron 相関 id) |
| symbol | text NOT NULL |
| decision | text NOT NULL |
| reason | text |
| price | real |
| indicators_json | text (debug 用) |

### Scheduler

\`runPullbackScheduler\` に \`onDecision?\` callback。各 route (HOLD/REJECT/ERROR/BUY/SELL 成功) で emit、sink 失敗は本体を落とさない (logging failure isolation)。\`runStrategyCron\` が D1 INSERT する sink を組み立てて注入。

### Dashboard

\`/dashboard/cron\`:
- 全銘柄の直近 50 判定 (default)
- \`?symbol=SOXL\` で絞り込み (symbol 名 link 経由で自動遷移)
- \`?limit=N\` max 200
- decision 色分け
- **reason を日本語化** (display layer の \`localizeReason\`、DB は英語保存で journal / tests 互換)

### 日本語化例

| English (DB / log) | Display (dashboard) |
|---|---|
| \`pullback 0.0023 > -0.01 (not deep enough)\` | 押し目 0.0023 が浅すぎ (閾値 -0.01) |
| \`sizing rejected: lot-size-round\` | サイジング拒否: 100株ロット未満 |
| \`50d return 0.01 <= 0.03 trend threshold\` | 50日 return 0.01 が閾値 0.03 未満 (uptrend 不成立) |
| \`bucket cap: semi projected 500 > 300\` | バケット cap: semi 合計 500 が上限 300 を超過 |

## Test plan

- [x] \`pnpm test\` — 330 passed (+2 cron route)
- [x] \`pnpm typecheck\` — clean
- [ ] staging deploy 後 \`/dashboard/cron\` で judged symbols が並ぶことをブラウザ確認
- [ ] \`?symbol=6752\` で絞り込み遷移

## 非対象 (follow-up)

- 7 日 TTL cleanup cron (別 PR、quote feed 同梱予定)
- Chart 系は #130 Phase A (独立並行)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 戦略決定ログを追加し、タイムスタンプ・シンボル・決定（BUY/SELL/HOLD/REJECT/ERROR）と任意のrequestId・理由・価格・指標を記録可能にしました。
  * ダッシュボードに「Cron」ページを追加。シンボルで絞り込み、最新順で過去決定を表示します。理由は表示時に日本語化されます。
  * 決定送信は失敗しても実行を止めない安全な記録フローを導入しました。

* **テスト**
  * Cronページの表示と認可に関するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->