### PR TITLE
feat(dashboard): /positions の現在値に source / 鮮度ラベル付与

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -340,11 +340,14 @@ function positionsBody(
           ? ((quote.price - pos.avgPrice) / pos.avgPrice) * 100
           : null
       const pnlClass = pnlPct === null ? 'muted' : pnlPct >= 0 ? 'ok' : 'err'
+      const quoteCell = quote
+        ? `${fmtNumber(quote.price, 2)} <span class="muted" style="font-size:11px">(${esc(quote.source)}, ${esc(formatQuoteAge(quote.asOf ?? quote.fetchedAt))})</span>`
+        : '<span class="muted">—</span>'
       return `<tr>
         <td><strong>${esc(s.symbol)}</strong></td>
         <td>${pos ? esc(pos.qty) : '<span class="muted">—</span>'}</td>
         <td>${pos ? fmtNumber(pos.avgPrice, 2) : '<span class="muted">—</span>'}</td>
-        <td>${quote ? fmtNumber(quote.price, 2) : '<span class="muted">—</span>'}</td>
+        <td>${quoteCell}</td>
         <td class="${pnlClass}">${pnlPct === null ? '—' : fmtNumber(pnlPct, 2) + '%'}</td>
         <td>${pendingSide ? esc(pendingSide) : '<span class="muted">—</span>'}</td>
         <td>${formatCooldown(s.cooldownUntil)}</td>
@@ -352,9 +355,16 @@ function positionsBody(
       </tr>`
     })
     .join('')
-  return `<table>
+  return `<p class="muted" style="font-size:12px">
+    現在値・評価損益は <strong>Yahoo Finance daily close</strong> ベース。
+    intraday は前日終値のままで実際の市場価格とは乖離します
+    (実約定損益は <a href="/dashboard/cron">/dashboard/cron</a> 「実 損益」列を参照)。
+    Webull last quote への切替は
+    <a href="https://github.com/ochanuco/webull-trading/issues/21">#21</a> 予定。
+  </p>
+  <table>
     <thead><tr>
-      <th>銘柄</th><th>数量</th><th>平均取得単価</th><th>現在値</th><th>評価損益</th>
+      <th>銘柄</th><th>数量</th><th>平均取得単価</th><th>現在値 (source, 鮮度)</th><th>評価損益</th>
       <th>未約定</th><th>クールダウン</th><th>更新時刻</th>
     </tr></thead>
     <tbody>${tbody}</tbody>
@@ -630,6 +640,26 @@ function formatCooldown(cooldownUntil: string | null): string {
     return '<span class="muted">—</span>'
   }
   return `<span class="warn">${esc(fmtJst(cooldownUntil))}</span>`
+}
+
+/**
+ * QuoteSnapshot.asOf (ISO) を「NN分前 / NN時間前 / NN日前」相対表記に。
+ * 現在値の鮮度を一目で見せるための表示用ヘルパー。Yahoo daily close は
+ * 数時間〜半日遅延があるため、評価損益が intraday 価格と乖離し得る。
+ * Webull last quote 接続後は #21 でこのラベルごと撤去予定。
+ */
+export function formatQuoteAge(asOf: string, now: Date = new Date()): string {
+  const t = new Date(asOf).getTime()
+  if (!Number.isFinite(t)) return '?'
+  const diffMs = now.getTime() - t
+  if (diffMs < 0) return 'just now'
+  const min = Math.floor(diffMs / 60_000)
+  if (min < 1) return 'just now'
+  if (min < 60) return `${min}m前`
+  const hr = Math.floor(min / 60)
+  if (hr < 24) return `${hr}h前`
+  const day = Math.floor(hr / 24)
+  return `${day}d前`
 }
 
 function formatConfigValue(v: unknown): string {

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -186,3 +186,27 @@ describe('dashboard', () => {
     expect(res.status).toBe(401)
   })
 })
+
+import { formatQuoteAge } from '../../src/routes/dashboard'
+
+describe('formatQuoteAge', () => {
+  const now = new Date('2026-04-25T10:00:00.000Z')
+  it('< 1 min → "just now"', () => {
+    expect(formatQuoteAge('2026-04-25T09:59:30.000Z', now)).toBe('just now')
+  })
+  it('minutes', () => {
+    expect(formatQuoteAge('2026-04-25T09:45:00.000Z', now)).toBe('15m前')
+  })
+  it('hours', () => {
+    expect(formatQuoteAge('2026-04-25T07:00:00.000Z', now)).toBe('3h前')
+  })
+  it('days', () => {
+    expect(formatQuoteAge('2026-04-23T10:00:00.000Z', now)).toBe('2d前')
+  })
+  it('future timestamp → "just now"', () => {
+    expect(formatQuoteAge('2026-04-26T00:00:00.000Z', now)).toBe('just now')
+  })
+  it('invalid → "?"', () => {
+    expect(formatQuoteAge('not-an-iso', now)).toBe('?')
+  })
+})


### PR DESCRIPTION
## Summary

`/dashboard/positions` の評価損益が **Yahoo Finance daily close (前日終値)** ベースであり、intraday には実際の市場価格と乖離して「逆転表示」(含み損表示なのに実 fill は利益) が起きうる問題への暫定対応。Webull last quote 接続 (#21) までの誤読防止。

## Changes

- 現在値セルに `(yahoo, NNm前)` 形式で **source と鮮度** を併記
- 表上部に「Yahoo daily close ベース、実 fill 損益は `/dashboard/cron`」への誘導メモ
- `formatQuoteAge(asOf, now)` ヘルパー (分→m前 / 時→h前 / 日→d前) + 単体テスト 6 ケース

## トレーダー視点の根拠

trading-strategist agent との議論で、

- 未実現損益の正は **broker last quote** (Webull)、Yahoo daily close は fallback only
- 「逆転表示」は信頼を最も毀損する UX → 即時に source 明示が必要
- 抜本対応は #21 (Webull OpenAPI 実運用化) で last quote 接続

という結論。本 PR は #21 着手前の 1st step。

## Related

- #21 へ follow-up scope (unrealized PnL を Webull last に切替) を comment で追記済
- 過去の SOXL ピンポン取引で「表示 loss / 実 fill +\$0.38 利益」が発生した原因と同じ構造

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (48 files / 368 tests passed、formatQuoteAge 6 ケース追加)
- [ ] staging で `/dashboard/positions` を目視確認、現在値セルに `(yahoo, NNh前)` が出ること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ポジションダッシュボードの「現在値」セルが充実し、見積価格に加えて引用情報の鮮度を表示
  * ダッシュボードに説明テキスト追加（Yahoo Finance の日次終値に基づくことを明記）
  * 時刻を「X分前」「X時間前」「X日前」形式で表示するユーティリティを追加

* **テスト**
  * 新ユーティリティのテストケースを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->