### PR TITLE
feat(dashboard): 個別銘柄チャートに下値支持線 (20日安値) 追加 + ラベル整理

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1408,10 +1408,11 @@ export async function pickDefaultSymbol(db: D1Database): Promise<string | null> 
 }
 
 export interface SymbolChartPoint {
-  timestamp: string // JST display string
+  timestamp: string // ISO UTC (time axis 用、client 側 Intl で JST 表示)
   price: number
   sma50: number | null
   high20d: number | null
+  low20d: number | null
 }
 
 export interface SymbolChartMarker {
@@ -1504,6 +1505,7 @@ export async function loadSymbolChart(
         price: Number(r.price),
         sma50: indicators.sma50,
         high20d: indicators.high20d,
+        low20d: indicators.low20d,
       }
     })
   const markers: SymbolChartMarker[] = (fillsResult.results ?? [])
@@ -1558,23 +1560,32 @@ export function extractSma50(indicatorsJson: string | null): number | null {
 interface ExtractedIndicators {
   sma50: number | null
   high20d: number | null
+  low20d: number | null
 }
 
 /**
  * indicators_json から chart で使う数値を一括抽出。JSON.parse 失敗 / 数値外は null。
+ * low20d は #158 follow-up で追加されたため、既存の indicators_json には未収録 →
+ * 古い行は null fallback で grace 化。新しい cron 実行から徐々に出揃う。
  */
 function parseIndicators(indicatorsJson: string | null): ExtractedIndicators {
-  if (!indicatorsJson) return { sma50: null, high20d: null }
+  if (!indicatorsJson) return { sma50: null, high20d: null, low20d: null }
   try {
-    const obj = JSON.parse(indicatorsJson) as { sma50?: unknown; high20d?: unknown }
+    const obj = JSON.parse(indicatorsJson) as {
+      sma50?: unknown
+      high20d?: unknown
+      low20d?: unknown
+    }
     return {
       sma50:
         typeof obj.sma50 === 'number' && Number.isFinite(obj.sma50) ? obj.sma50 : null,
       high20d:
         typeof obj.high20d === 'number' && Number.isFinite(obj.high20d) ? obj.high20d : null,
+      low20d:
+        typeof obj.low20d === 'number' && Number.isFinite(obj.low20d) ? obj.low20d : null,
     }
   } catch {
-    return { sma50: null, high20d: null }
+    return { sma50: null, high20d: null, low20d: null }
   }
 }
 
@@ -1787,8 +1798,9 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
       var pricesXY = sc.points.map(function (p) { return [p.timestamp, p.price]; });
       var smasXY = sc.points.map(function (p) { return p.sma50 == null ? [p.timestamp, null] : [p.timestamp, p.sma50]; });
 
-      // 押し目買いゾーン (high20d × (1 + pullbackMax) 〜 high20d × (1 + pullbackMin))。
-      // -3〜-15% の押し目レンジを time-series band として可視化。
+      // 押し目買いゾーン:
+      // - 上端 = high20d × (1 + pullbackMax)  ≒ 教科書の「上値抵抗線 (resistance)」
+      // - 下端 = high20d × (1 + pullbackMin)  = 押し目買いの下限 (-15% 以下は深すぎ)
       var pullbackMaxMul = 1 + sc.rules.pullbackMax;
       var pullbackMinMul = 1 + sc.rules.pullbackMin;
       var bandUpperXY = sc.points.map(function (p) {
@@ -1796,6 +1808,12 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
       });
       var bandLowerXY = sc.points.map(function (p) {
         return [p.timestamp, p.high20d == null ? null : p.high20d * pullbackMinMul];
+      });
+
+      // 下値支持線 (= 20 日安値、教科書の support line)。high20d と対称な指標で、
+      // ここを下回ると「直近 20 日のレンジ崩壊」= トレンド転換のサイン。
+      var supportXY = sc.points.map(function (p) {
+        return [p.timestamp, p.low20d == null ? null : p.low20d];
       });
 
       // markPoint は xAxis: ISO timestamp (time axis 上の実時刻位置)。category 不一致問題なし。
@@ -1822,22 +1840,24 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
 
       var symChart = echarts.init(document.getElementById('symbol-chart'));
       symChart.setOption({
-        title: { text: sc.symbol + ' price + SMA50 + 押し目ゾーン + entry/exit', left: 'center', textStyle: { fontSize: 14 } },
+        title: { text: sc.symbol + ' price + 抵抗/支持線 + 押し目ゾーン + entry/exit', left: 'center', textStyle: { fontSize: 14 } },
         tooltip: {
           trigger: 'axis',
           axisPointer: { label: { formatter: function (p) { return jstLabel(p.value); } } },
         },
-        legend: { top: 22 },
+        legend: { top: 22, type: 'scroll' },
         grid: { left: 60, right: 20, top: 60, bottom: 40 },
         xAxis: { type: 'time', axisLabel: { formatter: function (value) { return jstLabel(value); } } },
         yAxis: { type: 'value', scale: true },
         series: [
-          // overlay 4 本制限のため、保有時は band を非表示 (avg/stop/TP に集中)。
-          // 非保有時は band 表示 (entry trigger 圏内かを見る局面)。
+          // 保有時は band 非表示 (avg/stop/TP の 3 線に集中)、非保有時は band 表示
+          // (entry trigger 圏内かを見る局面)。下値支持線 (low20d) は常時表示で
+          // 「直近レンジ崩壊」を見える化。
           ...(sc.position ? [] : [
-            { name: '押し目ゾーン上端 (high20d × ' + (pullbackMaxMul).toFixed(2) + ')', type: 'line', data: bandUpperXY, lineStyle: { width: 0.8, color: '#057a55', type: 'dashed' }, symbol: 'none', connectNulls: false, z: 1 },
-            { name: '押し目ゾーン下端 (high20d × ' + (pullbackMinMul).toFixed(2) + ')', type: 'line', data: bandLowerXY, lineStyle: { width: 0.8, color: '#c22', type: 'dashed' }, symbol: 'none', connectNulls: false, z: 1 },
+            { name: '上値抵抗線 (high20d × ' + (pullbackMaxMul).toFixed(2) + ')', type: 'line', data: bandUpperXY, lineStyle: { width: 0.8, color: '#057a55', type: 'dashed' }, symbol: 'none', connectNulls: false, z: 1 },
+            { name: '押し目買い下限 (high20d × ' + (pullbackMinMul).toFixed(2) + ')', type: 'line', data: bandLowerXY, lineStyle: { width: 0.8, color: '#b25000', type: 'dashed' }, symbol: 'none', connectNulls: false, z: 1 },
           ]),
+          { name: '下値支持線 (20日安値)', type: 'line', data: supportXY, lineStyle: { width: 1, color: '#c22', type: 'solid' }, symbol: 'none', connectNulls: false, z: 1 },
           { name: 'price', type: 'line', data: pricesXY, lineStyle: { width: 1.5, color: '#1471a8' }, symbol: 'none', z: 5,
             markLine: positionMarkLines.length > 0 ? { silent: true, symbol: 'none', data: positionMarkLines } : undefined,
             markPoint: entries.length + exits.length > 0 ? { symbol: 'pin', symbolSize: 36, data: entries.concat(exits) } : undefined,

--- a/src/trading/strategy/indicators.ts
+++ b/src/trading/strategy/indicators.ts
@@ -17,6 +17,11 @@ export interface PullbackIndicatorSnapshot {
   sma50: number
   return50d: number
   high20d: number
+  /**
+   * 20 日安値 (low20d) — 戦略 ロジック上は未使用、dashboard 個別銘柄チャートで
+   * 「下値支持線」として可視化するために計算 (`high20d` と対称な指標)。
+   */
+  low20d: number
   atr20: number
   baselineAtr20: number
 }
@@ -31,12 +36,14 @@ export function computePullbackIndicators(bars: DailyBar[]): PullbackIndicatorSn
 
   const closes = bars.map((b) => b.close)
   const highs = bars.map((b) => b.high)
+  const lows = bars.map((b) => b.low)
   const last = closes[closes.length - 1]!
   const baseline = closes[closes.length - 50]!
   if (baseline <= 0) return null
 
   const sma50 = average(closes.slice(-50))
   const high20d = Math.max(...highs.slice(-20))
+  const low20d = Math.min(...lows.slice(-20))
   const return50d = (last - baseline) / baseline
 
   const trueRanges = computeTrueRanges(bars)
@@ -46,7 +53,7 @@ export function computePullbackIndicators(bars: DailyBar[]): PullbackIndicatorSn
   // against to decide whether to floor the size. 60 bars ≈ ~3 months daily.
   const baselineAtr20 = average(trueRanges.slice(-Math.min(trueRanges.length, 60)))
 
-  return { price: last, sma50, return50d, high20d, atr20, baselineAtr20 }
+  return { price: last, sma50, return50d, high20d, low20d, atr20, baselineAtr20 }
 }
 
 export function computeHoldBusinessDays(

--- a/test/trading/strategy/indicators.test.ts
+++ b/test/trading/strategy/indicators.test.ts
@@ -17,7 +17,7 @@ describe('computePullbackIndicators', () => {
     expect(computePullbackIndicators(makeBars([1, 2, 3]))).toBeNull()
   })
 
-  it('computes sma50 / return50d / high20d from the tail window', () => {
+  it('computes sma50 / return50d / high20d / low20d from the tail window', () => {
     const closes = Array.from({ length: 60 }, (_, i) => 100 + i)
     const result = computePullbackIndicators(makeBars(closes))
     expect(result).not.toBeNull()
@@ -29,6 +29,19 @@ describe('computePullbackIndicators', () => {
     expect(r.return50d).toBeCloseTo((159 - 110) / 110, 4)
     // high20d = max of highs for last 20 bars. highs are close*1.01.
     expect(r.high20d).toBeCloseTo(159 * 1.01, 4)
+    // low20d = min of lows for last 20 bars. lows are close*0.99, last 20 closes
+    // are 140..159 → min = 140 * 0.99
+    expect(r.low20d).toBeCloseTo(140 * 0.99, 4)
+  })
+
+  it('low20d picks the smallest low even when not the most recent bar', () => {
+    // 60 closes mostly increasing, but last 20 includes a dip to enforce the
+    // 20-bar window semantics. Set bar[55].low artificially low.
+    const closes = Array.from({ length: 60 }, (_, i) => 100 + i)
+    const bars = makeBars(closes)
+    bars[55]!.low = 50 // dip in last 20
+    const r = computePullbackIndicators(bars)!
+    expect(r.low20d).toBeCloseTo(50, 4)
   })
 })
 


### PR DESCRIPTION
## Summary

トレーダー教科書 (1 つ前のスクショ) の「下値支持線 / 上値抵抗線」フレームに合わせ、押し目ゾーンに加えて **20 日安値 (low20d)** を独立した support line として表示。ラベルも教科書認知と整合。

## ⚠️ Stacked on #166

本 PR は **[#166](https://github.com/ochanuco/webull-trading/pull/166) (time axis + DO position) にスタック**。BUY/SELL pin marker / avg/stop/TP 横線は #166 側で復活する。**先に #166 をマージしてください**。マージ後 GitHub が自動で本 PR の base を main に retarget。

## Changes

### Backend
- \`indicators.ts\`: \`PullbackIndicatorSnapshot\` に \`low20d\` 追加 (\`Math.min(...lows.slice(-20))\`)
- 戦略ロジック自体では未使用、可視化用の補助指標
- 既存 \`indicators_json\` の古い行は null fallback で grace 化、新 cron 実行から徐々に揃う

### Frontend (dashboard chart)
- 「下値支持線 (20日安値)」を **solid red line** で常時表示 (band と独立)
- ラベル整理:
  - 「押し目ゾーン上端」→ **上値抵抗線 (high20d × N)**
  - 「押し目ゾーン下端」→ **押し目買い下限 (high20d × N)**

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm test\` (411 tests, +1 for low20d dip edge case)
- [ ] staging で銘柄ごと chart 確認:
  - 「下値支持線 (20日安値)」がプロットされる (新 cron 走行後)
  - ラベルが教科書と一致 (上値抵抗線 / 押し目買い下限 / 下値支持線)
  - 既存古い行では null で sparse 描画 (壊れない)

## Trader 視点の根拠

trading-strategist agent の前回助言:
> overlay は 4 本以下に保たないと SMA50 と price 自体が読めなくなる
> Trader が chart を開く目的は entry timing と exit price の確認の2つだけ

→ 非保有時は **price + SMA50 + 上値抵抗 + 押し目下限 + 下値支持** の 5 本だが、上 2 本 (band) と下値支持は別概念で trader が分離認識可能なので許容。保有時は band 非表示で 4 本 (price + SMA50 + 下値支持 + 横線群) に収まる。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * チャートに20日間の安値支持線（下値支持線）を追加しました
  * チャート凡例をスクロール対応にしました

* **改善**
  * 過去のレコードとの互換性を向上させました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->