### PR TITLE
fix(dashboard): lot-size-round の「生 qty」を「リスク予算で賄える上限」に言い換え

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -416,9 +416,11 @@ export function localizeReason(en: string | null | undefined): string {
   // Sizing capReason
   // Sizing capReason — 診断値付きパターンを先に試行し、fallback で素の形に
   // もマッチさせる (旧ログとの互換維持)。
+  // lot-size-round: 「生 qty」は誤読 (発注しようとした株数と誤解される) なので
+  // 「リスク予算で賄える上限」に言い換え。実際は 0 株で発注せず reject。
   s = s.replace(
     /^sizing rejected: lot-size-round \(raw qty (\S+) < lot (\S+), stop (\S+), entry (\S+)\)$/,
-    'サイジング拒否: 生 qty $1 株が 1 lot ($2 株) 未満 (stop $3/株、entry $4)',
+    'サイジング拒否: リスク予算で賄える上限 $1 株が 1 lot ($2 株) に届かず (stop $3/株、entry $4)',
   )
   s = s.replace(/^sizing rejected: lot-size-round$/, 'サイジング拒否: ロット丸め後に最小取引単位未満')
   s = s.replace(

--- a/test/routes/localizeReason.test.ts
+++ b/test/routes/localizeReason.test.ts
@@ -65,7 +65,7 @@ describe('localizeReason', () => {
       localizeReason(
         'sizing rejected: lot-size-round (raw qty 98 < lot 100, stop 203.00, entry 2876)',
       ),
-    ).toBe('サイジング拒否: 生 qty 98 株が 1 lot (100 株) 未満 (stop 203.00/株、entry 2876)')
+    ).toBe('サイジング拒否: リスク予算で賄える上限 98 株が 1 lot (100 株) に届かず (stop 203.00/株、entry 2876)')
     expect(
       localizeReason('sizing rejected: insufficient-risk-budget (budget 0.00)'),
     ).toBe('サイジング拒否: リスク予算不足 (予算 0.00)')


### PR DESCRIPTION
## Summary

\`/dashboard/cron\` の「サイジング拒否: 生 qty 69 株が 1 lot (100 株) 未満」を見て operator が「69 株買おうとしたの?」と誤読する問題に対処。実際は:

- 69 株はリスク予算 ÷ stop distance で算出した **上限値** (これ以下なら買えるという数字)
- JP の 100 株 lot 制約で floor 丸め → 0 株、発注せず **reject**

表現を「**リスク予算で賄える上限 N 株が 1 lot (M 株) に届かず**」に変更。

### Before / After

| | 旧 | 新 |
|---|---|---|
| lot-size-round (診断値付き) | サイジング拒否: 生 qty 98 株が 1 lot (100 株) 未満 (stop 203.00/株、entry 2876) | **サイジング拒否: リスク予算で賄える上限 98 株が 1 lot (100 株) に届かず (stop 203.00/株、entry 2876)** |

## Test plan

- [x] \`pnpm test\` — 339 pass
- [x] \`pnpm typecheck\` — clean
- [ ] staging deploy 後ブラウザ目視

display layer のみの変更。英語 canonical / strategy / sizing 無変更。

## 関連

- #134 (merged) sizing reject reason 診断値埋め込み (本 PR は wording refinement)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 注文サイジング却下メッセージの日本語表記を改善し、より正確な情報提供を実現しました
  * 対応するテスト期待値を更新しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->