### PR TITLE
fix(dashboard): trend line を 1h 密点に展開し zoom 不問で描画

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1960,6 +1960,66 @@ export function fitTrendLineFromRecentPivots(
 }
 
 /**
+ * Trend line を「描画用の密点列」に展開する。
+ *
+ * 背景: ECharts の dataZoom + 2 点 line series は「片方の点が zoom 範囲外
+ * になると線が引かれない」既知挙動が widely 報告されている (issue #3637 系)。
+ * #189 で `filterMode: 'weakFilter'` に変更したが、それでもユーザ環境で
+ * trend line が描画されないケースが残った。
+ *
+ * 最も robust な解決策は line の data 自体を「常に zoom 範囲内に複数点が
+ * 入る粒度」にすること。ここでは intradayBars (1h candle、60 日で ~720 点)
+ * の各 timestamp で trend line の y 値を線形補間して、`[[t, y], ...]` の
+ * dense path に展開する。これで 5D (~120 点) や 1D zoom でも常に複数点が
+ * visible になり filterMode 不問で確実に描画される。
+ *
+ * 線形外挿: trend line は本来両側に伸びる概念線なので、p1 より過去側 / end
+ * より未来側の sample timestamp も同じ slope で外挿する (chart の見た目で
+ * 線が早期に「途切れる」のを避ける)。
+ *
+ * Fallback: sampleTimestamps が空 (Yahoo intraday fetch 失敗時 = 0 件) の
+ * とき、または line の 2 点が degenerate (t1 == t2) のときは 2 点
+ * endpoint をそのまま返す (旧挙動 = 描画は zoom 不安定だが少なくとも
+ * 全期間表示では出る)。
+ */
+export function densifyTrendLine(
+  line: TrendLineSegment | null,
+  sampleTimestamps: ReadonlyArray<string | number>,
+): Array<[number, number]> | null {
+  if (!line) return null
+  const t1 = new Date(line.pivots[0].timestamp).getTime()
+  const t2 = new Date(line.end.timestamp).getTime()
+  const y1 = line.pivots[0].price
+  const y2 = line.end.price
+  if (!Number.isFinite(t1) || !Number.isFinite(t2)) return null
+  if (!Number.isFinite(y1) || !Number.isFinite(y2)) return null
+  // degenerate: 2 点が同 timestamp → 線の slope 不定。fallback で 2 点返し。
+  if (t1 === t2) return [[t1, y1], [t2, y2]]
+  const slope = (y2 - y1) / (t2 - t1)
+  // sample timestamps を epoch ms に正規化、無効値は除外、unique + 昇順
+  const tsSet = new Set<number>()
+  for (const s of sampleTimestamps) {
+    const t = typeof s === 'number' ? s : new Date(s).getTime()
+    if (Number.isFinite(t)) tsSet.add(t)
+  }
+  // line の 2 点も常に含めて「pivot / end ちょうどでの y」を保証
+  tsSet.add(t1)
+  tsSet.add(t2)
+  const sorted = Array.from(tsSet).sort((a, b) => a - b)
+  // sample 0 件 (intradayBars 空) のときは 2 点 fallback
+  if (sorted.length < 2) return [[t1, y1], [t2, y2]]
+  const out: Array<[number, number]> = []
+  for (const t of sorted) {
+    const y = y1 + slope * (t - t1)
+    if (Number.isFinite(y)) out.push([t, y])
+  }
+  // out が空になることは tsSet に t1/t2 を入れているのでまず無いが、
+  // 安全のため最終 fallback。
+  if (out.length < 2) return [[t1, y1], [t2, y2]]
+  return out
+}
+
+/**
  * fill 行の BUY/SELL を決定する。
  * - 1st: pre_submit 行から JOIN で取得した side ('BUY'/'SELL') を採用
  * - 2nd: それも無い場合は realized_pnl の有無で推測
@@ -2356,23 +2416,62 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
       // を線形外挿)。教科書の「下値支持線 / 上値抵抗線」と同じ仕組み。
       // 検出失敗 (pivots < 2) なら null → 描画スキップ。
       //
-      // 過去 #185 / #187 / #188 で「描画されない」回帰があったが、根因は
-      // dataZoom の filterMode default 'filter' が 2 点しかない trend line
-      // series で 1 点 (古い pivot) が zoom 範囲外 → 点ごと filter → 残り
-      // 1 点で線が引けないというもの (ECharts issue #3637)。dataZoom 側で
-      // filterMode: 'weakFilter' にして両端いずれかが範囲内なら描画される
-      // ようにし、ここは 2 点 [oldPivot, chartEnd] の独立 line series で
-      // canonical に描く (markLine 経由は legend に出ないなど不便があった)。
-      // 数値 epoch ms に統一 (time axis の ISO 解釈揺らぎを排除)。
-      function trendLineXY(line) {
+      // 過去 #185 / #187 / #188 / #189 で「描画されない」回帰があったが、
+      // 根因は ECharts の dataZoom + 2 点 line series が「片方の点が zoom
+      // 範囲外になると線が引かれない」既知挙動 (issue #3637 系)。#189 で
+      // dataZoom の filterMode を 'weakFilter' に変えて改善したが、それでも
+      // ユーザ環境で残ケースがあった。本質的に robust にするため、line の
+      // data 自体を「常に zoom 範囲内に複数点が入る粒度」に展開する。
+      //
+      // 具体的には intradayBars (1h candle、60 日で ~720 点) の各 timestamp
+      // で trend line の y 値を線形補間し、[[t, y], ...] の dense path にす
+      // る。これで 5D (~120 点) や 1D zoom でも複数点が必ず visible になり
+      // filterMode 不問で線分が描画される。intradayBars が空 (Yahoo fetch
+      // 失敗) のときは 2 点 endpoint fallback (旧挙動)。
+      //
+      // 線形外挿: trend line は概念上両側に伸びる線なので、p1 より過去側 /
+      // end より未来側の sample も同じ slope で外挿する。
+      //
+      // ※ Server-side densifyTrendLine (export) と同じアルゴリズム。
+      //    unit test はそちらで担保する。client 側に inline するのは sc.*
+      //    オブジェクトを HTML script に埋めて echarts.init で消費するため。
+      var ohlcTimestamps = (sc.intradayBars || []).map(function (b) {
+        return new Date(b.timestamp).getTime();
+      });
+      function densifyTrendLine(line, sampleTimestamps) {
         if (!line) return null;
-        return [
-          [new Date(line.pivots[0].timestamp).getTime(), line.pivots[0].price],
-          [new Date(line.end.timestamp).getTime(), line.end.price],
-        ];
+        var t1 = new Date(line.pivots[0].timestamp).getTime();
+        var t2 = new Date(line.end.timestamp).getTime();
+        var y1 = line.pivots[0].price;
+        var y2 = line.end.price;
+        if (!Number.isFinite(t1) || !Number.isFinite(t2)) return null;
+        if (!Number.isFinite(y1) || !Number.isFinite(y2)) return null;
+        if (t1 === t2) return [[t1, y1], [t2, y2]];
+        var slope = (y2 - y1) / (t2 - t1);
+        var seen = Object.create(null);
+        var arr = [];
+        for (var i = 0; i < sampleTimestamps.length; i += 1) {
+          var t = sampleTimestamps[i];
+          if (!Number.isFinite(t)) continue;
+          if (seen[t]) continue;
+          seen[t] = true;
+          arr.push(t);
+        }
+        if (!seen[t1]) { seen[t1] = true; arr.push(t1); }
+        if (!seen[t2]) { seen[t2] = true; arr.push(t2); }
+        arr.sort(function (a, b) { return a - b; });
+        if (arr.length < 2) return [[t1, y1], [t2, y2]];
+        var out = [];
+        for (var j = 0; j < arr.length; j += 1) {
+          var tj = arr[j];
+          var yj = y1 + slope * (tj - t1);
+          if (Number.isFinite(yj)) out.push([tj, yj]);
+        }
+        if (out.length < 2) return [[t1, y1], [t2, y2]];
+        return out;
       }
-      var resistanceXY = trendLineXY(sc.resistanceLine);
-      var supportTrendXY = trendLineXY(sc.supportLine);
+      var resistanceXY = densifyTrendLine(sc.resistanceLine, ohlcTimestamps);
+      var supportTrendXY = densifyTrendLine(sc.supportLine, ohlcTimestamps);
       var pivotHighDots = sc.pivots
         .filter(function (pv) { return pv.type === 'high'; })
         .map(function (pv) { return [pv.timestamp, pv.price]; });
@@ -2566,13 +2665,15 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
             { name: '押し目ゾーン上端 (high20d × ' + (pullbackMaxMul).toFixed(2) + ')', type: 'line', data: bandUpperXY, lineStyle: { width: 0.6, color: '#057a55', type: 'dashed', opacity: 0.4 }, symbol: 'none', connectNulls: false, z: 1 },
             { name: '押し目ゾーン下端 (high20d × ' + (pullbackMinMul).toFixed(2) + ')', type: 'line', data: bandLowerXY, lineStyle: { width: 0.6, color: '#b25000', type: 'dashed', opacity: 0.4 }, symbol: 'none', connectNulls: false, z: 1 },
           ]),
-          // sloped trend lines: 直近 2 pivots を chart 末まで線形外挿した
-          // 2 点を独立 type:'line' series として描画。dataZoom filterMode は
-          // 上方で 'weakFilter' に設定済 → 古い pivot 端が zoom 範囲外でも
-          // line 自体は描画される (default 'filter' だと点ごと filter されて
-          // 残り 1 点で線が引けない既知症状)。z:7 で candle (z:5) / SMA50
-          // (z:6) より上に置き、線本体を最前面に。itemStyle.color は legend
-          // dot 色を lineStyle.color と揃えるため明示。
+          // sloped trend lines: 直近 2 pivots → chart 末への線形外挿 trend
+          // を、intradayBars 各 timestamp で y 補間した「dense path」として
+          // 描画。dataZoom filterMode が 'filter' / 'weakFilter' のどちら
+          // でも、zoom 範囲内に複数点が必ず入るので確実に描画される (2 点
+          // line series で zoom 縮めると seg-droppable な ECharts 既知挙動
+          // への根本対処)。z:7 で candle (z:5) / SMA50 (z:6) より上に置き、
+          // 線本体を最前面に。symbol:'none' で点 marker は出さない (見た目
+          // は変わらず元と同じ滑らかな直線)。itemStyle.color は legend dot
+          // 色を lineStyle.color と揃えるため明示。
           ...(resistanceXY ? [{
             name: '上値抵抗線 (sloped, 直近 2 pivot fit)', type: 'line', data: resistanceXY,
             lineStyle: { width: 1.8, color: '#1471a8', type: 'solid' }, symbol: 'none',

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -742,10 +742,12 @@ describe('computeChartWindowDays', () => {
 
 import {
   aggregateDailyCloses,
+  densifyTrendLine,
   detectFractalPivots,
   fitTrendLineFromRecentPivots,
   type SymbolChartPoint,
   type PivotPoint,
+  type TrendLineSegment,
 } from '../../src/routes/dashboard'
 
 describe('aggregateDailyCloses', () => {
@@ -879,6 +881,112 @@ describe('fitTrendLineFromRecentPivots', () => {
 
   it('endTimestamp 不正なら null', () => {
     expect(fitTrendLineFromRecentPivots([high1, high2], 'high', 'not-an-iso')).toBe(null)
+  })
+})
+
+describe('densifyTrendLine', () => {
+  // p1 = (t=0, y=100), end = (t=10, y=110) → slope 1/ms
+  // 実際の dashboard では epoch ms (~1.7e12) だが、線形補間の数学は
+  // origin 不変なので小さい数で test しても等価。
+  const baseLine: TrendLineSegment = {
+    pivots: [
+      { timestamp: new Date(0).toISOString(), price: 100, type: 'high' },
+      { timestamp: new Date(10).toISOString(), price: 110, type: 'high' },
+    ],
+    end: { timestamp: new Date(10).toISOString(), price: 110 },
+  }
+
+  it('line が null なら null', () => {
+    expect(densifyTrendLine(null, [0, 1, 2])).toBe(null)
+  })
+
+  it('intradayBars 各 timestamp で y を線形補間', () => {
+    const samples = [0, 2, 5, 8, 10]
+    const out = densifyTrendLine(baseLine, samples)
+    // slope = (110-100)/(10-0) = 1 → y = 100 + 1*t
+    expect(out).toEqual([
+      [0, 100],
+      [2, 102],
+      [5, 105],
+      [8, 108],
+      [10, 110],
+    ])
+  })
+
+  it('p1 / end の外側でも extrapolate (両側に伸びる)', () => {
+    // sample に -5 と 15 を含めると外挿される
+    const samples = [-5, 0, 10, 15]
+    const out = densifyTrendLine(baseLine, samples)
+    expect(out).toEqual([
+      [-5, 95],
+      [0, 100],
+      [10, 110],
+      [15, 115],
+    ])
+  })
+
+  it('intradayBars 空 (Yahoo fetch 失敗) のとき 2 点 endpoint fallback', () => {
+    const out = densifyTrendLine(baseLine, [])
+    expect(out).toEqual([
+      [0, 100],
+      [10, 110],
+    ])
+  })
+
+  it('ISO string sample timestamps も accept (各 b.timestamp は ISO)', () => {
+    const samples = [
+      new Date(0).toISOString(),
+      new Date(5).toISOString(),
+      new Date(10).toISOString(),
+    ]
+    const out = densifyTrendLine(baseLine, samples)
+    expect(out).toEqual([
+      [0, 100],
+      [5, 105],
+      [10, 110],
+    ])
+  })
+
+  it('重複 timestamp は dedupe + 昇順 sort', () => {
+    const samples = [10, 0, 5, 5, 10, 0]
+    const out = densifyTrendLine(baseLine, samples)
+    expect(out).toEqual([
+      [0, 100],
+      [5, 105],
+      [10, 110],
+    ])
+  })
+
+  it('NaN / 不正 timestamp は除外する', () => {
+    const samples: Array<string | number> = [
+      NaN,
+      'not-an-iso',
+      0,
+      5,
+      Number.POSITIVE_INFINITY,
+      10,
+    ]
+    const out = densifyTrendLine(baseLine, samples)
+    expect(out).toEqual([
+      [0, 100],
+      [5, 105],
+      [10, 110],
+    ])
+  })
+
+  it('p1 == end (degenerate) のとき 2 点 fallback (slope 不定)', () => {
+    const degenerate: TrendLineSegment = {
+      pivots: [
+        { timestamp: new Date(5).toISOString(), price: 100, type: 'high' },
+        { timestamp: new Date(5).toISOString(), price: 100, type: 'high' },
+      ],
+      end: { timestamp: new Date(5).toISOString(), price: 100 },
+    }
+    const out = densifyTrendLine(degenerate, [0, 5, 10])
+    expect(out).toEqual([
+      [5, 100],
+      [5, 100],
+    ])
   })
 })
 


### PR DESCRIPTION
## 根因

ECharts の `dataZoom` + 「2 点しか持たない line series」は、片方の端点が zoom 範囲外になると線分が描画されない既知挙動 (issue #3637 系) がある。

- #185 / #187 / #188 で「描画されない」回帰の都度別アプローチを試行
- #189 で `dataZoom.filterMode: 'weakFilter'` に変更 → 改善はしたが、ユーザ環境ではまだ trend line が消えるケースが残った
- 2 点 line series である限り、ECharts の line segment 補間挙動は zoom range / browser / data 配置で seg-droppable

## 修正

trend line series の `data` 自体を「常に zoom 範囲内に複数点が入る粒度」の密点列に展開する。

- 入力: `TrendLineSegment` (server-side で fitTrendLineFromRecentPivots が出した直近 2 pivot fit)
- サンプル粒度: `intradayBars` (1h candle、60 日で ~720 点) の各 timestamp
- 各 timestamp で `y = p1.price + slope * (t - p1.timestamp)` の線形補間
- 出力: `[[t1, y1], [t2, y2], ..., [tN, yN]]` (epoch ms)
- 結果: 5D zoom (~120 点) や 1D zoom でも複数点が必ず visible → filterMode 不問で描画

線形外挿: trend line は概念上両側に伸びる線なので、p1 より過去側 / end より未来側の sample も同じ slope で外挿。

Fallback:
- `intradayBars` が空 (Yahoo fetch 失敗) のとき → 2 点 endpoint をそのまま (旧挙動)
- pivot 2 点が degenerate (t1 == t2) のとき → 2 点 fallback

`#189` の `filterMode: 'weakFilter'` は副作用無く他 series にも有用なのでそのまま残す。

## 既存実装の整理

- `densifyTrendLine` を server-side `src/routes/dashboard.ts` に export → unit test で算式担保
- client side `<script>` にも同アルゴリズムを inline (`window.__chartData` の `sc.*` を直接消費するため)
- 独立 `type: 'line'` series 構成は維持 (markLine 経由は legend に出ないため)
- 2 点 line から密点 line に変えただけで、視覚的には元と同じ滑らかな直線

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test --run` 全 492 pass (新規 8 ケース含む)
- [x] `densifyTrendLine` の unit test 8 ケース:
  - line が null
  - intradayBars 各 timestamp で y を線形補間
  - p1 / end の外側でも extrapolate
  - intradayBars 空のとき 2 点 endpoint fallback
  - ISO string sample timestamps も accept
  - 重複 timestamp は dedupe + 昇順 sort
  - NaN / 不正 timestamp は除外
  - p1 == end (degenerate) のとき 2 点 fallback
- [ ] `pnpm dev` でユーザ環境の zoom 操作で trend line が常時描画されること
- [ ] 5D / 1D zoom (古い pivot が範囲外) で line が消えないこと
- [ ] Yahoo intraday fetch 失敗時に 2 点 fallback で全期間表示は出ること

## 関連

- #189 (`filterMode: 'weakFilter'`、merge 済) の上に積む
- #185 / #187 / #188 と同じ症状の根本対処