### PR TITLE
fix(dashboard): chart hover tooltip と zoom slider ラベルを JST 化

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -2358,9 +2358,11 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
       var dzInitial = data.zoomFromMs != null && data.zoomToMs != null
         ? { startValue: data.zoomFromMs, endValue: data.zoomToMs }
         : {};
+      // dataZoom slider 両端ラベルも JST で表示 (default だと UTC date string)
+      var dzCommon = { labelFormatter: function (value) { return jstLabel(value); } };
       var dataZoomCfg = [
         Object.assign({ type: 'inside', xAxisIndex: 0 }, dzInitial),
-        Object.assign({ type: 'slider', xAxisIndex: 0, height: 24, bottom: 8 }, dzInitial),
+        Object.assign({ type: 'slider', xAxisIndex: 0, height: 24, bottom: 8 }, dzCommon, dzInitial),
       ];
 
       var symChart = echarts.init(document.getElementById('symbol-chart'));
@@ -2369,6 +2371,31 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
         tooltip: {
           trigger: 'axis',
           axisPointer: { label: { formatter: function (p) { return jstLabel(p.value); } } },
+          // 既定の trigger:'axis' tooltip は header に axis value (時刻) を
+          // UTC 文字列で出すため、JST formatter を当てた custom formatter で上書き。
+          // candlestick 値は [open, close, low, high]、line は scalar として処理。
+          formatter: function (params) {
+            if (!Array.isArray(params) || params.length === 0) return '';
+            var ts = params[0].axisValue;
+            var lines = ['<div style="font-weight:600;font-size:11px">' + jstLabel(ts) + '</div>'];
+            for (var i = 0; i < params.length; i += 1) {
+              var p = params[i];
+              if (p.seriesType === 'candlestick' && Array.isArray(p.value)) {
+                // [timestamp, open, close, low, high]
+                lines.push('<div style="font-size:11px">' + p.marker + ' ' + p.seriesName +
+                  '  O ' + Number(p.value[1]).toFixed(2) +
+                  '  H ' + Number(p.value[4]).toFixed(2) +
+                  '  L ' + Number(p.value[3]).toFixed(2) +
+                  '  C ' + Number(p.value[2]).toFixed(2) + '</div>');
+              } else {
+                var v = Array.isArray(p.value) ? p.value[1] : p.value;
+                if (v == null) continue;
+                lines.push('<div style="font-size:11px">' + p.marker + ' ' + p.seriesName +
+                  ': ' + Number(v).toFixed(2) + '</div>');
+              }
+            }
+            return lines.join('');
+          },
         },
         legend: { top: 22, type: 'scroll' },
         // plot 面積最大化: grid 余白を絞り、splitLine 淡く、axisLine 非表示で


### PR DESCRIPTION
## Summary

ECharts の default で UTC date 文字列を出している 2 箇所を JST 化:

| 箇所 | default (UTC) | 修正後 |
|---|---|---|
| \`tooltip\` (\`trigger: 'axis'\`) の header (時刻) | UTC date string | \`jstLabel(axisValue)\` |
| \`dataZoom\` slider 両端の date label | UTC date string | \`labelFormatter: jstLabel\` |

\`xAxis.axisLabel\` と \`axisPointer.label\` は既に JST formatter 済みだが、tooltip header と slider 両端は default のまま漏れていたので統一。

## tooltip.formatter

custom HTML を返す関数で:
- header: \`jstLabel(axisValue)\` (太字、11px)
- candlestick series: \`O / H / L / C\` の 4 値
- line series: scalar 値 (null は省略)
- marker (色丸) を seriesName 横に出して trace と対応付け

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm test\` (469 tests)
- [ ] staging で確認:
  - chart hover で tooltip header が \`MM/DD HH:MM\` JST 形式
  - dataZoom slider の両端 date が JST 形式
  - candle hover で OHLC が表示

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * チャートのスライダーとツールチップに JST タイムスタンプが正しく表示されるようになりました。
  * ツールチップにローソク足チャートの詳細な価格情報（始値/高値/安値/終値）と各シリーズの値が表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->