### PR TITLE
feat(admin): /admin/symbols/:symbol/clear-cooldown で cooldown 強制解除

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -30,6 +30,30 @@ export const admin = new Hono<AppBindings>()
     return c.json({ symbol, settledCash: state.settledCash, updatedAt: state.updatedAt })
   })
   /**
+   * 強制的に cooldownUntil を過去時刻 (UNIX epoch 0) にして取引停止状態を解除する。
+   * 直前損切後の cooldown (reconcileFills が設定) を staging で即解除したい時に
+   * 使う。PositionStore.setCooldown は string 必須なので `new Date(0).toISOString()`
+   * を渡すことで「過去」扱いにして実質クリア。
+   */
+  .post('/symbols/:symbol/clear-cooldown', async (c) => {
+    const symbol = c.req.param('symbol').trim().toUpperCase()
+    if (symbol.length === 0) {
+      throw new ValidationError('symbol must be a non-empty path param', { field: 'symbol' })
+    }
+    if (!c.env.SYMBOL_STATE) {
+      throw new ValidationError('SYMBOL_STATE binding is not configured', { field: 'env' })
+    }
+    const pastIso = new Date(0).toISOString()
+    const client = new SymbolStateClient(c.env.SYMBOL_STATE)
+    const state = await client.setCooldown(symbol, pastIso)
+    return c.json({
+      symbol,
+      cooldownUntil: state.cooldownUntil,
+      note: 'cooldown を epoch に戻したため strategy の `> now` 判定で即失効',
+      updatedAt: state.updatedAt,
+    })
+  })
+  /**
    * Manual trigger for `runStrategyCron`. Returns the same `StrategyCronResult`
    * the hourly scheduled handler would console.log. Useful for debugging bar
    * fetch failures / skip reasons without waiting for :15 of the hour.

--- a/test/routes/admin.test.ts
+++ b/test/routes/admin.test.ts
@@ -102,3 +102,50 @@ describe('POST /admin/symbols/:symbol/seed-cash', () => {
     expect(captured.calls).toEqual([{ symbol: 'SOXL', amount: 12_345 }])
   })
 })
+
+describe('POST /admin/symbols/:symbol/clear-cooldown', () => {
+  function fakeCooldownNamespace(captured: { calls: Array<{ symbol: string; untilIso: string }> }) {
+    const stub = {
+      async setCooldown(symbol: string, untilIso: string) {
+        captured.calls.push({ symbol, untilIso })
+        return {
+          symbol,
+          position: null,
+          pendingOrder: null,
+          lastSignalAt: null,
+          cooldownUntil: untilIso,
+          settledCash: 0,
+          pendingSettlement: [],
+          lastExecutedPrice: null,
+          lastQuote: null,
+          updatedAt: '2026-04-25T00:00:00.000Z',
+        }
+      },
+    }
+    return {
+      idFromName: () => 'id',
+      get: () => stub,
+    } as unknown
+  }
+
+  it('401s without Basic Auth', async () => {
+    const app = createApp()
+    const res = await app.request('/admin/symbols/SOXL/clear-cooldown', { method: 'POST' }, baseEnv)
+    expect(res.status).toBe(401)
+  })
+
+  it('200s and sets cooldown to epoch 0 (effectively cleared)', async () => {
+    const captured = { calls: [] as Array<{ symbol: string; untilIso: string }> }
+    const app = createApp()
+    const res = await app.request(
+      '/admin/symbols/soxl/clear-cooldown',
+      { method: 'POST', headers: { ...authHeader } },
+      { ...baseEnv, SYMBOL_STATE: fakeCooldownNamespace(captured) },
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { symbol: string; cooldownUntil: string }
+    expect(body.symbol).toBe('SOXL')
+    expect(body.cooldownUntil).toBe('1970-01-01T00:00:00.000Z')
+    expect(captured.calls).toEqual([{ symbol: 'SOXL', untilIso: '1970-01-01T00:00:00.000Z' }])
+  })
+})


### PR DESCRIPTION
## Summary

損失 SELL 後に reconcileFills が設定する \`cooldownUntil\` を operator が staging で即解除したい時のための admin endpoint。

## 変更

- \`POST /admin/symbols/:symbol/clear-cooldown\` 追加
- 内部実装: \`setCooldown(symbol, new Date(0).toISOString())\` で過去時刻を書き込み、strategy の \`cooldownUntil > now\` 判定で即失効
- \`setCooldown\` は string 必須 (nullable 化は schema 変更になるので避ける)

## 利用例 (deploy 後)

\`\`\`bash
op run --env-file=.dev.vars -- sh -c '
curl -s -X POST -u "\$BASIC_AUTH_USER:\$BASIC_AUTH_PASSWORD" \\
  "https://webull-trading-staging.teacatus.workers.dev/admin/symbols/SOXL/clear-cooldown"
' | jq
\`\`\`

## 運用メモ (SPY 無効化)

本 PR とは別件だが、SPY は Webull JP UAT で取引できないため \`symbol_config.active=0\` に SQL UPDATE 済 (SQL 直接実行、コード変更なし)。

## Test plan

- [x] \`pnpm test\` — 360 passed (+2: 401 / 200 ケース)
- [x] \`pnpm typecheck\` — clean
- [ ] staging deploy 後 curl で SOXL cooldown クリアを確認

## 関連

- #143 realized_pnl 表示 (直近損失観察から cooldown 解除要望が発生)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 管理者がシンボルの取引クールダウンをクリアする機能が追加されました。認証が必要です。

* **テスト**
  * 新しい管理者機能の認証要件とクールダウンクリア動作を検証するテストが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->