### PR TITLE
fix(dashboard): trend line を Yahoo daily bars 60 日 fetch ベースに切替

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -9,6 +9,7 @@ import { and, asc, desc, eq } from 'drizzle-orm'
 import { PortfolioStateClient } from '../trading/state/PortfolioStateClient'
 import { SymbolStateClient } from '../trading/state/SymbolStateClient'
 import type { SymbolState } from '../trading/state/types'
+import { YahooBarClient } from '../infrastructure/quotes/YahooBarClient'
 
 /**
  * Read-only operator dashboard (#121). Server-rendered HTML via Hono — no
@@ -1585,14 +1586,40 @@ export async function loadSymbolChart(
     }))
   // DO query の結果が undefined = binding 無し or fetch 失敗 → derive にフォールバック
   const position = doPosition !== undefined ? doPosition : deriveOpenPosition(markers)
-  // sloped trend lines: cron-eval price を JST 日次に dedupe → 5-bar fractal で
-  // swing pivot 検出 → 直近 2 pivots を結んで延長線 fit。pivots が 2 未満なら null。
-  const dailyCloses = aggregateDailyCloses(points)
+  // sloped trend lines: Yahoo daily bars を 60 日 fetch して fractal pivot 検出。
+  // POC 開始直後は strategy_decision_log が数日分しか無く cron-eval dedup では
+  // pivot 検出に必要な 5 日 (k=2) すら集まらないので、Yahoo の本物日足を使う。
+  // 失敗時は cron-eval dedup にフォールバック。
+  const yahooBars = await fetchYahooBarsForChart(symbol, 60)
+  const dailyCloses = yahooBars.length >= 5 ? yahooBars : aggregateDailyCloses(points)
   const pivots = detectFractalPivots(dailyCloses, 2)
   const lastTimestamp = points.length > 0 ? points[points.length - 1]!.timestamp : null
   const resistanceLine = lastTimestamp ? fitTrendLineFromRecentPivots(pivots, 'high', lastTimestamp) : null
   const supportLine = lastTimestamp ? fitTrendLineFromRecentPivots(pivots, 'low', lastTimestamp) : null
   return { symbol, points, markers, position, rules, resistanceLine, supportLine, pivots }
+}
+
+/**
+ * Yahoo daily bars を chart 用に fetch (lookback 営業日)。失敗時は空配列で
+ * fallback を呼出元に伝える。timestamp は date 部分 + 16:00 UTC (≈ 1:00 JST
+ * 翌日 ≈ "evening of date") で擬似生成。trend line の傾き計算のための
+ * 相対位置は十分。
+ */
+export async function fetchYahooBarsForChart(
+  symbol: string,
+  lookback: number,
+): Promise<Array<{ jstDate: string; close: number; timestamp: string }>> {
+  const client = new YahooBarClient()
+  try {
+    const bars = await client.getDailyBars(symbol, lookback)
+    return bars.map((b) => ({
+      jstDate: b.date,
+      close: b.close,
+      timestamp: `${b.date}T16:00:00.000Z`,
+    }))
+  } catch {
+    return []
+  }
 }
 
 /**
@@ -2110,7 +2137,12 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
         legend: { top: 22, type: 'scroll' },
         grid: { left: 60, right: 20, top: 60, bottom: 40 },
         xAxis: { type: 'time', axisLabel: { formatter: function (value) { return jstLabel(value); } } },
-        yAxis: { type: 'value', min: yMin, max: yMax },
+        // showMinLabel/showMaxLabel: false で boundary label の異常表示を抑制。
+        // ECharts で時々 yAxis の min/max 位置に巨大数字 ("7711183" 等) が
+        // 描画される現象 (ECharts 内部の axis pointer 計算と markPoint coord
+        // 干渉が疑われる)。実際の plot 範囲は正常なので boundary label を
+        // 隠すだけで chart は読みやすくなる。
+        yAxis: { type: 'value', min: yMin, max: yMax, axisLabel: { showMinLabel: false, showMaxLabel: false } },
         series: [
           // 保有時は押し目バンド非表示 (avg/stop/TP に集中)、非保有時は淡く表示
           // (戦略 rule の参考、トレンドラインが主役なので opacity 0.4)。

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1589,21 +1589,29 @@ export async function loadSymbolChart(
   // sloped trend lines: Yahoo daily bars を 60 日 fetch して fractal pivot 検出。
   // POC 開始直後は strategy_decision_log が数日分しか無く cron-eval dedup では
   // pivot 検出に必要な 5 日 (k=2) すら集まらないので、Yahoo の本物日足を使う。
-  // 失敗時は cron-eval dedup にフォールバック。
-  const yahooBars = await fetchYahooBarsForChart(symbol, 60)
+  // 失敗時 (network 等) は cron-eval dedup にフォールバック。
+  const lastTimestamp = points.length > 0 ? points[points.length - 1]!.timestamp : null
+  const yahooBarsRaw = await fetchYahooBarsForChart(symbol, 60)
+  // Yahoo bars が chart 表示範囲 (lastTimestamp) より新しい日を含むと、
+  // pivot dot / trend line 終点が表示範囲外に extend される。表示範囲を超える
+  // bar は除外。lastTimestamp が無い (chart 自体空) なら filtering 不要。
+  const yahooBars =
+    lastTimestamp == null ? yahooBarsRaw : yahooBarsRaw.filter((b) => b.timestamp <= lastTimestamp)
   const dailyCloses = yahooBars.length >= 5 ? yahooBars : aggregateDailyCloses(points)
   const pivots = detectFractalPivots(dailyCloses, 2)
-  const lastTimestamp = points.length > 0 ? points[points.length - 1]!.timestamp : null
   const resistanceLine = lastTimestamp ? fitTrendLineFromRecentPivots(pivots, 'high', lastTimestamp) : null
   const supportLine = lastTimestamp ? fitTrendLineFromRecentPivots(pivots, 'low', lastTimestamp) : null
   return { symbol, points, markers, position, rules, resistanceLine, supportLine, pivots }
 }
 
 /**
- * Yahoo daily bars を chart 用に fetch (lookback 営業日)。失敗時は空配列で
- * fallback を呼出元に伝える。timestamp は date 部分 + 16:00 UTC (≈ 1:00 JST
- * 翌日 ≈ "evening of date") で擬似生成。trend line の傾き計算のための
- * 相対位置は十分。
+ * Yahoo daily bars を chart 用に fetch (lookback 営業日)。timestamp は date
+ * 部分 + 16:00 UTC (≈ 1:00 JST 翌日 ≈ "evening of date") で擬似生成、
+ * trend line の傾き計算には相対精度として十分。
+ *
+ * エラー方針: caller contract 違反 (RangeError = lookback 不正) は呼出元の
+ * 実装バグなので throw 再送出する。それ以外 (network / parse / 一時的
+ * fetch 失敗) のみ空配列で fallback を呼出元に伝える。
  */
 export async function fetchYahooBarsForChart(
   symbol: string,
@@ -1617,7 +1625,10 @@ export async function fetchYahooBarsForChart(
       close: b.close,
       timestamp: `${b.date}T16:00:00.000Z`,
     }))
