### PR TITLE
feat(dashboard): 15 分足 candlestick + price line 共存

### DIFF
--- a/src/infrastructure/quotes/YahooBarClient.ts
+++ b/src/infrastructure/quotes/YahooBarClient.ts
@@ -118,6 +118,89 @@ export class YahooBarClient implements BarClient {
     const bars = normalizeYahooChart(json, lookback)
     return bars
   }
+
+  /**
+   * 15 分足 (またはその他 intraday) bars を取得。Yahoo `interval=15m` の
+   * range 上限は 60d。dashboard chart の candlestick / 短期 trend 可視化用。
+   * trend / SMA50 等の indicator は引き続き daily で計算するので getDailyBars
+   * と用途を分ける。timestamp は ISO UTC (秒精度)。
+   */
+  async getIntradayBars(symbol: string, interval: IntradayInterval): Promise<IntradayBar[]> {
+    const yahooSymbol = toYahooSymbol(symbol)
+    const url = new URL(`/v8/finance/chart/${encodeURIComponent(yahooSymbol)}`, this.baseUrl)
+    url.searchParams.set('interval', interval)
+    url.searchParams.set('range', '60d')
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs)
+    let response: Response
+    try {
+      response = await this.fetchFn(url.href, {
+        method: 'GET',
+        headers: { Accept: 'application/json', 'User-Agent': this.userAgent },
+        signal: controller.signal,
+      })
+    } catch (error) {
+      throw new BrokerRequestError(
+        `Yahoo intraday bar fetch failed: ${error instanceof Error ? error.message : String(error)}`,
+        `GET /v8/finance/chart/${yahooSymbol}?interval=${interval}`,
+        { cause: error instanceof Error ? error : undefined },
+      )
+    } finally {
+      clearTimeout(timeoutId)
+    }
+    if (!response.ok) {
+      throw brokerErrorForStatus(
+        response.status,
+        `Yahoo intraday bar request failed with status ${response.status}`,
+        `GET /v8/finance/chart/${yahooSymbol}?interval=${interval}`,
+      )
+    }
+    const json = (await response.json()) as YahooChartResponse
+    return normalizeIntradayChart(json)
+  }
+}
+
+export type IntradayInterval = '5m' | '15m' | '30m' | '60m'
+
+export interface IntradayBar {
+  /** ISO UTC timestamp (Yahoo は epoch second を返す → ms 化して toISOString) */
+  timestamp: string
+  open: number
+  high: number
+  low: number
+  close: number
+}
+
+/**
+ * Intraday 用 normalize。daily と違い `slice(-lookback)` の trim は不要
+ * (Yahoo intraday は元から 60d 程度なので)。timestamp は秒精度 ISO UTC を保持。
+ */
+function normalizeIntradayChart(json: YahooChartResponse): IntradayBar[] {
+  const result = json.chart?.result?.[0]
+  const timestamps = result?.timestamp
+  const q = result?.indicators?.quote?.[0]
+  if (!timestamps || !q) return []
+  const opens = q.open ?? []
+  const highs = q.high ?? []
+  const lows = q.low ?? []
+  const closes = q.close ?? []
+  const bars: IntradayBar[] = []
+  for (let i = 0; i < timestamps.length; i += 1) {
+    const open = opens[i]
+    const high = highs[i]
+    const low = lows[i]
+    const close = closes[i]
+    if (!isPositiveFinite(open) || !isPositiveFinite(high) || !isPositiveFinite(low) || !isPositiveFinite(close)) {
+      continue
+    }
+    if (low > high) continue
+    const ts = timestamps[i]
+    if (typeof ts !== 'number' || !Number.isFinite(ts)) continue
+    const timestamp = new Date(ts * 1000).toISOString()
+    bars.push({ timestamp, open, high, low, close })
+  }
+  bars.sort((a, b) => (a.timestamp < b.timestamp ? -1 : a.timestamp > b.timestamp ? 1 : 0))
+  return bars
 }
 
 /**

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1499,9 +1499,9 @@ export interface TrendLineSegment {
   end: { timestamp: string; price: number }
 }
 
-/** 日次 OHLC (Yahoo daily bars 由来)、candlestick 描画用 */
-export interface DailyOhlcBar {
-  /** ISO UTC: `YYYY-MM-DDT16:00:00Z` (≈ JST 翌 1:00 ≈ "evening of date") */
+/** 15 分足 OHLC (Yahoo intraday bars 由来)、candlestick 描画用 */
+export interface OhlcBar {
+  /** ISO UTC (Yahoo intraday は秒精度の bar 開始時刻) */
   timestamp: string
   open: number
   high: number
@@ -1522,7 +1522,7 @@ export interface SymbolChartData {
   /** 検出された swing pivots (chart 上の小さな丸で表示する想定) */
   pivots: PivotPoint[]
   /** Yahoo 日次 OHLC、candlestick 描画用 (空配列 = Yahoo fetch 失敗) */
-  dailyBars: DailyOhlcBar[]
+  intradayBars: OhlcBar[]
 }
 
 /**
@@ -1657,15 +1657,28 @@ export async function loadSymbolChart(
   const supportLine = lastTimestamp
     ? fitTrendLineFromRecentPivots(pivots, 'low', lastTimestamp)
     : null
-  // candlestick: Yahoo bars (lastTimestamp フィルタ済) を OHLC 形に成形。
-  // pivot 検出と違い regime / window 制限は不要 (chart 全期間表示)。
-  const dailyBars: DailyOhlcBar[] = yahooBars.map((b) => ({
-    timestamp: b.timestamp,
-    open: b.open,
-    high: b.high,
-    low: b.low,
-    close: b.close,
-  }))
+  // candlestick: 15 分足 (intraday) を Yahoo から fetch。daily より細かい
+  // 動きが見える + cron が 15 分間隔で動くのと cadence が一致。失敗 (network /
+  // Yahoo intraday range 制限など) なら空配列で line だけ表示にフォールバック。
+  let intradayBars: OhlcBar[] = []
+  try {
+    const intraday = await new YahooBarClient().getIntradayBars(symbol, '15m')
+    // lastTimestamp フィルタ: chart x 軸範囲を超える bar (将来に出るはずの bar)
+    // を除外。lastTimestamp が無いときは全件採用。
+    intradayBars = (cronLastTs == null
+      ? intraday
+      : intraday.filter((b) => b.timestamp <= cronLastTs)
+    ).map((b) => ({
+      timestamp: b.timestamp,
+      open: b.open,
+      high: b.high,
+      low: b.low,
+      close: b.close,
+    }))
+  } catch (err) {
+    if (err instanceof RangeError) throw err
+    // network / parse error → 空 fallback
+  }
   return {
     symbol,
     points: mergedPoints,
@@ -1675,7 +1688,7 @@ export async function loadSymbolChart(
     resistanceLine,
     supportLine,
     pivots,
-    dailyBars,
+    intradayBars: intradayBars,
   }
 }
 
@@ -2201,9 +2214,14 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
       var smasXY = sc.points.map(function (p) { return p.sma50 == null ? [p.timestamp, null] : [p.timestamp, p.sma50]; });
       // candlestick の data shape: [timestamp, open, close, low, high]
       // (ECharts 標準順序、Western 規約 OHLC とは順番違うので注意)。
-      var ohlcXY = (sc.dailyBars || []).map(function (b) {
+      var ohlcXY = (sc.intradayBars || []).map(function (b) {
         return [b.timestamp, b.open, b.close, b.low, b.high];
       });
+      // price line: candle と共存する読みやすい close-trace。intraday bar が
+      // あれば close を、無ければ cron-eval mergedPoints の price を採用。
+      var priceLineXY = (sc.intradayBars && sc.intradayBars.length > 0)
+        ? sc.intradayBars.map(function (b) { return [b.timestamp, b.close]; })
+        : sc.points.map(function (p) { return [p.timestamp, p.price]; });
 
       // 押し目買いゾーン:
       // - 上端 = high20d × (1 + pullbackMax)  ≒ 教科書の「上値抵抗線 (resistance)」
@@ -2314,7 +2332,7 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
         }
         pushIfFinite(p.low20d);
       });
-      (sc.dailyBars || []).forEach(function (b) {
+      (sc.intradayBars || []).forEach(function (b) {
         pushIfFinite(b.high);
         pushIfFinite(b.low);
       });
@@ -2396,11 +2414,16 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
             name: 'swing low', type: 'scatter', data: pivotLowDots,
             symbolSize: 6, itemStyle: { color: '#c22', borderColor: '#fff', borderWidth: 1 }, z: 4,
           }] : []),
-          // candlestick: 日次 OHLC を表示。Western 規約 (close >= open = 緑、
+          // candlestick: 15 分足 OHLC を表示。Western 規約 (close >= open = 緑、
           // close < open = 赤)。markPoint / markLine もここに anchor。
           // ohlcXY が空なら series 自体をスキップ (Yahoo fetch 失敗時の保険)。
+          // price 線 (close trace、薄い青、z=3) を candle の上に重ねて
+          // 「全体の流れ」を読みやすくする (#175 後の user request)。
+          { name: 'price (close)', type: 'line', data: priceLineXY,
+            lineStyle: { width: 1, color: '#1471a8', opacity: 0.6 },
+            symbol: 'none', connectNulls: false, z: 3 },
           ...(ohlcXY.length > 0 ? [{
-            name: 'price (OHLC)', type: 'candlestick', data: ohlcXY,
+            name: 'price (15m OHLC)', type: 'candlestick', data: ohlcXY,
             itemStyle: {
               color: '#057a55',     // bullish (close >= open)
               color0: '#c22',       // bearish (close < open)

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -1003,7 +1003,7 @@ describe('computeZoomRange', () => {
       resistanceLine: null,
       supportLine: null,
       pivots: [],
-      dailyBars: [],
+      intradayBars: [],
     }
   }
 
@@ -1047,7 +1047,7 @@ describe('computeZoomRange', () => {
     const chart: SymbolChartData = {
       symbol: 'X', points: [], markers: [], position: null,
       rules: { pullbackMax: 0, pullbackMin: 0, stopPct: 0, takeProfitPct: 0, timeStopDays: 10 },
-      resistanceLine: null, supportLine: null, pivots: [], dailyBars: [],
+      resistanceLine: null, supportLine: null, pivots: [], intradayBars: [],
     }
     expect(computeZoomRange(null, null, chart)).toBeNull()
   })


### PR DESCRIPTION
## Summary

ユーザ要望 2 件を 1 PR で対応:
1. \`#175\` で price line が candlestick 化で消えていた → 復活 (line と candle 両方表示)
2. daily 足は粗い → **15 分足**に切替 (cron 間隔と同じ cadence)

## YahooBarClient 拡張

| 追加 | 内容 |
|---|---|
| \`getIntradayBars(symbol, '15m')\` | Yahoo \`/v8/finance/chart?interval=15m&range=60d\` を呼出。timestamp は ISO UTC 秒精度で daily と違い anchor 不要 |
| \`IntradayInterval\` / \`IntradayBar\` 型 | 5m/15m/30m/60m を typed enum、bar shape は OHLC + 秒精度 timestamp |
| \`normalizeIntradayChart\` | sanity check は daily と共通 (positive finite + \`low ≤ high\`) |

## chart 側

- 型 / フィールド rename: \`DailyOhlcBar\` → \`OhlcBar\`、\`SymbolChartData.dailyBars\` → \`intradayBars\` (semantics shift)
- \`loadSymbolChart\` で daily fetch (trend / pivot 用) と並行に **15m fetch** (candle 用) — 二系統を分ける
- Yahoo intraday 失敗時は candle 自体スキップして line だけで表示 (graceful)
- 既存 candle (z=5) の手前に **price line (close trace)** を z=3 で追加
  - intraday があれば 15m close、なければ cron-eval \`mergedPoints.price\`
  - 薄い青 \`#1471a8\`、\`opacity: 0.6\`、\`width: 1\`

## 設計判断

- daily / 15m を両方 fetch することで:
  - **trend line / pivot 検出は daily** (60 暦日の swing 構造、regime filter 効く)
  - **candlestick は 15m** (intraday の細かい OHLC が見える)
  - 役割分担明確、お互いを邪魔しない
- price line と candle は同じ data source なので情報重複だが、line は「流れの読みやすさ」、candle は「OHLC 詳細」で UX 上の役割が違う

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm test\` (464 tests, 既存 fixtures rename のみ)
- [ ] staging で SOXL chart 確認:
  - 15 分間隔の candlestick が描画される
  - 薄い青の price line が candle の上を撫でる
  - SMA50 / 押し目バンド / トレンドライン / pivot ドット / BUY/SELL pin が変わらず重畳
  - dataZoom slider で範囲調整

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * インtraday（日中）バーデータ取得機能を追加しました。複数の時間足（5分、15分、30分、60分）に対応しています。
  * シンボルチャートを15分足のローソク足チャートで表示するように更新しました。終値トレンドラインのオーバーレイ表示も追加されました。

* **テスト**
  * チャートテストを新しいデータ形式に対応させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->