### PR TITLE
feat(dashboard): SMA50 line を chart に戻す + 1D/5D/1M/All プリセット zoom

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -2218,6 +2218,10 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
       var ohlcXY = (sc.intradayBars || []).map(function (b) {
         return [b.timestamp, b.open, b.close, b.low, b.high];
       });
+      // SMA50 line: cron-eval points から取得 (daily で計算された値の推移)。
+      // y 軸 range には含めないので、軸範囲外なら ECharts が auto-clip。
+      // 軸内のときだけ price との位置関係 (上 / 下) が読める TradingView ライク。
+      var smasXY = sc.points.map(function (p) { return p.sma50 == null ? [p.timestamp, null] : [p.timestamp, p.sma50]; });
       // (close line は削除: candle が close を含むので冗長、overnight gap で
       //  斜めに横断する視覚ノイズが発生していたため #176 → #177 で除去)
 
@@ -2448,8 +2452,10 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
               },
             } : undefined,
           }] : []),
-          // SMA50 line は chart 撤去 (15m chart の y 軸を引き伸ばすため)。
-          // 現在値は chart 上部 badge で表示する (renderCurrentIndicatorsBadge)。
+          // SMA50 line: y 軸 range は candle 範囲だけで決めるので、SMA50 が
+          // 範囲外なら ECharts が自動 clip する。範囲内なら price との位置
+          // 関係 (上 / 下) が読める。現在値は inline badge にも併記。
+          { name: 'SMA50', type: 'line', data: smasXY, lineStyle: { width: 1, color: '#888', type: 'dashed' }, symbol: 'none', connectNulls: true, z: 2 },
         ],
       });
       window.addEventListener('resize', function () { symChart.resize(); });
@@ -2489,11 +2495,27 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
           } catch (e) { /* noop */ }
         }, 200);
       });
+
+      // preset zoom buttons (1D / 5D / 1M / All) の click handler。
+      // dispatchAction で dataZoom を更新 → 既存の dataZoom listener が
+      // URL ?from / ?to も連動更新する。
+      var presetButtons = document.querySelectorAll('.zoom-preset');
+      for (var pi = 0; pi < presetButtons.length; pi += 1) {
+        presetButtons[pi].addEventListener('click', function (ev) {
+          var fromMs = Number(ev.currentTarget.getAttribute('data-from-ms'));
+          var toMs = Number(ev.currentTarget.getAttribute('data-to-ms'));
+          if (!Number.isFinite(fromMs) || !Number.isFinite(toMs)) return;
+          // inside / slider 両方を同期更新
+          symChart.dispatchAction({ type: 'dataZoom', dataZoomIndex: 0, startValue: fromMs, endValue: toMs });
+          symChart.dispatchAction({ type: 'dataZoom', dataZoomIndex: 1, startValue: fromMs, endValue: toMs });
+        });
+      }
     });
   `
   return `${renderSymbolPickerForTab(args)}
   ${renderCurrentIndicatorsBadge(args.symbolChart)}
   <div id="symbol-chart" style="width:100%;height:460px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;margin-top:12px"></div>
