### PR TITLE
fix(strategy): cron の price source を Yahoo intraday 1h close に切替 (chart candle と整合)

### DIFF
--- a/src/infrastructure/quotes/BarClient.ts
+++ b/src/infrastructure/quotes/BarClient.ts
@@ -17,8 +17,32 @@ function resolveBarCategory(symbol: string): BarCategory {
   return US_ETF_SYMBOLS.has(symbol) ? 'US_ETF' : 'US_STOCK'
 }
 
+/**
+ * 5/15/30/60 分足。Yahoo `/v8/finance/chart` の `interval` enum と一致。
+ * 戦略 cron は最新 1h close を indicators.price として使うため `60m` を渡す。
+ */
+export type IntradayInterval = '5m' | '15m' | '30m' | '60m'
+
+/**
+ * Intraday OHLC bar。`timestamp` は秒精度の ISO UTC (Yahoo の epoch second を
+ * `new Date(ts*1000).toISOString()` 化したもの)。
+ */
+export interface IntradayBar {
+  timestamp: string
+  open: number
+  high: number
+  low: number
+  close: number
+}
+
 export interface BarClient {
   getDailyBars(symbol: string, lookback: number): Promise<DailyBar[]>
+  /**
+   * Optional intraday fetch。strategy cron が「当日最新 1h close」を fill 価格
+   * として使う際に呼び出す。未実装の client (Webull 等) は省略可で、cron 側は
+   * fallback して daily close を使う。
+   */
+  getIntradayBars?(symbol: string, interval: IntradayInterval): Promise<IntradayBar[]>
 }
 
 export interface WebullBarClientEnv {

--- a/src/infrastructure/quotes/YahooBarClient.ts
+++ b/src/infrastructure/quotes/YahooBarClient.ts
@@ -1,7 +1,12 @@
 import type { DailyBar } from '../../trading/strategy/indicators'
 import { BrokerRequestError, brokerErrorForStatus } from '../../shared/errors'
 import { inferWebullMarket } from '../webull/mapper'
-import type { BarClient } from './BarClient'
+import type { BarClient, IntradayBar, IntradayInterval } from './BarClient'
+
+// Re-export so existing dashboard / chart code that imports these types
+// from `YahooBarClient` keeps working. Source-of-truth lives in BarClient
+// to avoid a circular import (YahooBarClient implements BarClient).
+export type { IntradayBar, IntradayInterval }
 
 const DEFAULT_BASE_URL = 'https://query1.finance.yahoo.com'
 const DEFAULT_TIMEOUT_MS = 5_000
@@ -158,17 +163,6 @@ export class YahooBarClient implements BarClient {
     const json = (await response.json()) as YahooChartResponse
     return normalizeIntradayChart(json)
   }
-}
-
-export type IntradayInterval = '5m' | '15m' | '30m' | '60m'
-
-export interface IntradayBar {
-  /** ISO UTC timestamp (Yahoo は epoch second を返す → ms 化して toISOString) */
-  timestamp: string
-  open: number
-  high: number
-  low: number
-  close: number
 }
 
 /**

--- a/src/trading/strategy/indicators.ts
+++ b/src/trading/strategy/indicators.ts
@@ -30,8 +30,18 @@ export interface PullbackIndicatorSnapshot {
  * Computes the inputs PullbackUptrendStrategy needs from the last ~60 daily
  * bars. `bars` must be oldest-first. Returns `null` when the window is too
  * short — strategy stays HOLD rather than fire on half-initialized data.
+ *
+ * `intradayPrice` (optional) は cron が当日最新 1h close を渡す経路。指定が
+ * あればそれを `price` として採用 (= chart 表示の candle と整合する fill 価格)。
+ * NaN / Infinity / 0 / 負値 / null / undefined はすべて無視して daily close
+ * (前日終値) に fallback し、既存挙動と等価になる。SMA50 / ATR / return50d /
+ * high20d / low20d は引き続き daily bars から計算する (intradayPrice は影響
+ * しない)。
  */
