### PR TITLE
feat(sizing): reject reason に診断値を埋め込み dashboard で日本語化

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -414,10 +414,24 @@ export function localizeReason(en: string | null | undefined): string {
     (_m, p, r) => `BUY 判定: 押し目 ${fmtPct(p)}、上昇トレンド継続 (50日 return ${fmtPct(r)})`,
   )
   // Sizing capReason
+  // Sizing capReason — 診断値付きパターンを先に試行し、fallback で素の形に
+  // もマッチさせる (旧ログとの互換維持)。
+  s = s.replace(
+    /^sizing rejected: lot-size-round \(raw qty (\S+) < lot (\S+), stop (\S+), entry (\S+)\)$/,
+    'サイジング拒否: 生 qty $1 株が 1 lot ($2 株) 未満 (stop $3/株、entry $4)',
+  )
   s = s.replace(/^sizing rejected: lot-size-round$/, 'サイジング拒否: ロット丸め後に最小取引単位未満')
+  s = s.replace(
+    /^sizing rejected: insufficient-risk-budget \(budget (\S+)\)$/,
+    'サイジング拒否: リスク予算不足 (予算 $1)',
+  )
   s = s.replace(/^sizing rejected: insufficient-risk-budget$/, 'サイジング拒否: リスク予算不足')
   s = s.replace(/^sizing rejected: atr-floor$/, 'サイジング拒否: ATR floor (vol 崩壊)')
   s = s.replace(/^sizing rejected: symbol-cap$/, 'サイジング拒否: 銘柄別 notional cap 超過')
