### PR TITLE
feat(dashboard): 戦略可視化 Phase 3 — PnL 分布 + 統計テーブル (#158)

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -73,11 +73,14 @@ export const dashboard = new Hono<AppBindings>()
       return c.html(layout('チャート', unavailable('DB not bound')))
     }
     try {
-      const [equity, decisions] = await Promise.all([
+      const [equity, decisions, pnls] = await Promise.all([
         loadEquityCurve(c.env.DB),
         loadDecisionBreakdown(c.env.DB),
+        loadTradePnls(c.env.DB),
       ])
-      return c.html(layout('チャート', chartsBody({ equity, decisions })))
+      const stats = computeTradeStats(pnls)
+      const histogram = computePnlHistogram(pnls)
+      return c.html(layout('チャート', chartsBody({ equity, decisions, pnls, stats, histogram })))
     } catch (err) {
       return c.html(layout('チャート', unavailable(messageOf(err))))
     }
@@ -1193,6 +1196,138 @@ export function aggregateDecisionRows(
 }
 
 /**
+ * Per-trade realized PnL を全件取得 (#158 Phase 3)。
+ *
+ * trade_journal.realized_pnl は SELL fill に確定損益が記録される (BUY は null)。
+ * 戦略のエッジが本物か偽物かを見るために、勝率・profit factor・expectancy を
+ * 計算 + 分布を histogram で可視化する。
+ */
+export async function loadTradePnls(db: D1Database): Promise<number[]> {
+  const result = await db
+    .prepare(
+      `SELECT realized_pnl AS pnl
+       FROM trade_journal
+       WHERE realized_pnl IS NOT NULL
+         AND trade_event_type = 'post_submit'
+       ORDER BY id ASC`,
+    )
+    .all<{ pnl: number }>()
+  return (result.results ?? []).map((r) => Number(r.pnl)).filter((n) => Number.isFinite(n))
+}
+
+export interface TradeStats {
+  count: number
+  wins: number
+  losses: number
+  /** 0..1 (勝率) */
+  winRate: number
+  avgWin: number
+  avgLoss: number // 負値
+  /** 総利益 / |総損失|。loss=0 のときは Infinity (UI 側で "—" 表示) */
+  profitFactor: number
+  /** 1 trade あたり期待損益 = winRate * avgWin + (1-winRate) * avgLoss */
+  expectancy: number
+  total: number
+}
+
+/**
+ * 「エッジが本物か」を 1 表で見るためのサマリ統計。break-even (pnl=0) は wins / losses
+ * どちらにも入れない (エクスペクタンシ計算で 0 として中立に効く)。
+ */
+export function computeTradeStats(pnls: number[]): TradeStats {
+  if (pnls.length === 0) {
+    return { count: 0, wins: 0, losses: 0, winRate: 0, avgWin: 0, avgLoss: 0, profitFactor: 0, expectancy: 0, total: 0 }
+  }
+  let wins = 0
+  let losses = 0
+  let sumWin = 0
+  let sumLoss = 0
+  let total = 0
+  for (const p of pnls) {
+    total += p
+    if (p > 0) {
+      wins += 1
+      sumWin += p
+    } else if (p < 0) {
+      losses += 1
+      sumLoss += p
+    }
+  }
+  const decisive = wins + losses
+  const winRate = decisive > 0 ? wins / decisive : 0
+  const avgWin = wins > 0 ? sumWin / wins : 0
+  const avgLoss = losses > 0 ? sumLoss / losses : 0
+  const profitFactor = sumLoss < 0 ? sumWin / Math.abs(sumLoss) : sumWin > 0 ? Infinity : 0
+  const expectancy = winRate * avgWin + (1 - winRate) * avgLoss
+  return { count: pnls.length, wins, losses, winRate, avgWin, avgLoss, profitFactor, expectancy, total }
+}
+
+export interface PnlHistogramBin {
+  label: string // "(-5, -3]" など
+  binStart: number
+  binEnd: number
+  binCenter: number
+  count: number
+}
+
+/**
+ * pnl 値を最大 12 ビンの histogram に。範囲は対称 (max(|min|, max)) で
+ * 0 を境に正/負で色分け可能にする。サンプルが少なすぎるとビン数を減らす。
+ */
+export function computePnlHistogram(pnls: number[], maxBins = 12): PnlHistogramBin[] {
+  if (pnls.length === 0) return []
+  const absMax = Math.max(...pnls.map(Math.abs))
+  if (absMax === 0) {
+    return [{ label: '0', binStart: 0, binEnd: 0, binCenter: 0, count: pnls.length }]
+  }
+  const bins = Math.min(maxBins, Math.max(3, Math.ceil(Math.sqrt(pnls.length))))
+  const range = absMax * 2
+  const width = range / bins
+  const out: PnlHistogramBin[] = []
+  for (let i = 0; i < bins; i += 1) {
+    const start = -absMax + width * i
+    const end = start + width
+    out.push({
+      label: `(${start.toFixed(1)}, ${end.toFixed(1)}]`,
+      binStart: start,
+      binEnd: end,
+      binCenter: (start + end) / 2,
+      count: 0,
+    })
+  }
+  for (const p of pnls) {
+    // 末尾の bin は閉区間 [end, end] を含むよう特別処理
+    let idx = Math.floor((p - -absMax) / width)
+    if (idx >= bins) idx = bins - 1
+    if (idx < 0) idx = 0
+    out[idx]!.count += 1
+  }
+  return out
+}
+
+function renderTradeStatsTable(s: TradeStats): string {
+  if (s.count === 0) return ''
+  const fmt = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
+  const pct = (n: number) => (Number.isFinite(n) ? (n * 100).toFixed(1) + '%' : '—')
+  const pf = Number.isFinite(s.profitFactor) ? s.profitFactor.toFixed(2) : '∞'
+  const expClass = s.expectancy > 0 ? 'ok' : s.expectancy < 0 ? 'err' : 'muted'
+  return `<table style="margin-top:12px">
+    <thead><tr><th>件数</th><th>勝</th><th>負</th><th>勝率</th><th>平均利益</th><th>平均損失</th><th>profit factor</th><th>expectancy / trade</th><th>合計</th></tr></thead>
+    <tbody><tr>
+      <td>${s.count}</td>
+      <td class="ok">${s.wins}</td>
+      <td class="err">${s.losses}</td>
+      <td>${pct(s.winRate)}</td>
+      <td class="ok">${fmt(s.avgWin)}</td>
+      <td class="err">${fmt(s.avgLoss)}</td>
+      <td>${pf}</td>
+      <td class="${expClass}">${fmt(s.expectancy)}</td>
+      <td class="${s.total > 0 ? 'ok' : s.total < 0 ? 'err' : 'muted'}">${fmt(s.total)}</td>
+    </tr></tbody>
+  </table>`
+}
+
+/**
  * `<script>...</script>` 内に埋め込む JSON を XSS 安全にする。
  * ブラウザは `</script>` を「文字列の中でも」script 終端と解釈するので、
  * `<` を unicode escape して中和する。
@@ -1202,7 +1337,15 @@ export function safeJsonScript(varName: string, data: unknown): string {
   return `<script>window.${varName} = ${json};</script>`
 }
 
-function chartsBody(args: { equity: EquityPoint[]; decisions: DecisionBreakdownPoint[] }): string {
+interface ChartsViewModel {
+  equity: EquityPoint[]
+  decisions: DecisionBreakdownPoint[]
+  pnls: number[]
+  stats: TradeStats
+  histogram: PnlHistogramBin[]
+}
+
+function chartsBody(args: ChartsViewModel): string {
   if (args.equity.length === 0 && args.decisions.length === 0) {
     return `<p class="muted">まだ判定ログも実 fill も無いためチャートを描けません。最初の cron 実行 / SELL 約定後に表示されます。</p>`
   }
@@ -1249,6 +1392,33 @@ function chartsBody(args: { equity: EquityPoint[]; decisions: DecisionBreakdownP
         window.addEventListener('resize', function () { dbChart.resize(); });
       }
 
+      // ---- PnL 分布 histogram (#158 Phase 3) ----
+      var pnlHistEl = document.getElementById('pnl-hist-chart');
+      if (pnlHistEl && data.histogram && data.histogram.length > 0) {
+        var pnlHist = echarts.init(pnlHistEl);
+        pnlHist.setOption({
+          title: { text: 'Per-trade realized PnL 分布', left: 'center', textStyle: { fontSize: 14 } },
+          tooltip: {
+            trigger: 'axis',
+            axisPointer: { type: 'shadow' },
+            formatter: function (params) {
+              var p = params[0];
+              return p.name + ': ' + p.value + ' trades';
+            },
+          },
+          grid: { left: 50, right: 20, top: 40, bottom: 40 },
+          xAxis: { type: 'category', data: data.histogram.map(function (b) { return b.label; }) },
+          yAxis: { type: 'value', name: 'trades' },
+          series: [{
+            type: 'bar',
+            data: data.histogram.map(function (b) {
+              return { value: b.count, itemStyle: { color: b.binCenter >= 0 ? '#057a55' : '#c22' } };
+            }),
+          }],
+        });
+        window.addEventListener('resize', function () { pnlHist.resize(); });
+      }
+
       var equityEl = document.getElementById('equity-chart');
       var ddEl = document.getElementById('dd-chart');
       if (equityEl && ddEl && data.equity.length > 0) {
@@ -1292,6 +1462,8 @@ function chartsBody(args: { equity: EquityPoint[]; decisions: DecisionBreakdownP
   <div id="equity-chart" style="width:100%;height:320px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;margin-top:12px"></div>
   <div id="dd-chart" style="width:100%;height:280px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;margin-top:12px"></div>
   <div id="decision-chart" style="width:100%;height:320px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;margin-top:12px"></div>
+  <div id="pnl-hist-chart" style="width:100%;height:320px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;margin-top:12px"></div>
+  ${renderTradeStatsTable(args.stats)}
   <p id="chart-status" class="warn" style="font-size:12px;margin-top:8px"></p>
   ${safeJsonScript('__chartData', args)}
   <script src="${ECHARTS_CDN}" defer></script>

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -440,7 +440,7 @@ describe('safeJsonScript', () => {
   })
 })
 
-import { aggregateDecisionRows } from '../../src/routes/dashboard'
+import { aggregateDecisionRows, computeTradeStats, computePnlHistogram } from '../../src/routes/dashboard'
 
 describe('aggregateDecisionRows', () => {
   it('日付ごとに decision を集計', () => {
@@ -475,5 +475,71 @@ describe('aggregateDecisionRows', () => {
       { day: '2026-04-24', decision: 'HOLD', n: 1 },
     ])
     expect(out.map((p) => p.date)).toEqual(['2026-04-23', '2026-04-24', '2026-04-25'])
+  })
+})
+
+describe('computeTradeStats', () => {
+  it('空配列はゼロ統計', () => {
+    const s = computeTradeStats([])
+    expect(s).toEqual({ count: 0, wins: 0, losses: 0, winRate: 0, avgWin: 0, avgLoss: 0, profitFactor: 0, expectancy: 0, total: 0 })
+  })
+
+  it('勝率 / 平均利益・損失 / profit factor', () => {
+    const s = computeTradeStats([10, -5, 8, -3, 12])
+    expect(s.count).toBe(5)
+    expect(s.wins).toBe(3)
+    expect(s.losses).toBe(2)
+    expect(s.winRate).toBeCloseTo(0.6)
+    expect(s.avgWin).toBeCloseTo(10) // (10+8+12)/3
+    expect(s.avgLoss).toBeCloseTo(-4) // (-5 + -3) / 2
+    expect(s.profitFactor).toBeCloseTo(30 / 8)
+    expect(s.total).toBe(22)
+    expect(s.expectancy).toBeGreaterThan(0)
+  })
+
+  it('全勝なら profit factor は Infinity', () => {
+    const s = computeTradeStats([10, 5])
+    expect(s.profitFactor).toBe(Infinity)
+  })
+
+  it('全敗なら profit factor は 0、expectancy は負', () => {
+    const s = computeTradeStats([-10, -5])
+    expect(s.profitFactor).toBe(0)
+    expect(s.expectancy).toBeLessThan(0)
+  })
+
+  it('break-even (pnl=0) は勝負カウントに入れず expectancy 中立', () => {
+    const s = computeTradeStats([0, 0, 0])
+    expect(s.wins).toBe(0)
+    expect(s.losses).toBe(0)
+    expect(s.winRate).toBe(0)
+    expect(s.expectancy).toBe(0)
+  })
+})
+
+describe('computePnlHistogram', () => {
+  it('空は空', () => {
+    expect(computePnlHistogram([])).toEqual([])
+  })
+
+  it('absMax の対称範囲でビン分割し全件分類', () => {
+    const out = computePnlHistogram([1, 2, -1, -2, 0, 3, -3])
+    const total = out.reduce((acc, b) => acc + b.count, 0)
+    expect(total).toBe(7)
+    expect(out.length).toBeGreaterThanOrEqual(3)
+    // 範囲は ±3 で対称
+    expect(out[0]!.binStart).toBeCloseTo(-3)
+    expect(out[out.length - 1]!.binEnd).toBeCloseTo(3)
+  })
+
+  it('全 0 は単一ビン', () => {
+    const out = computePnlHistogram([0, 0])
+    expect(out).toEqual([{ label: '0', binStart: 0, binEnd: 0, binCenter: 0, count: 2 }])
+  })
+
+  it('境界値 (max abs ちょうど) も末尾ビンに入る', () => {
+    const out = computePnlHistogram([5, -5])
+    const total = out.reduce((acc, b) => acc + b.count, 0)
+    expect(total).toBe(2)
   })
 })


### PR DESCRIPTION
## Summary

[#158](https://github.com/ochanuco/webull-trading/issues/158) Phase 3。\`trade_journal.realized_pnl\` から per-trade 損益を取得、histogram + サマリ統計 (件数 / 勝 / 負 / 勝率 / 平均利益 / 平均損失 / profit factor / expectancy / 合計) を表示。

## Why

「戦略のエッジが本物か偽物か」を 1 表 + 1 グラフで判定 (\`#158\` 判定基準 #2)。

## Changes

- \`loadTradePnls\`: SELL fill (\`post_submit\` + \`realized_pnl IS NOT NULL\`) を全件取得
- \`computeTradeStats\`:
  - break-even (pnl=0) は wins/losses どちらにも入れず expectancy 中立
  - 全勝時の profit factor は \`Infinity\` → UI で \`∞\` 表示
- \`computePnlHistogram\`: \`absMax\` の対称範囲で \`sqrt(N)\` を目安にビン分割、最大 12 ビン。0 を境に正/負で色分け
- \`renderTradeStatsTable\`: HTML テーブルで色付け表示 (勝=緑、負=赤、expectancy 正負で色変化)
- 単体テスト: 統計 5 ケース + histogram 4 ケース

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm test\` (394 tests)
- [ ] staging で \`/dashboard/charts\` を確認、histogram と統計テーブルが描画されること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
  * ダッシュボードに売買損益分析機能が追加されました
  * 取引成績統計（勝率、利益係数、期待値）が表示されるようになりました
  * 売買損益分布を示す新しいチャートが追加されました
  * 取引統計の概要テーブルが追加されました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->