### PR TITLE
feat(dashboard): cron reason 日本語表現を改善 (entry/exit 明示 + % 表記)

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -388,11 +388,15 @@ export function localizeReason(en: string | null | undefined): string {
   s = s.replace(/^take-profit hit: pnl (\S+) >= (\S+)$/, (_m, p, t) => `利確到達 (pnl ${fmtPct(p)} ≥ ${fmtPct(t)}) (exit)`)
   s = s.replace(/^stop-loss hit: pnl (\S+) <= (\S+)$/, (_m, p, t) => `損切到達 (pnl ${fmtPct(p)} ≤ ${fmtPct(t)}) (exit)`)
   s = s.replace(/^time-stop hit: held (\S+) >= (\S+)$/, '時間切れ (保有 $1 ≥ $2) (exit)')
-  s = s.replace(/^holding: pnl (\S+) within \(([^)]+)\)$/, (_m, p, r) => `保有継続 (pnl ${fmtPct(p)}、範囲 ${r}) (exit)`)
+  // holding の range 上下限も % 化して表示を統一 (CodeRabbit #133)。
+  s = s.replace(
+    /^holding: pnl (\S+) within \(([^,]+),\s*([^)]+)\)$/,
+    (_m, p, low, high) => `保有継続 (pnl ${fmtPct(p)}、範囲 ${fmtPct(low)} 〜 ${fmtPct(high)}) (exit)`,
+  )
   // Entry filter (未保有、entry 条件未達)
   s = s.replace(
     /^50d return (\S+) <= (\S+) trend threshold$/,
-    (_m, r, t) => `entry 見送り: 50日 return ${fmtPct(r)} < 必要値 ${fmtPct(t)} (上昇トレンド filter)`,
+    (_m, r, t) => `entry 見送り: 50日 return ${fmtPct(r)} ≤ 必要値 ${fmtPct(t)} (上昇トレンド filter)`,
   )
   s = s.replace(/^price (\S+) <= sma50 (\S+)$/, 'entry 見送り: 価格 $1 ≤ SMA50 $2 (上昇トレンド filter)')
   s = s.replace(/^invalid 20d high$/, 'entry 見送り: 20日高値が無効')

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -362,27 +362,53 @@ function formatConfigValue(v: unknown): string {
   return String(v)
 }
 
+/** Numeric string ratio → percent string (0.0108 → "1.08%"). fallback は原文字列。 */
+function fmtPct(s: string): string {
+  const n = Number(s)
+  if (!Number.isFinite(n)) return s
+  return `${(n * 100).toFixed(2)}%`
+}
+
 /**
  * Strategy / sizing が出力する英語 reason を日本語に翻訳する display helper。
  * ログ DB には英語のまま保存し、表示時のみ翻訳 (テスト互換性を崩さない)。
- * 動的数値はそのまま残すため正規表現で置換。
+ *
+ * 命名規則:
+ *   - entry 系 HOLD は「entry 見送り:」prefix (entry filter 未達を示す)
+ *   - exit 系 HOLD/SELL は「(exit)」suffix (保有ポジションの出口判定)
+ *   - 比率 (0.0108 等) は %表記に変換 (読みやすさ)
  */