+  s = s.replace(
+    /^sizing rejected: invalid-stop \(stopDistance (\S+)\)$/,
+    'サイジング拒否: stop 距離が無効 ($1)',
+  )
   s = s.replace(/^sizing rejected: invalid-stop$/, 'サイジング拒否: stop 距離が無効')
   s = s.replace(/^sizing rejected: zero qty$/, 'サイジング拒否: qty が 0')
   // Scheduler inline

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -222,7 +222,10 @@ export async function runPullbackScheduler(
         kAtr: rule.kAtr,
       })
       if (sizing.quantity <= 0) {
-        const reason = `sizing rejected: ${sizing.capReason ?? 'zero qty'}`
+        const reason = buildSizingRejectReason(sizing, {
+          lotSize: options.lotSize ?? 1,
+          entryPrice: indicators.price,
+        })
         summary.rejected.push({ symbol: upper, reason })
         await emitDecision({ symbol: upper, decision: 'REJECT', reason, price: indicators.price, indicatorsJson: JSON.stringify(indicators) })
         continue
@@ -430,5 +433,33 @@ function buildIntent(symbol: string, side: 'BUY' | 'SELL', qty: number, price: n
 
 function messageOf(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
+}
+
+/**
+ * Build an operator-actionable reject reason from a sizing failure。
+ * 単に capReason を出すと「なぜ失敗したか / 何を直せばよいか」が見えない
+ * (例: `lot-size-round` だけでは raw qty も stop も予算も分からない)。
+ * 失敗 route ごとに diagnostic 値を埋め込む。localizeReason 側が regex で
+ * 日本語化する。
+ */
+function buildSizingRejectReason(
+  sizing: import('./pullbackSizing').PullbackSizingResult,
+  ctx: { lotSize: number; entryPrice: number },
+): string {
+  const cr = sizing.capReason
+  if (cr === 'lot-size-round') {
+    const raw = sizing.rawQuantity ?? 0
+    const stop = sizing.stopDistance ?? 0
+    return `sizing rejected: lot-size-round (raw qty ${raw} < lot ${ctx.lotSize}, stop ${stop.toFixed(2)}, entry ${ctx.entryPrice})`
+  }
+  if (cr === 'insufficient-risk-budget') {
+    const budget = sizing.riskBudget ?? 0
+    return `sizing rejected: insufficient-risk-budget (budget ${budget.toFixed(2)})`
+  }
+  if (cr === 'invalid-stop') {
+    const stop = sizing.stopDistance ?? 0
+    return `sizing rejected: invalid-stop (stopDistance ${stop})`
+  }
+  return `sizing rejected: ${cr ?? 'zero qty'}`
 }
 

--- a/src/trading/strategy/pullbackSizing.ts
+++ b/src/trading/strategy/pullbackSizing.ts
@@ -36,6 +36,16 @@ export interface PullbackSizingResult {
     | 'invalid-stop'
     | 'insufficient-risk-budget'
     | 'lot-size-round'
+  /**
+   * Diagnostic fields populated on every run。reject reason を組み立てる時に
+   * operator がすぐ原因を把握できるようにする。
+   * - `rawQuantity`: lot-size 丸めの前の qty (1 lot に何株足りないか分かる)
+   * - `stopDistance`: max(kAtr * atr20, |entry * stopPct|)
+   * - `riskBudget`: equity * riskPerTradePct
+   */
+  rawQuantity?: number
+  stopDistance?: number
+  riskBudget?: number
 }
 
 /**
@@ -57,12 +67,12 @@ export function computePullbackSizing(input: PullbackSizingInput): PullbackSizin
   const stopDistance = atrStop > pctStop ? atrStop : pctStop
 
   if (!Number.isFinite(stopDistance) || stopDistance <= 0) {
-    return { quantity: 0, notional: 0, capped: true, capReason: 'invalid-stop' }
+    return { quantity: 0, notional: 0, capped: true, capReason: 'invalid-stop', stopDistance }
   }
 
   const riskBudget = input.equity * riskPct
   if (!Number.isFinite(riskBudget) || riskBudget <= 0) {
-    return { quantity: 0, notional: 0, capped: true, capReason: 'insufficient-risk-budget' }
+    return { quantity: 0, notional: 0, capped: true, capReason: 'insufficient-risk-budget', stopDistance, riskBudget }
   }
 
   let quantity = Math.floor(riskBudget / stopDistance)
@@ -92,19 +102,21 @@ export function computePullbackSizing(input: PullbackSizingInput): PullbackSizin
   if (!Number.isFinite(lotSize) || !Number.isInteger(lotSize) || lotSize <= 0) {
     lotSize = 1
   }
+  // pre-lot-round を diagnostic 用に捕捉 (symbol-cap で clamp されていれば
+  // その clamp 後の qty、されていなければ rawQuantity と同じ)
+  const preLotQuantity = quantity
   if (lotSize > 1) {
     const rounded = Math.floor(quantity / lotSize) * lotSize
     if (rounded !== quantity) {
       quantity = rounded
       notional = quantity * input.entryPrice
-      // Guard that quantity and notional are finite after rounding.
       if (!Number.isFinite(quantity) || !Number.isFinite(notional)) {
-        return { quantity: 0, notional: 0, capped: true, capReason: 'lot-size-round' }
+        return { quantity: 0, notional: 0, capped: true, capReason: 'lot-size-round', rawQuantity: preLotQuantity, stopDistance, riskBudget }
       }
       capped = true
       capReason = rounded === 0 ? 'lot-size-round' : capReason ?? 'lot-size-round'
     }
   }
 
-  return { quantity, notional, capped, capReason }
+  return { quantity, notional, capped, capReason, rawQuantity: preLotQuantity, stopDistance, riskBudget }
 }

--- a/src/trading/strategy/pullbackSizing.ts
+++ b/src/trading/strategy/pullbackSizing.ts
@@ -37,11 +37,15 @@ export interface PullbackSizingResult {
     | 'insufficient-risk-budget'
     | 'lot-size-round'
   /**
-   * Diagnostic fields populated on every run。reject reason を組み立てる時に
-   * operator がすぐ原因を把握できるようにする。
-   * - `rawQuantity`: lot-size 丸めの前の qty (1 lot に何株足りないか分かる)
-   * - `stopDistance`: max(kAtr * atr20, |entry * stopPct|)
-   * - `riskBudget`: equity * riskPerTradePct
+   * Diagnostic fields populated only when applicable per decision/reject route;
+   * may be undefined otherwise. These are diagnostic-only for debugging and
+   * help operators understand the reject reason.
+   * - `rawQuantity`: pre-lot-size quantity (shows how much short of 1 lot).
+   *   Filled on lot-size-round path and in successful sizing path.
+   * - `stopDistance`: max(kAtr * atr20, |entry * stopPct|).
+   *   Filled on invalid-stop, insufficient-risk-budget, lot-size-round, and successful paths.
+   * - `riskBudget`: equity * riskPerTradePct.
+   *   Filled on insufficient-risk-budget, lot-size-round, and successful paths.
    */
   rawQuantity?: number
   stopDistance?: number

--- a/test/routes/localizeReason.test.ts
+++ b/test/routes/localizeReason.test.ts
@@ -45,7 +45,7 @@ describe('localizeReason', () => {
     ).toBe('BUY 判定: 押し目 -3.00%、上昇トレンド継続 (50日 return 12.00%)')
   })
 
-  it('keeps sizing / scheduler / bucket reasons as-is (already clear)', () => {
+  it('keeps sizing / scheduler / bucket reasons as-is (legacy forms)', () => {
     expect(localizeReason('sizing rejected: lot-size-round')).toBe(
       'サイジング拒否: ロット丸め後に最小取引単位未満',
     )
@@ -56,6 +56,22 @@ describe('localizeReason', () => {
     expect(
       localizeReason('bucket cap: semi projected 500 > 300'),
     ).toBe('バケット cap: semi 合計 500 が上限 300 を超過')
+  })
+
+  it('localizes sizing rejects with diagnostic values', () => {
+    // lot-size-round with raw qty / stop / entry → operator can see how
+    // close we were to 1 lot.
+    expect(
+      localizeReason(
+        'sizing rejected: lot-size-round (raw qty 98 < lot 100, stop 203.00, entry 2876)',
+      ),
+    ).toBe('サイジング拒否: 生 qty 98 株が 1 lot (100 株) 未満 (stop 203.00/株、entry 2876)')
+    expect(
+      localizeReason('sizing rejected: insufficient-risk-budget (budget 0.00)'),
+    ).toBe('サイジング拒否: リスク予算不足 (予算 0.00)')
+    expect(
+      localizeReason('sizing rejected: invalid-stop (stopDistance 0)'),
+    ).toBe('サイジング拒否: stop 距離が無効 (0)')
   })
 
   it('does not touch unknown strings (forward-compat for new reason formats)', () => {

--- a/test/strategy/pullbackSizing.test.ts
+++ b/test/strategy/pullbackSizing.test.ts
@@ -107,6 +107,32 @@ describe('computePullbackSizing', () => {
     expect(result.capReason).toBe('lot-size-round')
   })
 
+  it('populates diagnostic fields (rawQuantity / stopDistance / riskBudget)', () => {
+    // equity 100k, risk 0.4% → budget 400。entry 100 × stopPct -4% → pctStop 4。
+    // atr20 × kAtr = 2×2 = 4。max = 4。raw qty = floor(400 / 4) = 100。
+    const result = computePullbackSizing(baseInput())
+    expect(result.rawQuantity).toBe(100)
+    expect(result.stopDistance).toBe(4)
+    expect(result.riskBudget).toBe(400)
+  })
+
+  it('rawQuantity reflects pre-lot-round value so operators can see the gap', () => {
+    // entry 1297 atr20 24 kAtr 2 → atrStop 48、pctStop 1297*0.04=51.88。stop≒52。
+    // equity 2M risk 0.4% → budget 8000。raw qty = floor(8000/51.88) = 154。
+    // lot 100 → rounded 100 (allowed) → diagnostic rawQuantity still 154.
+    const result = computePullbackSizing(
+      baseInput({
+        equity: 2_000_000,
+        entryPrice: 1297,
+        atr20: 24,
+        baselineAtr20: 24,
+        lotSize: 100,
+      }),
+    )
+    expect(result.quantity).toBe(100)
+    expect(result.rawQuantity).toBe(154)
+  })
+
   it('uses the ATR-based stop when wider than the pct-based stop', () => {
     // atr20=3 × kAtr=2 → atr stop = 6 > pct stop 4. floor(400 / 6) = 66.
     const result = computePullbackSizing(


### PR DESCRIPTION
## Summary

\`/dashboard/cron\` の reject reason 「サイジング拒否: ロット丸め後に最小取引単位未満」だけでは **なぜ / どれだけ足りないか** が operator に見えない。\`lot-size-round\` / \`insufficient-risk-budget\` / \`invalid-stop\` の各 route に診断値を埋め込み、localizeReason 側で日本語化。

### 変更

- \`PullbackSizingResult\` に診断 field 追加:
  - \`rawQuantity\`: lot 丸め前の qty (1 lot に何株足りないか)
  - \`stopDistance\`: max(kAtr × atr20, pct stop)
  - \`riskBudget\`: equity × riskPerTradePct
- \`pullbackScheduler\` に \`buildSizingRejectReason\` helper 追加。route 別に診断値入り reason を組み立て。
- \`localizeReason\` に診断値付きパターンを追加、legacy 素の形も fallback で残す。

### Before / After

| | 旧 | 新 |
|---|---|---|
| lot-size-round | サイジング拒否: ロット丸め後に最小取引単位未満 | **サイジング拒否: 生 qty 98 株が 1 lot (100 株) 未満 (stop 203.00/株、entry 2876)** |
| insufficient-risk-budget | サイジング拒否: リスク予算不足 | **サイジング拒否: リスク予算不足 (予算 0.00)** |
| invalid-stop | サイジング拒否: stop 距離が無効 | **サイジング拒否: stop 距離が無効 (0)** |

operator は 「98 → 2 株足りない」「stop 203 → tighter にすれば届く」「予算を +2% 増やせば 100 株」等、直接 action に移せる。

## Test plan

- [x] \`pnpm test\` — 339 passed (+3)
- [x] \`pnpm typecheck\` — clean
- [ ] staging deploy 後 \`/dashboard/cron?symbol=6752\` で診断値付き reason が表示されるか確認

## 関連

- #132 per-symbol log dashboard (本 PR は reason 内容の refinement)
- #133 reason 日本語化 (entry/exit prefix)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * サイジング拒否時の通知に詳しい診断情報（raw数量、ストップ距離、リスク予算、エントリー値など）が含まれるようになりました。
  * ローカライズ済みの拒否理由は、詳しいパラメータを含む文字列も正しく翻訳・表示します。

* **テスト**
  * 診断情報の生成と表示（pre-round raw数量の差分含む）を検証するテストが追加されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->