### PR TITLE
feat: cronログと採用ロジックtraceをJSON分析可能にする

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,13 +47,16 @@ export default {
       ctx.waitUntil(
         runStrategyCron(env, { requestId }).then(
           (result) => {
+            const { decisions: _decisions, ...summary } = result.summary
             console.log(
               JSON.stringify({
                 event: 'strategy_cron_run',
+                logSchema: result.analysis.schema,
                 requestId,
                 symbols: result.symbols,
                 skipReason: result.skipReason,
-                summary: result.summary,
+                summary,
+                analysis: result.analysis,
               }),
             )
           },

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -4,7 +4,7 @@ import { loadGlobalConfigFrom } from '../infrastructure/db/globalConfigLoader'
 import { loadSymbolUniverse } from '../infrastructure/db/symbolUniverse'
 import { createDb } from '../infrastructure/db/tradeJournalRepo'
 import { strategyDecisionLog, tradeJournal } from '../infrastructure/db/schema'
-import { and, desc, eq } from 'drizzle-orm'
+import { and, asc, desc, eq } from 'drizzle-orm'
 import { PortfolioStateClient } from '../trading/state/PortfolioStateClient'
 import { SymbolStateClient } from '../trading/state/SymbolStateClient'
 import type { SymbolState } from '../trading/state/types'
@@ -64,6 +64,82 @@ export const dashboard = new Hono<AppBindings>()
       loadSymbolUniverse(c.env),
     ])
     return c.html(layout('設定', configBody(global, universe)))
+  })
+  .get('/cron/json', async (c) => {
+    if (!c.env.DB) {
+      return jsonPretty({ error: 'db_not_bound', message: 'DB binding is not configured' }, 503)
+    }
+    const db = createDb(c.env.DB)
+    const requestedRequestId = c.req.query('requestId')?.trim()
+    try {
+      let requestId = requestedRequestId && requestedRequestId.length > 0
+        ? requestedRequestId
+        : undefined
+      if (!requestId) {
+        const latest = await db
+          .select({ requestId: strategyDecisionLog.requestId })
+          .from(strategyDecisionLog)
+          .orderBy(desc(strategyDecisionLog.id))
+          .limit(50)
+        requestId = latest.find((row) => row.requestId !== null)?.requestId ?? undefined
+      }
+      if (!requestId) {
+        return jsonPretty({ error: 'no_cron_logs', message: 'strategy_decision_log has no request_id rows' }, 404)
+      }
+
+      const rows = await db
+        .select({
+          id: strategyDecisionLog.id,
+          timestamp: strategyDecisionLog.timestamp,
+          requestId: strategyDecisionLog.requestId,
+          symbol: strategyDecisionLog.symbol,
+          decision: strategyDecisionLog.decision,
+          reason: strategyDecisionLog.reason,
+          price: strategyDecisionLog.price,
+          indicatorsJson: strategyDecisionLog.indicatorsJson,
+          clientOrderId: strategyDecisionLog.clientOrderId,
+          filledPrice: tradeJournal.filledPrice,
+          filledQty: tradeJournal.filledQty,
+          realizedPnl: tradeJournal.realizedPnl,
+          brokerStatus: tradeJournal.brokerStatus,
+        })
+        .from(strategyDecisionLog)
+        .leftJoin(
+          tradeJournal,
+          and(
+            eq(strategyDecisionLog.clientOrderId, tradeJournal.clientOrderId),
+            eq(tradeJournal.tradeEventType, 'post_submit'),
+          ),
+        )
+        .where(eq(strategyDecisionLog.requestId, requestId))
+        .orderBy(asc(strategyDecisionLog.id))
+
+      return jsonPretty({
+        schema: 'dashboard_cron_export.v1',
+        exportedAt: new Date().toISOString(),
+        requestId,
+        rowCount: rows.length,
+        decisions: rows.map((row) => ({
+          id: row.id,
+          timestamp: row.timestamp,
+          symbol: row.symbol,
+          decision: row.decision,
+          reason: row.reason,
+          localizedReason: localizeReason(row.reason),
+          price: row.price,
+          indicators: parseJsonObject(row.indicatorsJson),
+          clientOrderId: row.clientOrderId,
+          broker: {
+            status: row.brokerStatus,
+            filledPrice: row.filledPrice,
+            filledQty: row.filledQty,
+            realizedPnl: row.realizedPnl,
+          },
+        })),
+      })
+    } catch (err) {
+      return jsonPretty({ error: 'cron_json_export_failed', message: messageOf(err) }, 500)
+    }
   })
   .get('/cron', async (c) => {
     if (!c.env.DB) {
@@ -217,6 +293,22 @@ ${body}
 
 function unavailable(reason: string): string {
   return `<p class="warn">利用不可: ${esc(reason)}</p>`
+}
+
+function jsonPretty(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload, null, 2), {
+    status,
+    headers: { 'content-type': 'application/json; charset=utf-8' },
+  })
+}
+
+function parseJsonObject(value: string | null | undefined): unknown {
+  if (!value) return null
+  try {
+    return JSON.parse(value)
+  } catch {
+    return value
+  }
 }
 
 function indexBody(): string {
@@ -611,8 +703,8 @@ function cronBody(
   symbolFilter: string | undefined,
 ): string {
   const header = symbolFilter
-    ? `<p class="muted">Showing ${rows.length} decisions for <strong>${esc(symbolFilter)}</strong> (limit=${limit}, max 200)。<a href="/dashboard/cron">全銘柄へ戻る</a></p>`
-    : `<p class="muted">Showing ${rows.length} decisions (limit=${limit}, max 200)。<code>?symbol=SOXL</code> で絞り込み可能。</p>`
+    ? `<p class="muted">Showing ${rows.length} decisions for <strong>${esc(symbolFilter)}</strong> (limit=${limit}, max 200)。<a href="/dashboard/cron">全銘柄へ戻る</a> / <a href="/dashboard/cron/json" target="_blank" rel="noreferrer">最新run JSON</a></p>`
+    : `<p class="muted">Showing ${rows.length} decisions (limit=${limit}, max 200)。<code>?symbol=SOXL</code> で絞り込み可能。<a href="/dashboard/cron/json" target="_blank" rel="noreferrer">最新run JSON</a></p>`
   if (rows.length === 0) {
     return `${header}<p class="muted">判定ログがまだありません。</p>`
   }

--- a/src/trading/domain/Signal.ts
+++ b/src/trading/domain/Signal.ts
@@ -2,6 +2,16 @@ export type SignalAction = 'BUY' | 'SELL' | 'HOLD'
 
 export type GeneratedAtIso = string
 
+export interface DecisionTraceStep {
+  label: string
+  label_ja?: string
+  passed: boolean
+  actual?: number | string | boolean | null
+  operator?: '<' | '<=' | '>' | '>=' | '==' | '!=' | 'between' | 'exists' | 'not_exists'
+  threshold?: number | string | boolean | null | [number, number]
+  message?: string
+}
+
 export interface Signal {
   action: SignalAction
   symbol: string
@@ -9,4 +19,5 @@ export interface Signal {
   price: number
   reason: string
   generatedAtIso: GeneratedAtIso
+  trace?: DecisionTraceStep[]
 }

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -1,5 +1,6 @@
 import type { BarClient } from '../../infrastructure/quotes/BarClient'
 import { logPostSubmit, logPreSubmit } from '../../infrastructure/logger/tradeJournal'
+import type { DecisionTraceStep } from '../domain/Signal'
 import { inferTradingMarket } from '../domain/tradingCalendar'
 import type { Execution } from '../execution/Execution'
 import type { PositionStore } from '../state/PositionStore'
@@ -67,6 +68,7 @@ export interface PullbackSchedulerOptions {
     indicatorsJson?: string
     /** BUY/SELL 成立時のみ設定。dashboard が trade_journal と JOIN する key (#143)。 */
     clientOrderId?: string
+    trace?: DecisionTraceStep[]
   }) => Promise<void> | void
   /**
    * cron fire 単位の correlation id。emit 失敗時の構造化ログに含めることで
@@ -85,6 +87,27 @@ export interface PullbackRunSummary {
   holds: number
   rejected: Array<{ symbol: string; reason: string }>
   errors: Array<{ symbol: string; message: string }>
+  /**
+   * One JSON-copyable record per symbol decision. This mirrors
+   * strategy_decision_log so a single cron run can be analyzed without
+   * reconstructing context from scattered log lines.
+   */
+  decisions: PullbackDecisionTrace[]
+}
+
+export interface PullbackDecisionTrace {
+  symbol: string
+  decision: 'BUY' | 'SELL' | 'HOLD' | 'REJECT' | 'ERROR'
+  reason?: string
+  price?: number
+  indicatorsJson?: string
+  trace?: DecisionTraceStep[]
+  clientOrderId?: string | null
+  order?: {
+    side: 'BUY' | 'SELL'
+    quantity: number
+    notional: number
+  }
 }
 
 /**
@@ -114,13 +137,29 @@ export async function runPullbackScheduler(
     holds: 0,
     rejected: [],
     errors: [],
+    decisions: [],
   }
 
   // Logging helper: sink が投げても本体を落とさない (logging failure isolation)。
-  const emitDecision = async (record: Parameters<NonNullable<typeof options.onDecision>>[0]): Promise<void> => {
+  const emitDecision = async (
+    record: Parameters<NonNullable<typeof options.onDecision>>[0] & {
+      order?: PullbackDecisionTrace['order']
+    },
+  ): Promise<void> => {
+    summary.decisions.push({
+      symbol: record.symbol,
+      decision: record.decision,
+      ...(record.reason !== undefined ? { reason: record.reason } : {}),
+      ...(record.price !== undefined ? { price: record.price } : {}),
+      ...(record.indicatorsJson !== undefined ? { indicatorsJson: record.indicatorsJson } : {}),
+      ...(record.trace !== undefined ? { trace: record.trace } : {}),
+      ...(record.clientOrderId !== undefined ? { clientOrderId: record.clientOrderId } : {}),
+      ...(record.order !== undefined ? { order: record.order } : {}),
+    })
     if (!options.onDecision) return
     try {
-      await options.onDecision(record)
+      const { order: _order, ...dbRecord } = record
+      await options.onDecision(dbRecord)
     } catch (err) {
       console.error(
         JSON.stringify({
@@ -205,6 +244,7 @@ export async function runPullbackScheduler(
         reason: signal.reason,
         price: indicators.price,
         indicatorsJson: JSON.stringify(indicators),
+        trace: signal.trace,
       })
       continue
     }
@@ -229,20 +269,39 @@ export async function runPullbackScheduler(
           entryPrice: indicators.price,
         })
         summary.rejected.push({ symbol: upper, reason })
-        await emitDecision({ symbol: upper, decision: 'REJECT', reason, price: indicators.price, indicatorsJson: JSON.stringify(indicators) })
+        await emitDecision({
+          symbol: upper,
+          decision: 'REJECT',
+          reason,
+          price: indicators.price,
+          indicatorsJson: JSON.stringify(indicators),
+          trace: appendTrace(signal.trace, traceStep('sizing.quantity_positive', false, sizing.quantity, '>', 0, sizing.capReason)),
+        })
         continue
       }
       if (!Number.isFinite(indicators.price) || indicators.price <= 0) {
         const reason = `invalid price: ${indicators.price}`
         summary.rejected.push({ symbol: upper, reason })
-        await emitDecision({ symbol: upper, decision: 'REJECT', reason, price: indicators.price })
+        await emitDecision({
+          symbol: upper,
+          decision: 'REJECT',
+          reason,
+          price: indicators.price,
+          trace: appendTrace(signal.trace, traceStep('scheduler.price_valid', false, indicators.price, '>', 0)),
+        })
         continue
       }
       const notional = sizing.quantity * indicators.price
       if (!Number.isFinite(notional) || notional <= 0) {
         const reason = `invalid notional: ${notional} (qty=${sizing.quantity}, price=${indicators.price})`
         summary.rejected.push({ symbol: upper, reason })
-        await emitDecision({ symbol: upper, decision: 'REJECT', reason, price: indicators.price })
+        await emitDecision({
+          symbol: upper,
+          decision: 'REJECT',
+          reason,
+          price: indicators.price,
+          trace: appendTrace(signal.trace, traceStep('scheduler.notional_valid', false, notional, '>', 0)),
+        })
         continue
       }
       const bucket = options.symbolBucketMap?.[upper]
@@ -255,7 +314,14 @@ export async function runPullbackScheduler(
       if (!bucketDecision.allowed) {
         const reason = bucketDecision.reason ?? 'bucket cap'
         summary.rejected.push({ symbol: upper, reason })
-        await emitDecision({ symbol: upper, decision: 'REJECT', reason, price: indicators.price, indicatorsJson: JSON.stringify(indicators) })
+        await emitDecision({
+          symbol: upper,
+          decision: 'REJECT',
+          reason,
+          price: indicators.price,
+          indicatorsJson: JSON.stringify(indicators),
+          trace: appendTrace(signal.trace, traceStep('risk.bucket_cap', false, notional, '<=', bucket ? options.bucketCapMap?.[bucket] ?? null : null, reason)),
+        })
         continue
       }
       if (bucket && bucketDecision.newExposure !== undefined) {
@@ -267,26 +333,50 @@ export async function runPullbackScheduler(
       if (state.position === null) {
         const reason = 'SELL without position'
         summary.rejected.push({ symbol: upper, reason })
-        await emitDecision({ symbol: upper, decision: 'REJECT', reason, price: indicators.price })
+        await emitDecision({
+          symbol: upper,
+          decision: 'REJECT',
+          reason,
+          price: indicators.price,
+          trace: appendTrace(signal.trace, traceStep('scheduler.sell_position_exists', false, false, 'exists', true)),
+        })
         continue
       }
       if (!Number.isFinite(state.position.qty) || state.position.qty <= 0) {
         const reason = `invalid position qty: ${state.position.qty}`
         summary.rejected.push({ symbol: upper, reason })
-        await emitDecision({ symbol: upper, decision: 'REJECT', reason, price: indicators.price })
+        await emitDecision({
+          symbol: upper,
+          decision: 'REJECT',
+          reason,
+          price: indicators.price,
+          trace: appendTrace(signal.trace, traceStep('scheduler.position_qty_valid', false, state.position.qty, '>', 0)),
+        })
         continue
       }
       if (!Number.isFinite(indicators.price) || indicators.price <= 0) {
         const reason = `invalid price: ${indicators.price}`
         summary.rejected.push({ symbol: upper, reason })
-        await emitDecision({ symbol: upper, decision: 'REJECT', reason, price: indicators.price })
+        await emitDecision({
+          symbol: upper,
+          decision: 'REJECT',
+          reason,
+          price: indicators.price,
+          trace: appendTrace(signal.trace, traceStep('scheduler.price_valid', false, indicators.price, '>', 0)),
+        })
         continue
       }
       const notional = state.position.qty * indicators.price
       if (!Number.isFinite(notional) || notional <= 0) {
         const reason = `invalid notional: ${notional} (qty=${state.position.qty}, price=${indicators.price})`
         summary.rejected.push({ symbol: upper, reason })
-        await emitDecision({ symbol: upper, decision: 'REJECT', reason, price: indicators.price })
+        await emitDecision({
+          symbol: upper,
+          decision: 'REJECT',
+          reason,
+          price: indicators.price,
+          trace: appendTrace(signal.trace, traceStep('scheduler.notional_valid', false, notional, '>', 0)),
+        })
         continue
       }
       intent = buildIntent(upper, 'SELL', state.position.qty, indicators.price)
@@ -296,7 +386,13 @@ export async function runPullbackScheduler(
     if (!Number.isFinite(expiresAtMs) || expiresAtMs <= now().getTime()) {
       const reason = `invalid expiresAt computed from pendingLockTtlMs: ${pendingLockTtlMs}`
       summary.rejected.push({ symbol: upper, reason })
-      await emitDecision({ symbol: upper, decision: 'REJECT', reason, price: indicators.price })
+      await emitDecision({
+        symbol: upper,
+        decision: 'REJECT',
+        reason,
+        price: indicators.price,
+        trace: appendTrace(signal.trace, traceStep('scheduler.pending_lock_expiry_valid', false, expiresAtMs, '>', now().getTime())),
+      })
       continue
     }
     const lockResult = await options.positionStore.lockPendingOrder(upper, {
@@ -308,7 +404,13 @@ export async function runPullbackScheduler(
     if (!lockResult.ok) {
       const reason = 'pending order already in flight'
       summary.rejected.push({ symbol: upper, reason })
-      await emitDecision({ symbol: upper, decision: 'REJECT', reason, price: indicators.price })
+      await emitDecision({
+        symbol: upper,
+        decision: 'REJECT',
+        reason,
+        price: indicators.price,
+        trace: appendTrace(signal.trace, traceStep('scheduler.pending_lock_acquired', false, false, '==', true)),
+      })
       continue
     }
 
@@ -350,6 +452,7 @@ export async function runPullbackScheduler(
         // DB には英語 canonical で保存。表示層 (localizeReason) で日本語化。
         reason: `broker submit error: ${messageOf(error)}`,
         price: indicators.price,
+        trace: appendTrace(signal.trace, traceStep('broker.submit', false, messageOf(error), '==', 'submitted')),
       })
       try {
         logPostSubmit({
@@ -402,6 +505,12 @@ export async function runPullbackScheduler(
       price: intent.price,
       indicatorsJson: JSON.stringify(indicators),
       clientOrderId: intent.clientOrderId,
+      trace: appendTrace(signal.trace, traceStep('broker.submit', true, result.mode, '==', 'submitted')),
+      order: {
+        side: intent.side,
+        quantity: intent.quantity,
+        notional: intent.notional,
+      },
     })
 
     if (result.mode === 'DRY_RUN') {
@@ -438,6 +547,48 @@ function messageOf(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
+function appendTrace(
+  trace: DecisionTraceStep[] | undefined,
+  ...steps: DecisionTraceStep[]
+): DecisionTraceStep[] {
+  return [...(trace ?? []), ...steps]
+}
+
+function traceStep(
+  label: string,
+  passed: boolean,
+  actual?: DecisionTraceStep['actual'],
+  operator?: DecisionTraceStep['operator'],
+  threshold?: DecisionTraceStep['threshold'],
+  message?: string,
+): DecisionTraceStep {
+  return {
+    label,
+    label_ja: labelJa(label),
+    passed,
+    ...(actual !== undefined ? { actual } : {}),
+    ...(operator !== undefined ? { operator } : {}),
+    ...(threshold !== undefined ? { threshold } : {}),
+    ...(message !== undefined ? { message } : {}),
+  }
+}
+
+function labelJa(label: string): string {
+  return TRACE_LABEL_JA[label] ?? label
+}
+
+const TRACE_LABEL_JA: Record<string, string> = {
+  'sizing.quantity_positive': '発注数量が1株/1単元以上ある',
+  'scheduler.price_valid': '株価が有効',
+  'scheduler.notional_valid': '発注金額が有効',
+  'scheduler.sell_position_exists': '売却対象の建玉がある',
+  'scheduler.position_qty_valid': '建玉数量が有効',
+  'scheduler.pending_lock_expiry_valid': '注文ロック期限が有効',
+  'scheduler.pending_lock_acquired': '注文ロックを取得できた',
+  'risk.bucket_cap': '同グループ建玉上限内',
+  'broker.submit': '証券会社への発注送信',
+}
+
 /**
  * Build an operator-actionable reject reason from a sizing failure。
  * 単に capReason を出すと「なぜ失敗したか / 何を直せばよいか」が見えない
@@ -465,4 +616,3 @@ function buildSizingRejectReason(
   }
   return `sizing rejected: ${cr ?? 'zero qty'}`
 }
-

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -13,7 +13,7 @@ import {
   logStrategyDecision,
   strategyDecisionDbOrUndefined,
 } from '../../infrastructure/logger/strategyDecisionLog'
-import { runPullbackScheduler, type PullbackRunSummary } from './pullbackScheduler'
+import { runPullbackScheduler, type PullbackDecisionTrace, type PullbackRunSummary } from './pullbackScheduler'
 
 const DEFAULT_EQUITY_USD = 10_000
 const DEFAULT_EQUITY_JPY = 1_500_000
@@ -22,12 +22,70 @@ const JP_LOT_SIZE = 100
 export interface StrategyCronResult {
   summary: PullbackRunSummary
   symbols: string[]
+  /**
+   * Operator/AI analysis packet. Safe for logs: no broker secrets or raw
+   * Webull payloads, only config/risk context and per-symbol decisions.
+   */
+  analysis: StrategyCronAnalysis
   skipReason?:
     | 'trading_disabled'
     | 'no_tradable_symbols'
     | 'no_bridge_state'
     | 'portfolio_halted'
     | 'drawdown_kill'
+}
+
+export interface StrategyCronAnalysis {
+  schema: 'strategy_cron_analysis.v1'
+  generatedAt: string
+  requestId?: string
+  config: {
+    dryRun: boolean
+    tradingEnabled: boolean
+    pullbackRule: {
+      stopPct: number
+      takeProfitPct: number
+      timeStopDays: number
+      pullbackMax: number
+      pullbackMin: number
+      minReturn50d: number
+      requireAboveSma50: boolean
+      kAtr: number
+    }
+    risk: {
+      basePerTradePct: number
+      scaledPerTradePct?: number
+      ddHalfThreshold: number
+      ddHaltThreshold: number
+      drawdownKillThreshold: number
+      bucketExposurePct: number
+    }
+  }
+  universe: {
+    symbols: string[]
+    byCurrency: Record<SymbolCurrency, string[]>
+    symbolMaxNotional: Record<string, number>
+    symbolBucket: Record<string, string>
+  }
+  portfolio?: {
+    dailyStartEquity: number
+    dailyRealizedPnl: number
+    tradingDisabledUntil: string | null
+    updatedAt: string
+  }
+  drawdownScale?: {
+    step: 'normal' | 'half' | 'halt'
+    scale: number
+    drawdown: number
+  }
+  runs: Array<{
+    currency: SymbolCurrency
+    equity: number
+    lotSize: number
+    symbols: string[]
+    bucketCapMap: Record<string, number>
+  }>
+  decisions: PullbackDecisionTrace[]
 }
 
 /**
@@ -61,6 +119,7 @@ export async function runStrategyCron(
     holds: 0,
     rejected: [],
     errors: [],
+    decisions: [],
   })
 
   const [global, universe] = await Promise.all([
@@ -68,18 +127,60 @@ export async function runStrategyCron(
     loadSymbolUniverse(env),
   ])
 
+  const defaultRule = {
+    stopPct: global.pullbackDefaultStopPct,
+    takeProfitPct: global.pullbackDefaultTakeProfitPct,
+    timeStopDays: global.pullbackDefaultTimeStopDays,
+    pullbackMax: global.pullbackDefaultPullbackMax,
+    pullbackMin: global.pullbackDefaultPullbackMin,
+    minReturn50d: global.pullbackDefaultMinReturn50d,
+    requireAboveSma50: global.pullbackDefaultRequireAboveSma50,
+    kAtr: global.pullbackDefaultKAtr,
+  }
+  const byCurrency: Record<SymbolCurrency, string[]> = { USD: [], JPY: [] }
+  for (const sym of universe.allowedSymbols) {
+    const cur = universe.symbolCurrency[sym] ?? 'USD'
+    byCurrency[cur].push(sym)
+  }
+  const analysisBase = (): StrategyCronAnalysis => ({
+    schema: 'strategy_cron_analysis.v1',
+    generatedAt: new Date().toISOString(),
+    requestId: options.requestId,
+    config: {
+      dryRun: global.dryRun,
+      tradingEnabled: global.tradingEnabled,
+      pullbackRule: defaultRule,
+      risk: {
+        basePerTradePct: global.riskBasePerTradePct,
+        ddHalfThreshold: global.riskDdHalfThreshold,
+        ddHaltThreshold: global.riskDdHaltThreshold,
+        drawdownKillThreshold: global.drawdownKillThreshold,
+        bucketExposurePct: global.bucketExposurePct,
+      },
+    },
+    universe: {
+      symbols: universe.allowedSymbols,
+      byCurrency,
+      symbolMaxNotional: universe.symbolMaxNotional,
+      symbolBucket: universe.symbolBucket,
+    },
+    runs: [],
+    decisions: [],
+  })
+
   if (!global.tradingEnabled) {
-    return { summary: emptySummary(), symbols: [], skipReason: 'trading_disabled' }
+    return { summary: emptySummary(), symbols: [], analysis: analysisBase(), skipReason: 'trading_disabled' }
   }
 
   if (universe.allowedSymbols.length === 0) {
-    return { summary: emptySummary(), symbols: [], skipReason: 'no_tradable_symbols' }
+    return { summary: emptySummary(), symbols: [], analysis: analysisBase(), skipReason: 'no_tradable_symbols' }
   }
 
   if (!env.SYMBOL_STATE) {
     return {
       summary: emptySummary(),
       symbols: universe.allowedSymbols,
+      analysis: analysisBase(),
       skipReason: 'no_bridge_state',
     }
   }
@@ -94,13 +195,24 @@ export async function runStrategyCron(
     return {
       summary: emptySummary(),
       symbols: universe.allowedSymbols,
+      analysis: analysisBase(),
       skipReason: 'portfolio_halted',
     }
   }
   const portfolioStore = new PortfolioStateClient(env.PORTFOLIO_STATE)
   let portfolioSnapshot: Awaited<ReturnType<typeof portfolioStore.getPortfolio>>
+  let analysis = analysisBase()
   try {
     portfolioSnapshot = await portfolioStore.getPortfolio()
+    analysis = {
+      ...analysis,
+      portfolio: {
+        dailyStartEquity: portfolioSnapshot.dailyStartEquity,
+        dailyRealizedPnl: portfolioSnapshot.dailyRealizedPnl,
+        tradingDisabledUntil: portfolioSnapshot.tradingDisabledUntil,
+        updatedAt: portfolioSnapshot.updatedAt,
+      },
+    }
     const now = Date.now()
     if (portfolioSnapshot.tradingDisabledUntil) {
       const disabledUntilMs = new Date(portfolioSnapshot.tradingDisabledUntil).getTime()
@@ -108,6 +220,7 @@ export async function runStrategyCron(
         return {
           summary: emptySummary(),
           symbols: universe.allowedSymbols,
+          analysis,
           skipReason: 'portfolio_halted',
         }
       }
@@ -118,6 +231,7 @@ export async function runStrategyCron(
         return {
           summary: emptySummary(),
           symbols: universe.allowedSymbols,
+          analysis,
           skipReason: 'drawdown_kill',
         }
       }
@@ -126,6 +240,7 @@ export async function runStrategyCron(
     return {
       summary: emptySummary(),
       symbols: universe.allowedSymbols,
+      analysis,
       skipReason: 'portfolio_halted',
     }
   }
@@ -152,6 +267,21 @@ export async function runStrategyCron(
     halfThreshold: global.riskDdHalfThreshold,
     haltThreshold: global.riskDdHaltThreshold,
   })
+  analysis = {
+    ...analysis,
+    config: {
+      ...analysis.config,
+      risk: {
+        ...analysis.config.risk,
+        scaledPerTradePct: global.riskBasePerTradePct * ddScale.scale,
+      },
+    },
+    drawdownScale: {
+      step: ddScale.step,
+      scale: ddScale.scale,
+      drawdown: ddScale.drawdown,
+    },
+  }
   if (ddScale.step !== 'normal') {
     console.log(
       JSON.stringify({
@@ -176,23 +306,6 @@ export async function runStrategyCron(
 
   // Pullback デフォルト rule は D1 global_config に寄せた (#118)。
   // 実運用中の tuning は `UPDATE global_config SET ...` で即反映可能。
-  const defaultRule = {
-    stopPct: global.pullbackDefaultStopPct,
-    takeProfitPct: global.pullbackDefaultTakeProfitPct,
-    timeStopDays: global.pullbackDefaultTimeStopDays,
-    pullbackMax: global.pullbackDefaultPullbackMax,
-    pullbackMin: global.pullbackDefaultPullbackMin,
-    minReturn50d: global.pullbackDefaultMinReturn50d,
-    requireAboveSma50: global.pullbackDefaultRequireAboveSma50,
-    kAtr: global.pullbackDefaultKAtr,
-  }
-
-  const byCurrency: Record<SymbolCurrency, string[]> = { USD: [], JPY: [] }
-  for (const sym of universe.allowedSymbols) {
-    const cur = universe.symbolCurrency[sym] ?? 'USD'
-    byCurrency[cur].push(sym)
-  }
-
   const summary = emptySummary()
   const runs: Array<{ currency: SymbolCurrency; equity: number; lotSize: number; symbols: string[] }> = []
   if (byCurrency.USD.length > 0) {
@@ -225,6 +338,13 @@ export async function runStrategyCron(
     for (const b of buckets) {
       bucketCapMap[b] = run.equity * global.bucketExposurePct
     }
+    analysis.runs.push({
+      currency: run.currency,
+      equity: run.equity,
+      lotSize: run.lotSize,
+      symbols: run.symbols,
+      bucketCapMap,
+    })
     const decisionDb = strategyDecisionDbOrUndefined(env)
     const sub = await runPullbackScheduler({
       symbols: run.symbols,
@@ -252,9 +372,11 @@ export async function runStrategyCron(
     summary.holds += sub.holds
     summary.rejected.push(...sub.rejected)
     summary.errors.push(...sub.errors)
+    summary.decisions.push(...sub.decisions)
+    analysis.decisions.push(...sub.decisions)
   }
 
-  return { summary, symbols: universe.allowedSymbols }
+  return { summary, symbols: universe.allowedSymbols, analysis }
 }
 
 function sanitizeEquity(value: number | null | undefined, fallback: number): number {

--- a/src/trading/strategy/strategies/PullbackUptrendStrategy.ts
+++ b/src/trading/strategy/strategies/PullbackUptrendStrategy.ts
@@ -1,4 +1,4 @@
-import type { Signal } from '../../domain/Signal'
+import type { DecisionTraceStep, Signal } from '../../domain/Signal'
 import type { PendingOrderLock, PositionState } from '../../state/types'
 
 export interface PullbackIndicators {
@@ -82,62 +82,100 @@ export class PullbackUptrendStrategy {
   decide(input: PullbackInput): Signal {
     const rule = this.resolveRule(input.symbol)
     const now = input.now
+    const trace: DecisionTraceStep[] = []
 
     if (input.pendingOrder !== null) {
-      return hold(input, 'pending order in flight')
+      trace.push(step('guard.pending_order_absent', false, true, 'not_exists', false, 'pending order in flight'))
+      return hold(input, 'pending order in flight', trace)
     }
+    trace.push(step('guard.pending_order_absent', true, false, 'not_exists', false))
+
     if (input.cooldownUntil && new Date(input.cooldownUntil).getTime() > now.getTime()) {
-      return hold(input, `cooldown active until ${input.cooldownUntil}`)
+      trace.push(step('guard.cooldown_inactive', false, input.cooldownUntil, '<=', now.toISOString(), 'cooldown active'))
+      return hold(input, `cooldown active until ${input.cooldownUntil}`, trace)
     }
+    trace.push(step('guard.cooldown_inactive', true, input.cooldownUntil, '<=', now.toISOString()))
 
     if (input.position !== null) {
-      return this.exitDecision(input, input.position, rule)
+      trace.push(step('route.position_open', true, input.position.qty, '>', 0))
+      return this.exitDecision(input, input.position, rule, trace)
     }
-    return this.entryDecision(input, rule)
+    trace.push(step('route.position_open', false, 0, '>', 0))
+    return this.entryDecision(input, rule, trace)
   }
 
-  private exitDecision(input: PullbackInput, position: PositionState, rule: SymbolRule): Signal {
+  private exitDecision(
+    input: PullbackInput,
+    position: PositionState,
+    rule: SymbolRule,
+    trace: DecisionTraceStep[],
+  ): Signal {
     const pnlPct = (input.indicators.price - position.avgPrice) / position.avgPrice
 
     if (pnlPct >= rule.takeProfitPct) {
-      return sell(input, position, `take-profit hit: pnl ${pnlPct.toFixed(4)} >= ${rule.takeProfitPct}`)
+      trace.push(step('exit.take_profit', true, pnlPct, '>=', rule.takeProfitPct))
+      return sell(input, position, `take-profit hit: pnl ${pnlPct.toFixed(4)} >= ${rule.takeProfitPct}`, trace)
     }
+    trace.push(step('exit.take_profit', false, pnlPct, '>=', rule.takeProfitPct))
+
     if (pnlPct <= rule.stopPct) {
-      return sell(input, position, `stop-loss hit: pnl ${pnlPct.toFixed(4)} <= ${rule.stopPct}`)
+      trace.push(step('exit.stop_loss', true, pnlPct, '<=', rule.stopPct))
+      return sell(input, position, `stop-loss hit: pnl ${pnlPct.toFixed(4)} <= ${rule.stopPct}`, trace)
     }
+    trace.push(step('exit.stop_loss', false, pnlPct, '<=', rule.stopPct))
+
     if (input.holdBusinessDays >= rule.timeStopDays) {
+      trace.push(step('exit.time_stop', true, input.holdBusinessDays, '>=', rule.timeStopDays))
       return sell(
         input,
         position,
         `time-stop hit: held ${input.holdBusinessDays}d >= ${rule.timeStopDays}d`,
+        trace,
       )
     }
-    return hold(input, `holding: pnl ${pnlPct.toFixed(4)} within (${rule.stopPct}, ${rule.takeProfitPct})`)
+    trace.push(step('exit.time_stop', false, input.holdBusinessDays, '>=', rule.timeStopDays))
+    trace.push(step('exit.hold_position', true, pnlPct, 'between', [rule.stopPct, rule.takeProfitPct]))
+    return hold(input, `holding: pnl ${pnlPct.toFixed(4)} within (${rule.stopPct}, ${rule.takeProfitPct})`, trace)
   }
 
-  private entryDecision(input: PullbackInput, rule: SymbolRule): Signal {
+  private entryDecision(input: PullbackInput, rule: SymbolRule, trace: DecisionTraceStep[]): Signal {
     const ind = input.indicators
     if (ind.return50d <= rule.minReturn50d) {
-      return hold(input, `50d return ${ind.return50d.toFixed(4)} <= ${rule.minReturn50d} trend threshold`)
+      trace.push(step('entry.trend_50d_return', false, ind.return50d, '>', rule.minReturn50d))
+      return hold(input, `50d return ${ind.return50d.toFixed(4)} <= ${rule.minReturn50d} trend threshold`, trace)
     }
+    trace.push(step('entry.trend_50d_return', true, ind.return50d, '>', rule.minReturn50d))
+
     if (rule.requireAboveSma50 && ind.price <= ind.sma50) {
-      return hold(input, `price ${ind.price} <= sma50 ${ind.sma50}`)
+      trace.push(step('entry.above_sma50', false, ind.price, '>', ind.sma50))
+      return hold(input, `price ${ind.price} <= sma50 ${ind.sma50}`, trace)
     }
+    trace.push(step('entry.above_sma50', true, ind.price, '>', ind.sma50, rule.requireAboveSma50 ? undefined : 'disabled by rule'))
+
     if (ind.high20d <= 0) {
-      return hold(input, 'invalid 20d high')
+      trace.push(step('entry.high20d_valid', false, ind.high20d, '>', 0))
+      return hold(input, 'invalid 20d high', trace)
     }
+    trace.push(step('entry.high20d_valid', true, ind.high20d, '>', 0))
+
     const pullback = (ind.price - ind.high20d) / ind.high20d
     if (pullback > rule.pullbackMax) {
-      return hold(input, `pullback ${pullback.toFixed(4)} > ${rule.pullbackMax} (not deep enough)`)
+      trace.push(step('entry.pullback_not_too_shallow', false, pullback, '<=', rule.pullbackMax))
+      return hold(input, `pullback ${pullback.toFixed(4)} > ${rule.pullbackMax} (not deep enough)`, trace)
     }
+    trace.push(step('entry.pullback_not_too_shallow', true, pullback, '<=', rule.pullbackMax))
+
     if (pullback < rule.pullbackMin) {
-      return hold(input, `pullback ${pullback.toFixed(4)} < ${rule.pullbackMin} (too deep)`)
+      trace.push(step('entry.pullback_not_too_deep', false, pullback, '>=', rule.pullbackMin))
+      return hold(input, `pullback ${pullback.toFixed(4)} < ${rule.pullbackMin} (too deep)`, trace)
     }
-    return buy(input, `pullback ${pullback.toFixed(4)} in uptrend (50d return ${ind.return50d.toFixed(4)})`)
+    trace.push(step('entry.pullback_not_too_deep', true, pullback, '>=', rule.pullbackMin))
+    trace.push(step('entry.adopt_buy', true, pullback, 'between', [rule.pullbackMin, rule.pullbackMax]))
+    return buy(input, `pullback ${pullback.toFixed(4)} in uptrend (50d return ${ind.return50d.toFixed(4)})`, trace)
   }
 }
 
-function hold(input: PullbackInput, reason: string): Signal {
+function hold(input: PullbackInput, reason: string, trace: DecisionTraceStep[]): Signal {
   return {
     action: 'HOLD',
     symbol: input.symbol,
@@ -145,10 +183,11 @@ function hold(input: PullbackInput, reason: string): Signal {
     price: input.indicators.price,
     reason,
     generatedAtIso: input.now.toISOString(),
+    trace,
   }
 }
 
-function buy(input: PullbackInput, reason: string): Signal {
+function buy(input: PullbackInput, reason: string, trace: DecisionTraceStep[]): Signal {
   // Quantity is resolved by the sizing module (pullbackSizing.ts); signal
   // carries 0 here so downstream code knows to compute it.
   return {
@@ -158,10 +197,16 @@ function buy(input: PullbackInput, reason: string): Signal {
     price: input.indicators.price,
     reason,
     generatedAtIso: input.now.toISOString(),
+    trace,
   }
 }
 
-function sell(input: PullbackInput, position: PositionState, reason: string): Signal {
+function sell(
+  input: PullbackInput,
+  position: PositionState,
+  reason: string,
+  trace: DecisionTraceStep[],
+): Signal {
   return {
     action: 'SELL',
     symbol: input.symbol,
@@ -169,5 +214,45 @@ function sell(input: PullbackInput, position: PositionState, reason: string): Si
     price: input.indicators.price,
     reason,
     generatedAtIso: input.now.toISOString(),
+    trace,
   }
+}
+
+function step(
+  label: string,
+  passed: boolean,
+  actual?: DecisionTraceStep['actual'],
+  operator?: DecisionTraceStep['operator'],
+  threshold?: DecisionTraceStep['threshold'],
+  message?: string,
+): DecisionTraceStep {
+  return {
+    label,
+    label_ja: labelJa(label),
+    passed,
+    ...(actual !== undefined ? { actual } : {}),
+    ...(operator !== undefined ? { operator } : {}),
+    ...(threshold !== undefined ? { threshold } : {}),
+    ...(message !== undefined ? { message } : {}),
+  }
+}
+
+function labelJa(label: string): string {
+  return TRACE_LABEL_JA[label] ?? label
+}
+
+const TRACE_LABEL_JA: Record<string, string> = {
+  'guard.pending_order_absent': '未約定注文がない',
+  'guard.cooldown_inactive': 'クールダウン中ではない',
+  'route.position_open': '建玉を保有中',
+  'entry.trend_50d_return': '50日騰落率が上昇トレンド条件を満たす',
+  'entry.above_sma50': '株価が50日移動平均線を上回る',
+  'entry.high20d_valid': '直近20日高値が有効',
+  'entry.pullback_not_too_shallow': '押し目が浅すぎない',
+  'entry.pullback_not_too_deep': '押し目が深すぎない',
+  'entry.adopt_buy': '買い採用',
+  'exit.take_profit': '利確条件を満たす',
+  'exit.stop_loss': '損切り条件を満たす',
+  'exit.time_stop': '時間切れ手仕舞い条件を満たす',
+  'exit.hold_position': '保有継続条件内',
 }

--- a/test/strategy/pullbackUptrendStrategy.test.ts
+++ b/test/strategy/pullbackUptrendStrategy.test.ts
@@ -53,12 +53,29 @@ describe('PullbackUptrendStrategy entry', () => {
     const signal = strategy.decide(goodEntryInput())
     expect(signal.action).toBe('BUY')
     expect(signal.quantity).toBe(0) // sizing resolves this downstream
+    expect(signal.trace?.map((step) => [step.label, step.passed])).toEqual([
+      ['guard.pending_order_absent', true],
+      ['guard.cooldown_inactive', true],
+      ['route.position_open', false],
+      ['entry.trend_50d_return', true],
+      ['entry.above_sma50', true],
+      ['entry.high20d_valid', true],
+      ['entry.pullback_not_too_shallow', true],
+      ['entry.pullback_not_too_deep', true],
+      ['entry.adopt_buy', true],
+    ])
+    expect(signal.trace?.find((step) => step.label === 'entry.adopt_buy')?.label_ja).toBe('買い採用')
   })
 
   it('HOLDs when 50d return is below the +8% trend threshold', () => {
     const input = goodEntryInput()
     input.indicators.return50d = 0.05
-    expect(strategy.decide(input).action).toBe('HOLD')
+    const signal = strategy.decide(input)
+    expect(signal.action).toBe('HOLD')
+    expect(signal.trace?.at(-1)).toMatchObject({
+      label: 'entry.trend_50d_return',
+      passed: false,
+    })
   })
 
   it('HOLDs when price is at or below sma50', () => {
@@ -117,6 +134,7 @@ describe('PullbackUptrendStrategy exit priority', () => {
     const signal = strategy.decide(withPosition(108, 20))
     expect(signal.action).toBe('SELL')
     expect(signal.reason).toMatch(/take-profit/)
+    expect(signal.trace?.at(-1)).toMatchObject({ label: 'exit.take_profit', passed: true })
   })
 
   it('SELLs on stop-loss before time-stop', () => {

--- a/test/trading/strategy/pullbackScheduler.test.ts
+++ b/test/trading/strategy/pullbackScheduler.test.ts
@@ -93,6 +93,15 @@ describe('runPullbackScheduler', () => {
     const intent = execution.calls[0] as { side: string; quantity: number }
     expect(intent.side).toBe('BUY')
     expect(intent.quantity).toBeGreaterThan(0)
+    expect(summary.decisions).toHaveLength(1)
+    expect(summary.decisions[0]).toMatchObject({
+      symbol: 'AAPL',
+      decision: 'BUY',
+      order: { side: 'BUY' },
+    })
+    expect(summary.decisions[0]?.trace?.map((step) => step.label)).toContain('entry.adopt_buy')
+    expect(summary.decisions[0]?.trace?.map((step) => step.label)).toContain('broker.submit')
+    expect(summary.decisions[0]?.trace?.find((step) => step.label === 'broker.submit')?.label_ja).toBe('証券会社への発注送信')
   })
 
   it('HOLDs (and does not submit) when bars are too short for indicators', async () => {
@@ -110,6 +119,13 @@ describe('runPullbackScheduler', () => {
     expect(summary.buys).toBe(0)
     expect(summary.rejected).toEqual([
       { symbol: 'AAPL', reason: 'insufficient bars for indicators' },
+    ])
+    expect(summary.decisions).toEqual([
+      {
+        symbol: 'AAPL',
+        decision: 'REJECT',
+        reason: 'insufficient bars for indicators',
+      },
     ])
     expect(execution.calls).toHaveLength(0)
   })

--- a/test/trading/strategy/runStrategyCron.test.ts
+++ b/test/trading/strategy/runStrategyCron.test.ts
@@ -33,6 +33,8 @@ describe('runStrategyCron', () => {
     const result = await runStrategyCron(env)
     expect(result.skipReason).toBe('trading_disabled')
     expect(result.summary.evaluated).toBe(0)
+    expect(result.analysis.schema).toBe('strategy_cron_analysis.v1')
+    expect(result.analysis.config.tradingEnabled).toBe(false)
   })
 
   it('skips with no_tradable_symbols when universe is empty', async () => {
@@ -100,6 +102,7 @@ describe('runStrategyCron', () => {
     } as unknown as Parameters<typeof runStrategyCron>[0]
     const result = await runStrategyCron(envWithoutPortfolio)
     expect(result.skipReason).toBe('portfolio_halted')
+    expect(result.analysis.universe.symbols).toEqual(['SOXL', 'SOXS'])
   })
 
   it('fail-closes to portfolio_halted on invalid tradingDisabledUntil timestamp', async () => {


### PR DESCRIPTION
## 概要

Cron実行結果を、AIにそのまま渡して分析しやすい構造化JSONとして扱えるようにしました。あわせて、Pullback戦略の採用/不採用ロジックとscheduler/risk/brokerの各ゲートをtraceとして残し、各stepに機械向けの `label` と人間向けの `label_ja` を付与しています。

## 変更内容

- Cron完了時に `strategy_cron_run` の1行JSONログを出力し、`analysis` に設定値、universe、run結果、decision一覧を集約
- Pullback採用ロジックにtraceを追加し、`entry.adopt_buy` などの判定stepごとに `passed` / `actual` / `operator` / `threshold` を記録
- scheduler/risk/broker側の判定にもtraceを追加し、発注数量、価格、notional、pending lock、bucket cap、broker submitを追跡
- trace stepに日本語説明用の `label_ja` を追加
- `/dashboard/cron/json` を追加し、最新runまたは指定 `requestId` のcron decisionをpretty JSONでコピー可能に変更
- `/dashboard/cron` に最新run JSONへのリンクを追加

## 期待する使い方

Cloudflare cron logやdashboard JSON exportからJSONをコピーし、AIに渡して「なぜこの銘柄が採用/不採用だったか」「どの条件で落ちたか」「運用設定とdecisionが整合しているか」を分析できます。

## 検証

- `pnpm run typecheck`
- `pnpm test -- test/strategy/pullbackUptrendStrategy.test.ts test/trading/strategy/pullbackScheduler.test.ts`
- 上記testコマンドではVitestが全体実行され、`48 files / 362 tests` passed

## 補足

- `.claude/scheduled_tasks.lock` は未追跡のまま残し、このPRには含めていません。
- ローカルの `gh` 認証トークンが無効だったため、branch pushはSSH、PR作成/更新はGitHub connectorで実施しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **New Features**
  * ストラテジー実行の決定トレース機能を追加し、取引判断の詳細なステップを記録
  * ダッシュボードにJSON形式でのエクスポート機能を追加

* **Tests**
  * 決定トレース機能の検証テストを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->