-function localizeReason(en: string | null | undefined): string {
+export function localizeReason(en: string | null | undefined): string {
   if (!en) return '-'
   let s = en
-  // Strategy signal.reason パターン
+  // Pending / cooldown (entry 前ガード)
   s = s.replace(/^pending order in flight$/, '発注中 (lock 保持)')
   s = s.replace(/^cooldown active until (.+)$/, 'クールダウン中 ($1 まで)')
-  s = s.replace(/^take-profit hit: pnl (\S+) >= (\S+)$/, '利確到達 (pnl $1 ≥ $2)')
-  s = s.replace(/^stop-loss hit: pnl (\S+) <= (\S+)$/, '損切到達 (pnl $1 ≤ $2)')
-  s = s.replace(/^time-stop hit: held (\S+) >= (\S+)$/, '時間切れ (保有 $1 ≥ $2)')
-  s = s.replace(/^holding: pnl (\S+) within \(([^)]+)\)$/, '保有継続 (pnl $1、範囲 $2)')
-  s = s.replace(/^50d return (\S+) <= (\S+) trend threshold$/, '50日 return $1 が閾値 $2 未満 (uptrend 不成立)')
-  s = s.replace(/^price (\S+) <= sma50 (\S+)$/, '価格 $1 が SMA50 $2 以下 (uptrend 不成立)')
-  s = s.replace(/^invalid 20d high$/, '20日高値が無効')
-  s = s.replace(/^pullback (\S+) > (\S+) \(not deep enough\)$/, '押し目 $1 が浅すぎ (閾値 $2)')
-  s = s.replace(/^pullback (\S+) < (\S+) \(too deep\)$/, '押し目 $1 が深すぎ (閾値 $2)')
-  s = s.replace(/^pullback (\S+) in uptrend \(50d return (\S+)\)$/, '押し目 $1、uptrend 継続 (50日 return $2)')
+  // Exit 判定 (保有ポジション)
+  s = s.replace(/^take-profit hit: pnl (\S+) >= (\S+)$/, (_m, p, t) => `利確到達 (pnl ${fmtPct(p)} ≥ ${fmtPct(t)}) (exit)`)
+  s = s.replace(/^stop-loss hit: pnl (\S+) <= (\S+)$/, (_m, p, t) => `損切到達 (pnl ${fmtPct(p)} ≤ ${fmtPct(t)}) (exit)`)
+  s = s.replace(/^time-stop hit: held (\S+) >= (\S+)$/, '時間切れ (保有 $1 ≥ $2) (exit)')
+  s = s.replace(/^holding: pnl (\S+) within \(([^)]+)\)$/, (_m, p, r) => `保有継続 (pnl ${fmtPct(p)}、範囲 ${r}) (exit)`)
+  // Entry filter (未保有、entry 条件未達)
+  s = s.replace(
+    /^50d return (\S+) <= (\S+) trend threshold$/,
+    (_m, r, t) => `entry 見送り: 50日 return ${fmtPct(r)} < 必要値 ${fmtPct(t)} (上昇トレンド filter)`,
+  )
+  s = s.replace(/^price (\S+) <= sma50 (\S+)$/, 'entry 見送り: 価格 $1 ≤ SMA50 $2 (上昇トレンド filter)')
+  s = s.replace(/^invalid 20d high$/, 'entry 見送り: 20日高値が無効')
+  s = s.replace(
+    /^pullback (\S+) > (\S+) \(not deep enough\)$/,
+    (_m, p, t) => `entry 見送り: 押し目 ${fmtPct(p)} が浅すぎる (閾値 ${fmtPct(t)})`,
+  )
+  s = s.replace(
+    /^pullback (\S+) < (\S+) \(too deep\)$/,
+    (_m, p, t) => `entry 見送り: 押し目 ${fmtPct(p)} が深すぎる (閾値 ${fmtPct(t)})`,
+  )
+  // BUY: entry 成立 (strategy signal)
+  s = s.replace(
+    /^pullback (\S+) in uptrend \(50d return (\S+)\)$/,
+    (_m, p, r) => `BUY 判定: 押し目 ${fmtPct(p)}、上昇トレンド継続 (50日 return ${fmtPct(r)})`,
+  )
   // Sizing capReason
   s = s.replace(/^sizing rejected: lot-size-round$/, 'サイジング拒否: ロット丸め後に最小取引単位未満')
   s = s.replace(/^sizing rejected: insufficient-risk-budget$/, 'サイジング拒否: リスク予算不足')

--- a/test/routes/localizeReason.test.ts
+++ b/test/routes/localizeReason.test.ts
@@ -12,7 +12,7 @@ describe('localizeReason', () => {
     // The dashboard reason that confused the operator in #132 (6971 HOLD).
     expect(
       localizeReason('50d return 0.0108 <= 0.03 trend threshold'),
-    ).toBe('entry 見送り: 50日 return 1.08% < 必要値 3.00% (上昇トレンド filter)')
+    ).toBe('entry 見送り: 50日 return 1.08% ≤ 必要値 3.00% (上昇トレンド filter)')
     expect(localizeReason('price 100 <= sma50 105')).toBe(
       'entry 見送り: 価格 100 ≤ SMA50 105 (上昇トレンド filter)',
     )
@@ -35,7 +35,7 @@ describe('localizeReason', () => {
       '時間切れ (保有 10d ≥ 10d) (exit)',
     )
     expect(localizeReason('holding: pnl 0.02 within (-0.04, 0.07)')).toBe(
-      '保有継続 (pnl 2.00%、範囲 -0.04, 0.07) (exit)',
+      '保有継続 (pnl 2.00%、範囲 -4.00% 〜 7.00%) (exit)',
     )
   })
 

