### PR TITLE
feat(dashboard): 個別銘柄チャートに dataZoom slider + 銘柄跨ぎの URL 永続化

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -104,6 +104,11 @@ export const dashboard = new Hono<AppBindings>()
       }
       // tab === 'symbol'
       const symbolParam = c.req.query('symbol')?.toUpperCase().trim() || undefined
+      // ?from / ?to (ISO UTC) で chart x-axis のズーム範囲を URL に持つ。
+      // 銘柄切替を跨いで維持される (picker URL に伝搬)。dataZoom slider 操作で
+      // client 側が history.replaceState で URL を更新する。
+      const zoomFrom = parseIsoTimestamp(c.req.query('from'))
+      const zoomTo = parseIsoTimestamp(c.req.query('to'))
       const [universe, global] = await Promise.all([
         loadSymbolUniverse(c.env),
         loadGlobalConfigFrom(c.env),
@@ -141,6 +146,11 @@ export const dashboard = new Hono<AppBindings>()
       const symbolChart = focusSymbol
         ? await loadSymbolChart(c.env, focusSymbol, rules)
         : null
+      // zoom range の妥当性: from < to を保証、不整合なら null fallback
+      const zoom =
+        zoomFrom !== null && zoomTo !== null && zoomFrom < zoomTo
+          ? { from: zoomFrom, to: zoomTo }
+          : null
       return c.html(
         layout(
           'チャート',
@@ -150,6 +160,7 @@ export const dashboard = new Hono<AppBindings>()
             symbolChart,
             availableSymbols: universe.allowedSymbols,
             strategyParams,
+            zoom,
           }),
         ),
       )
@@ -1915,12 +1926,25 @@ export interface StrategyParamsSnapshot {
   kAtr: number
 }
 
+/**
+ * ISO UTC timestamp (例: "2026-04-15T00:00:00Z" / 末尾 Z 無し可) として
+ * パース可能なら Date を返し、不正なら null。Number.isFinite で防御。
+ */
+export function parseIsoTimestamp(raw: string | undefined): Date | null {
+  if (!raw || raw.trim() === '') return null
+  const d = new Date(raw)
+  if (!Number.isFinite(d.getTime())) return null
+  return d
+}
+
 interface ChartsBodySymbol {
   tab: 'symbol'
   focusSymbol: string | null
   symbolChart: SymbolChartData | null
   availableSymbols: string[]
   strategyParams: StrategyParamsSnapshot
+  /** dataZoom 初期範囲。null なら全期間 (full data) */
+  zoom: { from: Date; to: Date } | null
 }
 
 type ChartsBodyArgs = ChartsBodyOverview | ChartsBodyQuality | ChartsBodySymbol
@@ -2231,6 +2255,17 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
         }
       }
 
+      // dataZoom: 下部 slider + inside (wheel/pinch zoom)。初期 zoom 範囲は
+      // ?from / ?to URL params (data.zoomFromMs / zoomToMs)。zoom 操作時に
+      // history.replaceState で URL を更新 → 銘柄切替を跨いでも range を維持。
+      var dzInitial = data.zoomFromMs != null && data.zoomToMs != null
+        ? { startValue: data.zoomFromMs, endValue: data.zoomToMs }
+        : {};
+      var dataZoomCfg = [
+        Object.assign({ type: 'inside', xAxisIndex: 0 }, dzInitial),
+        Object.assign({ type: 'slider', xAxisIndex: 0, height: 24, bottom: 8 }, dzInitial),
+      ];
+
       var symChart = echarts.init(document.getElementById('symbol-chart'));
       symChart.setOption({
         title: { text: sc.symbol + ' price + トレンドライン + 押し目ゾーン + entry/exit', left: 'center', textStyle: { fontSize: 14 } },
@@ -2239,7 +2274,9 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
           axisPointer: { label: { formatter: function (p) { return jstLabel(p.value); } } },
         },
         legend: { top: 22, type: 'scroll' },
-        grid: { left: 60, right: 20, top: 60, bottom: 40 },
+        // bottom slider 用に grid.bottom を確保 (slider 24px + 余白)
+        grid: { left: 60, right: 20, top: 60, bottom: 64 },
+        dataZoom: dataZoomCfg,
         xAxis: { type: 'time', axisLabel: { formatter: function (value) { return jstLabel(value); } } },
         // showMinLabel/showMaxLabel: false で boundary label の異常表示を抑制。
         // ECharts で時々 yAxis の min/max 位置に巨大数字 ("7711183" 等) が
@@ -2298,12 +2335,37 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
         ],
       });
       window.addEventListener('resize', function () { symChart.resize(); });
