### PR TITLE
fix(dashboard): trend line を SMA50 line series の markLine に host

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -2357,25 +2357,32 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
       // 検出失敗 (pivots < 2) なら null → 描画スキップ。
       function trendLineXY(line) {
         if (!line) return null;
+        // ECharts time axis は ISO string も accept するが、markLine + candle 上で
+        // 描画されない事例があったため数値 epoch ms に変換。line series の data
+        // 側も同形式に揃える (axis 解釈の揺らぎを排除)。
         return [
-          [line.pivots[0].timestamp, line.pivots[0].price],
-          [line.end.timestamp, line.end.price],
+          [new Date(line.pivots[0].timestamp).getTime(), line.pivots[0].price],
+          [new Date(line.end.timestamp).getTime(), line.end.price],
         ];
       }
       var resistanceXY = trendLineXY(sc.resistanceLine);
       var supportTrendXY = trendLineXY(sc.supportLine);
-      // ECharts time axis + candlestick mixed の rendering で、独立 type:'line'
-      // series の trend line が candle (z:5) の上 (z:7) に置いても visual に
-      // 描画されないユースケースがあった (legend には出るが線本体だけ描かれない)。
-      // candle series の markLine は仕様上必ず series 上層に描かれるので、
-      // 同じ 2 点を candle.markLine.data に重ねて描画ロバストネスを担保する。
-      // line series は legend / hover tooltip 用に残す (描画されてもされなくても
-      // markLine と完全重なるので overdraw は無視できる)。
+      // ECharts の独立 type:'line' series は #185 で z:7 (candle z:5 上) に
+      // しても visual に描画されない症状があった (legend は出るが線本体抜け)。
+      // #187 で candle.markLine 経由で描画させたが解消せず — candlestick の
+      // markLine が slanted line を期待通りに描かないか coord 解釈が異なる
+      // 可能性。SMA50 (type:'line', z:6) を host にして markLine を載せ替える。
+      // 一般 line series の markLine は slanted [start, end] coord を確実に
+      // 描画するため (ECharts 通常用例)。
       function trendMarkLine(line, color) {
         if (!line) return null;
         return [
-          { coord: [line.pivots[0].timestamp, line.pivots[0].price], lineStyle: { color: color, width: 1.8, type: 'solid' } },
-          { coord: [line.end.timestamp, line.end.price] },
+          {
+            coord: [new Date(line.pivots[0].timestamp).getTime(), line.pivots[0].price],
+            symbol: 'none',
+            lineStyle: { color: color, width: 1.8, type: 'solid' },
+          },
+          { coord: [new Date(line.end.timestamp).getTime(), line.end.price], symbol: 'none' },
         ];
       }
       var trendMarkLineData = [];
@@ -2561,19 +2568,19 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
             { name: '押し目ゾーン上端 (high20d × ' + (pullbackMaxMul).toFixed(2) + ')', type: 'line', data: bandUpperXY, lineStyle: { width: 0.6, color: '#057a55', type: 'dashed', opacity: 0.4 }, symbol: 'none', connectNulls: false, z: 1 },
             { name: '押し目ゾーン下端 (high20d × ' + (pullbackMinMul).toFixed(2) + ')', type: 'line', data: bandLowerXY, lineStyle: { width: 0.6, color: '#b25000', type: 'dashed', opacity: 0.4 }, symbol: 'none', connectNulls: false, z: 1 },
           ]),
-          // sloped trend lines (5-bar fractal pivot fit)。教科書「下値支持線 /
-          // 上値抵抗線」相当。pivots が 2 未満なら data: null で render skip。
-          // z は candle (5) より上。candle が密集している range では
-          // z<5 の trend line がほぼ全て candle に隠れて見えない回帰があった
-          // (legend には出るが線本体が rendered out)。SMA50 (z:6) と同様に
-          // candle の上に持ち上げ、線幅も少し太くする。
+          // sloped trend lines は SMA50 series の markLine に host (下方)。
+          // 凡例表示用に空 line series を 1 個ずつ並べておく (markLine は legend に
+          // 出ない、独立 type:'line' series は描画されない既知症状を回避)。
           ...(resistanceXY ? [{
-            name: '上値抵抗線 (sloped, 直近 2 pivot fit)', type: 'line', data: resistanceXY,
-            lineStyle: { width: 1.8, color: '#1471a8', type: 'solid' }, symbol: 'none', z: 7,
+            name: '上値抵抗線 (sloped, 直近 2 pivot fit)', type: 'line', data: [],
+            lineStyle: { width: 1.8, color: '#1471a8', type: 'solid' }, symbol: 'none',
+            // legend で同じ色の dot を出すため itemStyle.color も指定。
+            itemStyle: { color: '#1471a8' },
           }] : []),
           ...(supportTrendXY ? [{
-            name: '下値支持線 (sloped, 直近 2 pivot fit)', type: 'line', data: supportTrendXY,
-            lineStyle: { width: 1.8, color: '#c22', type: 'solid' }, symbol: 'none', z: 7,
+            name: '下値支持線 (sloped, 直近 2 pivot fit)', type: 'line', data: [],
+            lineStyle: { width: 1.8, color: '#c22', type: 'solid' }, symbol: 'none',
+            itemStyle: { color: '#c22' },
           }] : []),
           // swing pivot dots (見つけた pivot を可視化、debug + 教育用)。
           // candle (z:5) より上に出さないと candle 帯と重なる pivot が消える。
