### PR TITLE
feat(dashboard): 個別銘柄チャート default zoom を直近 7 日に変更

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -146,11 +146,12 @@ export const dashboard = new Hono<AppBindings>()
       const symbolChart = focusSymbol
         ? await loadSymbolChart(c.env, focusSymbol, rules)
         : null
-      // zoom range の妥当性: from < to を保証、不整合なら null fallback
-      const zoom =
-        zoomFrom !== null && zoomTo !== null && zoomFrom < zoomTo
-          ? { from: zoomFrom, to: zoomTo }
-          : null
+      // zoom range: ?from / ?to が valid (from < to) ならそれを使う、なければ
+      // chart の最終 point から逆算で「直近 7 日」をデフォルト。理由:
+      // - 60 日全体表示は trend / pin / SMA50 が見えづらい (#15 で指摘)
+      // - 7 日は cron / 押し目 / 直近 fill 確認に最適な daily-trader の窓
+      // - lastTimestamp 基準なので休場や POC 開始直後でも broken にならない
+      const zoom = computeZoomRange(zoomFrom, zoomTo, symbolChart)
       return c.html(
         layout(
           'チャート',
@@ -1944,6 +1945,36 @@ export function parseIsoTimestamp(raw: string | undefined): Date | null {
   const d = new Date(s)
   if (!Number.isFinite(d.getTime())) return null
   return d
+}
+
+/** chart の zoom 初期 window 既定: 直近 7 日 (UI で zoom 操作可能) */
+export const DEFAULT_ZOOM_WINDOW_MS = 7 * 24 * 3600 * 1000
+
+/**
+ * chart x-axis の zoom 範囲を決める:
+ * 1. URL params (zoomFrom / zoomTo) が valid (from < to) → それを採用
+ * 2. URL に無い + chart に points がある → 直近 7 日 (lastTimestamp - 7d ～ lastTimestamp)
+ * 3. それ以外 (chart 自体空) → null (= 全体表示 / no zoom)
+ *
+ * lastTimestamp 基準なので、休場日や POC 開始直後で `now()` 基準が data
+ * 範囲外になるケースでも broken にならない。
+ */
+export function computeZoomRange(
+  zoomFrom: Date | null,
+  zoomTo: Date | null,
+  chart: SymbolChartData | null,
+): { from: Date; to: Date } | null {
+  if (zoomFrom !== null && zoomTo !== null && zoomFrom < zoomTo) {
+    return { from: zoomFrom, to: zoomTo }
+  }
+  if (!chart || chart.points.length === 0) return null
+  const lastPoint = chart.points[chart.points.length - 1]!
+  const lastMs = new Date(lastPoint.timestamp).getTime()
+  if (!Number.isFinite(lastMs)) return null
+  return {
+    from: new Date(lastMs - DEFAULT_ZOOM_WINDOW_MS),
+    to: new Date(lastMs),
+  }
 }
 
 interface ChartsBodySymbol {

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -989,3 +989,70 @@ describe('parseIsoTimestamp', () => {
     expect(parseIsoTimestamp('1777705200000')).toBeNull()
   })
 })
+
+import { computeZoomRange, DEFAULT_ZOOM_WINDOW_MS, type SymbolChartData } from '../../src/routes/dashboard'
+
+describe('computeZoomRange', () => {
+  function fakeChart(lastTs: string): SymbolChartData {
+    return {
+      symbol: 'X',
+      points: [{ timestamp: lastTs, price: 100, sma50: null, high20d: null, low20d: null }],
+      markers: [],
+      position: null,
+      rules: { pullbackMax: 0, pullbackMin: 0, stopPct: 0, takeProfitPct: 0, timeStopDays: 10 },
+      resistanceLine: null,
+      supportLine: null,
+      pivots: [],
+    }
+  }
+
+  it('valid URL params なら from < to をそのまま採用', () => {
+    const from = new Date('2026-04-15T00:00:00Z')
+    const to = new Date('2026-04-22T00:00:00Z')
+    const out = computeZoomRange(from, to, null)
+    expect(out).toEqual({ from, to })
+  })
+
+  it('URL params 無 + points 有 → lastTimestamp 基準で直近 7 日', () => {
+    const chart = fakeChart('2026-04-25T00:00:00Z')
+    const out = computeZoomRange(null, null, chart)
+    expect(out).not.toBeNull()
+    expect(out!.to.toISOString()).toBe('2026-04-25T00:00:00.000Z')
+    // 7 日前 = 2026-04-18
+    expect(out!.from.getTime()).toBe(out!.to.getTime() - DEFAULT_ZOOM_WINDOW_MS)
+    expect(out!.from.toISOString()).toBe('2026-04-18T00:00:00.000Z')
+  })
+
+  it('from >= to (不整合) は default 7 日にフォールバック', () => {
+    const chart = fakeChart('2026-04-25T00:00:00Z')
+    const reversedFrom = new Date('2026-04-25T00:00:00Z')
+    const reversedTo = new Date('2026-04-15T00:00:00Z')
+    const out = computeZoomRange(reversedFrom, reversedTo, chart)
+    expect(out).not.toBeNull()
+    expect(out!.from.toISOString()).toBe('2026-04-18T00:00:00.000Z')
+  })
+
+  it('chart が null でも params あれば valid', () => {
+    const from = new Date('2026-04-15T00:00:00Z')
+    const to = new Date('2026-04-22T00:00:00Z')
+    expect(computeZoomRange(from, to, null)).toEqual({ from, to })
+  })
+
+  it('chart 空 + params 無 → null (zoom なし)', () => {
+    expect(computeZoomRange(null, null, null)).toBeNull()
+  })
+
+  it('points 配列空 + params 無 → null', () => {
+    const chart: SymbolChartData = {
+      symbol: 'X', points: [], markers: [], position: null,
+      rules: { pullbackMax: 0, pullbackMin: 0, stopPct: 0, takeProfitPct: 0, timeStopDays: 10 },
+      resistanceLine: null, supportLine: null, pivots: [],
+    }
+    expect(computeZoomRange(null, null, chart)).toBeNull()
+  })
+
+  it('lastPoint timestamp 不正 → null (defensive)', () => {
+    const chart = fakeChart('not-an-iso')
+    expect(computeZoomRange(null, null, chart)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

URL params (\`?from\` / \`?to\`) が無い時の chart 初期表示窓を **直近 7 日** に変更。dataZoom slider は維持なので任意期間にズーム可能。

## Why

- 60 日全体表示は pin / SMA50 / 押し目バンドが見えづらい (#15 ユーザ指摘)
- 7 日は cron 直近 / 押し目 / 直近 fill 確認に最適な daily-trader 窓
- \`lastTimestamp\` 基準なので休場日 / POC 開始直後で \`now()\` 基準が data 範囲外になるケースでも broken にならない

## 実装

\`computeZoomRange(zoomFrom, zoomTo, chart)\` を新規抽出。優先順位:

| # | 条件 | 結果 |
|---|---|---|
| 1 | URL params が valid (from < to) | それを採用 |
| 2 | points あり | \`lastTimestamp - 7d ～ lastTimestamp\` |
| 3 | chart 空 | null (no zoom = 全体表示) |

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm test\` (461 tests, +7 for computeZoomRange)
- [ ] staging で確認:
  - 初期 \`/dashboard/charts?tab=symbol&symbol=SOXL\` で 7 日窓表示
  - slider で全 60 日展開可能
  - URL params 付き bookmark でその range 復元
  - 銘柄切替で zoom 維持

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * シンボルチャートのズーム機能をより堅牢に改善しました。URLパラメータが無い場合や無効な場合、デフォルトで直近7日間のウィンドウを自動表示するようになりました。チャートデータがない場合の処理も最適化されています。

* **テスト**
  * ズーム範囲選択ロジックの包括的なユニットテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->