-  } catch {
+  } catch (err) {
+    // RangeError は呼出元コード側の lookback 不正 (実装ミス)。silent fallback で
+    // 隠さず再送出して dashboard handler の try/catch まで伝える。
+    if (err instanceof RangeError) throw err
     return []
   }
 }


### PR DESCRIPTION
## Summary

スクショ #11 で判明した「トレンドラインが全く描画されない」根本原因を解消。

## 原因

- 直前の #170 では cron-eval price (= 15 分毎 Yahoo close 複製) を JST 日次 dedup → fractal pivot 検出 (k=2 で最低 5 ユニーク日要) という設計
- しかし staging の \`strategy_decision_log\` は POC 開始から **2 日分しかない** (04/24, 04/25 の SOXL 例)
- → pivot 検出 0 → 線描画スキップ

## 修正

- \`fetchYahooBarsForChart(symbol, 60)\`: \`YahooBarClient.getDailyBars()\` で本物の日足 60 日を fetch、close 価格で pivot 検出
- Yahoo fetch 失敗時 / 5 日未満なら従来の cron-eval dedup へ fallback
- timestamp は \`{date}T16:00:00Z\` (≈ JST 翌 1:00 ≈ "evening of date") で擬似生成。trend line の傾き計算には十分な相対精度

## 副次

\`yAxis.axisLabel\` に \`showMinLabel: false, showMaxLabel: false\` を追加。
スクショ #7 #8 #11 で boundary label に巨大数字 (\`7711183\` / \`0651855\` 等) が描画される現象 (ECharts の axis pointer + markPoint coord 干渉が疑われるが特定不可) の workaround。実 plot 範囲は正常なので boundary を隠すだけで読みやすくなる。

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm test\` (442 tests, 既存の trend line logic test は変更なし)
- [ ] staging で SOXL chart 確認:
  - sloped 抵抗線 / 支持線が描画される (Yahoo 60 日で pivot 検出)
  - swing high/low ドットが可視化される
  - yAxis 両端の異常 label が消える

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 過去60日分の実データを優先利用してトレンドライン／ピボット検出の精度を向上
  * 実データが不足する場合は従来の集計に自動フォールバック
  * y軸の端点ラベル表示を抑制し、誤った大きな数値の表示を防止してチャートの見やすさを改善
<!-- end of auto-generated comment: release notes by coderabbit.ai -->