+
+      // dataZoom 変更で URL の ?from / ?to を更新 (replaceState なので history
+      // 汚染なし)。debounce 200ms で連続操作中の URL flicker を抑制。
+      var dzTimer = null;
+      symChart.on('dataZoom', function () {
+        if (dzTimer) clearTimeout(dzTimer);
+        dzTimer = setTimeout(function () {
+          var opt = symChart.getOption();
+          var dz = opt.dataZoom && opt.dataZoom[0];
+          if (!dz) return;
+          var sv = dz.startValue;
+          var ev = dz.endValue;
+          if (sv == null || ev == null) return;
+          try {
+            var url = new URL(window.location.href);
+            url.searchParams.set('from', new Date(sv).toISOString());
+            url.searchParams.set('to', new Date(ev).toISOString());
+            window.history.replaceState({}, '', url.toString());
+          } catch (e) { /* noop */ }
+        }, 200);
+      });
     });
   `
   return `${renderSymbolPickerForTab(args)}
-  <div id="symbol-chart" style="width:100%;height:420px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;margin-top:12px"></div>
+  <div id="symbol-chart" style="width:100%;height:460px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;margin-top:12px"></div>
   ${renderStrategyParamsPanel(args.strategyParams)}
-  ${safeJsonScript('__chartData', { symbolChart: args.symbolChart })}
+  ${safeJsonScript('__chartData', {
+    symbolChart: args.symbolChart,
+    zoomFromMs: args.zoom ? args.zoom.from.getTime() : null,
+    zoomToMs: args.zoom ? args.zoom.to.getTime() : null,
+  })}
   <script src="${ECHARTS_CDN}" defer></script>
   <script>${initScript}</script>`
 }
@@ -2407,10 +2469,14 @@ export function renderStrategyParamsPanel(p: StrategyParamsSnapshot): string {
 
 function renderSymbolPickerForTab(args: ChartsBodySymbol): string {
   if (args.availableSymbols.length === 0) return ''
+  // 銘柄切替時にズーム範囲を維持するため、現在の from/to を picker URL に伝搬
+  const zoomQs = args.zoom
+    ? `&from=${encodeURIComponent(args.zoom.from.toISOString())}&to=${encodeURIComponent(args.zoom.to.toISOString())}`
+    : ''
   const opts = args.availableSymbols
     .map(
       (s) =>
-        `<a href="/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(s)}" style="margin-right:6px;${
+        `<a href="/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(s)}${zoomQs}" style="margin-right:6px;${
           s === args.focusSymbol ? 'font-weight:600;text-decoration:underline' : ''
         }">${esc(s)}</a>`,
     )

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1927,12 +1927,21 @@ export interface StrategyParamsSnapshot {
 }
 
 /**
- * ISO UTC timestamp (例: "2026-04-15T00:00:00Z" / 末尾 Z 無し可) として
- * パース可能なら Date を返し、不正なら null。Number.isFinite で防御。
+ * ISO UTC timestamp (例: "2026-04-15T00:00:00Z") をパースして Date を返す。
+ * timezone marker (末尾 Z または ±HH:MM offset) が無い datetime 文字列は
+ * `new Date` だと local time 扱いになり (JST runner で意図しないシフト)、
+ * JSDoc の "UTC timestamp" 約束に違反する。`T` を含むのに tz が無ければ
+ * `Z` を補って UTC と解釈させる。date-only ("2026-04-15") は ECMAScript
+ * 仕様で既に UTC 解釈なので変更不要。
  */
 export function parseIsoTimestamp(raw: string | undefined): Date | null {
   if (!raw || raw.trim() === '') return null
-  const d = new Date(raw)
+  let s = raw.trim()
+  const hasTz = /[Zz]$|[+-]\d{2}:?\d{2}$/.test(s)
+  if (s.includes('T') && !hasTz) {
+    s = `${s}Z`
+  }
+  const d = new Date(s)
   if (!Number.isFinite(d.getTime())) return null
   return d
 }
@@ -2338,6 +2347,8 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
 
       // dataZoom 変更で URL の ?from / ?to を更新 (replaceState なので history
       // 汚染なし)。debounce 200ms で連続操作中の URL flicker を抑制。
+      // 同時に symbol picker / tab strip の '?tab=symbol' リンクの href も
+      // 上書き → 銘柄切替で zoom が古い range に reset されない。
       var dzTimer = null;
       symChart.on('dataZoom', function () {
         if (dzTimer) clearTimeout(dzTimer);
@@ -2349,10 +2360,23 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
           var ev = dz.endValue;
           if (sv == null || ev == null) return;
           try {
+            var fromIso = new Date(sv).toISOString();
+            var toIso = new Date(ev).toISOString();
             var url = new URL(window.location.href);
-            url.searchParams.set('from', new Date(sv).toISOString());
-            url.searchParams.set('to', new Date(ev).toISOString());
+            url.searchParams.set('from', fromIso);
+            url.searchParams.set('to', toIso);
             window.history.replaceState({}, '', url.toString());
+            // server-render 時の picker / tab strip リンクは古い from/to を
+            // 持っているので、ここで href を新値に書き換える。
+            var symbolLinks = document.querySelectorAll('a[href*="tab=symbol"]');
+            for (var i = 0; i < symbolLinks.length; i += 1) {
+              try {
+                var linkUrl = new URL(symbolLinks[i].href);
+                linkUrl.searchParams.set('from', fromIso);
+                linkUrl.searchParams.set('to', toIso);
+                symbolLinks[i].href = linkUrl.toString();
+              } catch (e) { /* noop per-link */ }
+            }
           } catch (e) { /* noop */ }
         }, 200);
       });

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -954,8 +954,21 @@ describe('parseIsoTimestamp', () => {
     expect(d!.toISOString()).toBe('2026-04-25T13:00:00.000Z')
   })
 
