### PR TITLE
feat(dashboard): 個別銘柄チャートに押し目ゾーン + 保有時の avg/stop/TP 線

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -102,7 +102,10 @@ export const dashboard = new Hono<AppBindings>()
       }
       // tab === 'symbol'
       const symbolParam = c.req.query('symbol')?.toUpperCase().trim() || undefined
-      const universe = await loadSymbolUniverse(c.env)
+      const [universe, global] = await Promise.all([
+        loadSymbolUniverse(c.env),
+        loadGlobalConfigFrom(c.env),
+      ])
       const allowed = new Set(universe.allowedSymbols)
       const defaultSymbol = await pickDefaultSymbol(c.env.DB)
       const focusSymbol =
@@ -111,7 +114,18 @@ export const dashboard = new Hono<AppBindings>()
           : defaultSymbol && allowed.has(defaultSymbol)
             ? defaultSymbol
             : universe.allowedSymbols[0] ?? null
-      const symbolChart = focusSymbol ? await loadSymbolChart(c.env.DB, focusSymbol) : null
+      // ルール閾値は global_config から。per-symbol override は POC で未対応
+      // (symbol_rules table を引かない)。トレーダーが「だいたい同じ目安」を
+      // 視覚化したいのが要件なので global で十分、override 対応は follow-up
+      const rules: SymbolChartRules = {
+        pullbackMax: global.pullbackDefaultPullbackMax,
+        pullbackMin: global.pullbackDefaultPullbackMin,
+        stopPct: global.pullbackDefaultStopPct,
+        takeProfitPct: global.pullbackDefaultTakeProfitPct,
+      }
+      const symbolChart = focusSymbol
+        ? await loadSymbolChart(c.env.DB, focusSymbol, rules)
+        : null
       return c.html(
         layout(
           'チャート',
@@ -1393,6 +1407,7 @@ export interface SymbolChartPoint {
   timestamp: string // JST display string
   price: number
   sma50: number | null
+  high20d: number | null
 }
 
 export interface SymbolChartMarker {
@@ -1403,18 +1418,43 @@ export interface SymbolChartMarker {
   realizedPnl: number | null
 }
 
+export interface SymbolChartPosition {
+  /** 平均取得単価 (= 直近 BUY filled_price、partial fill / add は未対応 POC) */
+  avgPrice: number
+  /** entry timestamp (JST 表示用文字列) */
+  openedAt: string
+}
+
+export interface SymbolChartRules {
+  /** -0.03 = -3% (押し目浅すぎ閾値) */
+  pullbackMax: number
+  /** -0.15 = -15% (押し目深すぎ閾値) */
+  pullbackMin: number
+  /** -0.04 = -4% (損切ライン) */
+  stopPct: number
+  /** 0.07 = +7% (利食ライン) */
+  takeProfitPct: number
+}
+
 export interface SymbolChartData {
   symbol: string
   points: SymbolChartPoint[]
   markers: SymbolChartMarker[]
+  /** 現保有 (BUY → SELL がまだない) ならその情報、なければ null */
+  position: SymbolChartPosition | null
+  rules: SymbolChartRules
 }
 
 /**
- * 直近 200 件の strategy_decision_log と全 fill markers を返す。
- * sma50 は indicators_json (JSON) から抜く — JSON.parse が失敗したら null
+ * 直近 200 件の strategy_decision_log と全 fill markers + 現保有 + ルール閾値を返す。
+ * sma50 / high20d は indicators_json から抜く — JSON.parse 失敗は null fallback
  * (履歴の indicators スキーマが変わっていても落ちない fail-graceful)。
  */
-export async function loadSymbolChart(db: D1Database, symbol: string): Promise<SymbolChartData> {
+export async function loadSymbolChart(
+  db: D1Database,
+  symbol: string,
+  rules: SymbolChartRules,
+): Promise<SymbolChartData> {
   const [logsResult, fillsResult] = await Promise.all([
     db
       .prepare(
@@ -1449,11 +1489,15 @@ export async function loadSymbolChart(db: D1Database, symbol: string): Promise<S
   // markPoint の xAxis 一致のため points / markers 両方で同じ formatter を使う。
   const points: SymbolChartPoint[] = logs
     .filter((r) => r.price !== null && Number.isFinite(Number(r.price)))
-    .map((r) => ({
-      timestamp: fmtJst(r.timestamp),
-      price: Number(r.price),
-      sma50: extractSma50(r.indicators_json),
-    }))
+    .map((r) => {
+      const indicators = parseIndicators(r.indicators_json)
+      return {
+        timestamp: fmtJst(r.timestamp),
+        price: Number(r.price),
+        sma50: indicators.sma50,
+        high20d: indicators.high20d,
+      }
+    })
   const markers: SymbolChartMarker[] = (fillsResult.results ?? [])
     .filter((r) => (r.side === 'BUY' || r.side === 'SELL') && r.filled_price !== null)
     .map((r) => ({
@@ -1463,17 +1507,46 @@ export async function loadSymbolChart(db: D1Database, symbol: string): Promise<S
       qty: r.filled_qty === null ? null : Number(r.filled_qty),
       realizedPnl: r.realized_pnl === null ? null : Number(r.realized_pnl),
     }))
-  return { symbol, points, markers }
+  return { symbol, points, markers, position: deriveOpenPosition(markers), rules }
+}
+
+/**
+ * 直近 fills を時系列で巻き戻し、最後に「BUY → SELL」で閉じていなければ
+ * 現保有とみなす。partial fill / position add は POC 未対応 (直近 BUY だけ採用)。
+ */
+export function deriveOpenPosition(markers: SymbolChartMarker[]): SymbolChartPosition | null {
+  let latestBuy: SymbolChartMarker | null = null
+  for (const m of markers) {
+    if (m.side === 'BUY') latestBuy = m
+    else if (m.side === 'SELL') latestBuy = null
+  }
+  return latestBuy ? { avgPrice: latestBuy.price, openedAt: latestBuy.timestamp } : null
 }
 
 export function extractSma50(indicatorsJson: string | null): number | null {
-  if (!indicatorsJson) return null
+  return parseIndicators(indicatorsJson).sma50
+}
+
+interface ExtractedIndicators {
+  sma50: number | null
+  high20d: number | null
+}
+
+/**
+ * indicators_json から chart で使う数値を一括抽出。JSON.parse 失敗 / 数値外は null。
+ */
+function parseIndicators(indicatorsJson: string | null): ExtractedIndicators {
+  if (!indicatorsJson) return { sma50: null, high20d: null }
   try {
-    const obj = JSON.parse(indicatorsJson) as { sma50?: unknown }
-    if (typeof obj.sma50 === 'number' && Number.isFinite(obj.sma50)) return obj.sma50
-    return null
+    const obj = JSON.parse(indicatorsJson) as { sma50?: unknown; high20d?: unknown }
+    return {
+      sma50:
+        typeof obj.sma50 === 'number' && Number.isFinite(obj.sma50) ? obj.sma50 : null,
+      high20d:
+        typeof obj.high20d === 'number' && Number.isFinite(obj.high20d) ? obj.high20d : null,
+    }
   } catch {
-    return null
+    return { sma50: null, high20d: null }
   }
 }
 
@@ -1674,6 +1747,15 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
       var ts = sc.points.map(function (p) { return p.timestamp; });
       var prices = sc.points.map(function (p) { return p.price; });
       var smas = sc.points.map(function (p) { return p.sma50 == null ? null : p.sma50; });
+
+      // 押し目買いゾーン (high20d × (1 + pullbackMax) 〜 high20d × (1 + pullbackMin))。
+      // -3〜-15% の押し目レンジを time-series band として可視化。
+      // band の中に price が入ると entry trigger 圏内、というのが戦略の心臓部。
+      var pullbackMaxMul = 1 + sc.rules.pullbackMax;
+      var pullbackMinMul = 1 + sc.rules.pullbackMin;
+      var bandUpper = sc.points.map(function (p) { return p.high20d == null ? null : p.high20d * pullbackMaxMul; });
+      var bandLower = sc.points.map(function (p) { return p.high20d == null ? null : p.high20d * pullbackMinMul; });
+
       var entries = sc.markers.filter(function (m) { return m.side === 'BUY'; }).map(function (m) {
         return { name: 'BUY', xAxis: m.timestamp, yAxis: m.price, label: { formatter: 'BUY @' + m.price.toFixed(2), color: '#057a55', position: 'top' }, itemStyle: { color: '#057a55' } };
       });
@@ -1681,19 +1763,37 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
         var pnlLabel = m.realizedPnl == null ? '' : ' (' + (m.realizedPnl >= 0 ? '+' : '') + m.realizedPnl.toFixed(2) + ')';
         return { name: 'SELL', xAxis: m.timestamp, yAxis: m.price, label: { formatter: 'SELL @' + m.price.toFixed(2) + pnlLabel, color: '#c22', position: 'bottom' }, itemStyle: { color: '#c22' } };
       });
+
+      // 保有中なら avg / stop / take-profit を水平 markLine で。
+      // 横線は markLine の yAxis 値で固定 (xAxis はチャート全幅)。
+      var positionMarkLines = [];
+      if (sc.position) {
+        var avg = sc.position.avgPrice;
+        var stopPrice = avg * (1 + sc.rules.stopPct);
+        var tpPrice = avg * (1 + sc.rules.takeProfitPct);
+        positionMarkLines = [
+          { yAxis: avg, lineStyle: { color: '#444', type: 'solid', width: 1 }, label: { formatter: 'avg ' + avg.toFixed(2), position: 'insideStartTop', color: '#444' } },
+          { yAxis: stopPrice, lineStyle: { color: '#c22', type: 'dashed', width: 1 }, label: { formatter: 'stop ' + stopPrice.toFixed(2) + ' (' + (sc.rules.stopPct * 100).toFixed(0) + '%)', position: 'insideStartBottom', color: '#c22' } },
+          { yAxis: tpPrice, lineStyle: { color: '#057a55', type: 'dashed', width: 1 }, label: { formatter: 'TP ' + tpPrice.toFixed(2) + ' (+' + (sc.rules.takeProfitPct * 100).toFixed(0) + '%)', position: 'insideStartTop', color: '#057a55' } },
+        ];
+      }
+
       var symChart = echarts.init(document.getElementById('symbol-chart'));
       symChart.setOption({
-        title: { text: sc.symbol + ' price + SMA50 + entry/exit', left: 'center', textStyle: { fontSize: 14 } },
+        title: { text: sc.symbol + ' price + SMA50 + 押し目ゾーン + entry/exit', left: 'center', textStyle: { fontSize: 14 } },
         tooltip: { trigger: 'axis' },
         legend: { top: 22 },
         grid: { left: 60, right: 20, top: 60, bottom: 40 },
         xAxis: { type: 'category', data: ts },
         yAxis: { type: 'value', scale: true },
         series: [
-          { name: 'price', type: 'line', data: prices, lineStyle: { width: 1.5, color: '#1471a8' }, symbol: 'none' },
-          { name: 'SMA50', type: 'line', data: smas, lineStyle: { width: 1, color: '#888', type: 'dashed' }, symbol: 'none', connectNulls: true },
-          { name: 'entry/exit', type: 'scatter', data: [],
-            markPoint: { symbol: 'pin', symbolSize: 36, data: entries.concat(exits) } },
+          { name: '押し目ゾーン上端 (high20d × ' + (pullbackMaxMul).toFixed(2) + ')', type: 'line', data: bandUpper, lineStyle: { width: 0.8, color: '#057a55', type: 'dashed' }, symbol: 'none', connectNulls: true, z: 1 },
+          { name: '押し目ゾーン下端 (high20d × ' + (pullbackMinMul).toFixed(2) + ')', type: 'line', data: bandLower, lineStyle: { width: 0.8, color: '#c22', type: 'dashed' }, symbol: 'none', connectNulls: true, z: 1 },
+          { name: 'price', type: 'line', data: prices, lineStyle: { width: 1.5, color: '#1471a8' }, symbol: 'none', z: 5,
+            markLine: positionMarkLines.length > 0 ? { silent: true, symbol: 'none', data: positionMarkLines } : undefined,
+            markPoint: { symbol: 'pin', symbolSize: 36, data: entries.concat(exits) },
+          },
+          { name: 'SMA50', type: 'line', data: smas, lineStyle: { width: 1, color: '#888', type: 'dashed' }, symbol: 'none', connectNulls: true, z: 2 },
         ],
       });
       window.addEventListener('resize', function () { symChart.resize(); });

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1787,8 +1787,11 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
         xAxis: { type: 'category', data: ts },
         yAxis: { type: 'value', scale: true },
         series: [
-          { name: '押し目ゾーン上端 (high20d × ' + (pullbackMaxMul).toFixed(2) + ')', type: 'line', data: bandUpper, lineStyle: { width: 0.8, color: '#057a55', type: 'dashed' }, symbol: 'none', connectNulls: true, z: 1 },
-          { name: '押し目ゾーン下端 (high20d × ' + (pullbackMinMul).toFixed(2) + ')', type: 'line', data: bandLower, lineStyle: { width: 0.8, color: '#c22', type: 'dashed' }, symbol: 'none', connectNulls: true, z: 1 },
+          // 押し目ゾーン band は保有時は非表示 (overlay 4 本制限対策)
+          ...(sc.position ? [] : [
+            { name: '押し目ゾーン上端 (high20d × ' + (pullbackMaxMul).toFixed(2) + ')', type: 'line', data: bandUpper, lineStyle: { width: 0.8, color: '#057a55', type: 'dashed' }, symbol: 'none', connectNulls: false, z: 1 },
+            { name: '押し目ゾーン下端 (high20d × ' + (pullbackMinMul).toFixed(2) + ')', type: 'line', data: bandLower, lineStyle: { width: 0.8, color: '#c22', type: 'dashed' }, symbol: 'none', connectNulls: false, z: 1 },
+          ]),
           { name: 'price', type: 'line', data: prices, lineStyle: { width: 1.5, color: '#1471a8' }, symbol: 'none', z: 5,
             markLine: positionMarkLines.length > 0 ? { silent: true, symbol: 'none', data: positionMarkLines } : undefined,
             markPoint: { symbol: 'pin', symbolSize: 36, data: entries.concat(exits) },

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -585,3 +585,34 @@ describe('parseChartsTab', () => {
     expect(parseChartsTab('OVERVIEW')).toBe('overview') // 大文字も既知扱いせず default に
   })
 })
+
+import { deriveOpenPosition } from '../../src/routes/dashboard'
+
+describe('deriveOpenPosition', () => {
+  const buy = (ts: string, price: number) => ({ timestamp: ts, side: 'BUY' as const, price, qty: 1, realizedPnl: null })
+  const sell = (ts: string, price: number, pnl: number) => ({ timestamp: ts, side: 'SELL' as const, price, qty: 1, realizedPnl: pnl })
+
+  it('空配列は null', () => {
+    expect(deriveOpenPosition([])).toBe(null)
+  })
+
+  it('BUY のみ → 現保有', () => {
+    expect(deriveOpenPosition([buy('2026-04-23', 100)])).toEqual({
+      avgPrice: 100,
+      openedAt: '2026-04-23',
+    })
+  })
+
+  it('BUY → SELL → 閉鎖済 (null)', () => {
+    expect(deriveOpenPosition([buy('2026-04-23', 100), sell('2026-04-24', 105, 5)])).toBe(null)
+  })
+
+  it('BUY → SELL → BUY → 直近 BUY が現保有', () => {
+    const ms = [buy('2026-04-20', 100), sell('2026-04-21', 95, -5), buy('2026-04-23', 110)]
+    expect(deriveOpenPosition(ms)).toEqual({ avgPrice: 110, openedAt: '2026-04-23' })
+  })
+
+  it('SELL のみ (POC で発生しないが defensively) → null', () => {
+    expect(deriveOpenPosition([sell('2026-04-23', 100, 5)])).toBe(null)
+  })
+})


### PR DESCRIPTION
## Summary

trading-strategist agent との協議で「entry timing と exit price の確認に直結する」3 線を個別銘柄チャートに追加。**4 本以下に抑える鉄則** (それ以上は SMA50 と price 自体が読めなくなる) のもと、必須 3 線のみ採用。

## 追加した線

| 線 | 表示条件 | 式 | 何が分かる |
|---|---|---|---|
| 押し目買いゾーン (上端) | 常時 | `high20d × (1 + pullbackMax)` (緑点線) | -3% 押し目 (買い圏内の上限) |
| 押し目買いゾーン (下端) | 常時 | `high20d × (1 + pullbackMin)` (赤点線) | -15% 押し目 (買い圏内の下限) |
| avgPrice | 保有時のみ | 平均取得単価 (灰実線) | 損益分岐 |
| 損切ライン | 保有時のみ | `avgPrice × (1 + stopPct)` (赤点線) | あと何 % で損切り |
| 利食ライン | 保有時のみ | `avgPrice × (1 + takeProfitPct)` (緑点線) | R:R 視覚化 |

押し目ゾーンは **time-series band** (each point の high20d を反映) で、戦略の心臓部 = 「band 内に price が入ると entry trigger 圏内」が一目で分かる。

## スコープ外 (POC 未対応 / follow-up)

- **時間切れ縦線** (10 営業日 exit): xAxis を category にしているため未来時刻のマッピングが煩雑、保留
- **per-symbol rule override**: \`symbol_rules\` テーブル参照せず global default のみ採用
- **partial fill / position add**: \`deriveOpenPosition\` は直近 BUY → SELL シーケンスで単純判定

## 主な変更

- \`SymbolChartPoint\` に \`high20d\` 追加 (indicators_json から抽出)
- \`SymbolChartData\` に \`position\` / \`rules\` 追加
- \`parseIndicators\`: sma50 / high20d を一括抽出 (\`extractSma50\` 互換維持)
- \`deriveOpenPosition\`: markers 時系列で BUY → SELL シーケンス分析
- ハンドラは \`loadGlobalConfigFrom\` 並列で rules 取得

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm test\` (410 tests, +5 for deriveOpenPosition)
- [ ] staging で銘柄ごと chart 確認:
  - 押し目バンド (緑点線・赤点線) が price に追従して描画される
  - 保有中銘柄に avg / stop / TP の 3 本横線が出る
  - 非保有銘柄では横線が出ない (band のみ)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * シンボルチャートにプルバック（押し目）ゾーン帯域を表示
  * オープンポジション時に平均価格・ストップロス・テイクプロフィットの水平マーカーを表示
  * グローバル設定からチャート用ルールが自動適用されるように
  * チャートタイトルに「押し目ゾーン」概念を反映

* **テスト**
  * ポジション検出ロジックの動作を確認する単体テストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->