+  ${renderZoomPresetButtons(args.symbolChart)}
   ${renderStrategyParamsPanel(args.strategyParams)}
   ${safeJsonScript('__chartData', {
     symbolChart: args.symbolChart,
@@ -2599,6 +2621,40 @@ export function renderStrategyParamsPanel(p: StrategyParamsSnapshot): string {
       per-symbol override は POC scope では未対応。
     </p>
   </details>`
+}
+
+/**
+ * dataZoom プリセット (1D / 5D / 1M / All)。TradingView ライクの 1 click ズーム。
+ * lastTimestamp 基準で from/to を data-attr に焼き、client 側 click handler で
+ * symChart.dispatchAction({ type: 'dataZoom', startValue, endValue }) を発火する。
+ * 既存の dataZoom listener が URL を replaceState で更新するので、preset でも
+ * URL ?from / ?to が同期される。
+ */
+export function renderZoomPresetButtons(chart: SymbolChartData | null): string {
+  if (!chart || chart.points.length === 0) return ''
+  const lastPoint = chart.points[chart.points.length - 1]!
+  const lastMs = new Date(lastPoint.timestamp).getTime()
+  if (!Number.isFinite(lastMs)) return ''
+  const earliestMs = (() => {
+    const first = chart.points[0]
+    if (!first) return lastMs
+    const ms = new Date(first.timestamp).getTime()
+    return Number.isFinite(ms) ? ms : lastMs
+  })()
+  const day = 24 * 3600 * 1000
+  const presets: Array<{ label: string; fromMs: number; toMs: number }> = [
+    { label: '1D', fromMs: lastMs - 1 * day, toMs: lastMs },
+    { label: '5D', fromMs: lastMs - 5 * day, toMs: lastMs },
+    { label: '1M', fromMs: lastMs - 30 * day, toMs: lastMs },
+    { label: 'All', fromMs: earliestMs, toMs: lastMs },
+  ]
+  const buttons = presets
+    .map(
+      (p) =>
+        `<button class="zoom-preset" data-from-ms="${p.fromMs}" data-to-ms="${p.toMs}" style="margin-right:6px;padding:3px 10px;font-size:12px;background:#fafafa;border:1px solid #d0d0d5;border-radius:4px;cursor:pointer;color:#1d1d1f">${esc(p.label)}</button>`,
+    )
+    .join('')
+  return `<p style="margin:8px 0 0">${buttons}</p>`
 }
 
 /**

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -2362,9 +2362,11 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
       var dzInitial = data.zoomFromMs != null && data.zoomToMs != null
         ? { startValue: data.zoomFromMs, endValue: data.zoomToMs }
         : {};
+      // dataZoom slider 両端ラベルも JST で表示 (default だと UTC date string)
+      var dzCommon = { labelFormatter: function (value) { return jstLabel(value); } };
       var dataZoomCfg = [
         Object.assign({ type: 'inside', xAxisIndex: 0 }, dzInitial),
-        Object.assign({ type: 'slider', xAxisIndex: 0, height: 24, bottom: 8 }, dzInitial),
+        Object.assign({ type: 'slider', xAxisIndex: 0, height: 24, bottom: 8 }, dzCommon, dzInitial),
       ];
 
       var symChart = echarts.init(document.getElementById('symbol-chart'));
@@ -2373,6 +2375,30 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
         tooltip: {
           trigger: 'axis',
           axisPointer: { label: { formatter: function (p) { return jstLabel(p.value); } } },
+          // 既定の trigger:'axis' tooltip は header に axis value (時刻) を
+          // UTC 文字列で出すため、JST formatter を当てた custom formatter で上書き。
+          // candlestick 値は [open, close, low, high]、line は scalar として処理。
+          formatter: function (params) {
+            if (!Array.isArray(params) || params.length === 0) return '';
+            var ts = params[0].axisValue;
+            var lines = ['<div style="font-weight:600;font-size:11px">' + jstLabel(ts) + '</div>'];
+            for (var i = 0; i < params.length; i += 1) {
+              var p = params[i];
+              if (p.seriesType === 'candlestick' && Array.isArray(p.value)) {
+                lines.push('<div style="font-size:11px">' + p.marker + ' ' + p.seriesName +
+                  '  O ' + Number(p.value[1]).toFixed(2) +
+                  '  H ' + Number(p.value[4]).toFixed(2) +
+                  '  L ' + Number(p.value[3]).toFixed(2) +
+                  '  C ' + Number(p.value[2]).toFixed(2) + '</div>');
+              } else {
+                var v = Array.isArray(p.value) ? p.value[1] : p.value;
+                if (v == null) continue;
+                lines.push('<div style="font-size:11px">' + p.marker + ' ' + p.seriesName +
+                  ': ' + Number(v).toFixed(2) + '</div>');
+              }
+            }
+            return lines.join('');
+          },
         },
         legend: { top: 22, type: 'scroll' },
         // plot 面積最大化: grid 余白を絞り、splitLine 淡く、axisLine 非表示で

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -1138,3 +1138,63 @@ describe('renderCurrentIndicatorsBadge', () => {
     expect(html).toContain('—') // high20d / low20d
   })
 })
+
+import { renderZoomPresetButtons } from '../../src/routes/dashboard'
+
+describe('renderZoomPresetButtons', () => {
+  function fakeChart(points: SymbolChartPoint[]): SymbolChartData {
+    return {
+      symbol: 'X', points, markers: [], position: null,
+      rules: { pullbackMax: 0, pullbackMin: 0, stopPct: 0, takeProfitPct: 0, timeStopDays: 10 },
+      resistanceLine: null, supportLine: null, pivots: [], intradayBars: [],
+    }
+  }
+
+  it('chart null / points 空なら空文字', () => {
+    expect(renderZoomPresetButtons(null)).toBe('')
+    expect(renderZoomPresetButtons(fakeChart([]))).toBe('')
+  })
+
+  it('points あれば 1D / 5D / 1M / All の 4 ボタン', () => {
+    const chart = fakeChart([
+      { timestamp: '2026-04-01T00:00:00.000Z', price: 100, sma50: null, high20d: null, low20d: null },
+      { timestamp: '2026-04-25T00:00:00.000Z', price: 120, sma50: null, high20d: null, low20d: null },
+    ])
+    const html = renderZoomPresetButtons(chart)
+    expect(html).toContain('>1D<')
+    expect(html).toContain('>5D<')
+    expect(html).toContain('>1M<')
+    expect(html).toContain('>All<')
+    expect(html.match(/class="zoom-preset"/g)?.length).toBe(4)
+  })
+
+  it('1D ボタンの from は lastTimestamp - 1day、to は lastTimestamp', () => {
+    const chart = fakeChart([
+      { timestamp: '2026-04-25T00:00:00.000Z', price: 120, sma50: null, high20d: null, low20d: null },
+    ])
+    const html = renderZoomPresetButtons(chart)
+    const lastMs = new Date('2026-04-25T00:00:00.000Z').getTime()
+    const day = 24 * 3600 * 1000
+    expect(html).toContain(`data-from-ms="${lastMs - day}"`)
+    expect(html).toContain(`data-to-ms="${lastMs}"`)
+  })
+
+  it('All ボタンは earliest 〜 latest を範囲に', () => {
+    const chart = fakeChart([
+      { timestamp: '2026-02-01T00:00:00.000Z', price: 50, sma50: null, high20d: null, low20d: null },
+      { timestamp: '2026-04-25T00:00:00.000Z', price: 120, sma50: null, high20d: null, low20d: null },
+    ])
+    const html = renderZoomPresetButtons(chart)
+    const earliestMs = new Date('2026-02-01T00:00:00.000Z').getTime()
+    const lastMs = new Date('2026-04-25T00:00:00.000Z').getTime()
+    expect(html).toContain(`data-from-ms="${earliestMs}"`)
+    expect(html).toContain(`data-to-ms="${lastMs}"`)
+  })
+
+  it('lastPoint timestamp 不正なら空文字', () => {
+    const chart = fakeChart([
+      { timestamp: 'not-an-iso', price: 100, sma50: null, high20d: null, low20d: null },
+    ])
+    expect(renderZoomPresetButtons(chart)).toBe('')
+  })
+})


### PR DESCRIPTION
## Summary

スクショ #21 (TradingView 参考) で 2 件の改善:

## 1. SMA50 line を chart に復活

\`#177\` で SMA50 line 自体を撤去 (y軸引き伸ばし対策) したが、price との位置関係 (上 / 下) が読めなくなり TradingView 的な体験から退化。

**修正**: SMA50 line を series に戻す。**y軸 range 計算には引き続き含めない**ので、軸範囲外なら ECharts が auto-clip → SMA50 が現在価格と大幅乖離してても candle の縦圧縮は起きない (#177 の core fix は維持)。軸内のときだけ price との位置関係が見える。inline badge も併存で数値 context は維持。

## 2. 1D / 5D / 1M / All プリセット zoom ボタン

slider drag だけだと TradingView の 1D/5D/1M ボタンの **1-click ズーム**体験に届かない。chart 下部にプリセット 4 ボタンを設置。

| ボタン | 範囲 |
|---|---|
| 1D | lastTimestamp − 1d 〜 lastTimestamp |
| 5D | lastTimestamp − 5d 〜 lastTimestamp |
| 1M | lastTimestamp − 30d 〜 lastTimestamp |
| All | earliest 〜 lastTimestamp |

実装:
- \`renderZoomPresetButtons\`: server-side で lastTimestamp 基準の from/to を data-attr に焼く
- client click handler: \`dispatchAction({ type: 'dataZoom', startValue, endValue })\` を inside / slider 両方に発火
- 既存 dataZoom listener が URL \`?from\` / \`?to\` を \`replaceState\` で連動更新

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm test\` (474 tests, +5 for renderZoomPresetButtons)
- [ ] staging で確認:
  - SMA50 灰色破線が chart に再描画される (軸範囲内のとき)
  - 軸範囲外のとき auto-clip で消える (candle 圧縮なし)
  - 1D / 5D / 1M / All ボタンクリックで chart が即 zoom される
  - URL \`?from=...&to=...\` がボタンクリックで連動更新
  - 銘柄切替でも zoom range 維持

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * シンボルチャートにSMA50プロットを再導入しました（欠損値を跨いで表示）。
  * チャートのツールチップを日本時間表示に改善し、ローソク足とスカラー系列で適切に値を表示するようにしました。
  * TradingView風ズームプリセットボタン（1日/5日/1ヶ月/全期間）を追加し、内蔵・スライダー両方のズームを同期して適用します。
  * データズームのスライダー端点ラベルを日本時間で表示するようにしました。

* **テスト**
  * ズームプリセットボタンの動作を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->