### PR TITLE
feat(dashboard): zoom に応じて y 軸を visible 範囲に動的タイト fit

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -2486,14 +2486,61 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
       });
       window.addEventListener('resize', function () { symChart.resize(); });
 
+      // visible 範囲 (zoom 後の x 軸 startMs〜endMs) 内の candle high/low /
+      // markers / position 線を集めて y 軸 range を再計算。zoom out / preset
+      // 切替で「縦に空白が広がる」現象を防ぎプロ chart 風のタイト fit に。
+      function recomputeYAxis() {
+        var opt = symChart.getOption();
+        var dz = opt.dataZoom && opt.dataZoom[0];
+        if (!dz) return;
+        var startMs = dz.startValue;
+        var endMs = dz.endValue;
+        if (startMs == null || endMs == null) return;
+        var visibleY = [];
+        function pushIfFinite(v) {
+          if (v != null && typeof v === 'number' && Number.isFinite(v)) visibleY.push(v);
+        }
+        (sc.intradayBars || []).forEach(function (b) {
+          var t = new Date(b.timestamp).getTime();
+          if (Number.isFinite(t) && t >= startMs && t <= endMs) {
+            pushIfFinite(b.high);
+            pushIfFinite(b.low);
+          }
+        });
+        sc.markers.forEach(function (m) {
+          var t = new Date(m.timestamp).getTime();
+          if (Number.isFinite(t) && t >= startMs && t <= endMs) pushIfFinite(m.price);
+        });
+        // 保有期間が visible 範囲と重なっていれば position 線を含める
+        if (sc.position) {
+          var openedAtMs = new Date(sc.position.openedAt).getTime();
+          if (Number.isFinite(openedAtMs) && openedAtMs <= endMs) {
+            var avg = sc.position.avgPrice;
+            pushIfFinite(avg);
+            pushIfFinite(avg * (1 + sc.rules.stopPct));
+            pushIfFinite(avg * (1 + sc.rules.takeProfitPct));
+          }
+        }
+        if (visibleY.length === 0) return;
+        var rawMin = Math.min.apply(null, visibleY);
+        var rawMax = Math.max.apply(null, visibleY);
+        if (!Number.isFinite(rawMin) || !Number.isFinite(rawMax)) return;
+        var pad = Math.max((rawMax - rawMin) * 0.05, 0.5);
+        symChart.setOption({ yAxis: { min: rawMin - pad, max: rawMax + pad } });
+      }
+      // 初回 render 後に一度実行 (default zoom 範囲に y を tight fit)
+      recomputeYAxis();
+
       // dataZoom 変更で URL の ?from / ?to を更新 (replaceState なので history
       // 汚染なし)。debounce 200ms で連続操作中の URL flicker を抑制。
       // 同時に symbol picker / tab strip の '?tab=symbol' リンクの href も
       // 上書き → 銘柄切替で zoom が古い range に reset されない。
+      // y 軸も visible 範囲に再 fit (recomputeYAxis、debounce 内で)。
       var dzTimer = null;
       symChart.on('dataZoom', function () {
         if (dzTimer) clearTimeout(dzTimer);
         dzTimer = setTimeout(function () {
+          recomputeYAxis();
           var opt = symChart.getOption();
           var dz = opt.dataZoom && opt.dataZoom[0];
           if (!dz) return;


### PR DESCRIPTION
## Summary

スクショ #22 で「y軸が 40 まで伸びて縦 30% が空白」問題を解消。zoom 操作で y軸も連動して visible 範囲にタイト fit する **TradingView 風の UX**。

## 原因

\`yAxis\` に explicit \`min\`/\`max\` を設定 (markLine 範囲外切れ防止) しており、zoom しても full data 範囲基準で固定されていた。Yahoo intraday の 60 日 data 内に SOXL の \`39.52\` (low20d) が含まれて y軸を引き伸ばしていた。

## 修正

client 側 \`recomputeYAxis()\` 新規実装。dataZoom 後の visible 範囲 (startMs〜endMs) 内の候補だけ集めて y軸を再計算:

- \`intradayBars\` の \`high\` / \`low\`
- \`markers\` (BUY/SELL) の price
- position 線 (\`avg\` / \`stop\` / TP) — 保有期間が visible に重なるとき
- ±5% padding (markLine が枠外で切れないよう)

initial render 後に 1 回 + dataZoom event の debounce 内で実行。

## UX フロー

1. 初回ロード: default zoom (直近 7 日) に y軸 tight fit
2. slider drag: 範囲変更 → y軸も連動 fit (debounce 200ms)
3. preset ボタン (1D / 5D / 1M / All) クリック: dispatchAction → dataZoom event 発火 → y軸 fit
4. URL \`?from\`/\`?to\` 復元: 同じく y軸 fit
5. 銘柄切替: 新銘柄の data で再 fit

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm test\` (474 tests, client side のみ変更なので unit test 影響なし)
- [ ] staging で確認:
  - default zoom で y 軸が candle 範囲だけにタイト fit (40-60 の空白消失)
  - 1D / 5D / All ボタンで y 軸も連動 zoom
  - slider drag でも y 軸連動

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 改善

* **新機能**
  * キャンドルスティックチャートのズーム操作時に、y軸の範囲が動的に調整されるようになりました。これにより、チャート表示時の余白が最適化され、より明確なデータ表示が可能になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->