### PR TITLE
fix(dashboard): trend line を candle.markLine 経由で描画 (z 隠蔽回避)

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -2364,6 +2364,25 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
       }
       var resistanceXY = trendLineXY(sc.resistanceLine);
       var supportTrendXY = trendLineXY(sc.supportLine);
+      // ECharts time axis + candlestick mixed の rendering で、独立 type:'line'
+      // series の trend line が candle (z:5) の上 (z:7) に置いても visual に
+      // 描画されないユースケースがあった (legend には出るが線本体だけ描かれない)。
+      // candle series の markLine は仕様上必ず series 上層に描かれるので、
+      // 同じ 2 点を candle.markLine.data に重ねて描画ロバストネスを担保する。
+      // line series は legend / hover tooltip 用に残す (描画されてもされなくても
+      // markLine と完全重なるので overdraw は無視できる)。
+      function trendMarkLine(line, color) {
+        if (!line) return null;
+        return [
+          { coord: [line.pivots[0].timestamp, line.pivots[0].price], lineStyle: { color: color, width: 1.8, type: 'solid' } },
+          { coord: [line.end.timestamp, line.end.price] },
+        ];
+      }
+      var trendMarkLineData = [];
+      var rmark = trendMarkLine(sc.resistanceLine, '#1471a8');
+      if (rmark) trendMarkLineData.push(rmark);
+      var smark = trendMarkLine(sc.supportLine, '#c22');
+      if (smark) trendMarkLineData.push(smark);
       var pivotHighDots = sc.pivots
         .filter(function (pv) { return pv.type === 'high'; })
         .map(function (pv) { return [pv.timestamp, pv.price]; });
@@ -2584,7 +2603,15 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
               borderWidth: 1.5,
             },
             z: 5,
-            markLine: positionMarkLines.length > 0 ? { silent: true, symbol: 'none', data: positionMarkLines } : undefined,
+            markLine: (positionMarkLines.length + trendMarkLineData.length) > 0 ? {
+              silent: true,
+              symbol: 'none',
+              // position lines (avg/stop/TP) と sloped trend lines を 1 つの
+              // markLine.data に集約。markLine は ECharts 仕様上 series 上層に
+              // 描かれるので、独立 line series で起きていた candle 隠蔽問題を
+              // 回避できる。
+              data: positionMarkLines.concat(trendMarkLineData),
+            } : undefined,
             markPoint: entries.length + exits.length > 0 ? {
               symbol: 'pin', symbolSize: 24, data: entries.concat(exits),
               tooltip: {


### PR DESCRIPTION
## Summary
ユーザ報告「マージしたけど (trend line) 出ない / ローソク足を足したタイミングで消えてる」。candlestick 化 (#175) 以降、独立 \`type:'line'\` の trend line series は **凡例には出るが線本体だけ rendered out** する症状。#185 で z:7 (candle z:5 上) に持ち上げても解消せず、ECharts time axis + candlestick + 2 点 line series 混在の特定組合せが原因と推定。

## 検証
AAPL 30 日 close の simulation test (1 回限り、本コミットには含めない) で server 側は両 trend line 共 non-null を返すことを確認:
- resistance: 258.6 (04/04) → 267.4 (04/25)
- support: 258.5 (04/14) → 272.0 (04/25)

= 凡例に出ているとおり、サーバ計算は正常。問題は **client 側の rendering**。

## 修正
trend line を candle series の \`markLine\` 経由で重ねて描画。markLine は ECharts 仕様上 series 上層に必ず描かれるため z-order / canvas 合成の影響を受けない。

- 既存 \`type:'line'\` trend line series は legend / hover tooltip 用に温存 (markLine と完全重なるので overdraw は無視できる)
- position lines (avg/stop/TP) と trend lines を \`candle.markLine.data\` 1 配列に集約
- 色は markLineItem 単位の \`lineStyle.color\` で個別指定 (青 #1471a8 / 赤 #c22)

## Test plan
- [x] \`pnpm typecheck\` — pass
- [x] \`pnpm test --run\` — 484 pass
- [ ] staging で AAPL chart に 上値抵抗線 (青) と 下値支持線 (赤) が candle 上に描画されるか確認
- [ ] zoom in/out で線が visible 範囲内で連続描画されるか確認
- [ ] SOXL のような regime 不一致銘柄は引き続き「線無し」(server null) で OK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* ダッシュボードのチャート表示を改善しました。ロウソク足チャート上に抵抗線とサポートラインが直接表示されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->