@@ -2603,15 +2610,10 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
               borderWidth: 1.5,
             },
             z: 5,
-            markLine: (positionMarkLines.length + trendMarkLineData.length) > 0 ? {
-              silent: true,
-              symbol: 'none',
-              // position lines (avg/stop/TP) と sloped trend lines を 1 つの
-              // markLine.data に集約。markLine は ECharts 仕様上 series 上層に
-              // 描かれるので、独立 line series で起きていた candle 隠蔽問題を
-              // 回避できる。
-              data: positionMarkLines.concat(trendMarkLineData),
-            } : undefined,
+            // position lines (avg/stop/TP) は candle 上 markLine。trend lines
+            // は candlestick の markLine では描画 robust ではなかったため SMA50
+            // 側の markLine に移動 (下方参照)。
+            markLine: positionMarkLines.length > 0 ? { silent: true, symbol: 'none', data: positionMarkLines } : undefined,
             markPoint: entries.length + exits.length > 0 ? {
               symbol: 'pin', symbolSize: 24, data: entries.concat(exits),
               tooltip: {
@@ -2632,7 +2634,20 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
           // 行間も Yahoo 日次で線が繋がる)。candle (z:5) より上に置いて細い
           // candle 帯に重なっても見えるようにする。色は TradingView 系で
           // SMA に多用される orange (#f59e0b)、solid 1.4px。
-          { name: 'SMA50', type: 'line', data: smasXY, lineStyle: { width: 1.4, color: '#f59e0b', type: 'solid' }, symbol: 'none', connectNulls: true, z: 6 },
+          {
+            name: 'SMA50', type: 'line', data: smasXY,
+            lineStyle: { width: 1.4, color: '#f59e0b', type: 'solid' },
+            symbol: 'none', connectNulls: true, z: 6,
+            // trend lines を SMA50 line series の markLine に host。
+            // type:'line' series の markLine は slanted [start, end] coord を
+            // 公式に supported (candlestick の markLine は #187 で host にしたが
+            // 描画されず)。silent で hover 反応無効にし overdraw を最小化。
+            markLine: trendMarkLineData.length > 0 ? {
+              silent: true,
+              symbol: 'none',
+              data: trendMarkLineData,
+            } : undefined,
+          },
         ],
       });
       window.addEventListener('resize', function () { symChart.resize(); });


### PR DESCRIPTION
## Summary
#187 (candle.markLine 経由) でも「未だ出ない」報告。candlestick の markLine が slanted \`[start, end]\` coord をうまく描画しない (or coord 解釈が一般 line series と異なる) 可能性が浮上したため、host を **SMA50 (type:'line') series の markLine に変更**。type:'line' series の markLine は公式に slanted markLine を支援する。

## 変更
- trend lines を SMA50 series の \`markLine\` に host 移行
- coord は ISO string → **数値 epoch ms** に統一 (time axis 解釈の揺らぎ排除)
- 凡例用に **空 data の trend line series** を 1 個ずつ温存 (markLine 自体は legend に出ない)
- candle.markLine は position lines (avg/stop/TP) のみに戻す
- 独立 trend line の \`type:'line'\` series 描画は廃止 (legend hint のみ)

## Test plan
- [x] \`pnpm typecheck\` — pass
- [x] \`pnpm test --run\` — 484 pass
- [ ] staging で AAPL chart に sloped trend line が描画されるか確認 (これで出なければ markLine 仕様限界、別アプローチ要)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * シンボルチャートのトレンドライン表示ロジックを更新しました。
  * サポート/レジスタンスラインの表示方法を調整しました。
  * チャートの可視化パフォーマンスを最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->