### PR TITLE
fix: Cron reason詳細を人間向けに整理する

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -71,11 +71,18 @@ export const dashboard = new Hono<AppBindings>()
     }
     const db = createDb(c.env.DB)
     const requestedRequestId = c.req.query('requestId')?.trim()
+    const requestedDecisionId = c.req.query('decisionId')?.trim()
     try {
+      const decisionId = requestedDecisionId && requestedDecisionId.length > 0
+        ? Number.parseInt(requestedDecisionId, 10)
+        : undefined
+      if (requestedDecisionId && (!Number.isFinite(decisionId) || decisionId === undefined || decisionId <= 0)) {
+        return jsonPretty({ error: 'invalid_decision_id', message: 'decisionId must be a positive integer' }, 400)
+      }
       let requestId = requestedRequestId && requestedRequestId.length > 0
         ? requestedRequestId
         : undefined
-      if (!requestId) {
+      if (!requestId && decisionId === undefined) {
         const latest = await db
           .select({ requestId: strategyDecisionLog.requestId })
           .from(strategyDecisionLog)
@@ -83,10 +90,13 @@ export const dashboard = new Hono<AppBindings>()
           .limit(50)
         requestId = latest.find((row) => row.requestId !== null)?.requestId ?? undefined
       }
-      if (!requestId) {
+      if (!requestId && decisionId === undefined) {
         return jsonPretty({ error: 'no_cron_logs', message: 'strategy_decision_log has no request_id rows' }, 404)
       }
 
+      const filter = decisionId !== undefined
+        ? eq(strategyDecisionLog.id, decisionId)
+        : eq(strategyDecisionLog.requestId, requestId as string)
       const rows = await db
         .select({
           id: strategyDecisionLog.id,
@@ -111,13 +121,13 @@ export const dashboard = new Hono<AppBindings>()
             eq(tradeJournal.tradeEventType, 'post_submit'),
           ),
         )
-        .where(eq(strategyDecisionLog.requestId, requestId))
+        .where(filter)
         .orderBy(asc(strategyDecisionLog.id))
 
       return jsonPretty({
         schema: 'dashboard_cron_export.v1',
         exportedAt: new Date().toISOString(),
-        requestId,
+        ...(decisionId !== undefined ? { decisionId } : { requestId }),
         rowCount: rows.length,
         decisions: rows.map((row) => ({
           id: row.id,
@@ -270,6 +280,7 @@ const STYLE = `
   .reason-panel{margin-top:8px;padding:10px;border:1px solid #e5e5ea;border-radius:6px;background:#fafafa;color:#1d1d1f;max-width:680px}
   .reason-panel div{margin:0 0 8px}
   .reason-panel div:last-child{margin-bottom:0}
+  .reason-panel ul{margin:4px 0 10px;padding-left:20px}
   .reason-panel code{white-space:pre-wrap;word-break:break-word}
   .reason-panel pre{margin:4px 0 0;white-space:pre-wrap;word-break:break-word;font-size:12px}
 `
@@ -889,9 +900,11 @@ function cronReasonCell(row: {
 }): string {
   const localized = localizeReason(row.reason)
   const rawReason = row.reason ?? '-'
-  const requestLink = row.requestId
-    ? `<a href="/dashboard/cron/json?requestId=${encodeURIComponent(row.requestId)}" target="_blank" rel="noreferrer">${esc(row.requestId)}</a>`
+  const decisionJsonLink = `<a href="/dashboard/cron/json?decisionId=${row.id}" target="_blank" rel="noreferrer">この判定だけのJSON</a>`
+  const runJsonLink = row.requestId
+    ? `<a href="/dashboard/cron/json?requestId=${encodeURIComponent(row.requestId)}" target="_blank" rel="noreferrer">run全体JSON</a> <span class="muted">(${esc(row.requestId)})</span>`
     : '-'
+  const humanDetails = describeCronReason(row.reason)
   const indicators = row.indicatorsJson
     ? JSON.stringify(parseJsonObject(row.indicatorsJson), null, 2)
     : null
@@ -899,13 +912,31 @@ function cronReasonCell(row: {
   return `<details class="reason-details">
     <summary>${esc(localized || '-')}</summary>
     <div class="reason-panel">
-      <div><strong>decision id</strong><br><code>${row.id}</code></div>
+      <div><strong>読み方</strong>${humanDetails}</div>
+      <div><strong>JSON</strong><br>${decisionJsonLink} / ${runJsonLink}</div>
       <div><strong>raw reason</strong><br><code>${esc(rawReason)}</code></div>
-      <div><strong>requestId / run JSON</strong><br>${requestLink}</div>
-      <div><strong>clientOrderId</strong><br><code>${esc(row.clientOrderId ?? '-')}</code></div>
+      <div><strong>decision id / clientOrderId</strong><br><code>${row.id}</code> / <code>${esc(row.clientOrderId ?? '-')}</code></div>
       <div><strong>indicators</strong><br>${indicators ? `<pre>${esc(indicators)}</pre>` : '<span class="muted">-</span>'}</div>
     </div>
   </details>`
+}
+
+function describeCronReason(reason: string | null | undefined): string {
+  if (!reason) return '<p class="muted">詳細理由なし</p>'
+
+  const lotSizeRound = reason.match(
+    /^sizing rejected: lot-size-round \(raw qty (\S+) < lot (\S+), stop (\S+), entry (\S+)\)$/,
+  )
+  if (lotSizeRound) {
+    const [, rawQty, lot, stop, entry] = lotSizeRound
+    return `<ul>
+      <li>計算上は ${esc(rawQty)} 株まで建てられるが、必要な売買単位 ${esc(lot)} 株に届かないため発注しません。</li>
+      <li>評価時の株価は ${esc(entry)}、損切り幅は ${esc(stop)} / 株です。</li>
+      <li>このままだと単元未満なので、リスク予算・銘柄上限・売買単位のいずれかが変わらない限り発注されません。</li>
+    </ul>`
+  }
+
+  return `<p>${esc(localizeReason(reason))}</p>`
 }
 
 /**

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -73,11 +73,15 @@ export const dashboard = new Hono<AppBindings>()
     const requestedRequestId = c.req.query('requestId')?.trim()
     const requestedDecisionId = c.req.query('decisionId')?.trim()
     try {
-      const decisionId = requestedDecisionId && requestedDecisionId.length > 0
-        ? Number.parseInt(requestedDecisionId, 10)
-        : undefined
-      if (requestedDecisionId && (!Number.isFinite(decisionId) || decisionId === undefined || decisionId <= 0)) {
-        return jsonPretty({ error: 'invalid_decision_id', message: 'decisionId must be a positive integer' }, 400)
+      let decisionId: number | undefined
+      if (requestedDecisionId && requestedDecisionId.length > 0) {
+        if (!/^[1-9]\d*$/.test(requestedDecisionId)) {
+          return jsonPretty({ error: 'invalid_decision_id', message: 'decisionId must be a positive integer' }, 400)
+        }
+        decisionId = Number(requestedDecisionId)
+        if (!Number.isSafeInteger(decisionId) || decisionId <= 0) {
+          return jsonPretty({ error: 'invalid_decision_id', message: 'decisionId must be a positive integer' }, 400)
+        }
       }
       let requestId = requestedRequestId && requestedRequestId.length > 0
         ? requestedRequestId

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -69,6 +69,7 @@ function fakeCronDb(rows: unknown[]) {
     where: vi.fn(() => query),
     orderBy: vi.fn(() => query),
     limit: vi.fn(async () => rows),
+    then: (resolve: (value: unknown[]) => unknown) => Promise.resolve(resolve(rows)),
   }
   return {
     select: vi.fn(() => query),
@@ -204,12 +205,12 @@ describe('dashboard', () => {
           id: 123,
           timestamp: '2026-04-23T00:00:00.000Z',
           requestId: 'req-1',
-          symbol: 'SOXL',
-          decision: 'BUY',
-          reason: 'pullback -0.0500 in uptrend (50d return 0.1000)',
-          price: 10,
-          indicatorsJson: '{"price":10,"return50d":0.1}',
-          clientOrderId: 'coid-1',
+          symbol: '7203',
+          decision: 'REJECT',
+          reason: 'sizing rejected: lot-size-round (raw qty 79 < lot 100, stop 286.00, entry 3765)',
+          price: 3765,
+          indicatorsJson: '{"price":3765,"return50d":0.45873692367299496}',
+          clientOrderId: null,
           filledPrice: null,
           filledQty: null,
           realizedPnl: null,
@@ -222,10 +223,48 @@ describe('dashboard', () => {
     const body = await res.text()
 
     expect(body).toContain('<details class="reason-details">')
-    expect(body).toContain('買い: 上昇トレンド中の押し目買い')
+    expect(body).toContain('発注スキップ: 売買単位未満')
+    expect(body).toContain('計算上は 79 株まで建てられるが、必要な売買単位 100 株に届かないため発注しません。')
+    expect(body).toContain('/dashboard/cron/json?decisionId=123')
     expect(body).toContain('<strong>raw reason</strong>')
-    expect(body).toContain('/dashboard/cron/json?requestId=req-1')
-    expect(body).toContain('&quot;return50d&quot;: 0.1')
+    expect(body).toContain('run全体JSON')
+    expect(body).toContain('&quot;return50d&quot;: 0.45873692367299496')
+  })
+
+  it('exports a single cron decision JSON by decisionId', async () => {
+    vi.mocked(createDb).mockReturnValue(
+      fakeCronDb([
+        {
+          id: 868,
+          timestamp: '2026-04-23T00:00:00.000Z',
+          requestId: 'req-1',
+          symbol: '7203',
+          decision: 'REJECT',
+          reason: 'sizing rejected: lot-size-round (raw qty 79 < lot 100, stop 286.00, entry 3765)',
+          price: 3765,
+          indicatorsJson: '{"price":3765}',
+          clientOrderId: null,
+          filledPrice: null,
+          filledQty: null,
+          realizedPnl: null,
+          brokerStatus: null,
+        },
+      ]) as unknown as ReturnType<typeof createDb>,
+    )
+    const app = createApp()
+    const res = await app.request(
+      '/dashboard/cron/json?decisionId=868',
+      { headers: authHeader },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body).toMatchObject({
+      decisionId: 868,
+      rowCount: 1,
+      decisions: [{ id: 868, symbol: '7203' }],
+    })
   })
 
   it('cron page requires basic auth', async () => {

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -267,6 +267,25 @@ describe('dashboard', () => {
     })
   })
 
+  it('rejects non-whole cron decisionId values', async () => {
+    const app = createApp()
+
+    for (const decisionId of ['123abc', '1.5', '0', '-1', '9007199254740992']) {
+      const res = await app.request(
+        `/dashboard/cron/json?decisionId=${encodeURIComponent(decisionId)}`,
+        { headers: authHeader },
+        { ...baseEnv, DB: {} as D1Database },
+      )
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body).toEqual({
+        error: 'invalid_decision_id',
+        message: 'decisionId must be a positive integer',
+      })
+    }
+  })
+
   it('cron page requires basic auth', async () => {
     const app = createApp()
     const res = await app.request('/dashboard/cron', {}, baseEnv)


### PR DESCRIPTION
## 概要

Cron reason詳細が raw reason / indicators 中心で、人間が読むにはまだ辛い状態だったため、詳細パネルを運用者向けに整理しました。あわせて、`run JSON` が同一cron内の他銘柄も含むことが分かりづらかったため、単一decisionだけを返すJSONリンクを追加しました。

## 変更内容

- `reason` 詳細パネルの先頭に「読み方」を追加
- `sizing rejected: lot-size-round` を運用者向けに説明
  - 計算上の建玉可能株数
  - 必要な売買単位
  - 株価と損切り幅
  - なぜ発注されなかったか
- `/dashboard/cron/json?decisionId=<id>` を追加し、単一decisionだけのJSONを返せるように変更
- 詳細パネルのJSONリンクを以下に分離
  - この判定だけのJSON
  - run全体JSON
- dashboard testに単一decision JSON exportの回帰テストを追加

## 検証

- `pnpm run typecheck`
- `pnpm test -- test/routes/dashboard.test.ts test/routes/localizeReason.test.ts`
- 上記testコマンドではVitestが全体実行され、`48 files / 364 tests` passed

## 補足

- `.agents/` は未追跡のまま残し、このPRには含めていません。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Cron JSON エクスポートで決定ID（decisionId）による単一決定の取得に対応しました（決定ID指定時は決定単位のJSONを返します）。
  * ダッシュボード Cron ページに「読み方」セクションを追加し、決定理由の構造化された説明（例：売買単位未満の説明）を表示します。
  * JSON ダウンロードリンクが決定単位と実行全体の両方を選べる構成に更新されました。

* **不具合修正**
  * decisionId の入力検証を強化し、不正な値に対して適切なエラー応答を返すようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->