### PR TITLE
fix(dashboard): pin label overlap / 古い entry 不可視 / yAxis NaN 防御

### DIFF
--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -2,6 +2,12 @@ import { sql } from 'drizzle-orm'
 import { check, index, integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core'
 
 /**
+ * Schema-level max for pullbackDefaultTimeStopDays. Exported so chart window
+ * logic can stay consistent with DB constraint.
+ */
+export const MAX_TIME_STOP_DAYS = 365
+
+/**
  * append-only trade decision / order lifecycle log. A single row per logical
  * event (`decision` → `intent` → `pre_submit` → `post_submit` → `fill` /
  * `exit`). Column shape is intentionally flat — schema mirrors
@@ -228,7 +234,7 @@ export const globalConfig = sqliteTable(
     ),
     pullbackDefaultTimeStopDaysRange: check(
       'global_config_pullback_default_time_stop_days_range',
-      sql`${t.pullbackDefaultTimeStopDays} > 0 AND ${t.pullbackDefaultTimeStopDays} <= 365`,
+      sql`${t.pullbackDefaultTimeStopDays} > 0 AND ${t.pullbackDefaultTimeStopDays} <= ${MAX_TIME_STOP_DAYS}`,
     ),
     pullbackDefaultPullbackMaxRange: check(
       'global_config_pullback_default_pullback_max_range',

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1477,12 +1477,15 @@ export async function loadSymbolChart(
   if (!db) throw new Error('DB binding not available')
   const [logsResult, fillsResult, doPosition] = await Promise.all([
     db
+      // 14 日窓: timeStopDays=10 営業日を覆う + 数日バッファ。LIMIT 200 (約 50h)
+      // だと 04/21 BUY のような古い entry が chart 範囲外で pin が render されない。
+      // 14 日 × 15 分 cadence = 1344 行 ≒ 200KB JSON、ECharts time axis で許容範囲。
       .prepare(
         `SELECT timestamp, price, indicators_json
          FROM strategy_decision_log
          WHERE symbol = ?
-         ORDER BY id DESC
-         LIMIT 200`,
+           AND timestamp >= datetime('now', '-14 days')
+         ORDER BY id ASC`,
       )
       .bind(symbol)
       .all<{ timestamp: string; price: number | null; indicators_json: string | null }>(),
@@ -1516,7 +1519,7 @@ export async function loadSymbolChart(
       }>(),
     fetchDoPosition(env, symbol),
   ])
-  const logs = (logsResult.results ?? []).reverse() // ASC for chart
+  const logs = logsResult.results ?? [] // SQL は既に ASC で返している
   const points: SymbolChartPoint[] = logs
     .filter((r) => r.price !== null && Number.isFinite(Number(r.price)))
     .map((r) => {
@@ -1874,12 +1877,15 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
       });
 
       // markPoint は xAxis: ISO timestamp (time axis 上の実時刻位置)。category 不一致問題なし。
+      // pin label を短縮: BUY/SELL は色 (緑/赤) で識別、price だけ表示。
+      // close-time fill (15 分以内) で label 重なりが起きにくい。pnl は SELL のみ
+      // 末尾に短く付与 (例: "120.19 +0.4")。詳細は hover tooltip で。
       var entries = sc.markers.filter(function (m) { return m.side === 'BUY'; }).map(function (m) {
-        return { name: 'BUY', coord: [m.timestamp, m.price], label: { formatter: 'BUY @' + m.price.toFixed(2), color: '#057a55', position: 'top' }, itemStyle: { color: '#057a55' } };
+        return { name: 'BUY', coord: [m.timestamp, m.price], value: m.price, label: { formatter: m.price.toFixed(2), color: '#057a55', position: 'top', distance: 6, fontSize: 11 }, itemStyle: { color: '#057a55' } };
       });
       var exits = sc.markers.filter(function (m) { return m.side === 'SELL'; }).map(function (m) {
-        var pnlLabel = m.realizedPnl == null ? '' : ' (' + (m.realizedPnl >= 0 ? '+' : '') + m.realizedPnl.toFixed(2) + ')';
-        return { name: 'SELL', coord: [m.timestamp, m.price], label: { formatter: 'SELL @' + m.price.toFixed(2) + pnlLabel, color: '#c22', position: 'bottom' }, itemStyle: { color: '#c22' } };
+        var pnlLabel = m.realizedPnl == null ? '' : ' ' + (m.realizedPnl >= 0 ? '+' : '') + m.realizedPnl.toFixed(1);
+        return { name: 'SELL', coord: [m.timestamp, m.price], value: m.price, label: { formatter: m.price.toFixed(2) + pnlLabel, color: '#c22', position: 'bottom', distance: 6, fontSize: 11 }, itemStyle: { color: '#c22' } };
       });
 
       // 保有中なら avg / stop / take-profit を水平 markLine。
@@ -1898,28 +1904,35 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
       }
 
       // ECharts の scale:true は markLine を yAxis range に含めないため、
-      // TP / stop が data 範囲外だと枠の外で見えなくなる (実際にスクショで TP が
-      // 130 上限を超えて消えた)。data 全体 + position lines + markers を考慮した
-      // explicit min/max を計算して padding を加える。
+      // TP / stop が data 範囲外だと枠の外で見えなくなる。data 全体 +
+      // position lines + markers を考慮した explicit min/max + padding。
+      // NaN / Infinity が混入すると Math.min/max が NaN を返し、
+      // 結果 yAxis が壊れる (axis label に巨大数が出る回帰例あり) ので
+      // pushIfFinite で防御。
       var allY = [];
+      function pushIfFinite(v) {
+        if (v != null && typeof v === 'number' && Number.isFinite(v)) allY.push(v);
+      }
       sc.points.forEach(function (p) {
-        if (p.price != null) allY.push(p.price);
-        if (p.sma50 != null) allY.push(p.sma50);
-        if (p.high20d != null) {
-          allY.push(p.high20d * pullbackMaxMul);
-          allY.push(p.high20d * pullbackMinMul);
+        pushIfFinite(p.price);
+        pushIfFinite(p.sma50);
+        if (p.high20d != null && Number.isFinite(p.high20d)) {
+          pushIfFinite(p.high20d * pullbackMaxMul);
+          pushIfFinite(p.high20d * pullbackMinMul);
         }
-        if (p.low20d != null) allY.push(p.low20d);
+        pushIfFinite(p.low20d);
       });
-      sc.markers.forEach(function (m) { if (m.price != null) allY.push(m.price); });
-      extraYValues.forEach(function (v) { allY.push(v); });
+      sc.markers.forEach(function (m) { pushIfFinite(m.price); });
+      extraYValues.forEach(function (v) { pushIfFinite(v); });
       var yMin, yMax;
       if (allY.length > 0) {
         var rawMin = Math.min.apply(null, allY);
         var rawMax = Math.max.apply(null, allY);
-        var pad = Math.max((rawMax - rawMin) * 0.05, 0.5);
-        yMin = rawMin - pad;
-        yMax = rawMax + pad;
+        if (Number.isFinite(rawMin) && Number.isFinite(rawMax)) {
+          var pad = Math.max((rawMax - rawMin) * 0.05, 0.5);
+          yMin = rawMin - pad;
+          yMax = rawMax + pad;
+        }
       }
 
       var symChart = echarts.init(document.getElementById('symbol-chart'));
@@ -1944,7 +1957,7 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
           { name: '下値支持線 (20日安値)', type: 'line', data: supportXY, lineStyle: { width: 1, color: '#c22', type: 'solid' }, symbol: 'none', connectNulls: false, z: 1 },
           { name: 'price', type: 'line', data: pricesXY, lineStyle: { width: 1.5, color: '#1471a8' }, symbol: 'none', z: 5,
             markLine: positionMarkLines.length > 0 ? { silent: true, symbol: 'none', data: positionMarkLines } : undefined,
-            markPoint: entries.length + exits.length > 0 ? { symbol: 'pin', symbolSize: 36, data: entries.concat(exits) } : undefined,
+            markPoint: entries.length + exits.length > 0 ? { symbol: 'pin', symbolSize: 24, data: entries.concat(exits) } : undefined,
           },
           { name: 'SMA50', type: 'line', data: smasXY, lineStyle: { width: 1, color: '#888', type: 'dashed' }, symbol: 'none', connectNulls: true, z: 2 },
         ],

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1883,13 +1883,26 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
       // markPoint は xAxis: ISO timestamp (time axis 上の実時刻位置)。category 不一致問題なし。
       // pin label を短縮: BUY/SELL は色 (緑/赤) で識別、price だけ表示。
       // close-time fill (15 分以内) で label 重なりが起きにくい。pnl は SELL のみ
-      // 末尾に短く付与 (例: "120.19 +0.4")。詳細は hover tooltip で。
+      // 末尾に小数 1 桁で付与 (例: "120.19 +0.4")。詳細 (full-precision PnL /
+      // qty / timestamp) は markPoint hover tooltip で表示。
+      // realizedPnl と filledQty を data に保持し tooltip.formatter から
+      // full-precision で読む (label の toFixed(1) で丸めた値とは独立)。
       var entries = sc.markers.filter(function (m) { return m.side === 'BUY'; }).map(function (m) {
-        return { name: 'BUY', coord: [m.timestamp, m.price], value: m.price, label: { formatter: m.price.toFixed(2), color: '#057a55', position: 'top', distance: 6, fontSize: 11 }, itemStyle: { color: '#057a55' } };
+        return {
+          name: 'BUY', coord: [m.timestamp, m.price], value: m.price,
+          realizedPnl: null, qty: m.qty, fillTimestamp: m.timestamp,
+          label: { formatter: m.price.toFixed(2), color: '#057a55', position: 'top', distance: 6, fontSize: 11 },
+          itemStyle: { color: '#057a55' },
+        };
       });
       var exits = sc.markers.filter(function (m) { return m.side === 'SELL'; }).map(function (m) {
         var pnlLabel = m.realizedPnl == null ? '' : ' ' + (m.realizedPnl >= 0 ? '+' : '') + m.realizedPnl.toFixed(1);
-        return { name: 'SELL', coord: [m.timestamp, m.price], value: m.price, label: { formatter: m.price.toFixed(2) + pnlLabel, color: '#c22', position: 'bottom', distance: 6, fontSize: 11 }, itemStyle: { color: '#c22' } };
+        return {
+          name: 'SELL', coord: [m.timestamp, m.price], value: m.price,
+          realizedPnl: m.realizedPnl, qty: m.qty, fillTimestamp: m.timestamp,
+          label: { formatter: m.price.toFixed(2) + pnlLabel, color: '#c22', position: 'bottom', distance: 6, fontSize: 11 },
+          itemStyle: { color: '#c22' },
+        };
       });
 
       // 保有中なら avg / stop / take-profit を水平 markLine。
@@ -1961,7 +1974,24 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
           { name: '下値支持線 (20日安値)', type: 'line', data: supportXY, lineStyle: { width: 1, color: '#c22', type: 'solid' }, symbol: 'none', connectNulls: false, z: 1 },
           { name: 'price', type: 'line', data: pricesXY, lineStyle: { width: 1.5, color: '#1471a8' }, symbol: 'none', z: 5,
             markLine: positionMarkLines.length > 0 ? { silent: true, symbol: 'none', data: positionMarkLines } : undefined,
-            markPoint: entries.length + exits.length > 0 ? { symbol: 'pin', symbolSize: 24, data: entries.concat(exits) } : undefined,
+            markPoint: entries.length + exits.length > 0 ? {
+              symbol: 'pin', symbolSize: 24, data: entries.concat(exits),
+              // 個別 pin hover で full-precision の realized PnL / qty / 時刻を
+              // 表示。label は短縮表記なので、ここで補完情報を出す。
+              // 親 tooltip の trigger:'axis' に上書きされないよう trigger:'item'。
+              tooltip: {
+                trigger: 'item',
+                formatter: function (p) {
+                  var d = p.data;
+                  var pnl = d.realizedPnl == null
+                    ? ''
+                    : '<br/>realized PnL: ' + (d.realizedPnl >= 0 ? '+' : '') + d.realizedPnl.toFixed(2);
+                  var qty = d.qty == null ? '' : '<br/>qty: ' + d.qty;
+                  var ts = d.fillTimestamp == null ? '' : '<br/>fill: ' + jstLabel(d.fillTimestamp);
+                  return d.name + ' @ ' + d.value.toFixed(2) + pnl + qty + ts;
+                },
+              },
+            } : undefined,
           },
           { name: 'SMA50', type: 'line', data: smasXY, lineStyle: { width: 1, color: '#888', type: 'dashed' }, symbol: 'none', connectNulls: true, z: 2 },
         ],

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1481,10 +1481,14 @@ export async function loadSymbolChart(
       // だと 04/21 BUY のような古い entry が chart 範囲外で pin が render されない。
       // 14 日 × 15 分 cadence = 1344 行 ≒ 200KB JSON、ECharts time axis で許容範囲。
       .prepare(
+        // strftime で右辺を ISO UTC 形式 ("...T...:...Z") に揃える。
+        // datetime() のデフォルト出力は "YYYY-MM-DD HH:MM:SS" (空白区切り)
+        // で、stored 形式 "YYYY-MM-DDTHH:MM:SS.SSSZ" との文字列比較では境界が
+        // 約 1 日ぶれる (cutoff 当日の時刻前 row が誤って included される)。
         `SELECT timestamp, price, indicators_json
          FROM strategy_decision_log
          WHERE symbol = ?
-           AND timestamp >= datetime('now', '-14 days')
+           AND timestamp >= strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-14 days')
          ORDER BY id ASC`,
       )
       .bind(symbol)

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1454,14 +1454,18 @@ export interface SymbolChartRules {
   timeStopDays: number
 }
 
+/** Chart window の上限日数。timeStopDays が大きくても肥大化を防ぐ */
+const MAX_WINDOW_DAYS = 90
+
 /**
  * Chart SQL の window 日数を timeStopDays から動的に決める。
  * 営業日 N → カレンダー N×7/5 + 祝日バッファ + 安全マージン ≈ 2N+4。
  * timeStopDays=10 → 24 日。年末年始 / 大型連休跨ぎでも entry 取りこぼさない。
+ * floor=14, ceiling=MAX_WINDOW_DAYS で clamp してカレンダー window の肥大化を防ぐ。
  */
 export function computeChartWindowDays(timeStopDays: number): number {
   const dynamic = Math.ceil(timeStopDays * 2 + 4)
-  return Math.max(dynamic, 14)
+  return Math.min(Math.max(dynamic, 14), MAX_WINDOW_DAYS)
 }
 
 export interface SymbolChartData {

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -132,6 +132,7 @@ export const dashboard = new Hono<AppBindings>()
         pullbackMin: strategyParams.pullbackMin,
         stopPct: strategyParams.stopPct,
         takeProfitPct: strategyParams.takeProfitPct,
+        timeStopDays: strategyParams.timeStopDays,
       }
       // SymbolStateDO の position が ground truth (avgPrice / openedAt が
       // partial fill / position add も反映済)。trade_journal からの derive は
@@ -1449,6 +1450,18 @@ export interface SymbolChartRules {
   stopPct: number
   /** 0.07 = +7% (利食ライン) */
   takeProfitPct: number
+  /** 営業日。chart の SQL window 計算に使う (chart logic では非使用) */
+  timeStopDays: number
+}
+
+/**
+ * Chart SQL の window 日数を timeStopDays から動的に決める。
+ * 営業日 N → カレンダー N×7/5 + 祝日バッファ + 安全マージン ≈ 2N+4。
+ * timeStopDays=10 → 24 日。年末年始 / 大型連休跨ぎでも entry 取りこぼさない。
+ */
+export function computeChartWindowDays(timeStopDays: number): number {
+  const dynamic = Math.ceil(timeStopDays * 2 + 4)
+  return Math.max(dynamic, 14)
 }
 
 export interface SymbolChartData {
@@ -1475,23 +1488,21 @@ export async function loadSymbolChart(
 ): Promise<SymbolChartData> {
   const db = env.DB
   if (!db) throw new Error('DB binding not available')
+  const windowDays = computeChartWindowDays(rules.timeStopDays)
   const [logsResult, fillsResult, doPosition] = await Promise.all([
     db
-      // 14 日窓: timeStopDays=10 営業日を覆う + 数日バッファ。LIMIT 200 (約 50h)
-      // だと 04/21 BUY のような古い entry が chart 範囲外で pin が render されない。
-      // 14 日 × 15 分 cadence = 1344 行 ≒ 200KB JSON、ECharts time axis で許容範囲。
+      // 動的 window: timeStopDays から computeChartWindowDays(N) で計算
+      // (default 10 営業日 → 24 カレンダー日)。祝日 / 連休跨ぎでも entry を
+      // 取りこぼさない。strftime で右辺を ISO UTC 形式 ("...T...:...Z") に
+      // 揃える (default datetime() の空白区切りでは stored ISO と境界がぶれる)。
       .prepare(
-        // strftime で右辺を ISO UTC 形式 ("...T...:...Z") に揃える。
-        // datetime() のデフォルト出力は "YYYY-MM-DD HH:MM:SS" (空白区切り)
-        // で、stored 形式 "YYYY-MM-DDTHH:MM:SS.SSSZ" との文字列比較では境界が
-        // 約 1 日ぶれる (cutoff 当日の時刻前 row が誤って included される)。
         `SELECT timestamp, price, indicators_json
          FROM strategy_decision_log
          WHERE symbol = ?
-           AND timestamp >= strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-14 days')
+           AND timestamp >= strftime('%Y-%m-%dT%H:%M:%fZ', 'now', ?)
          ORDER BY id ASC`,
       )
-      .bind(symbol)
+      .bind(symbol, `-${windowDays} days`)
       .all<{ timestamp: string; price: number | null; indicators_json: string | null }>(),
     db
       // post_submit 行は side が null (writer は pre_submit にしか side を入れない)。
@@ -1857,6 +1868,14 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
       function jstLabel(value) {
         return jstFmt.format(new Date(value)).replace(/\\//g, '/');
       }
+      // fill 時刻は秒精度で表示 (同分内 fills を区別するため)。axisLabel は
+      // 分単位で密度を保つ (秒まで出すと x 軸ラベルが詰まる)。
+      var jstFmtSec = new Intl.DateTimeFormat('ja-JP', {
+        timeZone: 'Asia/Tokyo', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false,
+      });
+      function jstLabelSec(value) {
+        return jstFmtSec.format(new Date(value)).replace(/\\//g, '/');
+      }
 
       // [timestamp, value] のペアで time axis に渡す。null は connectNulls/sparse に。
       var pricesXY = sc.points.map(function (p) { return [p.timestamp, p.price]; });
@@ -1987,7 +2006,7 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
                     ? ''
                     : '<br/>realized PnL: ' + (d.realizedPnl >= 0 ? '+' : '') + d.realizedPnl.toFixed(2);
                   var qty = d.qty == null ? '' : '<br/>qty: ' + d.qty;
-                  var ts = d.fillTimestamp == null ? '' : '<br/>fill: ' + jstLabel(d.fillTimestamp);
+                  var ts = d.fillTimestamp == null ? '' : '<br/>fill: ' + jstLabelSec(d.fillTimestamp);
                   return d.name + ' @ ' + d.value.toFixed(2) + pnl + qty + ts;
                 },
               },

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -4,7 +4,7 @@ import type { Env } from '../config/env'
 import { loadGlobalConfigFrom } from '../infrastructure/db/globalConfigLoader'
 import { loadSymbolUniverse } from '../infrastructure/db/symbolUniverse'
 import { createDb } from '../infrastructure/db/tradeJournalRepo'
-import { strategyDecisionLog, tradeJournal } from '../infrastructure/db/schema'
+import { MAX_TIME_STOP_DAYS, strategyDecisionLog, tradeJournal } from '../infrastructure/db/schema'
 import { and, asc, desc, eq } from 'drizzle-orm'
 import { PortfolioStateClient } from '../trading/state/PortfolioStateClient'
 import { SymbolStateClient } from '../trading/state/SymbolStateClient'
@@ -1454,8 +1454,12 @@ export interface SymbolChartRules {
   timeStopDays: number
 }
 
-/** Chart window の上限日数。timeStopDays が大きくても肥大化を防ぐ */
-const MAX_WINDOW_DAYS = 90
+/**
+ * Chart window の上限日数。schema の MAX_TIME_STOP_DAYS (365) から計算。
+ * timeStopDays が大きくても肥大化を防ぐ。
+ * MAX_TIME_STOP_DAYS=365 → 2*365+4 = 734 カレンダー日。
+ */
+const MAX_WINDOW_DAYS = Math.ceil(MAX_TIME_STOP_DAYS * 2 + 4)
 
 /**
  * Chart SQL の window 日数を timeStopDays から動的に決める。

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -714,3 +714,28 @@ describe('renderStrategyParamsPanel', () => {
     expect(html).toContain('default から変更されている')
   })
 })
+
+import { computeChartWindowDays } from '../../src/routes/dashboard'
+
+describe('computeChartWindowDays', () => {
+  it('default 10 営業日 → 24 カレンダー日', () => {
+    expect(computeChartWindowDays(10)).toBe(24)
+  })
+
+  it('短い保持 (5 営業日) でも最低 14 日確保', () => {
+    expect(computeChartWindowDays(5)).toBe(14)
+  })
+
+  it('長期保持 (20 営業日) → 44 日 (祝日 / 連休跨ぎを覆う)', () => {
+    expect(computeChartWindowDays(20)).toBe(44)
+  })
+
+  it('1 営業日 → floor 14 日', () => {
+    expect(computeChartWindowDays(1)).toBe(14)
+  })
+
+  it('小数 (4.5 営業日) でも切り上げ', () => {
+    expect(computeChartWindowDays(4.5)).toBe(14) // 13 < 14 floor
+    expect(computeChartWindowDays(5.5)).toBe(15) // ceil(15) = 15
+  })
+})


### PR DESCRIPTION
## Summary

スクショ確認で判明した 3 件を 1 PR で:

### 1. pin label の重なり (Image #7 SOXL)

ping-pong で 15-30 分間隔の連続 fill (\`BUY 119.81 → SELL 120.19 → BUY 120.78 → SELL 120.43\`) が同 price 帯に密集すると label collision。

- label の \`BUY @ \` / \`SELL @ \` prefix を削除、**price 数値のみ** に短縮
- pin \`symbolSize\` を 36 → 24 に縮小、label \`fontSize: 11\`、\`distance: 6\`
- SELL の pnl 表記も \`(+0.38)\` → \`+0.4\` に短縮 (詳細は hover tooltip)

### 2. 古い fill の pin が描画されない (Image #8 AAPL)

**原因**: strategy_decision_log を \`LIMIT 200\` (約 50h 分) で window を切っているため、04/21 の AAPL BUY が chart 範囲外で markPoint が render されない。

**修正**: SQL を \`WHERE timestamp >= datetime('now', '-14 days') ORDER BY id ASC\` に変更。\`timeStopDays = 10 営業日\` を覆う設計。14 日 × 15 分 cadence = 1344 行 ≒ 200KB JSON、ECharts time axis で許容範囲。

### 3. yAxis 巨大値の防御

スクショで \`"7711183"\` などの異常 label が y 軸両端に出る件 — \`allY\` 集計で NaN / Infinity が混入すると \`Math.min/max\` が NaN を返し \`yAxis: { min: NaN, max: NaN }\` で壊れる回帰例。

**修正**: \`pushIfFinite\` で \`Number.isFinite\` 検証、両端 \`rawMin\`/\`rawMax\` が finite な場合のみ explicit min/max を採用、不正なら undefined fallback (ECharts auto fit)。

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm test\` (424 tests, 描画依存テストは staging 確認に委ねる)
- [ ] staging で確認:
  - SOXL chart で pin が読みやすく表示 (短い label + 小さい pin)
  - AAPL chart で 04/21 の BUY pin が描画される (chart 範囲が 14 日に拡大)
  - y 軸両端の異常 label が消える

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * Y軸範囲計算で非有限値（NaN/Infinity）を除外し、表示崩れを防止しました。

* **改善**
  * チャート表示期間をビジネス日からカレンダー日へ変換し、14〜90日の範囲でクランプして安定表示を保証します。
  * 履歴ログ取得を時間窓で絞り、表示順序を正しく反映します。
  * BUY/SELLピンのラベルを簡潔化し、実現損益（小数2桁）や数量、秒精度時刻はホバーで詳細表示します。

* **テスト**
  * チャート表示期間変換の挙動（境界値・端数処理含む）を検証する単体テストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->