### PR TITLE
fix(dashboard): trend line の regime filter 後 raw fallback を廃止

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1672,33 +1672,41 @@ export async function loadSymbolChart(
       pivotsAll: detectFractalPivots(dailyClosesIn(PIVOT_WINDOW_DAYS_WIDE), 1),
     },
   ]
-  function pivotsForType(type: 'high' | 'low'): PivotPoint[] {
+  // regime filter は意味のあるガード (現価格 ±50% 外の pivot は別 regime
+  // = 旧価格帯 = 直近の trend を表さない)。前版は filter 後 < 2 のとき raw に
+  // fallback していたが、SOXL のように 40→128 と急騰した銘柄では filter 後
+  // 0 個 → raw fallback → 旧 regime (40-60) pivot で線が引かれる回帰があった。
+  // 修正: 各 tier は filter 後の集合のみを使う。filter 後 < 2 ならその tier は
+  // skip して次 tier (より緩い detection) を試す。全 tier 不足なら null を
+  // 返し、trend line を「無理に引かない」(=描画スキップ) を選択する。誤った
+  // 線を描くより無描画のほうが UX 上望ましい。
+  function pivotsForType(type: 'high' | 'low'): PivotPoint[] | null {
     for (const tier of tiers) {
       const filtered = applyRegimeFilter(tier.pivotsAll)
-      // 第一に regime filter 後で同 type 2 個。だめなら同 tier の raw で再試行。
       if (filtered.filter((p) => p.type === type).length >= 2) return filtered
-      if (tier.pivotsAll.filter((p) => p.type === type).length >= 2) return tier.pivotsAll
     }
-    // 全 tier 不足: 一番ゆるい tier 4 raw を返す (fitTrendLine 側で null になる
-    // 可能性は残るが、pivot dots だけでも表示する)
-    return tiers[tiers.length - 1]!.pivotsAll
+    return null
   }
-  const resistanceLine = lastTimestamp
-    ? fitTrendLineFromRecentPivots(pivotsForType('high'), 'high', lastTimestamp)
-    : null
-  const supportLine = lastTimestamp
-    ? fitTrendLineFromRecentPivots(pivotsForType('low'), 'low', lastTimestamp)
-    : null
-  // chart 上の pivot dots は実際に trend line に使った両 type の pivots 集合を
-  // union (重複除去)。filter で消えた pivot も含めると context が読みやすい
-  // ので tier ごとの raw も全部混ぜる。
+  const resistanceCandidate = pivotsForType('high')
+  const supportCandidate = pivotsForType('low')
+  const resistanceLine =
+    lastTimestamp && resistanceCandidate
+      ? fitTrendLineFromRecentPivots(resistanceCandidate, 'high', lastTimestamp)
+      : null
+  const supportLine =
+    lastTimestamp && supportCandidate
+      ? fitTrendLineFromRecentPivots(supportCandidate, 'low', lastTimestamp)
+      : null
+  // chart 上の pivot dots は trend line に採用した pivots に加え、各 tier の
+  // regime-filtered pivots を union (重複除去)。filter で除外された旧 regime
+  // pivot は意図的に表示しない (trend line と整合させる)。
   const pivots: PivotPoint[] = (() => {
     const seen = new Set<string>()
     const out: PivotPoint[] = []
     const sources: PivotPoint[][] = [
-      pivotsForType('high'),
-      pivotsForType('low'),
-      ...tiers.map((t) => t.pivotsAll),
+      ...(resistanceCandidate ? [resistanceCandidate] : []),
+      ...(supportCandidate ? [supportCandidate] : []),
+      ...tiers.map((t) => applyRegimeFilter(t.pivotsAll)),
     ]
     for (const src of sources) {
       for (const p of src) {


### PR DESCRIPTION
## Summary
SOXL 銘柄のスクショで 上値抵抗線 (青) ~60→63 ほぼ flat、下値支持線 (赤) ~60→12 急降下 (現値 128) と完全に regime 外の線が引かれていた。

原因は #184 の tier fallback 内に仕込まれていた **「regime filter 後 < 2 なら raw に fallback」** の二段目。SOXL のような急騰銘柄では filter 後 0 件 → raw fallback で旧 regime (40-60 帯) の pivot を採用 → 現価格と乖離した無意味な trend line になっていた。

regime filter (現価格 ±50%) の意義は「別 regime pivot を除外する」こと。raw fallback はそれを defeats する。

## 変更
- 各 tier は **regime-filtered pivots のみ** で「同 type ≥ 2」を判定
- filter 後 < 2 ならその tier を skip → 次の (より緩い detection の) tier
- 全 tier 不足なら `null` を返し、trend line は **描画しない**
- 誤線より無描画のほうが UX 上望ましい (「絶対 2 本ある」前提を捨てる)
- pivot dots も regime-filtered の union に揃え、旧 regime pivot は非表示

## Test plan
- [x] `pnpm typecheck` — pass
- [x] `pnpm test --run` — 484 pass
- [ ] staging で SOXL chart に regime 外の暴れた trend line が出ないこと確認
- [ ] AAPL chart に従来通り両 trend line が出ること確認
- [ ] 全 tier 不足の銘柄で legend / 線とも出ないこと確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * チャート表示におけるピボットポイントとトレンドラインのフィルタリング一貫性を改善しました。フィルタリング条件に基づいて、表示されるピボットとトレンドラインがより正確に一致するようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->