--- a/test/routes/localizeReason.test.ts
+++ b/test/routes/localizeReason.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { localizeReason } from '../../src/routes/dashboard'
+
+describe('localizeReason', () => {
+  it('returns "-" for null / undefined / empty', () => {
+    expect(localizeReason(null)).toBe('-')
+    expect(localizeReason(undefined)).toBe('-')
+    expect(localizeReason('')).toBe('-')
+  })
+
+  it('prefixes entry-side HOLD reasons with "entry 見送り:" and converts ratios to %', () => {
+    // The dashboard reason that confused the operator in #132 (6971 HOLD).
+    expect(
+      localizeReason('50d return 0.0108 <= 0.03 trend threshold'),
+    ).toBe('entry 見送り: 50日 return 1.08% < 必要値 3.00% (上昇トレンド filter)')
+    expect(localizeReason('price 100 <= sma50 105')).toBe(
+      'entry 見送り: 価格 100 ≤ SMA50 105 (上昇トレンド filter)',
+    )
+    expect(
+      localizeReason('pullback 0.0023 > -0.01 (not deep enough)'),
+    ).toBe('entry 見送り: 押し目 0.23% が浅すぎる (閾値 -1.00%)')
+    expect(
+      localizeReason('pullback -0.08 < -0.06 (too deep)'),
+    ).toBe('entry 見送り: 押し目 -8.00% が深すぎる (閾値 -6.00%)')
+  })
+
+  it('suffixes exit-side reasons with "(exit)"', () => {
+    expect(localizeReason('take-profit hit: pnl 0.08 >= 0.07')).toBe(
+      '利確到達 (pnl 8.00% ≥ 7.00%) (exit)',
+    )
+    expect(localizeReason('stop-loss hit: pnl -0.05 <= -0.04')).toBe(
+      '損切到達 (pnl -5.00% ≤ -4.00%) (exit)',
+    )
+    expect(localizeReason('time-stop hit: held 10d >= 10d')).toBe(
+      '時間切れ (保有 10d ≥ 10d) (exit)',
+    )
+    expect(localizeReason('holding: pnl 0.02 within (-0.04, 0.07)')).toBe(
+      '保有継続 (pnl 2.00%、範囲 -0.04, 0.07) (exit)',
+    )
+  })
+
+  it('translates BUY signal reason with % formatting', () => {
+    expect(
+      localizeReason('pullback -0.03 in uptrend (50d return 0.12)'),
+    ).toBe('BUY 判定: 押し目 -3.00%、上昇トレンド継続 (50日 return 12.00%)')
+  })
+
+  it('keeps sizing / scheduler / bucket reasons as-is (already clear)', () => {
+    expect(localizeReason('sizing rejected: lot-size-round')).toBe(
+      'サイジング拒否: ロット丸め後に最小取引単位未満',
+    )
+    expect(localizeReason('sizing rejected: insufficient-risk-budget')).toBe(
+      'サイジング拒否: リスク予算不足',
+    )
+    expect(localizeReason('SELL without position')).toBe('SELL 対象ポジションなし')
+    expect(
+      localizeReason('bucket cap: semi projected 500 > 300'),
+    ).toBe('バケット cap: semi 合計 500 が上限 300 を超過')
+  })
+
+  it('does not touch unknown strings (forward-compat for new reason formats)', () => {
+    expect(localizeReason('totally unknown reason text')).toBe(
+      'totally unknown reason text',
+    )
+  })
+})


### PR DESCRIPTION
## Summary

#132 merge 後の read-only feedback 反映。\`/dashboard/cron?symbol=6971\` の HOLD reason 「50日 return 0.0108 が閾値 0.03 未満 (uptrend 不成立)」が **未保有銘柄なのに "uptrend 不成立"** と見えて誤解を生むので、entry filter と exit 判定を表現で明示分離。

DB / log の英語 canonical は不変 — display layer の \`localizeReason\` のみ変更。

### 改善パターン

| 英 (DB) | 旧 訳 | 新 訳 |
|---|---|---|
| \`50d return 0.0108 <= 0.03 trend threshold\` | 50日 return 0.0108 が閾値 0.03 未満 (uptrend 不成立) | **entry 見送り:** 50日 return 1.08% < 必要値 3.00% (上昇トレンド filter) |
| \`price 100 <= sma50 105\` | 価格 100 が SMA50 105 以下 (uptrend 不成立) | **entry 見送り:** 価格 100 ≤ SMA50 105 (上昇トレンド filter) |
| \`pullback 0.0023 > -0.01 (not deep enough)\` | 押し目 0.0023 が浅すぎ (閾値 -0.01) | **entry 見送り:** 押し目 0.23% が浅すぎる (閾値 -1.00%) |
| \`take-profit hit: pnl 0.08 >= 0.07\` | 利確到達 (pnl 0.08 ≥ 0.07) | 利確到達 (pnl 8.00% ≥ 7.00%) **(exit)** |
| \`pullback -0.03 in uptrend (50d return 0.12)\` | 押し目 -0.03、uptrend 継続 (50日 return 0.12) | **BUY 判定:** 押し目 -3.00%、上昇トレンド継続 (50日 return 12.00%) |

### 内部変更

- \`fmtPct(s)\`: 数値文字列を % 表記に変換する safe helper (非有限は原文字列 fallback)
- \`localizeReason\` を \`export\` して unit test 可能に
- \`test/routes/localizeReason.test.ts\`: +6 ケース (entry / exit / BUY / sizing / 未知パターン前方互換)

## Test plan

- [x] \`pnpm test\` — 336 passed (+6)
- [x] \`pnpm typecheck\` — clean
- [ ] staging deploy 後 \`/dashboard/cron?symbol=6971\` で新表現が表示されることを目視

## 関連

- #132 (merged): per-symbol 判定ログ dashboard
- 本 PR: reason 文言のみの refinement (schema / strategy 無変更)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * 理由メッセージの数値をパーセンテージ表示に統一しました
  * 決済系理由に "(exit)" を付加して明示表示するようにしました
  * フィルター失敗は「entry 見送り:」で開始するようにし、閾値比較をパーセント表記にしました
  * BUYシグナルは「BUY 判定:」形式に統一し、戻り値などをパーセントで表示します

* **テスト**
  * 翻訳・整形の振る舞いを検証するテストを追加しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->