### PR TITLE
fix(dashboard): drawdown chart から intraday 閾値線を削除 (#158)

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -73,16 +73,8 @@ export const dashboard = new Hono<AppBindings>()
       return c.html(layout('チャート', unavailable('DB not bound')))
     }
     try {
-      const [equity, global] = await Promise.all([
-        loadEquityCurve(c.env.DB),
-        loadGlobalConfigFrom(c.env),
-      ])
-      const thresholds = {
-        half: global.riskDdHalfThreshold,
-        kill: global.drawdownKillThreshold,
-        halt: global.riskDdHaltThreshold,
-      }
-      return c.html(layout('チャート', chartsBody({ equity, thresholds })))
+      const equity = await loadEquityCurve(c.env.DB)
+      return c.html(layout('チャート', chartsBody({ equity })))
     } catch (err) {
       return c.html(layout('チャート', unavailable(messageOf(err))))
     }
@@ -1153,14 +1145,7 @@ export function safeJsonScript(varName: string, data: unknown): string {
   return `<script>window.${varName} = ${json};</script>`
 }
 
-interface DrawdownThresholds {
-  /** 比率 (-0.05 = -5%)。global_config から動的に読む */
-  half: number
-  kill: number
-  halt: number
-}
-
-function chartsBody(args: { equity: EquityPoint[]; thresholds: DrawdownThresholds }): string {
+function chartsBody(args: { equity: EquityPoint[] }): string {
   if (args.equity.length === 0) {
     return `<p class="muted">まだ実 fill (realized_pnl) が無いためエクイティカーブを描けません。最初の SELL が約定すると表示されます。</p>`
   }
@@ -1179,11 +1164,6 @@ function chartsBody(args: { equity: EquityPoint[]; thresholds: DrawdownThreshold
       var dates = data.equity.map(function (p) { return p.date; });
       var equity = data.equity.map(function (p) { return p.cumulativePnl; });
       var dd = data.equity.map(function (p) { return p.drawdownPct * 100; });
-      var halfPct = data.thresholds.half * 100;
-      var killPct = data.thresholds.kill * 100;
-      var haltPct = data.thresholds.halt * 100;
-      function flat(v) { return dates.map(function () { return v; }); }
-      function lbl(name, v) { return name + ' (' + v.toFixed(2) + '%)'; }
 
       var equityChart = echarts.init(document.getElementById('equity-chart'));
       equityChart.setOption({
@@ -1197,16 +1177,13 @@ function chartsBody(args: { equity: EquityPoint[]; thresholds: DrawdownThreshold
 
       var ddChart = echarts.init(document.getElementById('dd-chart'));
       ddChart.setOption({
-        title: { text: 'ドローダウン (peak からの下落率)', left: 'center', textStyle: { fontSize: 14 } },
+        title: { text: 'ドローダウン (累積 PnL の peak からの低下率)', left: 'center', textStyle: { fontSize: 14 } },
         tooltip: { trigger: 'axis', valueFormatter: function (v) { return Number(v).toFixed(2) + '%'; } },
         grid: { left: 50, right: 20, top: 40, bottom: 40 },
         xAxis: { type: 'category', data: dates },
         yAxis: { type: 'value', max: 0, axisLabel: { formatter: '{value}%' } },
         series: [
           { type: 'line', data: dd, areaStyle: { color: '#c22', opacity: 0.2 }, lineStyle: { color: '#c22', width: 1 } },
-          { type: 'line', data: flat(halfPct), lineStyle: { color: '#888', type: 'dashed', width: 1 }, symbol: 'none', name: lbl('risk_dd_half_threshold', halfPct) },
-          { type: 'line', data: flat(killPct), lineStyle: { color: '#b25000', type: 'dashed', width: 1 }, symbol: 'none', name: lbl('drawdown_kill_threshold', killPct) },
-          { type: 'line', data: flat(haltPct), lineStyle: { color: '#c22', type: 'dashed', width: 1 }, symbol: 'none', name: lbl('risk_dd_halt_threshold', haltPct) },
         ],
       });
 
@@ -1217,8 +1194,10 @@ function chartsBody(args: { equity: EquityPoint[]; thresholds: DrawdownThreshold
     });
   `
   return `<p class="muted" style="font-size:12px">
-    Phase 0+1: 累積 realized PnL とドローダウン。シード資金額を保持していないため
-    ドローダウンは「累積 PnL の peak からの低下率」で計算 (peak ≤ 0 のときは 0%)。
+    累積 realized PnL と peak からの下落率 (MaxDD)。戦略の長期パフォーマンス指標。
+    シード資金額を保持していないため下落率は「累積 PnL の peak からの相対」で計算
+    (peak ≤ 0 のときは 0%)。当日 intraday の risk halt 閾値 (drawdown_kill /
+    risk_dd_halt) は別概念のため重畳しない。
     残りのチャート (decision breakdown / PnL 分布 / 銘柄チャート) は
     <a href="https://github.com/ochanuco/webull-trading/issues/158">#158</a> で順次追加。
   </p>


### PR DESCRIPTION
## Summary

\`/dashboard/charts\` のドローダウン chart に重ねていた intraday halt 閾値線 (\`risk_dd_half_threshold\` / \`drawdown_kill_threshold\` / \`risk_dd_halt_threshold\`) を削除。

## Why

3 閾値は **PortfolioStateDO の「当日の dailyRealizedPnl ÷ dailyStartEquity」を判定対象とする intraday 用**。一方このチャートは **「累積 realized PnL の peak からの低下率 (MaxDD)」** で、期間 / 分母 / 用途すべて別レイヤー。

| 比較軸 | チャートのドローダウン | 閾値の判定対象 |
|---|---|---|
| 期間 | 累積 (inception → 今) | 当日 (00:00 JST → 今) |
| 分母 | peak (累積 PnL の最高値) | dailyStartEquity |
| 用途 | 戦略の長期評価 (MaxDD) | 1 日損失の risk halt |

両者を同じ chart に重畳すると、**累積 dd が -10% で kill 線 (-8%) を割っているように見えても実際は halt しない**、という誤読 UI になっていた (実機スクショで確認)。

## Changes

- \`chartsBody\` から \`thresholds\` 引数を削除
- \`/charts\` handler の \`loadGlobalConfigFrom\` 取得を削除
- \`DrawdownThresholds\` interface 削除
- 注釈に「intraday halt 閾値は別概念のため重畳しない」と明記
- chart title を「peak からの下落率」→「累積 PnL の peak からの低下率」に厳密化

## Future

intraday drawdown vs 閾値の可視化が欲しくなったら #158 の Phase 5+ で別チャート化 (PortfolioStateDO のスナップショット履歴が要る = データ層の追加)。

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm test\` (385 tests, 既存に変更なし)
- [ ] staging で \`/dashboard/charts\` 確認、ドローダウン chart に閾値線が無いこと

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ダッシュボードのドローダウンチャートから閾値オーバーレイ表示（リスク管理ラインなど）を削除しました。

* **Changes**
  * チャートはエクイティカーブとドローダウンデータのみを表示するようになりました。
  * チャートタイトルと説明を更新し、MaxDD（ピーク相対ドローダウン）を明確にし、日中の閾値は表示されていないことを明示しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->