### PR TITLE
fix: Cron判定詳細にJSONをインライン表示する

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -136,23 +136,7 @@ export const dashboard = new Hono<AppBindings>()
         exportedAt: new Date().toISOString(),
         ...(decisionId !== undefined ? { decisionId } : { requestId }),
         rowCount: rows.length,
-        decisions: rows.map((row) => ({
-          id: row.id,
-          timestamp: row.timestamp,
-          symbol: row.symbol,
-          decision: row.decision,
-          reason: row.reason,
-          localizedReason: localizeReason(row.reason),
-          price: row.price,
-          indicators: parseJsonObject(row.indicatorsJson),
-          clientOrderId: row.clientOrderId,
-          broker: {
-            status: row.brokerStatus,
-            filledPrice: row.filledPrice,
-            filledQty: row.filledQty,
-            realizedPnl: row.realizedPnl,
-          },
-        })),
+        decisions: rows.map(cronDecisionJson),
       })
     } catch (err) {
       return jsonPretty({ error: 'cron_json_export_failed', message: messageOf(err) }, 500)
@@ -985,14 +969,22 @@ function cronBody(
 
 function cronReasonCell(row: {
   id: number
+  timestamp: string
   requestId: string | null
+  symbol: string
+  decision: string
   reason: string | null
+  price: number | null
   indicatorsJson?: string | null
   clientOrderId?: string | null
+  filledPrice?: number | null
+  filledQty?: number | null
+  realizedPnl?: number | null
+  brokerStatus?: string | null
 }): string {
   const localized = localizeReason(row.reason)
   const rawReason = row.reason ?? '-'
-  const decisionJsonLink = `<a href="/dashboard/cron/json?decisionId=${row.id}" target="_blank" rel="noreferrer">この判定だけのJSON</a>`
+  const decisionJson = JSON.stringify(cronDecisionJson(row), null, 2)
   const humanDetails = describeCronReason(row.reason)
 
   return `<details class="reason-details">
@@ -1002,9 +994,42 @@ function cronReasonCell(row: {
       <div><strong>RUNID</strong><br><code>${esc(row.requestId ?? '-')}</code></div>
       <div><strong>raw reason</strong><br><code>${esc(rawReason)}</code></div>
       <div><strong>decision id / clientOrderId</strong><br><code>${row.id}</code> / <code>${esc(row.clientOrderId ?? '-')}</code></div>
-      <div><strong>JSON</strong><br>${decisionJsonLink}</div>
+      <div><strong>JSON</strong><br><pre>${esc(decisionJson)}</pre></div>
     </div>
   </details>`
+}
+
+function cronDecisionJson(row: {
+  id: number
+  timestamp: string
+  symbol: string
+  decision: string
+  reason: string | null
+  price: number | null
+  indicatorsJson?: string | null
+  clientOrderId?: string | null
+  filledPrice?: number | null
+  filledQty?: number | null
+  realizedPnl?: number | null
+  brokerStatus?: string | null
+}) {
+  return {
+    id: row.id,
+    timestamp: row.timestamp,
+    symbol: row.symbol,
+    decision: row.decision,
+    reason: row.reason,
+    localizedReason: localizeReason(row.reason),
+    price: row.price,
+    indicators: parseJsonObject(row.indicatorsJson),
+    clientOrderId: row.clientOrderId,
+    broker: {
+      status: row.brokerStatus,
+      filledPrice: row.filledPrice,
+      filledQty: row.filledQty,
+      realizedPnl: row.realizedPnl,
+    },
+  }
 }
 
 function describeCronReason(reason: string | null | undefined): string {

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -225,13 +225,15 @@ describe('dashboard', () => {
     expect(body).toContain('<details class="reason-details">')
     expect(body).toContain('発注スキップ: 売買単位未満')
     expect(body).toContain('計算上は 79 株まで建てられるが、必要な売買単位 100 株に届かないため発注しません。')
-    expect(body).toContain('/dashboard/cron/json?decisionId=123')
     expect(body).toContain('<strong>RUNID</strong>')
     expect(body).toContain('<code>req-1</code>')
     expect(body).toContain('<strong>raw reason</strong>')
     expect(body).toContain('<strong>JSON</strong>')
+    expect(body).toContain('&quot;id&quot;: 123')
+    expect(body).toContain('&quot;indicators&quot;: {')
+    expect(body).toContain('&quot;return50d&quot;: 0.45873692367299496')
+    expect(body).not.toContain('/dashboard/cron/json?decisionId=123')
     expect(body).not.toContain('run全体JSON')
-    expect(body).not.toContain('&quot;return50d&quot;: 0.45873692367299496')
   })
 
   it('exports a single cron decision JSON by decisionId', async () => {


### PR DESCRIPTION
## 概要

Cron reason詳細の `JSON` をリンクではなく、その場でコピーできるインラインJSONとして表示します。`/dashboard/cron/json?decisionId=` と同じ単一decision構造を使うため、indicatorも詳細欄内のJSONから直接確認できます。

## 変更内容

- reason詳細の `JSON` をリンクから `<pre>` のインライン表示に変更
- `/dashboard/cron/json` と詳細欄で同じ `cronDecisionJson` helperを使うように整理
- `indicators` はインラインJSON内に含めて表示
- dashboard testをリンク非表示/JSON表示の仕様に更新

## 検証

- `pnpm run typecheck`
- `pnpm test -- test/routes/dashboard.test.ts`
- 上記testコマンドではVitestが全体実行され、`48 files / 378 tests` passed

## 補足

- `.agents/` は未追跡のまま残し、このPRには含めていません。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 改善

* **ダッシュボード**
  * クロン取引の理由詳細に表示される決定情報が、別ページへのリンクではなく、直接ページ内に埋め込まれるようになりました。これにより、ナビゲーション不要でより効率的に詳細情報を確認できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->