### PR TITLE
refactor(dashboard): 現在値 asOf を相対表記から絶対 JST 表記に変更

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -349,7 +349,7 @@ function positionsBody(
           : null
       const pnlClass = pnlPct === null ? 'muted' : pnlPct >= 0 ? 'ok' : 'err'
       const quoteCell = quote
-        ? `${fmtNumber(quote.price, 2)} <span class="muted" style="font-size:11px">(${esc(quote.source)}, ${esc(formatQuoteAge(quote.asOf ?? quote.fetchedAt))})</span>`
+        ? `${fmtNumber(quote.price, 2)} <span class="muted" style="font-size:11px">(${esc(quote.source)}, ${esc(formatQuoteAsOf(quote.asOf ?? quote.fetchedAt))})</span>`
         : '<span class="muted">—</span>'
       return `<tr>
         <td><strong>${esc(s.symbol)}</strong></td>
@@ -372,7 +372,7 @@ function positionsBody(
   </p>
   <table>
     <thead><tr>
-      <th>銘柄</th><th>数量</th><th>平均取得単価</th><th>現在値 (source, 鮮度)</th><th>評価損益</th>
+      <th>銘柄</th><th>数量</th><th>平均取得単価</th><th>現在値 (source, asOf)</th><th>評価損益</th>
       <th>未約定</th><th>クールダウン</th><th>更新時刻</th>
     </tr></thead>
     <tbody>${tbody}</tbody>
@@ -651,23 +651,17 @@ function formatCooldown(cooldownUntil: string | null): string {
 }
 
 /**
- * QuoteSnapshot.asOf (ISO) を「NN分前 / NN時間前 / NN日前」相対表記に。
- * 現在値の鮮度を一目で見せるための表示用ヘルパー。Yahoo daily close は
- * 数時間〜半日遅延があるため、評価損益が intraday 価格と乖離し得る。
- * Webull last quote 接続後は #21 でこのラベルごと撤去予定。
+ * QuoteSnapshot.asOf (ISO) を JST の絶対表記 `MM/DD HH:MM JST` に。
+ * 相対表記 (NN日前) は週末・場外で必ず古く見えてしまい「壊れている風」に
+ * 誤読されやすいため、絶対時刻を出して「金曜引け」と一目で分かるようにする。
+ * Webull last quote が intraday で更新されるようになったら撤去対象。
  */
-export function formatQuoteAge(asOf: string, now: Date = new Date()): string {
-  const t = new Date(asOf).getTime()
-  if (!Number.isFinite(t)) return '?'
-  const diffMs = now.getTime() - t
-  if (diffMs < 0) return 'just now'
-  const min = Math.floor(diffMs / 60_000)
-  if (min < 1) return 'just now'
-  if (min < 60) return `${min}m前`
-  const hr = Math.floor(min / 60)
-  if (hr < 24) return `${hr}h前`
-  const day = Math.floor(hr / 24)
-  return `${day}d前`
+export function formatQuoteAsOf(asOf: string): string {
+  const d = new Date(asOf)
+  if (!Number.isFinite(d.getTime())) return '?'
+  const parts = JST_FORMATTER.formatToParts(d)
+  const pick = (type: string) => parts.find((p) => p.type === type)?.value ?? ''
+  return `${pick('month')}/${pick('day')} ${pick('hour')}:${pick('minute')} JST`
 }
 
 function formatConfigValue(v: unknown): string {

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -235,26 +235,21 @@ describe('dashboard', () => {
   })
 })
 
-import { formatQuoteAge } from '../../src/routes/dashboard'
+import { formatQuoteAsOf } from '../../src/routes/dashboard'
 
-describe('formatQuoteAge', () => {
-  const now = new Date('2026-04-25T10:00:00.000Z')
-  it('< 1 min → "just now"', () => {
-    expect(formatQuoteAge('2026-04-25T09:59:30.000Z', now)).toBe('just now')
+describe('formatQuoteAsOf', () => {
+  it('US 金曜引け 16:00 ET → JST 翌 05:00', () => {
+    // 2026-04-24 20:00 UTC = 2026-04-25 05:00 JST (DST 中: ET = UTC-4)
+    expect(formatQuoteAsOf('2026-04-24T20:00:00.000Z')).toBe('04/25 05:00 JST')
   })
-  it('minutes', () => {
-    expect(formatQuoteAge('2026-04-25T09:45:00.000Z', now)).toBe('15m前')
+  it('JP 金曜引け 15:00 JST', () => {
+    // 2026-04-24 06:00 UTC = 2026-04-24 15:00 JST
+    expect(formatQuoteAsOf('2026-04-24T06:00:00.000Z')).toBe('04/24 15:00 JST')
   })
-  it('hours', () => {
-    expect(formatQuoteAge('2026-04-25T07:00:00.000Z', now)).toBe('3h前')
-  })
-  it('days', () => {
-    expect(formatQuoteAge('2026-04-23T10:00:00.000Z', now)).toBe('2d前')
-  })
-  it('future timestamp → "just now"', () => {
-    expect(formatQuoteAge('2026-04-26T00:00:00.000Z', now)).toBe('just now')
+  it('zero-pads month / day / hour', () => {
+    expect(formatQuoteAsOf('2026-01-05T00:00:00.000Z')).toBe('01/05 09:00 JST')
   })
   it('invalid → "?"', () => {
-    expect(formatQuoteAge('not-an-iso', now)).toBe('?')
+    expect(formatQuoteAsOf('not-an-iso')).toBe('?')
   })
 })


### PR DESCRIPTION
## Summary

`/dashboard/positions` 現在値セルの asOf を相対表記 (`2d前`) から絶対 JST (`04/24 21:00 JST`) に変更。

## Why

土日・祝日は market closed で last trade time が金曜引けに張り付くため、相対表記だと **必ず古く見えて「壊れている風」に誤読** される (cf. ユーザー報告: 土曜表示で `2d前` → 「2 日前になるのか…」)。絶対時刻なら「金曜引け」と一目で判別でき、休場中の自然な挙動として読める。

## Changes

- `formatQuoteAge` → `formatQuoteAsOf` (戻り値: `MM/DD HH:MM JST`)
- 表ヘッダ「現在値 (source, 鮮度)」→「現在値 (source, asOf)」
- 単体テストを絶対表記に書き換え (US 金曜引け / JP 金曜引け / zero-pad / invalid)

## Trade-off

- 鮮度判定にひと手間 (現在時刻と比較) かかる代わりに、誤読リスクを排除
- 「stale を強調する」UI が必要になったら時刻に色付けで対応 (本 PR では入れない)

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (48 files / 367 tests passed)
- [ ] staging で `/dashboard/positions` を確認、`(webull-snapshot, 04/DD HH:MM JST)` が表示されること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
* ポジションページの投資価格タイムスタンプ列の表示形式を、相対時間表示（「Xm前」など）から絶対JST タイムスタンプ表示に更新しました。列ヘッダーも「鮮度」から「asOf」に変更されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->