### PR TITLE
fix(dashboard): past cooldownUntil を「解除済」として em-dash 表示

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -255,7 +255,7 @@ function positionsBody(
         <td>${quote ? fmtNumber(quote.price, 2) : '<span class="muted">—</span>'}</td>
         <td class="${pnlClass}">${pnlPct === null ? '—' : fmtNumber(pnlPct, 2) + '%'}</td>
         <td>${pendingSide ? esc(pendingSide) : '<span class="muted">—</span>'}</td>
-        <td>${s.cooldownUntil ? esc(fmtJst(s.cooldownUntil)) : '<span class="muted">—</span>'}</td>
+        <td>${formatCooldown(s.cooldownUntil)}</td>
         <td class="muted">${esc(fmtJst(s.updatedAt))}</td>
       </tr>`
     })
@@ -421,6 +421,22 @@ const CONFIG_KEY_JA: Record<string, string> = {
   risk_dd_half_threshold: 'リスク半減閾値',
   risk_dd_halt_threshold: 'リスク停止閾値',
   bucket_exposure_pct: '同グループ建玉上限率',
+}
+
+/**
+ * cooldownUntil を保有状況テーブル向けに整形。null または past timestamp
+ * (admin /clear-cooldown で epoch 0 が書き込まれた状態等) は「解除済」
+ * 扱いで em-dash を返す。strategy 側の `cooldownUntil > now` 判定と表示を
+ * 整合させ、"1970-01-01 09:00:00 JST" がクールダウン列に残るように見える
+ * 不具合を解消する (#145 admin clear-cooldown の副作用)。
+ */
+function formatCooldown(cooldownUntil: string | null): string {
+  if (!cooldownUntil) return '<span class="muted">—</span>'
+  const ms = new Date(cooldownUntil).getTime()
+  if (!Number.isFinite(ms) || ms <= Date.now()) {
+    return '<span class="muted">—</span>'
+  }
+  return `<span class="warn">${esc(fmtJst(cooldownUntil))}</span>`
 }
 
 function formatConfigValue(v: unknown): string {

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -18,7 +18,7 @@ const baseEnv = {
 
 const authHeader = { Authorization: `Basic ${btoa('admin:secret')}` }
 
-function fakeSymbolStateNamespace() {
+function fakeSymbolStateNamespace(cooldownUntil: string | null = null) {
   const stub = {
     async getState(symbol: string) {
       return {
@@ -26,7 +26,7 @@ function fakeSymbolStateNamespace() {
         position: { qty: 10, avgPrice: 100, openedAt: '2026-04-20T00:00:00.000Z' },
         pendingOrder: null,
         lastSignalAt: null,
-        cooldownUntil: null,
+        cooldownUntil,
         settledCash: 0,
         pendingSettlement: [],
         lastExecutedPrice: null,
@@ -101,6 +101,31 @@ describe('dashboard', () => {
     const res = await app.request('/dashboard/positions', { headers: authHeader }, env)
     expect(res.status).toBe(200)
     expect(await res.text()).toContain('利用不可')
+  })
+
+  it('past cooldownUntil (epoch 0 from admin clear-cooldown) is shown as em-dash, not 1970', async () => {
+    const env = {
+      ...baseEnv,
+      DB: {} as D1Database,
+      SYMBOL_STATE: fakeSymbolStateNamespace('1970-01-01T00:00:00.000Z'),
+    }
+    const app = createApp()
+    const res = await app.request('/dashboard/positions', { headers: authHeader }, env)
+    const body = await res.text()
+    expect(body).not.toContain('1970-01-01')
+  })
+
+  it('future cooldownUntil is shown in JST', async () => {
+    const future = new Date(Date.now() + 3_600_000).toISOString()
+    const env = {
+      ...baseEnv,
+      DB: {} as D1Database,
+      SYMBOL_STATE: fakeSymbolStateNamespace(future),
+    }
+    const app = createApp()
+    const res = await app.request('/dashboard/positions', { headers: authHeader }, env)
+    const body = await res.text()
+    expect(body).toContain('JST')
   })
 
   it('renders portfolio page', async () => {

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -125,7 +125,7 @@ describe('dashboard', () => {
     const app = createApp()
     const res = await app.request('/dashboard/positions', { headers: authHeader }, env)
     const body = await res.text()
-    expect(body).toContain('JST')
+    expect(body).toMatch(/<span class="warn">[^<]*JST<\/span>/)
   })
 
   it('renders portfolio page', async () => {


### PR DESCRIPTION
## Summary

\`/dashboard/positions\` のクールダウン列に **\"1970-01-01 09:00:00 JST\"** と表示されて「まだクールダウン中?」と誤読される問題を修正。

## 原因

\`POST /admin/symbols/:symbol/clear-cooldown\` (#145) は cooldownUntil に epoch 0 (\`1970-01-01T00:00:00.000Z\`) を書き込むことで strategy の \`cooldownUntil > now\` 判定で **過去扱い → 無効化** する設計。動作は正しいが、dashboard 側は null チェックだけで fmtJst にかけていたため、epoch 0 がそのまま JST 表記されて画面に残っていた。

## 変更

- \`formatCooldown\` ヘルパ追加:
  - null / 非有限 → em-dash \`—\` (解除済)
  - past timestamp (epoch 0 含む) → em-dash \`—\` (解除済)
  - future timestamp → 警告色で JST 表記 (まだ active)
- strategy 側の \`cooldownUntil > now\` 判定と **同じ基準で表示** に切り替え

## Test plan

- [x] \`pnpm test\` — 362 passed (+2: past epoch / future)
- [x] \`pnpm typecheck\` — clean
- [ ] staging deploy 後 SOXL の 1970 表示が消えるか確認

## 関連

- #145 (merged): admin clear-cooldown endpoint (epoch 0 で解除する仕様の副作用)
- #146 (merged): dashboard 日本語化 (表示列の localize)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * ポジションダッシュボードのクールダウン表示を改善しました。無効または過去のタイムスタンプは「解除済」（ダッシュ）と表示され、有効な将来のクールダウンはJST形式で警告スタイルで強調表示されます。

* **Tests**
  * クールダウン表示の振る舞い（過去は解除済、将来はJSTで強調）を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->