### PR TITLE
fix(dashboard): chart 全期間 price line + position 線を保有期間に絞る + pivot regime filter

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1611,7 +1611,13 @@ export async function loadSymbolChart(
     ? new Date(lastTimestamp).getTime() - PIVOT_WINDOW_DAYS * 24 * 3600 * 1000
     : 0
   const recentBars = yahooBars.filter((b) => new Date(b.timestamp).getTime() >= pivotCutoffMs)
-  const dailyCloses = recentBars.length >= 5 ? recentBars : aggregateDailyCloses(points)
+  // Yahoo fetch 失敗時の cron-eval fallback でも cutoff を維持。timeStopDays
+  // が大きい設定で chart window が 30 日を超えるケースで、旧 regime の cron
+  // 日足が pivot 候補に紛れ込まないよう同じ cutoff を適用。
+  const recentCronCloses = aggregateDailyCloses(points).filter(
+    (p) => new Date(p.timestamp).getTime() >= pivotCutoffMs,
+  )
+  const dailyCloses = recentBars.length >= 5 ? recentBars : recentCronCloses
   const pivotsRaw = detectFractalPivots(dailyCloses, 2)
   // regime filter: 現在価格の ±50% を超える pivot は別 regime (3x rally など)
   // と判定して除外。「直近に類似する価格帯」の pivot だけ trend line に使う。
@@ -1648,14 +1654,15 @@ export function mergeYahooAndCronPoints(
   yahooBars: Array<{ jstDate: string; close: number; timestamp: string }>,
   cronPoints: SymbolChartPoint[],
 ): SymbolChartPoint[] {
+  // 不正 timestamp の cron point は最初に除外。残すと ECharts time 軸 / chart
+  // 末尾判定 (lastTimestamp = mergedPoints[-1]) が壊れる。
+  const validCronPoints = cronPoints.filter((p) =>
+    Number.isFinite(new Date(p.timestamp).getTime()),
+  )
   const cronJstDates = new Set(
-    cronPoints
-      .map((p) => {
-        const ms = new Date(p.timestamp).getTime()
-        if (!Number.isFinite(ms)) return null
-        return new Date(ms + 9 * 3600 * 1000).toISOString().slice(0, 10)
-      })
-      .filter((d): d is string => d !== null),
+    validCronPoints.map((p) =>
+      new Date(new Date(p.timestamp).getTime() + 9 * 3600 * 1000).toISOString().slice(0, 10),
+    ),
   )
   const yahooFiller: SymbolChartPoint[] = yahooBars
     .filter((b) => !cronJstDates.has(b.jstDate))
@@ -1666,7 +1673,7 @@ export function mergeYahooAndCronPoints(
       high20d: null,
       low20d: null,
     }))
-  return [...yahooFiller, ...cronPoints].sort((a, b) =>
+  return [...yahooFiller, ...validCronPoints].sort((a, b) =>
     a.timestamp < b.timestamp ? -1 : a.timestamp > b.timestamp ? 1 : 0,
   )
 }
@@ -2159,7 +2166,13 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
         var tpPrice = avg * (1 + sc.rules.takeProfitPct);
         extraYValues.push(avg, stopPrice, tpPrice);
         var openedAt = sc.position.openedAt;
-        var endTs = sc.points.length > 0 ? sc.points[sc.points.length - 1].timestamp : openedAt;
+        // openedAt > 最新 point (chart データが古い / position 直後でまだ
+        // strategy_decision_log に記録されていない) のとき、endTs が openedAt
+        // より過去に出ると markLine が逆向き (左側) に伸びる。max で clamp。
+        var latestTs = sc.points.length > 0 ? sc.points[sc.points.length - 1].timestamp : openedAt;
+        var endTs = new Date(latestTs).getTime() >= new Date(openedAt).getTime()
+          ? latestTs
+          : openedAt;
         positionMarkLines = [
           [
             { coord: [openedAt, avg], symbol: 'none', lineStyle: { color: '#444', type: 'solid', width: 1 }, label: { formatter: 'avg ' + avg.toFixed(2), position: 'start', color: '#444' } },

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1586,22 +1586,89 @@ export async function loadSymbolChart(
     }))
   // DO query の結果が undefined = binding 無し or fetch 失敗 → derive にフォールバック
   const position = doPosition !== undefined ? doPosition : deriveOpenPosition(markers)
