### PR TITLE
feat(dashboard): /positions の現在値を 2 source の新しい方を採用

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -417,7 +417,13 @@ export function pickFreshQuote(
   if (yahoo === null) return { price: webull.price, source: webull.source, asOf: webull.asOf }
   const w = new Date(webull.asOf).getTime()
   const y = new Date(yahoo.asOf).getTime()
-  return y > w
+  // 不正な ISO は "より古い" 扱い: 有効な側があればそちらを採用、両方
+  // 不正なら webull にタイブレーク (既存挙動維持)。`y > w` だけだと
+  // w=NaN の時に false 評価で不正な webull を選んでしまう回帰がある。
+  const wValid = Number.isFinite(w)
+  const yValid = Number.isFinite(y)
+  const pickYahoo = yValid && (!wValid || y > w)
+  return pickYahoo
     ? { price: yahoo.price, source: 'yahoo-bars', asOf: yahoo.asOf }
     : { price: webull.price, source: webull.source, asOf: webull.asOf }
 }

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -24,16 +24,19 @@ export const dashboard = new Hono<AppBindings>()
     }
     const universe = await loadSymbolUniverse(c.env)
     const client = new SymbolStateClient(c.env.SYMBOL_STATE)
-    const rows = await Promise.all(
-      universe.allowedSymbols.map(async (sym) => {
-        try {
-          return { sym, state: await client.getState(sym), error: null as string | null }
-        } catch (err) {
-          return { sym, state: null as SymbolState | null, error: messageOf(err) }
-        }
-      }),
-    )
-    return c.html(layout('保有状況', positionsBody(rows)))
+    const [rows, strategyPriceMap] = await Promise.all([
+      Promise.all(
+        universe.allowedSymbols.map(async (sym) => {
+          try {
+            return { sym, state: await client.getState(sym), error: null as string | null }
+          } catch (err) {
+            return { sym, state: null as SymbolState | null, error: messageOf(err) }
+          }
+        }),
+      ),
+      loadLatestStrategyPrices(c.env.DB, universe.allowedSymbols),
+    ])
+    return c.html(layout('保有状況', positionsBody(rows, strategyPriceMap)))
   })
   .get('/portfolio', async (c) => {
     if (!c.env.PORTFOLIO_STATE) {
@@ -345,8 +348,83 @@ function indexBody(): string {
 </ul>`
 }
 
+/**
+ * 各銘柄の「strategy が直近に判定で使った価格」を取得。
+ * Yahoo daily bars から計算された `indicators.price` が
+ * strategy_decision_log.price に書き出されているので、最新行を引く。
+ *
+ * Webull bridge が落ちて lastQuote が古い場合、こちらが新しければ
+ * dashboard の現在値表示に採用される (pickFreshQuote で比較)。
+ *
+ * 実装: D1 の `(symbol, id)` 複合 index を活かして symbol 並列で
+ * `ORDER BY id DESC LIMIT 1` を打つ。1 銘柄あたり 1 row のみ転送。
+ */
+async function loadLatestStrategyPrices(
+  db: D1Database,
+  symbols: string[],
+): Promise<Map<string, { price: number; asOf: string }>> {
+  if (symbols.length === 0) return new Map()
+  const drizzle = createDb(db)
+  // 個別 symbol の失敗で全体を 500 にしないよう per-symbol で catch。
+  // strategy_decision_log がまだ空の銘柄や DB 一時的エラーは「Yahoo 価格なし」
+  // として扱い、Webull lastQuote にフォールバックさせる。
+  const entries = await Promise.all(
+    symbols.map(async (sym) => {
+      try {
+        const row = await drizzle
+          .select({
+            symbol: strategyDecisionLog.symbol,
+            price: strategyDecisionLog.price,
+            timestamp: strategyDecisionLog.timestamp,
+          })
+          .from(strategyDecisionLog)
+          .where(eq(strategyDecisionLog.symbol, sym))
+          .orderBy(desc(strategyDecisionLog.id))
+          .limit(1)
+        const r = row[0]
+        if (!r || r.price === null || r.price === undefined) return null
+        return [r.symbol, { price: r.price, asOf: r.timestamp }] as const
+      } catch {
+        return null
+      }
+    }),
+  )
+  return new Map(entries.filter((e): e is readonly [string, { price: number; asOf: string }] => e !== null))
+}
+
+/**
+ * 表示用「現在値」の決定。dashboard が見せる現在値の source は
+ * 2 系統あり、bridge 障害などで Webull snapshot が古くなる場合がある:
+ *
+ * - webull-snapshot: SymbolStateDO.lastQuote (Webull bridge の 5 分 cron)
+ * - yahoo-bars: strategy_decision_log.price (Yahoo daily bars 経由、15 分 cron)
+ *
+ * 両方あれば asOf が新しい方を採用。strategy が判定に使う価格と表示が
+ * 一致するのが UX 上の正なので、片方だけしか無い場合もそちらを採る。
+ */
+interface ResolvedQuote {
+  price: number
+  source: string
+  asOf: string
+}
+
+export function pickFreshQuote(
+  webull: { price: number; source: string; asOf: string } | null,
+  yahoo: { price: number; asOf: string } | null,
+): ResolvedQuote | null {
+  if (webull === null && yahoo === null) return null
+  if (webull === null) return { price: yahoo!.price, source: 'yahoo-bars', asOf: yahoo!.asOf }
+  if (yahoo === null) return { price: webull.price, source: webull.source, asOf: webull.asOf }
+  const w = new Date(webull.asOf).getTime()
+  const y = new Date(yahoo.asOf).getTime()
+  return y > w
+    ? { price: yahoo.price, source: 'yahoo-bars', asOf: yahoo.asOf }
+    : { price: webull.price, source: webull.source, asOf: webull.asOf }
+}
+
 function positionsBody(
   rows: Array<{ sym: string; state: SymbolState | null; error: string | null }>,
+  strategyPriceMap: Map<string, { price: number; asOf: string }>,
 ): string {
   if (rows.length === 0) return `<p class="muted">有効な銘柄がありません。</p>`
   const tbody = rows
@@ -356,7 +434,11 @@ function positionsBody(
       }
       const s = r.state
       const pos = s.position
-      const quote = s.lastQuote
+      const webull = s.lastQuote
+        ? { price: s.lastQuote.price, source: s.lastQuote.source, asOf: s.lastQuote.asOf ?? s.lastQuote.fetchedAt }
+        : null
+      const yahoo = strategyPriceMap.get(s.symbol) ?? null
+      const quote = pickFreshQuote(webull, yahoo)
       const pendingSide = s.pendingOrder?.side
       const pnlPct =
         pos !== null && quote !== null && pos.avgPrice > 0
@@ -364,7 +446,7 @@ function positionsBody(
           : null
       const pnlClass = pnlPct === null ? 'muted' : pnlPct >= 0 ? 'ok' : 'err'
       const quoteCell = quote
-        ? `${fmtNumber(quote.price, 2)} <span class="muted" style="font-size:11px">(${esc(quote.source)}, ${esc(formatQuoteAsOf(quote.asOf ?? quote.fetchedAt))})</span>`
+        ? `${fmtNumber(quote.price, 2)} <span class="muted" style="font-size:11px">(${esc(quote.source)}, ${esc(formatQuoteAsOf(quote.asOf))})</span>`
         : '<span class="muted">—</span>'
       return `<tr>
         <td><strong>${esc(s.symbol)}</strong></td>

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -354,4 +354,26 @@ describe('pickFreshQuote', () => {
     const y = { price: 99, asOf: '2026-04-25T03:00:00.000Z' }
     expect(pickFreshQuote(w, y)).toEqual(w)
   })
+
+  it('Webull の asOf が不正なら Yahoo を採用', () => {
+    const w = { price: 100, source: 'webull-snapshot', asOf: 'not-an-iso' }
+    const y = { price: 128.32, asOf: '2026-04-25T03:00:00.000Z' }
+    expect(pickFreshQuote(w, y)).toEqual({
+      price: 128.32,
+      source: 'yahoo-bars',
+      asOf: y.asOf,
+    })
+  })
+
+  it('Yahoo の asOf が不正なら Webull を採用', () => {
+    const w = { price: 105.64, source: 'webull-snapshot', asOf: '2026-04-25T03:00:00.000Z' }
+    const y = { price: 99, asOf: 'not-an-iso' }
+    expect(pickFreshQuote(w, y)).toEqual(w)
+  })
+
+  it('両方不正でも crash せず Webull にタイブレーク', () => {
+    const w = { price: 100, source: 'webull-snapshot', asOf: 'bad-w' }
+    const y = { price: 99, asOf: 'bad-y' }
+    expect(pickFreshQuote(w, y)).toEqual(w)
+  })
 })

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -311,3 +311,47 @@ describe('formatQuoteAsOf', () => {
     expect(formatQuoteAsOf('not-an-iso')).toBe('?')
   })
 })
