### PR TITLE
feat(dashboard): セッション境界に縦の薄グレー点線を追加

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -2421,6 +2421,21 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
       var ohlcMs = ohlcBars.map(function (b) { return new Date(b.timestamp).getTime(); });
       var categories = ohlcBars.map(function (b) { return b.timestamp; });
 
+      // セッション境界 (休場 → 開場) 検出:
+      // category axis 化で休場 gap が詰まった結果 (#193)、視覚的に
+      // 「どこから新セッションか」が分かりにくくなった。1h interval なので
+      // 隣接 bar は通常 60 分差。週末 / 夜間 closed 後の最初の bar は数時間〜
+      // 数十時間ぶんの差が空く。閾値 90 分 (= 1.5h) で safe に検出し、後ろ側
+      // category index を「新セッションの開場点」として markLine 描画する。
+      // useCategoryAxis === false (intradayBars 空) の場合は描画 skip。
+      var sessionOpenIndices = [];
+      if (useCategoryAxis) {
+        var SESSION_GAP_MS = 90 * 60 * 1000;
+        for (var si = 1; si < ohlcMs.length; si++) {
+          if (ohlcMs[si] - ohlcMs[si - 1] >= SESSION_GAP_MS) sessionOpenIndices.push(si);
+        }
+      }
+
       // Map a millisecond timestamp to the nearest category index.
       // ohlcMs は intradayBars の順序 (= Yahoo の昇順) を保つ前提。binary search
       // で近接 index を返す。ohlcMs 空 (= time axis fallback) なら -1。
@@ -2893,6 +2908,22 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
             // として描画する (下方参照、densifyHorizontalLine 適用)。
             // candlestick の markLine は trend line / position line いずれも
             // dataZoom + 2 点だと「片端外で線が消える」回帰があるため使わない。
+            //
+            // ただしセッション境界の縦点線は xAxis: <category index> 指定で
+            // y 軸全幅にまたがる「真の vertical markLine」となり、ECharts の
+            // 描画 path が trend line (slanted 2-point markLine) とは別系統。
+            // 縦線方向は zoom 範囲外でも描画ロバスト (#193 follow-up)。
+            // category 軸モード時のみ data を積む (time axis fallback では空)。
+            markLine: sessionOpenIndices.length > 0 ? {
+              symbol: 'none',
+              silent: true,
+              label: { show: false },
+              lineStyle: { color: '#bbb', width: 1, type: 'dashed' },
+              z: 1,
+              data: sessionOpenIndices.map(function (idx) {
+                return { xAxis: idx };
+              }),
+            } : undefined,
             markPoint: entries.length + exits.length > 0 ? {
               symbol: 'pin', symbolSize: 24, data: entries.concat(exits),
               tooltip: {


### PR DESCRIPTION
## 動機

#193 で symbol chart の x 軸を category axis に切り替え、休場 gap を詰めて表示するようにした (TradingView 同等の挙動)。
副作用として「どこから新セッションか (= overnight / 週末 / 米国祝日明けの最初の bar)」が
詰まった bar 列の中で視覚的に判別できなくなった。

本 PR は **休場 → 開場 (各取引セッション境界)** に縦の薄グレー点線 (markLine) を引いて、
session 境界を視覚化する。

## 検出ロジック

- `intradayBars` (1h Yahoo intraday) の連続する 2 つの timestamp 差が **90 分 (1.5h) 以上** の箇所を「休場 → 開場 境界」とみなす
- 1h interval なので通常隣接 bar は 60 min 差。週末/夜間 closed なら数時間〜数十時間の gap が空く。1.5h 閾値で safe
- 後ろ側 category index = 新セッション開場点。これを `markLine.data` に積む

```js
var sessionOpenIndices = [];
if (useCategoryAxis) {
  var SESSION_GAP_MS = 90 * 60 * 1000;
  for (var si = 1; si < ohlcMs.length; si++) {
    if (ohlcMs[si] - ohlcMs[si - 1] >= SESSION_GAP_MS) sessionOpenIndices.push(si);
  }
}
```

## 描画方式

- candle series の `markLine` に `{ xAxis: <category index> }` 形式で積む
- `xAxis: <index>` 指定の **真の vertical markLine** は ECharts で y 軸全幅にまたがる線分を一気に描く描画 path で、trend line / position line で問題が出た「2 点 markLine が zoom 端で消える」回帰 (#3637 系) とは別系統 → 縦線方向は zoom にロバスト
- スタイル: `lineStyle: { color: '#bbb', width: 1, type: 'dashed' }`、`symbol: 'none'`、`silent: true`、`label: { show: false }`、`z: 1` (candle z:5 / SMA z:6 / position lines z:8 の邪魔をしない)
- `useCategoryAxis === false` (intradayBars 空 = time axis fallback) では `markLine` 自体を `undefined` にして描画 skip

## 変更ファイル

- `src/routes/dashboard.ts` のみ (chart init script 内)

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test --run` 500 tests all pass (純 client-side 描画ロジック、新規 helper 無しなので unit test 追加なし)
- [ ] visual 確認 (user): dashboard の symbol chart を開き、overnight / 週末明けの最初の bar の左側に薄グレー縦点線が出ることを確認
- [ ] visual 確認 (user): dataZoom で範囲を狭めても点線が描画されること
- [ ] visual 確認 (user): time axis fallback 時 (intradayBars 空シンボル) は点線が出ないこと

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

**新機能**
- シンボルチャートのカテゴリー軸モードでセッション境界を自動検出し、セッション開始位置を破線で視覚的に表示するよう改善

<!-- end of auto-generated comment: release notes by coderabbit.ai -->