-  it('Z 無し ISO も valid', () => {
-    expect(parseIsoTimestamp('2026-04-25T13:00:00')).not.toBeNull()
+  it('Z 無し ISO は UTC と解釈 (local time として 9 時間ずれない)', () => {
+    const d = parseIsoTimestamp('2026-04-25T13:00:00')
+    expect(d).not.toBeNull()
+    // runner の TZ に関わらず UTC 13:00 として解釈される
+    expect(d!.toISOString()).toBe('2026-04-25T13:00:00.000Z')
+  })
+
+  it('±HH:MM offset 付き ISO は offset 通り解釈', () => {
+    const d = parseIsoTimestamp('2026-04-25T13:00:00+09:00')
+    expect(d!.toISOString()).toBe('2026-04-25T04:00:00.000Z')
+  })
+
+  it('date-only 文字列は ECMAScript 仕様で UTC 解釈', () => {
+    const d = parseIsoTimestamp('2026-04-25')
+    expect(d!.toISOString()).toBe('2026-04-25T00:00:00.000Z')
   })
 
   it('undefined / 空文字列 / 空白は null', () => {

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -944,3 +944,35 @@ describe('mergeYahooAndCronPoints', () => {
     ])
   })
 })
+
+import { parseIsoTimestamp } from '../../src/routes/dashboard'
+
+describe('parseIsoTimestamp', () => {
+  it('valid ISO UTC は Date を返す', () => {
+    const d = parseIsoTimestamp('2026-04-25T13:00:00.000Z')
+    expect(d).not.toBeNull()
+    expect(d!.toISOString()).toBe('2026-04-25T13:00:00.000Z')
+  })
+
+  it('Z 無し ISO も valid', () => {
+    expect(parseIsoTimestamp('2026-04-25T13:00:00')).not.toBeNull()
+  })
+
+  it('undefined / 空文字列 / 空白は null', () => {
+    expect(parseIsoTimestamp(undefined)).toBeNull()
+    expect(parseIsoTimestamp('')).toBeNull()
+    expect(parseIsoTimestamp('   ')).toBeNull()
+  })
+
+  it('壊れた文字列は null', () => {
+    expect(parseIsoTimestamp('not-an-iso')).toBeNull()
+    expect(parseIsoTimestamp('2026-99-99')).toBeNull()
+  })
+
+  it('数字のみ文字列は invalid (Date は ISO format string のみ accept)', () => {
+    // new Date('1777705200000') は Invalid Date。URL から数字の timestamp ms を
+    // 渡されても reject される (ISO format でないので意図的)。client 側は
+    // 必ず ISO で URL を更新するので運用上問題なし。
+    expect(parseIsoTimestamp('1777705200000')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

スクショ #15 の「60 日 chart は範囲が広すぎて pin / SMA50 / 押し目バンドが見えづらい」要望に対応。

## ECharts dataZoom 二重構成

| component | 操作 |
|---|---|
| **inside** (\`xAxisIndex: 0\`) | chart 内マウスホイール / トラックパッド ピンチで zoom |
| **slider** (\`bottom: 8, height: 24\`) | 下部 slider UI、ハンドル drag で from/to 調整 |

両方とも \`xAxisIndex: 0\` で連動。\`grid.bottom\` を 64px に拡張、chart 高さも 460px に微増。

## URL params 永続化 (\`?from\` / \`?to\`)

- **server**: \`parseIsoTimestamp(c.req.query('from'/'to'))\` で zoom 初期範囲を decode、\`from < to\` validate
- **payload**: \`__chartData\` に \`zoomFromMs\` / \`zoomToMs\` (epoch ms) を載せ、client 側 \`dataZoom.startValue/endValue\` に反映
- **client**: \`symChart.on('dataZoom', ...)\` で \`history.replaceState\` に \`?from=ISO&to=ISO\` を書込 (debounce 200ms)

## 銘柄切替を跨ぐ zoom 維持

\`renderSymbolPickerForTab\` の各 symbol リンクに \`?from\` / \`?to\` を伝搬。URL 経由で server に渡る → 同じ初期 zoom で render される。**bookmark / share で現状再現可能**。

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm test\` (452 tests, +5 for parseIsoTimestamp)
- [ ] staging で確認:
  - 下部 slider で範囲を絞ると chart が zoom される
  - URL bar に \`?from=...&to=...\` が更新される (200ms 後)
  - 銘柄を SOXL → AAPL に切り替えると同じ範囲で表示される
  - URL bookmark で同じ zoom が再現する

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * チャートのズーム範囲をURLパラメータで指定・維持できるようになりました（表示の初期化、シンボル切替時の保持、表示領域の調整を含む）。
  * チャート表示のUI調整（ズームスライダーの追加とレイアウト/高さの最適化）を行いました。

* **テスト**
  * 日付/時刻パラメータの解析と検証を網羅するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->