### PR TITLE
fix: Cron判定詳細からrun全体JSONを外す

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -905,22 +905,16 @@ function cronReasonCell(row: {
   const localized = localizeReason(row.reason)
   const rawReason = row.reason ?? '-'
   const decisionJsonLink = `<a href="/dashboard/cron/json?decisionId=${row.id}" target="_blank" rel="noreferrer">この判定だけのJSON</a>`
-  const runJsonLink = row.requestId
-    ? `<a href="/dashboard/cron/json?requestId=${encodeURIComponent(row.requestId)}" target="_blank" rel="noreferrer">run全体JSON</a> <span class="muted">(${esc(row.requestId)})</span>`
-    : '-'
   const humanDetails = describeCronReason(row.reason)
-  const indicators = row.indicatorsJson
-    ? JSON.stringify(parseJsonObject(row.indicatorsJson), null, 2)
-    : null
 
   return `<details class="reason-details">
     <summary>${esc(localized || '-')}</summary>
     <div class="reason-panel">
       <div><strong>読み方</strong>${humanDetails}</div>
-      <div><strong>JSON</strong><br>${decisionJsonLink} / ${runJsonLink}</div>
+      <div><strong>RUNID</strong><br><code>${esc(row.requestId ?? '-')}</code></div>
       <div><strong>raw reason</strong><br><code>${esc(rawReason)}</code></div>
       <div><strong>decision id / clientOrderId</strong><br><code>${row.id}</code> / <code>${esc(row.clientOrderId ?? '-')}</code></div>
-      <div><strong>indicators</strong><br>${indicators ? `<pre>${esc(indicators)}</pre>` : '<span class="muted">-</span>'}</div>
+      <div><strong>JSON</strong><br>${decisionJsonLink}</div>
     </div>
   </details>`
 }

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -226,9 +226,12 @@ describe('dashboard', () => {
     expect(body).toContain('発注スキップ: 売買単位未満')
     expect(body).toContain('計算上は 79 株まで建てられるが、必要な売買単位 100 株に届かないため発注しません。')
     expect(body).toContain('/dashboard/cron/json?decisionId=123')
+    expect(body).toContain('<strong>RUNID</strong>')
+    expect(body).toContain('<code>req-1</code>')
     expect(body).toContain('<strong>raw reason</strong>')
-    expect(body).toContain('run全体JSON')
-    expect(body).toContain('&quot;return50d&quot;: 0.45873692367299496')
+    expect(body).toContain('<strong>JSON</strong>')
+    expect(body).not.toContain('run全体JSON')
+    expect(body).not.toContain('&quot;return50d&quot;: 0.45873692367299496')
   })
 
   it('exports a single cron decision JSON by decisionId', async () => {


### PR DESCRIPTION
## 概要

Cron reason詳細から `run全体JSON` を外し、表示項目を単一判定の確認に寄せました。Indicatorは詳細欄に直接展開せず、`この判定だけのJSON` リンクからそのまま確認する形にします。

## 変更内容

- reason詳細パネルから `run全体JSON` リンクを削除
- indicators の直接表示を削除
- 詳細パネルの項目を以下に整理
  - 読み方
  - RUNID
  - raw reason
  - decision id / clientOrderId
  - JSON (`この判定だけのJSON`)
- dashboard testを新しい表示仕様に更新

## 検証

- `pnpm run typecheck`
- `pnpm test -- test/routes/dashboard.test.ts`
- 上記testコマンドではVitestが全体実行され、`48 files / 369 tests` passed

## 補足

- `.agents/` は未追跡のまま残し、このPRには含めていません。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * ダッシュボードのcron詳細パネルUIを簡潔に整理しました。実行ID表示を改善し、JSON セクションを必要な情報のみに削減しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->