### PR TITLE
feat(dashboard): candlestick interval を 15m → 1h に変更

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1657,12 +1657,14 @@ export async function loadSymbolChart(
   const supportLine = lastTimestamp
     ? fitTrendLineFromRecentPivots(pivots, 'low', lastTimestamp)
     : null
-  // candlestick: 15 分足 (intraday) を Yahoo から fetch。daily より細かい
-  // 動きが見える + cron が 15 分間隔で動くのと cadence が一致。失敗 (network /
-  // Yahoo intraday range 制限など) なら空配列で line だけ表示にフォールバック。
+  // candlestick: 1 時間足 (intraday) を Yahoo から fetch。15m は overnight gap
+  // 後の clustering と barWidth 調整がシビアだったため、daily-trader 向けに
+  // 1h を default 採用 (Pullback Uptrend のような multi-day 戦略では十分な
+  // granularity)。Yahoo intraday range 制限 60d で chart 全期間カバー可能。
+  // 失敗 (network 等) なら空配列で fallback (candle 自体スキップ)。
   let intradayBars: OhlcBar[] = []
   try {
-    const intraday = await new YahooBarClient().getIntradayBars(symbol, '15m')
+    const intraday = await new YahooBarClient().getIntradayBars(symbol, '60m')
     // lastTimestamp フィルタ: chart x 軸範囲を超える bar (将来に出るはずの bar)
     // を除外。lastTimestamp が無いときは全件採用。
     intradayBars = (cronLastTs == null
@@ -2417,8 +2419,10 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
           // gap 後の細い candle を視認可能に。borderWidth 強めて
           // body と wick の対比を確保。
           ...(ohlcXY.length > 0 ? [{
-            name: 'price (15m OHLC)', type: 'candlestick', data: ohlcXY,
-            barWidth: 8,
+            name: 'price (1h OHLC)', type: 'candlestick', data: ohlcXY,
+            // 1h は 15m より時間軸の間隔が 4 倍広いので、barWidth も少し
+            // 広めに (相対的に gap 比率を一定に保つ)。
+            barWidth: 10,
             itemStyle: {
               color: '#057a55',     // bullish (close >= open)
               color0: '#c22',       // bearish (close < open)


### PR DESCRIPTION
## Summary

15 分足は overnight gap 後の clustering と barWidth 調整がシビアだった。Pullback Uptrend のような multi-day 戦略では **1 時間足**で十分な granularity。trader-strategist 助言の「price action 集中 / ノイズ削減」方針とも整合。

## 変更

- \`YahooBarClient.getIntradayBars(symbol, '60m')\` に切替
- candle \`barWidth\` 8 → 10 (1h は 15m より時間軸間隔が 4 倍広いので相対 gap 比率を一定に)
- legend label \`'price (15m OHLC)'\` → \`'price (1h OHLC)'\`

## scope 外 (将来の検討)

- **3 時間足**: Yahoo は 60m が intraday の最小最大単位、3h は server-side で 60m × 3 を aggregate する必要あり。需要あれば別 PR で実装。
- **interval URL toggle (15m / 1h / 3h)**: 同じく需要次第で別 PR。

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm test\` (469 tests)
- [ ] staging で SOXL chart 確認:
  - candle が 1 時間間隔で描画される
  - candle 1 本がしっかり面積を持つ
  - 既存の SMA50 badge / pin label / position lines / dataZoom slider はそのまま動作

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **機能改善**
  * シンボルチャートのロウソク足データ取得間隔を15分から1時間に変更
  * ロウソク足シリーズのラベルを「price (1h OHLC)」に更新
  * チャートの視認性向上のためロウソク足の幅を拡大

<!-- end of auto-generated comment: release notes by coderabbit.ai -->