+
+import { pickFreshQuote } from '../../src/routes/dashboard'
+
+describe('pickFreshQuote', () => {
+  const webullOld = { price: 105.64, source: 'webull-snapshot', asOf: '2026-04-23T02:50:00.000Z' }
+  const yahooNew = { price: 128.32, asOf: '2026-04-25T03:00:00.000Z' }
+
+  it('Webull が新しいときは Webull を採用', () => {
+    const w = { price: 100, source: 'webull-snapshot', asOf: '2026-04-25T05:00:00.000Z' }
+    const y = { price: 99, asOf: '2026-04-25T03:00:00.000Z' }
+    expect(pickFreshQuote(w, y)).toEqual(w)
+  })
+
+  it('Yahoo が新しいときは Yahoo を採用 (bridge 障害シナリオ)', () => {
+    const result = pickFreshQuote(webullOld, yahooNew)
+    expect(result).toEqual({ price: 128.32, source: 'yahoo-bars', asOf: yahooNew.asOf })
+  })
+
+  it('Webull のみの場合は Webull', () => {
+    expect(pickFreshQuote(webullOld, null)).toEqual({
+      price: 105.64,
+      source: 'webull-snapshot',
+      asOf: '2026-04-23T02:50:00.000Z',
+    })
+  })
+
+  it('Yahoo のみの場合は Yahoo', () => {
+    expect(pickFreshQuote(null, yahooNew)).toEqual({
+      price: 128.32,
+      source: 'yahoo-bars',
+      asOf: yahooNew.asOf,
+    })
+  })
+
+  it('両方 null は null', () => {
+    expect(pickFreshQuote(null, null)).toBe(null)
+  })
+
+  it('asOf 同値なら Webull (intraday の方が信頼性が高い前提)', () => {
+    const w = { price: 100, source: 'webull-snapshot', asOf: '2026-04-25T03:00:00.000Z' }
+    const y = { price: 99, asOf: '2026-04-25T03:00:00.000Z' }
+    expect(pickFreshQuote(w, y)).toEqual(w)
+  })
+})


