### PR TITLE
fix: Cron reasonカラムで詳細を展開できるようにする

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -162,6 +162,7 @@ export const dashboard = new Hono<AppBindings>()
           decision: strategyDecisionLog.decision,
           reason: strategyDecisionLog.reason,
           price: strategyDecisionLog.price,
+          indicatorsJson: strategyDecisionLog.indicatorsJson,
           clientOrderId: strategyDecisionLog.clientOrderId,
           filledPrice: tradeJournal.filledPrice,
           filledQty: tradeJournal.filledQty,
@@ -264,6 +265,13 @@ const STYLE = `
   .footer{margin-top:24px;font-size:11px;color:#86868b}
   details{margin-top:16px}
   summary{cursor:pointer;padding:6px 0;font-weight:600}
+  .reason-details{margin:0;min-width:260px}
+  .reason-details summary{padding:0;color:#06c;font-weight:400}
+  .reason-panel{margin-top:8px;padding:10px;border:1px solid #e5e5ea;border-radius:6px;background:#fafafa;color:#1d1d1f;max-width:680px}
+  .reason-panel div{margin:0 0 8px}
+  .reason-panel div:last-child{margin-bottom:0}
+  .reason-panel code{white-space:pre-wrap;word-break:break-word}
+  .reason-panel pre{margin:4px 0 0;white-space:pre-wrap;word-break:break-word;font-size:12px}
 `
 
 function layout(title: string, body: string): string {
@@ -794,6 +802,7 @@ function cronBody(
     decision: string
     reason: string | null
     price: number | null
+    indicatorsJson?: string | null
     clientOrderId?: string | null
     filledPrice?: number | null
     filledQty?: number | null
@@ -835,7 +844,7 @@ function cronBody(
         <td class="muted">${esc(fmtJst(r.timestamp))}</td>
         <td><a href="/dashboard/cron?symbol=${encodeURIComponent(r.symbol)}"><strong>${esc(r.symbol)}</strong></a></td>
         <td class="${cls}">${esc(r.decision)}</td>
-        <td>${esc(localizeReason(r.reason))}</td>
+        <td>${cronReasonCell(r)}</td>
         <td>${r.price === null ? '-' : fmtNumber(r.price, 2)}</td>
         <td class="muted">${esc(fillCell)}</td>
         <td>${realizedCell}</td>
@@ -849,6 +858,34 @@ function cronBody(
     </tr></thead>
     <tbody>${tbody}</tbody>
   </table>`
+}
+
+function cronReasonCell(row: {
+  id: number
+  requestId: string | null
+  reason: string | null
+  indicatorsJson?: string | null
+  clientOrderId?: string | null
+}): string {
+  const localized = localizeReason(row.reason)
+  const rawReason = row.reason ?? '-'
+  const requestLink = row.requestId
+    ? `<a href="/dashboard/cron/json?requestId=${encodeURIComponent(row.requestId)}" target="_blank" rel="noreferrer">${esc(row.requestId)}</a>`
+    : '-'
+  const indicators = row.indicatorsJson
+    ? JSON.stringify(parseJsonObject(row.indicatorsJson), null, 2)
+    : null
+
+  return `<details class="reason-details">
+    <summary>${esc(localized || '-')}</summary>
+    <div class="reason-panel">
+      <div><strong>decision id</strong><br><code>${row.id}</code></div>
+      <div><strong>raw reason</strong><br><code>${esc(rawReason)}</code></div>
+      <div><strong>requestId / run JSON</strong><br>${requestLink}</div>
+      <div><strong>clientOrderId</strong><br><code>${esc(row.clientOrderId ?? '-')}</code></div>
+      <div><strong>indicators</strong><br>${indicators ? `<pre>${esc(indicators)}</pre>` : '<span class="muted">-</span>'}</div>
+    </div>
+  </details>`
 }
 
 /**

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp } from '../../src/app'
 import { loadGlobalConfigFrom } from '../../src/infrastructure/db/globalConfigLoader'
+import { createDb } from '../../src/infrastructure/db/tradeJournalRepo'
 import { loadSymbolUniverse } from '../../src/infrastructure/db/symbolUniverse'
 import { makeGlobalConfigSnapshot, makeSymbolUniverse } from '../helpers/configFixtures'
 
@@ -9,6 +10,9 @@ vi.mock('../../src/infrastructure/db/globalConfigLoader', () => ({
 }))
 vi.mock('../../src/infrastructure/db/symbolUniverse', () => ({
   loadSymbolUniverse: vi.fn(),
+}))
+vi.mock('../../src/infrastructure/db/tradeJournalRepo', () => ({
+  createDb: vi.fn(),
 }))
 
 const baseEnv = {
@@ -56,6 +60,19 @@ function fakePortfolioNamespace(portfolio: {
     idFromName: () => 'id',
     get: () => stub,
   } as unknown
+}
+
+function fakeCronDb(rows: unknown[]) {
+  const query = {
+    from: vi.fn(() => query),
+    leftJoin: vi.fn(() => query),
+    where: vi.fn(() => query),
+    orderBy: vi.fn(() => query),
+    limit: vi.fn(async () => rows),
+  }
+  return {
+    select: vi.fn(() => query),
+  }
 }
 
 describe('dashboard', () => {
@@ -178,6 +195,37 @@ describe('dashboard', () => {
     const res = await app.request('/dashboard/cron', { headers: authHeader }, baseEnv)
     expect(res.status).toBe(200)
     expect(await res.text()).toContain('利用不可')
+  })
+
+  it('renders cron reason as clickable details', async () => {
+    vi.mocked(createDb).mockReturnValue(
+      fakeCronDb([
+        {
+          id: 123,
+          timestamp: '2026-04-23T00:00:00.000Z',
+          requestId: 'req-1',
+          symbol: 'SOXL',
+          decision: 'BUY',
+          reason: 'pullback -0.0500 in uptrend (50d return 0.1000)',
+          price: 10,
+          indicatorsJson: '{"price":10,"return50d":0.1}',
+          clientOrderId: 'coid-1',
+          filledPrice: null,
+          filledQty: null,
+          realizedPnl: null,
+          brokerStatus: null,
+        },
+      ]) as unknown as ReturnType<typeof createDb>,
+    )
+    const app = createApp()
+    const res = await app.request('/dashboard/cron', { headers: authHeader }, { ...baseEnv, DB: {} as D1Database })
+    const body = await res.text()
+
+    expect(body).toContain('<details class="reason-details">')
+    expect(body).toContain('買い: 上昇トレンド中の押し目買い')
+    expect(body).toContain('<strong>raw reason</strong>')
+    expect(body).toContain('/dashboard/cron/json?requestId=req-1')
+    expect(body).toContain('&quot;return50d&quot;: 0.1')
   })
 
   it('cron page requires basic auth', async () => {


### PR DESCRIPTION
## 概要

前回PRの意図として、Cron画面の `reason` カラムをクリックしたら詳細が見える体験にする想定でしたが、実際には通常テキスト表示のままでした。このPRで `reason` セルをクリック展開できる `<details>` 表示に変更します。

## 変更内容

- `/dashboard/cron` の `reason` セルを `<details><summary>` に変更
- summaryには既存の日本語化済みreasonを表示
- 展開時に以下を表示
  - decision id
  - raw reason
  - requestId と run JSONリンク
  - clientOrderId
  - indicators JSON
- Cron一覧クエリで `indicators_json` を取得するように変更
- dashboard testにreason詳細展開の回帰テストを追加

## 検証

- `pnpm run typecheck`
- `pnpm test -- test/routes/dashboard.test.ts`
- 上記testコマンドではVitestが全体実行され、`48 files / 363 tests` passed

## 補足

- `.claude/scheduled_tasks.lock` は未追跡のまま残し、このPRには含めていません。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
* cronダッシュボードの理由カラムが展開可能な詳細パネルに変更されました。翻訳されたテキスト、元のデータ、クライアント注文ID、および関連するJSONデータへのアクセスが可能になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->