### PR TITLE
feat(dashboard): 個別銘柄チャートを candlestick (OHLC) に置換

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1499,6 +1499,16 @@ export interface TrendLineSegment {
   end: { timestamp: string; price: number }
 }
 
+/** 日次 OHLC (Yahoo daily bars 由来)、candlestick 描画用 */
+export interface DailyOhlcBar {
+  /** ISO UTC: `YYYY-MM-DDT16:00:00Z` (≈ JST 翌 1:00 ≈ "evening of date") */
+  timestamp: string
+  open: number
+  high: number
+  low: number
+  close: number
+}
+
 export interface SymbolChartData {
   symbol: string
   points: SymbolChartPoint[]
@@ -1511,6 +1521,8 @@ export interface SymbolChartData {
   supportLine: TrendLineSegment | null
   /** 検出された swing pivots (chart 上の小さな丸で表示する想定) */
   pivots: PivotPoint[]
+  /** Yahoo 日次 OHLC、candlestick 描画用 (空配列 = Yahoo fetch 失敗) */
+  dailyBars: DailyOhlcBar[]
 }
 
 /**
@@ -1645,6 +1657,15 @@ export async function loadSymbolChart(
   const supportLine = lastTimestamp
     ? fitTrendLineFromRecentPivots(pivots, 'low', lastTimestamp)
     : null
+  // candlestick: Yahoo bars (lastTimestamp フィルタ済) を OHLC 形に成形。
+  // pivot 検出と違い regime / window 制限は不要 (chart 全期間表示)。
+  const dailyBars: DailyOhlcBar[] = yahooBars.map((b) => ({
+    timestamp: b.timestamp,
+    open: b.open,
+    high: b.high,
+    low: b.low,
+    close: b.close,
+  }))
   return {
     symbol,
     points: mergedPoints,
@@ -1654,6 +1675,7 @@ export async function loadSymbolChart(
     resistanceLine,
     supportLine,
     pivots,
+    dailyBars,
   }
 }
 
@@ -1702,12 +1724,15 @@ export function mergeYahooAndCronPoints(
 export async function fetchYahooBarsForChart(
   symbol: string,
   lookback: number,
-): Promise<Array<{ jstDate: string; close: number; timestamp: string }>> {
+): Promise<Array<{ jstDate: string; open: number; high: number; low: number; close: number; timestamp: string }>> {
   const client = new YahooBarClient()
   try {
     const bars = await client.getDailyBars(symbol, lookback)
     return bars.map((b) => ({
       jstDate: b.date,
+      open: b.open,
+      high: b.high,
+      low: b.low,
       close: b.close,
       timestamp: `${b.date}T16:00:00.000Z`,
     }))
@@ -2160,8 +2185,12 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
       }
 
       // [timestamp, value] のペアで time axis に渡す。null は connectNulls/sparse に。
-      var pricesXY = sc.points.map(function (p) { return [p.timestamp, p.price]; });
       var smasXY = sc.points.map(function (p) { return p.sma50 == null ? [p.timestamp, null] : [p.timestamp, p.sma50]; });
+      // candlestick の data shape: [timestamp, open, close, low, high]
+      // (ECharts 標準順序、Western 規約 OHLC とは順番違うので注意)。
+      var ohlcXY = (sc.dailyBars || []).map(function (b) {
+        return [b.timestamp, b.open, b.close, b.low, b.high];
+      });
 
       // 押し目買いゾーン:
       // - 上端 = high20d × (1 + pullbackMax)  ≒ 教科書の「上値抵抗線 (resistance)」
@@ -2272,6 +2301,10 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
         }
         pushIfFinite(p.low20d);
       });
+      (sc.dailyBars || []).forEach(function (b) {
+        pushIfFinite(b.high);
+        pushIfFinite(b.low);
+      });
       if (sc.resistanceLine) {
         pushIfFinite(sc.resistanceLine.pivots[0].price);
         pushIfFinite(sc.resistanceLine.pivots[1].price);
@@ -2350,13 +2383,21 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
             name: 'swing low', type: 'scatter', data: pivotLowDots,
             symbolSize: 6, itemStyle: { color: '#c22', borderColor: '#fff', borderWidth: 1 }, z: 4,
           }] : []),
-          { name: 'price', type: 'line', data: pricesXY, lineStyle: { width: 1.5, color: '#1471a8' }, symbol: 'none', z: 5,
+          // candlestick: 日次 OHLC を表示。Western 規約 (close >= open = 緑、
+          // close < open = 赤)。markPoint / markLine もここに anchor。
+          // ohlcXY が空なら series 自体をスキップ (Yahoo fetch 失敗時の保険)。
+          ...(ohlcXY.length > 0 ? [{
+            name: 'price (OHLC)', type: 'candlestick', data: ohlcXY,
+            itemStyle: {
+              color: '#057a55',     // bullish (close >= open)
+              color0: '#c22',       // bearish (close < open)
+              borderColor: '#057a55',
+              borderColor0: '#c22',
+            },
+            z: 5,
             markLine: positionMarkLines.length > 0 ? { silent: true, symbol: 'none', data: positionMarkLines } : undefined,
             markPoint: entries.length + exits.length > 0 ? {
               symbol: 'pin', symbolSize: 24, data: entries.concat(exits),
-              // 個別 pin hover で full-precision の realized PnL / qty / 時刻を
-              // 表示。label は短縮表記なので、ここで補完情報を出す。
-              // 親 tooltip の trigger:'axis' に上書きされないよう trigger:'item'。
               tooltip: {
                 trigger: 'item',
                 formatter: function (p) {
@@ -2370,7 +2411,7 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
                 },
               },
             } : undefined,
-          },
+          }] : []),
           { name: 'SMA50', type: 'line', data: smasXY, lineStyle: { width: 1, color: '#888', type: 'dashed' }, symbol: 'none', connectNulls: true, z: 2 },
         ],
       });

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1734,7 +1734,11 @@ export async function fetchYahooBarsForChart(
       high: b.high,
       low: b.low,
       close: b.close,
-      timestamp: `${b.date}T16:00:00.000Z`,
+      // JST 00:00 anchor: ECharts time axis (UTC) で JST formatter にかけると
+      // b.date と同じ JST カレンダー日に column が配置される。
+      // 旧実装 `${b.date}T16:00Z` だと JST 翌 01:00 に shift し、
+      // 例えば US bar "04/25" が JST 04/26 列に表示される回帰があった。
+      timestamp: anchorJstMidnight(b.date),
     }))
   } catch (err) {
     // RangeError は呼出元コード側の lookback 不正 (実装ミス)。silent fallback で
@@ -1742,6 +1746,15 @@ export async function fetchYahooBarsForChart(
     if (err instanceof RangeError) throw err
     return []
   }
+}
+
+/**
+ * "YYYY-MM-DD" を「その日の JST 00:00 = UTC -9h 前日 15:00」の ISO Z 文字列に。
+ * 例: "2026-04-25" → "2026-04-24T15:00:00.000Z" (JST 04/25 00:00)。
+ * Yahoo bar / 他のロジックとの timestamp 比較を Z 形式で揃えるため。
+ */
+export function anchorJstMidnight(date: string): string {
+  return new Date(`${date}T00:00:00+09:00`).toISOString()
 }
 
 /**

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -1003,6 +1003,7 @@ describe('computeZoomRange', () => {
       resistanceLine: null,
       supportLine: null,
       pivots: [],
+      dailyBars: [],
     }
   }
 
@@ -1046,7 +1047,7 @@ describe('computeZoomRange', () => {
     const chart: SymbolChartData = {
       symbol: 'X', points: [], markers: [], position: null,
       rules: { pullbackMax: 0, pullbackMin: 0, stopPct: 0, takeProfitPct: 0, timeStopDays: 10 },
-      resistanceLine: null, supportLine: null, pivots: [],
+      resistanceLine: null, supportLine: null, pivots: [], dailyBars: [],
     }
     expect(computeZoomRange(null, null, chart)).toBeNull()
   })

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -1057,3 +1057,29 @@ describe('computeZoomRange', () => {
     expect(computeZoomRange(null, null, chart)).toBeNull()
   })
 })
+
+import { anchorJstMidnight } from '../../src/routes/dashboard'
+
+describe('anchorJstMidnight', () => {
+  it('YYYY-MM-DD を JST 00:00 に anchor して ISO Z を返す', () => {
+    // JST 04/25 00:00 = UTC 04/24 15:00
+    expect(anchorJstMidnight('2026-04-25')).toBe('2026-04-24T15:00:00.000Z')
+  })
+
+  it('JST formatter (Asia/Tokyo) でレンダリングすると同じ b.date 日に表示される', () => {
+    const iso = anchorJstMidnight('2026-04-25')
+    const fmt = new Intl.DateTimeFormat('en-CA', {
+      timeZone: 'Asia/Tokyo',
+      year: 'numeric', month: '2-digit', day: '2-digit',
+    })
+    expect(fmt.format(new Date(iso))).toBe('2026-04-25')
+  })
+
+  it('複数日の anchor は時系列順にソート可能 (lexical = chronological)', () => {
+    const a = anchorJstMidnight('2026-04-23')
+    const b = anchorJstMidnight('2026-04-24')
+    const c = anchorJstMidnight('2026-04-25')
+    expect(a < b).toBe(true)
+    expect(b < c).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Yahoo daily bars は full OHLC を返しているが、これまで \`close\` だけ使って line 表示していた。**データは既にあった**ので candlestick に置換。

## 変更

| 箇所 | 内容 |
|---|---|
| \`fetchYahooBarsForChart\` | 戻り値に \`open / high / low\` を追加 |
| \`SymbolChartData.dailyBars\` (新規) | \`DailyOhlcBar[]\` を server-side で生成 |
| chart series \`price\` | \`type: 'line'\` → \`type: 'candlestick'\` |
| 配色 | 緑 (close ≥ open = bullish) / 赤 (bearish) の Western 規約 |
| markPoint / markLine | candlestick series に anchor |
| yAxis range | \`b.high\` / \`b.low\` を含めた上下 padding |

## トレードオフ

- 当日 intraday cron-eval (15-min granularity) は捨てた → daily 表示に統一
- 過去ヒゲが見えるようになり、押し目バンド / トレンドライン との位置関係が明確
- markPoint は引き続き fill 時刻 (秒精度) で配置されるので pin 位置は正確
- Yahoo fetch 失敗時は \`ohlcXY: []\` で series 自体を skip (保険)

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm test\` (461 tests, fixtures 2 箇所更新)
- [ ] staging で SOXL chart 確認:
  - 過去 60 日が candlestick で描画 (緑 / 赤)
  - SMA50 / 押し目バンド / トレンドライン / pivot ドットがそのまま重畳
  - BUY/SELL pin が candlestick 上に配置
  - avg/stop/TP markLine が保有期間に限定
  - dataZoom slider で範囲調整

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * シンボルチャートに日次OHLCローソク足表示を追加しました。Yahooデータが取得できない場合はローソク足を表示しません。
* **改善**
  * チャートのY軸スケーリングを調整し、ローソク足と指標が見切れないよう最適化しました。
  * 日付タイムスタンプを日本標準時の深夜基準で正規化して一貫した日次表示を実現しました。
* **テスト**
  * 日次タイムスタンプと表示順序を検証するテストを追加・更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->