### PR DESCRIPTION
## Summary

Webull bridge の US_ETF カテゴリが HTTP 500 を返し続けて SymbolStateDO の \`lastQuote\` が ~50h stale (SOXL/SOXS で再現中) になる問題への対応。strategy が判定に使う Yahoo daily bars の価格 (\`strategy_decision_log.price\`) と比較し、**asOf の新しい方を表示**。

## Why this approach

- 「strategy が見ている価格」と「dashboard が見せる価格」が一致するのが UX 上の正
- bridge が復旧した瞬間に自動で webull-snapshot に戻る (片方向の固定切替ではない)
- JP 銘柄は元々 \`groupSymbolsByCategory\` で unsupported = bridge を呼ばない設計のため、本 PR で初めて dashboard に「現在値」が出るようになる (今までは — 表示)

## Changes

- \`loadLatestStrategyPrices\`: D1 \`strategy_decision_log\` から symbol ごと最新 1 行を pull (\`(symbol, id)\` 複合 index covering)、per-symbol catch で部分失敗許容
- \`pickFreshQuote\`: webull-snapshot vs yahoo-bars の asOf 比較、新しい方を採用 / 片方のみは採用 / 両方 null は null / タイブレークは Webull 優先
- \`positionsBody\` が merge 済み quote を表示

## Bridge 障害との関係

- 検証用 Webull テスト API の US_ETF カテゴリ 500 は本 repo 外 (#22 領域)
- 本 PR は dashboard 側の **fallback で運用継続** が目的

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm test\` (375 tests, +6 for pickFreshQuote)
- [ ] staging で \`/dashboard/positions\` 確認:
  - SOXL/SOXS が \`(yahoo-bars, MM/DD HH:MM JST)\` でフレッシュ表示
  - JP 銘柄も同じく yahoo-bars で表示
  - AAPL/NVDA は \`(webull-snapshot, ...)\` のまま (bridge OK 時)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ダッシュボードのポジション表示で、複数の価格ソースから最新の価格を正しく選択して表示・計算するよう改善しました。
  * タイムスタンプや無効な値を考慮して最も新鮮な価格が優先され、損益計算の精度が向上しました。
* **テスト**
  * 価格選択ロジックの動作を検証する自動テストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->