-export function computePullbackIndicators(bars: DailyBar[]): PullbackIndicatorSnapshot | null {
+export function computePullbackIndicators(
+  bars: DailyBar[],
+  intradayPrice?: number | null,
+): PullbackIndicatorSnapshot | null {
   if (bars.length < 50) return null
 
   const closes = bars.map((b) => b.close)
@@ -53,7 +63,14 @@ export function computePullbackIndicators(bars: DailyBar[]): PullbackIndicatorSn
   // against to decide whether to floor the size. 60 bars ≈ ~3 months daily.
   const baselineAtr20 = average(trueRanges.slice(-Math.min(trueRanges.length, 60)))
 
-  return { price: last, sma50, return50d, high20d, low20d, atr20, baselineAtr20 }
+  // intradayPrice がきちんと正値の有限数なら採用、そうでなければ daily close。
+  // `> 0` で 0 / 負値もはじき、Number.isFinite で NaN / Infinity をはじく。
+  const price =
+    typeof intradayPrice === 'number' && Number.isFinite(intradayPrice) && intradayPrice > 0
+      ? intradayPrice
+      : last
+
+  return { price, sma50, return50d, high20d, low20d, atr20, baselineAtr20 }
 }
 
 export function computeHoldBusinessDays(

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -204,15 +204,28 @@ export async function runPullbackScheduler(
     summary.evaluated += 1
     const upper = symbol.toUpperCase()
     let bars: DailyBar[]
+    let intradayPrice: number | null = null
     try {
-      bars = await options.barClient.getDailyBars(symbol, lookback)
+      // Daily と intraday は別エンドポイント。並行で叩いて intraday 失敗は
+      // null fallback (= daily close 採用、既存挙動と等価)。daily 失敗は致命
+      // (indicators が出ない) なので throw のまま。
+      const dailyP = options.barClient.getDailyBars(symbol, lookback)
+      const intradayP = options.barClient.getIntradayBars
+        ? options.barClient.getIntradayBars(symbol, '60m').catch(() => [])
+        : Promise.resolve([])
+      const [dailyBars, intradayBars] = await Promise.all([dailyP, intradayP])
+      bars = dailyBars
+      // 最新 1h bar の close を fill 価格として使う。chart UI も同じ
+      // intraday endpoint を見ているので BUY pin と candle がズレない。
+      const lastIntraday = intradayBars[intradayBars.length - 1]
+      intradayPrice = lastIntraday ? lastIntraday.close : null
     } catch (error) {
       summary.errors.push({ symbol: upper, message: messageOf(error) })
       await emitDecision({ symbol: upper, decision: 'ERROR', reason: `bar fetch: ${messageOf(error)}` })
       continue
     }
 
-    const indicators = computePullbackIndicators(bars)
+    const indicators = computePullbackIndicators(bars, intradayPrice)
     if (!indicators) {
       summary.rejected.push({ symbol: upper, reason: 'insufficient bars for indicators' })
       await emitDecision({ symbol: upper, decision: 'REJECT', reason: 'insufficient bars for indicators' })

--- a/test/trading/strategy/indicators.test.ts
+++ b/test/trading/strategy/indicators.test.ts
@@ -43,6 +43,42 @@ describe('computePullbackIndicators', () => {
     const r = computePullbackIndicators(bars)!
     expect(r.low20d).toBeCloseTo(50, 4)
   })
+
+  describe('intradayPrice override', () => {
+    const closes = Array.from({ length: 60 }, (_, i) => 100 + i)
+    const bars = makeBars(closes)
+    // daily close ベースの fixture 値: last = 159, sma50 = 134.5, return50d = (159-110)/110
+    const dailyOnly = computePullbackIndicators(bars)!
+
+    it('uses intradayPrice as price when provided and positive', () => {
+      const r = computePullbackIndicators(bars, 200)!
+      expect(r.price).toBe(200)
+      // daily 系 indicator は intraday の影響を受けない
+      expect(r.sma50).toBeCloseTo(dailyOnly.sma50, 4)
+      expect(r.return50d).toBeCloseTo(dailyOnly.return50d, 4)
+      expect(r.high20d).toBeCloseTo(dailyOnly.high20d, 4)
+      expect(r.low20d).toBeCloseTo(dailyOnly.low20d, 4)
+      expect(r.atr20).toBeCloseTo(dailyOnly.atr20, 4)
+      expect(r.baselineAtr20).toBeCloseTo(dailyOnly.baselineAtr20, 4)
+    })
+
+    it('falls back to daily close when intradayPrice is omitted', () => {
+      const r = computePullbackIndicators(bars)!
+      expect(r.price).toBe(159)
+    })
+
+    it('falls back to daily close when intradayPrice is null', () => {
+      const r = computePullbackIndicators(bars, null)!
+      expect(r.price).toBe(159)
+    })
+
+    it('falls back to daily close on NaN / Infinity / 0 / negative', () => {
+      expect(computePullbackIndicators(bars, Number.NaN)!.price).toBe(159)
+      expect(computePullbackIndicators(bars, Number.POSITIVE_INFINITY)!.price).toBe(159)
+      expect(computePullbackIndicators(bars, 0)!.price).toBe(159)
+      expect(computePullbackIndicators(bars, -10)!.price).toBe(159)
+    })
+  })
 })
 
 describe('computeHoldBusinessDays', () => {

--- a/test/trading/strategy/pullbackScheduler.test.ts
+++ b/test/trading/strategy/pullbackScheduler.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import type { BarClient } from '../../../src/infrastructure/quotes/BarClient'
+import type { BarClient, IntradayBar } from '../../../src/infrastructure/quotes/BarClient'
 import type { Execution } from '../../../src/trading/execution/Execution'
 import type { PositionStore } from '../../../src/trading/state/PositionStore'
 import { emptySymbolState, type SymbolState } from '../../../src/trading/state/types'
@@ -150,5 +150,62 @@ describe('runPullbackScheduler', () => {
 
     expect(summary.errors).toEqual([{ symbol: 'BROKEN', message: 'upstream 500' }])
     expect(summary.buys).toBe(1)
+  })
+
+  it('uses intraday 1h close as fill price when getIntradayBars resolves', async () => {
+    // 既存 BUY fixture (uptrendBars) は daily last close = 117.5。chart UI と
+    // 整合させるため cron は intraday の最新 close を採用するのが今回の挙動。
+    // 117.5 とは別の値 (118.25) を返して fill 価格 (= intent.price) がそちらに
+    // なることを確認する。
+    const intradayBars: IntradayBar[] = [
+      { timestamp: '2026-04-20T13:00:00.000Z', open: 117.6, high: 118.4, low: 117.4, close: 118.0 },
+      { timestamp: '2026-04-20T14:00:00.000Z', open: 118.0, high: 118.5, low: 117.9, close: 118.25 },
+    ]
+    const store = makeStore({})
+    const execution = mockExecution()
+    const barClient: BarClient = {
+      getDailyBars: vi.fn(async () => uptrendBars()),
+      getIntradayBars: vi.fn(async () => intradayBars),
+    }
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient,
+      positionStore: store,
+      execution,
+      now: () => now,
+    })
+
+    expect(summary.buys).toBe(1)
+    expect(execution.calls).toHaveLength(1)
+    const intent = execution.calls[0] as { side: string; price: number }
+    expect(intent.side).toBe('BUY')
+    expect(intent.price).toBe(118.25)
+    // decision sink に渡る price も intraday 由来のものになっていること
+    expect(summary.decisions[0]?.price).toBe(118.25)
+  })
+
+  it('falls back to daily close when getIntradayBars rejects', async () => {
+    const store = makeStore({})
+    const execution = mockExecution()
+    const barClient: BarClient = {
+      getDailyBars: vi.fn(async () => uptrendBars()),
+      getIntradayBars: vi.fn(async () => {
+        throw new Error('yahoo 429')
+      }),
+    }
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient,
+      positionStore: store,
+      execution,
+      now: () => now,
+    })
+
+    // intraday 失敗は致命扱いせず daily close (= 117.5) で fallback。
+    expect(summary.buys).toBe(1)
+    const intent = execution.calls[0] as { side: string; price: number }
+    expect(intent.price).toBe(117.5)
   })
 })