-  // sloped trend lines: Yahoo daily bars を 60 日 fetch して fractal pivot 検出。
-  // POC 開始直後は strategy_decision_log が数日分しか無く cron-eval dedup では
-  // pivot 検出に必要な 5 日 (k=2) すら集まらないので、Yahoo の本物日足を使う。
-  // 失敗時 (network 等) は cron-eval dedup にフォールバック。
-  const lastTimestamp = points.length > 0 ? points[points.length - 1]!.timestamp : null
+
+  // Yahoo daily bars 60 日: chart 全体の price line + pivot 検出に使う。
+  // Yahoo fetch 失敗時は cron-eval points のみで描画 (短い price line になるが
+  // 致命的ではない)。lastTimestamp が無い (chart 自体空) なら filtering 不要。
   const yahooBarsRaw = await fetchYahooBarsForChart(symbol, 60)
-  // Yahoo bars が chart 表示範囲 (lastTimestamp) より新しい日を含むと、
-  // pivot dot / trend line 終点が表示範囲外に extend される。表示範囲を超える
-  // bar は除外。lastTimestamp が無い (chart 自体空) なら filtering 不要。
+  const cronLastTs = points.length > 0 ? points[points.length - 1]!.timestamp : null
   const yahooBars =
-    lastTimestamp == null ? yahooBarsRaw : yahooBarsRaw.filter((b) => b.timestamp <= lastTimestamp)
-  const dailyCloses = yahooBars.length >= 5 ? yahooBars : aggregateDailyCloses(points)
-  const pivots = detectFractalPivots(dailyCloses, 2)
-  const resistanceLine = lastTimestamp ? fitTrendLineFromRecentPivots(pivots, 'high', lastTimestamp) : null
-  const supportLine = lastTimestamp ? fitTrendLineFromRecentPivots(pivots, 'low', lastTimestamp) : null
-  return { symbol, points, markers, position, rules, resistanceLine, supportLine, pivots }
+    cronLastTs == null ? yahooBarsRaw : yahooBarsRaw.filter((b) => b.timestamp <= cronLastTs)
+
+  // Yahoo bar を points にマージして全期間 price line を実現。同 timestamp で
+  // 既に cron-eval point があればそちらを優先 (indicators が乗っているため)。
+  // Yahoo bar 由来の point は indicators フィールド全 null。
+  const mergedPoints = mergeYahooAndCronPoints(yahooBars, points)
+  const lastTimestamp =
+    mergedPoints.length > 0 ? mergedPoints[mergedPoints.length - 1]!.timestamp : null
+
+  // pivot 検出窓: 直近 30 暦日に絞ることで regime shift (例: 04/22 SOXL 3x
+  // rally) を跨ぐ無意味な trend line を避ける。30 日内に純粋 pivot が出ない
+  // = 直近で swing 構造が無い = trend line 不適用 (連続上昇 / 下降フェーズ)
+  // が正しい挙動。
+  const PIVOT_WINDOW_DAYS = 30
+  const pivotCutoffMs = lastTimestamp
+    ? new Date(lastTimestamp).getTime() - PIVOT_WINDOW_DAYS * 24 * 3600 * 1000
+    : 0
+  const recentBars = yahooBars.filter((b) => new Date(b.timestamp).getTime() >= pivotCutoffMs)
+  const dailyCloses = recentBars.length >= 5 ? recentBars : aggregateDailyCloses(points)
+  const pivotsRaw = detectFractalPivots(dailyCloses, 2)
+  // regime filter: 現在価格の ±50% を超える pivot は別 regime (3x rally など)
+  // と判定して除外。「直近に類似する価格帯」の pivot だけ trend line に使う。
+  const currentPrice =
+    mergedPoints.length > 0 ? mergedPoints[mergedPoints.length - 1]!.price : null
+  const pivots =
+    currentPrice == null
+      ? pivotsRaw
+      : pivotsRaw.filter((pv) => pv.price >= currentPrice * 0.5 && pv.price <= currentPrice * 1.5)
+  const resistanceLine = lastTimestamp
+    ? fitTrendLineFromRecentPivots(pivots, 'high', lastTimestamp)
+    : null
+  const supportLine = lastTimestamp
+    ? fitTrendLineFromRecentPivots(pivots, 'low', lastTimestamp)
+    : null
+  return {
+    symbol,
+    points: mergedPoints,
+    markers,
+    position,
+    rules,
+    resistanceLine,
+    supportLine,
+    pivots,
+  }
+}
+
+/**
+ * Yahoo daily bars と cron-eval points をマージ。同 JST 日では cron-eval を
+ * 優先 (indicators が乗っているため)、それ以外の日は Yahoo bar を price-only
+ * の point として追加。timestamp 昇順で返す。
+ */
+export function mergeYahooAndCronPoints(
+  yahooBars: Array<{ jstDate: string; close: number; timestamp: string }>,
+  cronPoints: SymbolChartPoint[],
+): SymbolChartPoint[] {
+  const cronJstDates = new Set(
+    cronPoints
+      .map((p) => {
+        const ms = new Date(p.timestamp).getTime()
+        if (!Number.isFinite(ms)) return null
+        return new Date(ms + 9 * 3600 * 1000).toISOString().slice(0, 10)
+      })
+      .filter((d): d is string => d !== null),
+  )
+  const yahooFiller: SymbolChartPoint[] = yahooBars
+    .filter((b) => !cronJstDates.has(b.jstDate))
+    .map((b) => ({
+      timestamp: b.timestamp,
+      price: b.close,
+      sma50: null,
+      high20d: null,
+      low20d: null,
+    }))
+  return [...yahooFiller, ...cronPoints].sort((a, b) =>
+    a.timestamp < b.timestamp ? -1 : a.timestamp > b.timestamp ? 1 : 0,
+  )
 }
 
 /**
@@ -2081,7 +2148,9 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
         };
       });
 
-      // 保有中なら avg / stop / take-profit を水平 markLine。
+      // 保有中なら avg / stop / take-profit を markLine。openedAt から最新まで
+      // のみ描画 (chart 全幅に伸ばすと「ずっと前から avg だった」と誤読される)。
+      // ECharts markLine の data は [start, end] の 2 点配列で線分指定。
       var positionMarkLines = [];
       var extraYValues = [];
       if (sc.position) {
@@ -2089,10 +2158,21 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
         var stopPrice = avg * (1 + sc.rules.stopPct);
         var tpPrice = avg * (1 + sc.rules.takeProfitPct);
         extraYValues.push(avg, stopPrice, tpPrice);
+        var openedAt = sc.position.openedAt;
+        var endTs = sc.points.length > 0 ? sc.points[sc.points.length - 1].timestamp : openedAt;
         positionMarkLines = [
-          { yAxis: avg, lineStyle: { color: '#444', type: 'solid', width: 1 }, label: { formatter: 'avg ' + avg.toFixed(2), position: 'insideStartTop', color: '#444' } },
-          { yAxis: stopPrice, lineStyle: { color: '#c22', type: 'dashed', width: 1 }, label: { formatter: 'stop ' + stopPrice.toFixed(2) + ' (' + (sc.rules.stopPct * 100).toFixed(0) + '%)', position: 'insideStartBottom', color: '#c22' } },
-          { yAxis: tpPrice, lineStyle: { color: '#057a55', type: 'dashed', width: 1 }, label: { formatter: 'TP ' + tpPrice.toFixed(2) + ' (+' + (sc.rules.takeProfitPct * 100).toFixed(0) + '%)', position: 'insideStartTop', color: '#057a55' } },
+          [
+            { coord: [openedAt, avg], symbol: 'none', lineStyle: { color: '#444', type: 'solid', width: 1 }, label: { formatter: 'avg ' + avg.toFixed(2), position: 'start', color: '#444' } },
+            { coord: [endTs, avg], symbol: 'none' },
+          ],
+          [
+            { coord: [openedAt, stopPrice], symbol: 'none', lineStyle: { color: '#c22', type: 'dashed', width: 1 }, label: { formatter: 'stop ' + stopPrice.toFixed(2) + ' (' + (sc.rules.stopPct * 100).toFixed(0) + '%)', position: 'start', color: '#c22' } },
+            { coord: [endTs, stopPrice], symbol: 'none' },
+          ],
+          [
+            { coord: [openedAt, tpPrice], symbol: 'none', lineStyle: { color: '#057a55', type: 'dashed', width: 1 }, label: { formatter: 'TP ' + tpPrice.toFixed(2) + ' (+' + (sc.rules.takeProfitPct * 100).toFixed(0) + '%)', position: 'start', color: '#057a55' } },
+            { coord: [endTs, tpPrice], symbol: 'none' },
+          ],
         ];
       }
 

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -881,3 +881,60 @@ describe('fitTrendLineFromRecentPivots', () => {
     expect(fitTrendLineFromRecentPivots([high1, high2], 'high', 'not-an-iso')).toBe(null)
   })
 })
+
+import { mergeYahooAndCronPoints } from '../../src/routes/dashboard'
+
+describe('mergeYahooAndCronPoints', () => {
+  it('Yahoo bar の日が cron-eval にあれば cron 優先 (indicators 保持)', () => {
+    const yahoo = [
+      { jstDate: '2026-04-23', close: 100, timestamp: '2026-04-23T16:00:00.000Z' },
+      { jstDate: '2026-04-24', close: 105, timestamp: '2026-04-24T16:00:00.000Z' },
+    ]
+    const cron: SymbolChartPoint[] = [
+      { timestamp: '2026-04-24T05:00:00.000Z', price: 104, sma50: 90, high20d: 110, low20d: 80 }, // JST 04/24
+    ]
+    const merged = mergeYahooAndCronPoints(yahoo, cron)
+    // 04/23: Yahoo, 04/24: cron (preferred)
+    expect(merged.length).toBe(2)
+    expect(merged[0]!.price).toBe(100) // Yahoo
+    expect(merged[0]!.sma50).toBe(null)
+    expect(merged[1]!.price).toBe(104) // cron preferred
+    expect(merged[1]!.sma50).toBe(90)
+  })
+
+  it('Yahoo に無い cron eval は保持される', () => {
+    const yahoo = [{ jstDate: '2026-04-23', close: 100, timestamp: '2026-04-23T16:00:00.000Z' }]
+    const cron: SymbolChartPoint[] = [
+      { timestamp: '2026-04-25T05:00:00.000Z', price: 110, sma50: null, high20d: null, low20d: null },
+    ]
+    const merged = mergeYahooAndCronPoints(yahoo, cron)
+    expect(merged.length).toBe(2)
+    expect(merged.map((p) => p.price)).toEqual([100, 110])
+  })
+
+  it('timestamp 昇順でソート', () => {
+    const yahoo = [
+      { jstDate: '2026-04-25', close: 110, timestamp: '2026-04-25T16:00:00.000Z' },
+      { jstDate: '2026-04-23', close: 100, timestamp: '2026-04-23T16:00:00.000Z' },
+    ]
+    const merged = mergeYahooAndCronPoints(yahoo, [])
+    expect(merged.map((p) => p.timestamp)).toEqual([
+      '2026-04-23T16:00:00.000Z',
+      '2026-04-25T16:00:00.000Z',
+    ])
+  })
+
+  it('空入力は空', () => {
+    expect(mergeYahooAndCronPoints([], [])).toEqual([])
+  })
+
+  it('cron timestamp が不正でも crash せず Yahoo は保持', () => {
+    const yahoo = [{ jstDate: '2026-04-23', close: 100, timestamp: '2026-04-23T16:00:00.000Z' }]
+    const cron: SymbolChartPoint[] = [
+      { timestamp: 'not-an-iso', price: 110, sma50: null, high20d: null, low20d: null },
+    ]
+    const merged = mergeYahooAndCronPoints(yahoo, cron)
+    // Yahoo は残る (jstDate 集合に bad cron 由来は入らない)
+    expect(merged.some((p) => p.timestamp === '2026-04-23T16:00:00.000Z')).toBe(true)
+  })
+})

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -928,13 +928,19 @@ describe('mergeYahooAndCronPoints', () => {
     expect(mergeYahooAndCronPoints([], [])).toEqual([])
   })
 
-  it('cron timestamp が不正でも crash せず Yahoo は保持', () => {
+  it('不正 timestamp の cron point は merged からも除外される', () => {
     const yahoo = [{ jstDate: '2026-04-23', close: 100, timestamp: '2026-04-23T16:00:00.000Z' }]
     const cron: SymbolChartPoint[] = [
       { timestamp: 'not-an-iso', price: 110, sma50: null, high20d: null, low20d: null },
+      { timestamp: '2026-04-25T05:00:00.000Z', price: 120, sma50: null, high20d: null, low20d: null },
     ]
     const merged = mergeYahooAndCronPoints(yahoo, cron)
-    // Yahoo は残る (jstDate 集合に bad cron 由来は入らない)
-    expect(merged.some((p) => p.timestamp === '2026-04-23T16:00:00.000Z')).toBe(true)
+    // Yahoo は残る + 有効な cron (04/25) は残る + 不正 cron は完全に除外
+    expect(merged.length).toBe(2)
+    expect(merged.some((p) => p.timestamp === 'not-an-iso')).toBe(false)
+    expect(merged.map((p) => p.timestamp)).toEqual([
+      '2026-04-23T16:00:00.000Z',
+      '2026-04-25T05:00:00.000Z',
+    ])
   })
 })


### PR DESCRIPTION
## Summary

スクショ #14 で判明した 3 問題を解消。**SOXL のような 04/22 頃に 3x rally した銘柄で trend line が古い regime の pivot に anchor され意味不明な低位置に降りていた**のが直接の問題。

## A. price line を Yahoo 60 日で fill

\`mergeYahooAndCronPoints\`: 同 JST 日では **cron-eval を優先** (indicators 保持)、それ以外の日は **Yahoo bar を price-only point として追加** (sma50 等 null)。chart 全期間に price 線が連続するようになる。SMA50 / 押し目バンドは recent days のみ表示 (\`connectNulls: true\` で sparse 描画)。

## B. avg/stop/TP を保有期間限定の線分に

markLine データを \`[start, end]\` の coord ペアに変更。chart 全幅横線 → \`openedAt\` から最新まで限定の線分。**「ずっと avg だった」と誤読される問題**が解消。

## C. pivot 検出を 30 日窓 + 価格 ±50% regime filter

- pivot 検出は **直近 30 暦日**の Yahoo bar のみ対象 → regime shift 跨ぎ pivot を排除
- 検出 pivots を更に **現在価格の ±50% 範囲**で filter → 3x rally などの異 regime pivot を除外
- 結果: recent 30 日に純粋 pivot が無い銘柄 (連続上昇 / 下降中) は trend line 不適用 — これが正しい挙動 (swing 構造が無いのに直線を引いても無意味)

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm test\` (447 tests, +5 for mergeYahooAndCronPoints)
- [ ] staging で SOXL chart 確認:
  - 全 60 日の price line が連続描画される
  - avg/stop/TP 線が直近の保有期間 (≈ 04/24-25) のみに限定
  - SOXL は trend line 出ない (連続上昇 → swing 不在で正しい挙動)
- [ ] AAPL chart で位置トレンドラインがあれば描画確認 (rally なし銘柄)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## チャート・ダッシュボード改善

* **改善**
  * ポジションマーカー（平均約定価格、ストップ、テイクプロフィット）がポジション開始時刻から最新時刻までの区間として表示されるようになりました
  * Yahooの過去60日価格と既存評価ポイントを統合し、重複日は評価ポイントを優先する形で表示されます
  * サポート／レジスタンス検出が直近30日を基準に限定され、外れ値を抑えた線分検出が向上しました
* **テスト**
  * 統合ロジックの振る舞いを検証する自動テストが追加されました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->