### PR TITLE
fix(dashboard): trend line を candle より上 (z) に出して可視化

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -2536,22 +2536,27 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
           ]),
           // sloped trend lines (5-bar fractal pivot fit)。教科書「下値支持線 /
           // 上値抵抗線」相当。pivots が 2 未満なら data: null で render skip。
+          // z は candle (5) より上。candle が密集している range では
+          // z<5 の trend line がほぼ全て candle に隠れて見えない回帰があった
+          // (legend には出るが線本体が rendered out)。SMA50 (z:6) と同様に
+          // candle の上に持ち上げ、線幅も少し太くする。
           ...(resistanceXY ? [{
             name: '上値抵抗線 (sloped, 直近 2 pivot fit)', type: 'line', data: resistanceXY,
-            lineStyle: { width: 1.5, color: '#1471a8', type: 'solid' }, symbol: 'none', z: 3,
+            lineStyle: { width: 1.8, color: '#1471a8', type: 'solid' }, symbol: 'none', z: 7,
           }] : []),
           ...(supportTrendXY ? [{
             name: '下値支持線 (sloped, 直近 2 pivot fit)', type: 'line', data: supportTrendXY,
-            lineStyle: { width: 1.5, color: '#c22', type: 'solid' }, symbol: 'none', z: 3,
+            lineStyle: { width: 1.8, color: '#c22', type: 'solid' }, symbol: 'none', z: 7,
           }] : []),
-          // swing pivot dots (見つけた pivot を可視化、debug + 教育用)
+          // swing pivot dots (見つけた pivot を可視化、debug + 教育用)。
+          // candle (z:5) より上に出さないと candle 帯と重なる pivot が消える。
           ...(pivotHighDots.length > 0 ? [{
             name: 'swing high', type: 'scatter', data: pivotHighDots,
-            symbolSize: 6, itemStyle: { color: '#1471a8', borderColor: '#fff', borderWidth: 1 }, z: 4,
+            symbolSize: 6, itemStyle: { color: '#1471a8', borderColor: '#fff', borderWidth: 1 }, z: 8,
           }] : []),
           ...(pivotLowDots.length > 0 ? [{
             name: 'swing low', type: 'scatter', data: pivotLowDots,
-            symbolSize: 6, itemStyle: { color: '#c22', borderColor: '#fff', borderWidth: 1 }, z: 4,
+            symbolSize: 6, itemStyle: { color: '#c22', borderColor: '#fff', borderWidth: 1 }, z: 8,
           }] : []),
           // candlestick: 15 分足 OHLC を表示。Western 規約 (close >= open = 緑、
           // candle: 主役。Western 規約 (close >= open = 緑、< = 赤)。


### PR DESCRIPTION
## Summary
凡例には 上値抵抗線・下値支持線 が両方出ているのに **線本体が描画されていない** 報告。原因は z-order: trend line `z:3` / pivot dots `z:4` が candle `z:5` の下にあり、candle 密集している range (5D zoom 等) では candle が線をほぼ全て覆ってしまっていた。pivot dots は単点なので candle 帯と縦方向にずれた位置で見えていたが、長い直線の trend line は visible 範囲全域で candle に隠れる。

#183 で SMA50 を `z:6` (candle 上) に持ち上げて見えるようになったのと同じ理屈で trend line / pivot dots にも適用。

## 変更
- 上値抵抗線 / 下値支持線: `z` 3 → 7、線幅 `1.5` → `1.8`
- swing high / low dots: `z` 4 → 8

## Test plan
- [x] `pnpm typecheck` — pass
- [x] `pnpm test --run` — 484 pass
- [ ] staging で AAPL chart に 上値抵抗線 (青) と 下値支持線 (赤) が candle 上に表示されるか確認
- [ ] 5D / 1M zoom でも常時可視か確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * シンボルキャンドルスティックチャートのトレンドラインとピボットマーカーの表示順序を最適化し、ローソク足の後ろに隠れなくなりました
  * レジスタンス/サポートラインの線幅を太くして視認性を向上させました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->