### PR DESCRIPTION
## 動機

User feedback: dashboard chart の BUY pin に表示される `filled_price` (例: 269.48) と、ほぼ同時刻の 1h candle の OHLC (例: H 268.02) が矛盾するケースがあった。

原因は cron 側 `computePullbackIndicators` が `price = closes[closes.length - 1]` (= Yahoo daily bars の最後の close = **前日の終値**) を採用していたこと。一方 chart UI は当日の 1h intraday candle を描画していたため、値の取得時刻 / 粒度が噛み合わず、DRY_RUN fill price と candle が見た目上ズレる。

User と相談して **option A: cron の price だけ intraday 化** を選択した。

## 変更概要

- `computePullbackIndicators(bars, intradayPrice?)` に optional 第二引数を追加。`intradayPrice` が finite かつ正値ならそれを `price` に採用、それ以外は従来通り daily close に fallback。SMA50 / ATR / return50d / high20d / low20d は引き続き daily bars から計算 (intradayPrice の影響を受けない)。
- `pullbackScheduler` で `barClient.getDailyBars` と `barClient.getIntradayBars(symbol, '60m')` を `Promise.all` で並行 fetch。intraday は `.catch(() => [])` で fail-safe。最新 1h bar の close を `intradayPrice` として `computePullbackIndicators` に渡す。
- `BarClient` interface に `getIntradayBars` を **optional method** として追加。Webull 側の bar client や既存テスト mock を壊さないため。
- `IntradayBar` / `IntradayInterval` の source-of-truth を `BarClient.ts` に移し、`YahooBarClient.ts` から re-export (循環 import 回避)。

## 副作用 (semantic change)

- 戦略判定の price source が「前日 close」→「当日最新 1h close」に変わる。BUY/SELL の trigger / sizing entry price が当日値ベースになるので、評価 timing 由来の若干の挙動差が出る。User 承認済み (option A 選択時)。
- intraday 取得が失敗した場合は従来挙動 (daily close) で動くので、Yahoo 障害時の fail-closed は維持。

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test --run` — 506/506 pass
- [x] `indicators.test.ts`: intradayPrice 採用 / null / NaN / Infinity / 0 / 負値 fallback / daily 系 indicator が intraday に影響されないこと
- [x] `pullbackScheduler.test.ts`: intraday close (118.25) が daily close (117.5) を上書きすることを assert (intent.price も decision.price も 118.25)、intraday reject 時に daily close へ fallback すること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * イントラデイ(日中)のOHLCデータ取得機能を追加しました。5分、15分、30分、60分の時間間隔に対応しています。
  * スケジューラーが日中のバーデータを自動的に取得し、価格計算に反映するようになりました。
  * 日中データが利用できない場合は、自動的に日次終値にフォールバックします。

* **Tests**
  * イントラデイ価格機能の包括的なテストカバレッジを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->