### PR TITLE
feat(backtest): Pullback Uptrend 戦略の offline backtest harness 実装 (#198)

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -6,6 +6,10 @@ import { PortfolioStateClient } from '../trading/state/PortfolioStateClient'
 import { SymbolStateClient } from '../trading/state/SymbolStateClient'
 import { reconcileFills } from '../trading/reconciliation/reconcileFills'
 import { runStrategyCron } from '../trading/strategy/runStrategyCron'
+import { YahooBarClient } from '../infrastructure/quotes/YahooBarClient'
+import { loadGlobalConfigFrom } from '../infrastructure/db/globalConfigLoader'
+import { runBacktest, type BacktestParams } from '../trading/backtest/runBacktest'
+import type { SymbolRule } from '../trading/strategy/strategies/PullbackUptrendStrategy'
 
 /**
  * Operator-only endpoints. Basic-auth-protected by the same middleware as
@@ -63,6 +67,106 @@ export const admin = new Hono<AppBindings>()
    */
   .post('/strategy/run', async (c) => {
     const result = await runStrategyCron(c.env)
+    return c.json(result)
+  })
+  /**
+   * Offline backtest harness for PullbackUptrendStrategy (issue #198)。
+   *
+   * Yahoo Finance daily bars を取って `runBacktest` に流し込み、結果 JSON を
+   * 返す。POC で `pullback_default_*` の妥当性を data-driven に評価するための
+   * tool — 実発注は **しない** (純粋計算)。
+   *
+   * Query:
+   *   - `symbol`         (required)  e.g. AAPL / 7203
+   *   - `from`, `to`     (required)  ISO date "YYYY-MM-DD"
+   *   - `initialCash`    (optional)  default 10000
+   *   - `stopPct`, `takeProfitPct`, `timeStopDays`, `pullbackMax`,
+   *     `pullbackMin`, `minReturn50d`, `kAtr` (optional)  global_config 既定
+   *     を override
+   *
+   * 返り値は `BacktestResult` をそのまま JSON 化したもの。in-memory only、
+   * D1 永続化は別 PR (issue #198 の `backtest_run` / `backtest_trade`)。
+   */
+  .get('/backtest', async (c) => {
+    const symbol = readRequiredParam(c.req.query('symbol'), 'symbol').toUpperCase()
+    const from = readRequiredParam(c.req.query('from'), 'from')
+    const to = readRequiredParam(c.req.query('to'), 'to')
+    if (!isYmd(from)) throw new ValidationError("'from' must be YYYY-MM-DD", { field: 'from' })
+    if (!isYmd(to)) throw new ValidationError("'to' must be YYYY-MM-DD", { field: 'to' })
+    if (from > to) {
+      throw new ValidationError("'from' must be <= 'to'", { field: 'from' })
+    }
+    const initialCash = readOptionalNumber(c.req.query('initialCash'), 'initialCash', 10_000, {
+      mustBePositive: true,
+    })
+
+    const global = await loadGlobalConfigFrom(c.env)
+    const rule: SymbolRule = {
+      stopPct: readOptionalNumber(
+        c.req.query('stopPct'),
+        'stopPct',
+        global.pullbackDefaultStopPct,
+        {},
+      ),
+      takeProfitPct: readOptionalNumber(
+        c.req.query('takeProfitPct'),
+        'takeProfitPct',
+        global.pullbackDefaultTakeProfitPct,
+        {},
+      ),
+      timeStopDays: readOptionalNumber(
+        c.req.query('timeStopDays'),
+        'timeStopDays',
+        global.pullbackDefaultTimeStopDays,
+        { mustBePositive: true },
+      ),
+      pullbackMax: readOptionalNumber(
+        c.req.query('pullbackMax'),
+        'pullbackMax',
+        global.pullbackDefaultPullbackMax,
+        {},
+      ),
+      pullbackMin: readOptionalNumber(
+        c.req.query('pullbackMin'),
+        'pullbackMin',
+        global.pullbackDefaultPullbackMin,
+        {},
+      ),
+      minReturn50d: readOptionalNumber(
+        c.req.query('minReturn50d'),
+        'minReturn50d',
+        global.pullbackDefaultMinReturn50d,
+        {},
+      ),
+      requireAboveSma50: global.pullbackDefaultRequireAboveSma50,
+      kAtr: readOptionalNumber(c.req.query('kAtr'), 'kAtr', global.pullbackDefaultKAtr, {
+        mustBePositive: true,
+      }),
+    }
+
+    // Need at least 50 warmup bars before `from` for SMA50; estimate generous
+    // lookback in calendar days then trim with `from`/`to`. ~1.6× fudge to
+    // cover holidays.
+    const lookbackDays = estimateLookbackDays(from, to)
+    const barClient = new YahooBarClient()
+    const allBars = await barClient.getDailyBars(symbol, lookbackDays)
+    const bars = allBars.filter((b) => b.date <= to)
+    // Keep at least the first 50 bars before `from` as warmup; if available
+    // we slice to (from - warmup_buffer)..to. Yahoo already returned them
+    // oldest-first.
+    const liveStartIdx = bars.findIndex((b) => b.date >= from)
+    const warmupKeep = 60
+    const sliced =
+      liveStartIdx >= 0 ? bars.slice(Math.max(0, liveStartIdx - warmupKeep)) : bars
+
+    const params: BacktestParams = {
+      symbol,
+      from,
+      to,
+      initialCash,
+      rule,
+    }
+    const result = await runBacktest(sliced, params)
     return c.json(result)
   })
   /**
@@ -154,4 +258,48 @@ function readAmount(body: unknown): number {
     throw new ValidationError('amount must be a finite number >= 0', { field: 'amount' })
   }
   return value
+}
+
+function readRequiredParam(value: string | undefined, field: string): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new ValidationError(`'${field}' query param is required`, { field })
+  }
+  return value.trim()
+}
+
+function readOptionalNumber(
+  value: string | undefined,
+  field: string,
+  defaultValue: number,
+  opts: { mustBePositive?: boolean },
+): number {
+  if (value === undefined || value === '') return defaultValue
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed)) {
+    throw new ValidationError(`'${field}' must be a finite number`, { field })
+  }
+  if (opts.mustBePositive && parsed <= 0) {
+    throw new ValidationError(`'${field}' must be > 0`, { field })
+  }
+  return parsed
+}
+
+function isYmd(value: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(value) && Number.isFinite(Date.parse(`${value}T00:00:00.000Z`))
+}
+
+/**
+ * Yahoo `getDailyBars` takes a bar count (lookback). Translate the requested
+ * date range into a generous bar count covering 60 warmup bars + (to-from)
+ * trading days plus a 50% holiday/weekend fudge factor. Capped at the largest
+ * Yahoo bucket (5y / ~1300 bars).
+ */
+function estimateLookbackDays(fromYmd: string, toYmd: string): number {
+  const a = Date.parse(`${fromYmd}T00:00:00.000Z`)
+  const b = Date.parse(`${toYmd}T00:00:00.000Z`)
+  if (!Number.isFinite(a) || !Number.isFinite(b) || b < a) return 200
+  const calendarDays = Math.max(1, Math.round((b - a) / 86_400_000) + 1)
+  // Trading days ≈ calendar * 5/7. Add 60 warmup + 20 buffer.
+  const tradingDays = Math.ceil(calendarDays * (5 / 7)) + 60 + 20
+  return Math.min(1300, Math.max(80, tradingDays))
 }

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -151,13 +151,20 @@ export const admin = new Hono<AppBindings>()
     const barClient = new YahooBarClient()
     const allBars = await barClient.getDailyBars(symbol, lookbackDays)
     const bars = allBars.filter((b) => b.date <= to)
-    // Keep at least the first 50 bars before `from` as warmup; if available
+    // Keep at least the first 60 bars before `from` as warmup; if available
     // we slice to (from - warmup_buffer)..to. Yahoo already returned them
     // oldest-first.
     const liveStartIdx = bars.findIndex((b) => b.date >= from)
+    if (liveStartIdx === -1) {
+      // No bars within [from, to]: Yahoo had no daily data for the requested
+      // window (e.g. `from` is in the future, or symbol delisted before
+      // `from`). Reject with 400 instead of silently running on the entire
+      // pre-`from` history (which would compute against an unrelated window
+      // and return a misleading 200).
+      throw new ValidationError('no bars found in requested range', { field: 'from' })
+    }
     const warmupKeep = 60
-    const sliced =
-      liveStartIdx >= 0 ? bars.slice(Math.max(0, liveStartIdx - warmupKeep)) : bars
+    const sliced = bars.slice(Math.max(0, liveStartIdx - warmupKeep))
 
     const params: BacktestParams = {
       symbol,

--- a/src/trading/backtest/runBacktest.ts
+++ b/src/trading/backtest/runBacktest.ts
@@ -115,8 +115,11 @@ export async function runBacktest(
   let peakEquity = params.initialCash
 
   // computePullbackIndicators requires >=50 bars. Walk forward starting at
-  // index 50 so the first decision has a full warmup window.
-  const warmup = 50
+  // index 60 so the first decision has the same recent 60-bar window the
+  // strategy assumes — and so admin.ts (which pre-slices with
+  // `warmupKeep = 60` before calling us) doesn't lose its first 10 live bars
+  // to under-warmed iterations.
+  const warmup = 60
 
   for (let i = warmup; i < bars.length; i += 1) {
     // Use bars up to and including the current day for the indicator window.
@@ -165,6 +168,15 @@ export async function runBacktest(
       }
     } else if (signal.action === 'SELL' && position !== null) {
       const price = today.close
+      if (!Number.isFinite(price) || price <= 0) {
+        // Defensive: a bad close (NaN / 0 / negative) on the SELL bar would
+        // poison realizedPnl, equity, Sharpe and MaxDD all at once. Refuse
+        // rather than silently corrupt the result. BUY side already rejects
+        // implicitly via `price > 0`.
+        throw new Error(
+          `runBacktest: invalid close price for ${params.symbol} on ${today.date}`,
+        )
+      }
       const realizedPnl = (price - position.avgPrice) * position.qty
       cash += position.qty * price
       trades.push({
@@ -196,6 +208,13 @@ export async function runBacktest(
   if (position !== null && bars.length > 0) {
     const last = bars[bars.length - 1]!
     const price = last.close
+    if (!Number.isFinite(price) || price <= 0) {
+      // Same rationale as the SELL branch — a bad final close would silently
+      // wreck totalPnl / equityCurve / Sharpe / MaxDD.
+      throw new Error(
+        `runBacktest: invalid close price for ${params.symbol} on ${last.date}`,
+      )
+    }
     const realizedPnl = (price - position.avgPrice) * position.qty
     cash += position.qty * price
     trades.push({

--- a/src/trading/backtest/runBacktest.ts
+++ b/src/trading/backtest/runBacktest.ts
@@ -1,0 +1,387 @@
+import { computePullbackIndicators, type DailyBar } from '../strategy/indicators'
+import {
+  PullbackUptrendStrategy,
+  type SymbolRule,
+} from '../strategy/strategies/PullbackUptrendStrategy'
+import type { PositionState } from '../state/types'
+
+/**
+ * Offline backtest harness for PullbackUptrendStrategy。issue #198。
+ *
+ * 既存の `PullbackUptrendStrategy.decide()` を **そのまま** 呼ぶことで
+ * live cron と同じ判定を再現する (= backtest と本番で divergence しない)。
+ * Sizing / risk gate / pending-lock はバイパスし、純粋な entry / exit
+ * 判定の収益性のみを評価する (POC で `pullback_default_*` を data-driven
+ * に tuning するための tool)。
+ *
+ * 使い方:
+ *   const bars = await yahoo.getDailyBars('AAPL', 300)  // warmup + live
+ *   const result = await runBacktest(bars, params)
+ *
+ * `bars` は **oldest-first** で、最初の 50 本以上は warmup (SMA50 / ATR
+ * 算出用) として消費される。それ以降の bar 各日でストラテジーを 1 tick
+ * 進める。
+ */
+
+export interface BacktestParams {
+  symbol: string
+  /** ISO date "YYYY-MM-DD". 含まれる bar の最も古い日 (warmup 込み) を表現するメタ情報。 */
+  from: string
+  to: string
+  /** 初期 cash (positions=0 起点)。BUY シグナル時に floor(cash/price) qty を発注。 */
+  initialCash: number
+  /** PullbackUptrendStrategy の rule。entry/exit 判定に使う。 */
+  rule: SymbolRule
+}
+
+export type ExitReason = 'TP' | 'STOP' | 'TIME_STOP' | 'END_OF_DATA'
+
+export interface BacktestTrade {
+  entryTimestamp: string
+  exitTimestamp: string
+  entryPrice: number
+  exitPrice: number
+  qty: number
+  realizedPnl: number
+  exitReason: ExitReason
+  /** Strategy が SELL 決定を出した理由 (TP/STOP/TIME_STOP) または END_OF_DATA。 */
+  exitDetail: string
+  holdingDays: number
+}
+
+export interface EquityPoint {
+  date: string
+  equity: number
+  /** Peak-to-current drawdown (<=0). 0 ならピーク更新中。 */
+  drawdown: number
+}
+
+export interface BacktestResult {
+  params: BacktestParams
+  trades: BacktestTrade[]
+  totalPnl: number
+  /** totalPnl / initialCash. initialCash<=0 なら 0。 */
+  totalReturn: number
+  /** 勝ち trade 数 / total trade 数. trades=0 なら 0。 */
+  winRate: number
+  avgWin: number
+  avgLoss: number
+  /** sum(wins) / |sum(losses)|. losses が 0 なら +Infinity (wins>0) または 0。 */
+  profitFactor: number
+  /** Daily equity returns ベース、252 営業日 annualized。equity 列が 1 以下なら 0。 */
+  sharpeRatio: number
+  /** Peak-to-trough の最大幅 (絶対金額、<=0)。 */
+  maxDrawdown: number
+  /** maxDrawdown / peak. peak<=0 なら 0。 */
+  maxDrawdownPct: number
+  totalTrades: number
+  avgHoldingDays: number
+  equityCurve: EquityPoint[]
+}
+
+const SECONDS_PER_DAY = 86_400_000
+
+/**
+ * Run the backtest synchronously over `bars`. Async signature is kept for
+ * future extension (loading bars internally) but the implementation is pure.
+ *
+ * 仕様:
+ * - 最初の 50 本は warmup (`computePullbackIndicators` が >=50 bars 必須)。
+ * - それ以降の各 bar に対し:
+ *   1. その bar までの直近 60 本で indicators を再計算
+ *   2. PullbackUptrendStrategy.decide() を呼ぶ
+ *   3. BUY → qty = floor(cash / close)、cash -= qty*close、position 開始
+ *   4. SELL → cash += qty * close、trade を記録、position をクローズ
+ *   5. 保有中なら equity = cash + qty * close、未保有なら equity = cash
+ *   6. equity curve / drawdown を更新
+ * - 期間末に position が残っていれば END_OF_DATA で強制クローズ。
+ */
+export async function runBacktest(
+  bars: DailyBar[],
+  params: BacktestParams,
+): Promise<BacktestResult> {
+  const trades: BacktestTrade[] = []
+  const equityCurve: EquityPoint[] = []
+
+  if (bars.length === 0) {
+    return finalize(params, trades, equityCurve)
+  }
+
+  const strategy = new PullbackUptrendStrategy(params.rule)
+
+  let cash = params.initialCash
+  let position: PositionState | null = null
+  let entryDate: string | null = null
+  let peakEquity = params.initialCash
+
+  // computePullbackIndicators requires >=50 bars. Walk forward starting at
+  // index 50 so the first decision has a full warmup window.
+  const warmup = 50
+
+  for (let i = warmup; i < bars.length; i += 1) {
+    // Use bars up to and including the current day for the indicator window.
+    // Strategy "decides at close" — we use today's close as both signal price
+    // and execution fill (T+0). Realistic enough for daily-bar offline eval;
+    // intra-day slippage is out of scope.
+    const window = bars.slice(Math.max(0, i + 1 - 60), i + 1)
+    const indicators = computePullbackIndicators(window, null)
+    const today = bars[i]!
+    if (!indicators) {
+      // Should not happen given warmup>=50, but bail safely.
+      pushEquity(equityCurve, today.date, valueAt(cash, position, today.close), { peak: peakEquity })
+      peakEquity = Math.max(peakEquity, valueAt(cash, position, today.close))
+      continue
+    }
+
+    const now = new Date(`${today.date}T00:00:00.000Z`)
+    const holdBusinessDays =
+      position !== null && entryDate
+        ? businessDaysBetween(entryDate, today.date)
+        : 0
+
+    const signal = strategy.decide({
+      symbol: params.symbol,
+      indicators,
+      position,
+      pendingOrder: null,
+      cooldownUntil: null,
+      holdBusinessDays,
+      now,
+    })
+
+    if (signal.action === 'BUY' && position === null) {
+      const price = today.close
+      if (price > 0 && cash > 0) {
+        const qty = Math.floor(cash / price)
+        if (qty > 0) {
+          cash -= qty * price
+          position = {
+            qty,
+            avgPrice: price,
+            openedAt: now.toISOString(),
+          }
+          entryDate = today.date
+        }
+      }
+    } else if (signal.action === 'SELL' && position !== null) {
+      const price = today.close
+      const realizedPnl = (price - position.avgPrice) * position.qty
+      cash += position.qty * price
+      trades.push({
+        entryTimestamp: position.openedAt,
+        exitTimestamp: now.toISOString(),
+        entryPrice: position.avgPrice,
+        exitPrice: price,
+        qty: position.qty,
+        realizedPnl,
+        exitReason: classifyExitReason(signal.reason),
+        exitDetail: signal.reason,
+        holdingDays: entryDate ? calendarDaysBetween(entryDate, today.date) : 0,
+      })
+      position = null
+      entryDate = null
+    }
+
+    const eq = valueAt(cash, position, today.close)
+    peakEquity = Math.max(peakEquity, eq)
+    equityCurve.push({
+      date: today.date,
+      equity: eq,
+      drawdown: peakEquity > 0 ? eq - peakEquity : 0,
+    })
+  }
+
+  // Force-close any open position at the last close so realized PnL is
+  // comparable across runs (otherwise totalPnl excludes the unrealized leg).
+  if (position !== null && bars.length > 0) {
+    const last = bars[bars.length - 1]!
+    const price = last.close
+    const realizedPnl = (price - position.avgPrice) * position.qty
+    cash += position.qty * price
+    trades.push({
+      entryTimestamp: position.openedAt,
+      exitTimestamp: new Date(`${last.date}T00:00:00.000Z`).toISOString(),
+      entryPrice: position.avgPrice,
+      exitPrice: price,
+      qty: position.qty,
+      realizedPnl,
+      exitReason: 'END_OF_DATA',
+      exitDetail: 'forced close at end of data',
+      holdingDays: entryDate ? calendarDaysBetween(entryDate, last.date) : 0,
+    })
+    position = null
+    entryDate = null
+    // Refresh the last equity point to reflect the realized cash.
+    if (equityCurve.length > 0) {
+      const lastPoint = equityCurve[equityCurve.length - 1]!
+      const newEq = cash
+      peakEquity = Math.max(peakEquity, newEq)
+      equityCurve[equityCurve.length - 1] = {
+        date: lastPoint.date,
+        equity: newEq,
+        drawdown: peakEquity > 0 ? newEq - peakEquity : 0,
+      }
+    }
+  }
+
+  return finalize(params, trades, equityCurve)
+}
+
+/**
+ * Annualized Sharpe ratio of a daily equity-return series.
+ * Returns 0 when stddev is 0 or the input has fewer than 2 returns
+ * (under-defined Sharpe — caller should treat this as "no signal" rather
+ * than a strong neutral).
+ */
+export function computeSharpe(dailyReturns: number[]): number {
+  if (dailyReturns.length < 2) return 0
+  let sum = 0
+  for (const r of dailyReturns) sum += r
+  const mean = sum / dailyReturns.length
+  let sqSum = 0
+  for (const r of dailyReturns) {
+    const d = r - mean
+    sqSum += d * d
+  }
+  const variance = sqSum / (dailyReturns.length - 1)
+  const stdev = Math.sqrt(variance)
+  if (stdev === 0 || !Number.isFinite(stdev)) return 0
+  return (mean / stdev) * Math.sqrt(252)
+}
+
+/**
+ * Compute peak-to-trough max drawdown of an equity curve.
+ * `maxDd` is signed (<=0); `maxDdPct` is the same drawdown divided by the
+ * peak that preceded it (e.g. -0.15 = 15% drawdown). Empty input → zeros.
+ */
+export function computeMaxDrawdown(
+  equityCurve: number[],
+): { maxDd: number; maxDdPct: number } {
+  if (equityCurve.length === 0) return { maxDd: 0, maxDdPct: 0 }
+  let peak = equityCurve[0]!
+  let maxDd = 0
+  let maxDdPct = 0
+  for (const eq of equityCurve) {
+    if (eq > peak) peak = eq
+    const dd = eq - peak
+    if (dd < maxDd) {
+      maxDd = dd
+      maxDdPct = peak > 0 ? dd / peak : 0
+    }
+  }
+  return { maxDd, maxDdPct }
+}
+
+function valueAt(cash: number, position: PositionState | null, price: number): number {
+  if (position === null) return cash
+  if (!Number.isFinite(price) || price <= 0) return cash + position.qty * position.avgPrice
+  return cash + position.qty * price
+}
+
+function pushEquity(
+  curve: EquityPoint[],
+  date: string,
+  equity: number,
+  ctx: { peak: number },
+): void {
+  curve.push({
+    date,
+    equity,
+    drawdown: ctx.peak > 0 ? equity - ctx.peak : 0,
+  })
+}
+
+/**
+ * Map the strategy's SELL reason text to a coarse exit category。
+ * `decide()` の reason は `take-profit hit ...` / `stop-loss hit ...` /
+ * `time-stop hit ...` 形式。startsWith で identify する (実装間結合は弱め)。
+ */
+function classifyExitReason(reason: string): ExitReason {
+  if (reason.startsWith('take-profit')) return 'TP'
+  if (reason.startsWith('stop-loss')) return 'STOP'
+  if (reason.startsWith('time-stop')) return 'TIME_STOP'
+  return 'END_OF_DATA'
+}
+
+function calendarDaysBetween(fromYmd: string, toYmd: string): number {
+  const a = Date.parse(`${fromYmd}T00:00:00.000Z`)
+  const b = Date.parse(`${toYmd}T00:00:00.000Z`)
+  if (!Number.isFinite(a) || !Number.isFinite(b)) return 0
+  return Math.max(0, Math.round((b - a) / SECONDS_PER_DAY))
+}
+
+/**
+ * 簡易な営業日カウント (土日除外)。祝日は無視 (offline backtest 用途では
+ * holiday カレンダーまで持つ overhead に見合わないため)。`PullbackUptrend
+ * Strategy` の time-stop 判定は holdBusinessDays で動くので、ここでの近似
+ * は exit timing に若干影響するが POC tuning には十分。
+ */
+function businessDaysBetween(fromYmd: string, toYmd: string): number {
+  const a = Date.parse(`${fromYmd}T00:00:00.000Z`)
+  const b = Date.parse(`${toYmd}T00:00:00.000Z`)
+  if (!Number.isFinite(a) || !Number.isFinite(b) || b <= a) return 0
+  let count = 0
+  for (let t = a + SECONDS_PER_DAY; t <= b; t += SECONDS_PER_DAY) {
+    const dow = new Date(t).getUTCDay()
+    if (dow !== 0 && dow !== 6) count += 1
+  }
+  return count
+}
+
+function finalize(
+  params: BacktestParams,
+  trades: BacktestTrade[],
+  equityCurve: EquityPoint[],
+): BacktestResult {
+  const totalTrades = trades.length
+  let wins = 0
+  let losses = 0
+  let sumWin = 0
+  let sumLoss = 0
+  let totalPnl = 0
+  let totalHoldingDays = 0
+  for (const t of trades) {
+    totalPnl += t.realizedPnl
+    totalHoldingDays += t.holdingDays
+    if (t.realizedPnl > 0) {
+      wins += 1
+      sumWin += t.realizedPnl
+    } else if (t.realizedPnl < 0) {
+      losses += 1
+      sumLoss += t.realizedPnl
+    }
+  }
+  const totalReturn = params.initialCash > 0 ? totalPnl / params.initialCash : 0
+  const winRate = totalTrades > 0 ? wins / totalTrades : 0
+  const avgWin = wins > 0 ? sumWin / wins : 0
+  const avgLoss = losses > 0 ? sumLoss / losses : 0
+  const profitFactor =
+    sumLoss === 0 ? (sumWin > 0 ? Number.POSITIVE_INFINITY : 0) : sumWin / Math.abs(sumLoss)
+
+  const equityValues = equityCurve.map((p) => p.equity)
+  const dailyReturns: number[] = []
+  for (let i = 1; i < equityValues.length; i += 1) {
+    const prev = equityValues[i - 1]!
+    const curr = equityValues[i]!
+    if (prev > 0) dailyReturns.push((curr - prev) / prev)
+  }
+  const sharpeRatio = computeSharpe(dailyReturns)
+  const { maxDd, maxDdPct } = computeMaxDrawdown(equityValues)
+
+  return {
+    params,
+    trades,
+    totalPnl,
+    totalReturn,
+    winRate,
+    avgWin,
+    avgLoss,
+    profitFactor,
+    sharpeRatio,
+    maxDrawdown: maxDd,
+    maxDrawdownPct: maxDdPct,
+    totalTrades,
+    avgHoldingDays: totalTrades > 0 ? totalHoldingDays / totalTrades : 0,
+    equityCurve,
+  }
+}

--- a/test/routes/adminBacktest.test.ts
+++ b/test/routes/adminBacktest.test.ts
@@ -128,6 +128,30 @@ describe('GET /admin/backtest', () => {
     expect(res.status).toBe(400)
   })
 
+  it('400s when no Yahoo bars fall within the requested range', async () => {
+    // Regression for the silent fallback bug: previously, when
+    // `bars.findIndex(b => b.date >= from)` returned -1 (i.e. Yahoo had
+    // nothing inside [from, to] — e.g. `from` is in the future / symbol
+    // delisted) the route ran the backtest against the *entire* prior
+    // history and returned 200. The endpoint must now reject with 400.
+    const pastBars = buildBars(100, Array(80).fill(1.005), '2024-01-01')
+
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify(buildYahooChart(pastBars)), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ) as unknown as typeof fetch
+
+    const app = createApp()
+    const res = await app.request(
+      '/admin/backtest?symbol=AAPL&from=2099-01-01&to=2099-12-31',
+      { headers: { ...authHeader } },
+      baseEnv,
+    )
+    expect(res.status).toBe(400)
+  })
+
   it('200s and returns BacktestResult shape on success', async () => {
     // Build an uptrend-then-pullback synthetic series long enough for SMA50.
     const warmup = buildBars(100, Array(80).fill(1.005), '2024-01-01')

--- a/test/routes/adminBacktest.test.ts
+++ b/test/routes/adminBacktest.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+import { createApp } from '../../src/app'
+import type { DailyBar } from '../../src/trading/strategy/indicators'
+
+const baseEnv = {
+  BASIC_AUTH_USER: 'admin',
+  BASIC_AUTH_PASSWORD: 'secret',
+}
+
+const authHeader = { Authorization: `Basic ${btoa('admin:secret')}` }
+
+/**
+ * Build a synthetic Yahoo-shaped chart payload from a list of DailyBar.
+ * Mirrors the columnar response that `normalizeYahooChart` consumes so the
+ * admin endpoint sees identical bars to what live YahooBarClient would
+ * deliver.
+ */
+function buildYahooChart(bars: DailyBar[]): unknown {
+  return {
+    chart: {
+      result: [
+        {
+          meta: { currency: 'USD', regularMarketPrice: bars.at(-1)?.close ?? 0 },
+          timestamp: bars.map((b) => Math.floor(Date.parse(`${b.date}T00:00:00.000Z`) / 1000)),
+          indicators: {
+            quote: [
+              {
+                open: bars.map((b) => b.open),
+                high: bars.map((b) => b.high),
+                low: bars.map((b) => b.low),
+                close: bars.map((b) => b.close),
+              },
+            ],
+          },
+        },
+      ],
+      error: null,
+    },
+  }
+}
+
+function buildBars(start: number, factors: number[], startDate = '2024-01-01'): DailyBar[] {
+  const bars: DailyBar[] = []
+  let close = start
+  let date = new Date(`${startDate}T00:00:00.000Z`)
+  for (let i = 0; i < factors.length; i += 1) {
+    close = close * factors[i]!
+    bars.push({
+      date: date.toISOString().slice(0, 10),
+      open: close * 0.999,
+      high: close * 1.001,
+      low: close * 0.998,
+      close,
+    })
+    date = new Date(date.getTime() + 86_400_000)
+  }
+  return bars
+}
+
+/**
+ * Stub `loadGlobalConfigFrom` so the route doesn't try to talk to a real D1
+ * binding. Returns the canonical defaults verbatim.
+ */
+vi.mock('../../src/infrastructure/db/globalConfigLoader', () => ({
+  loadGlobalConfigFrom: async () => ({
+    source: 'd1',
+    dryRun: true,
+    tradingEnabled: false,
+    marketHoursCheck: false,
+    maxOrderNotional: 100,
+    maxOrderNotionalUsd: 2000,
+    maxOrderNotionalJpy: 100000,
+    totalCapitalUsd: null,
+    totalCapitalJpy: null,
+    maxPortfolioExposurePct: 0.6,
+    drawdownKillThreshold: -0.02,
+    staleQuoteMs: 15 * 60 * 1_000,
+    gapRejectPct: 0.03,
+    spreadLimitPctUs: 0.0025,
+    spreadLimitPctJp: 0.006,
+    pullbackDefaultStopPct: -0.04,
+    pullbackDefaultTakeProfitPct: 0.07,
+    pullbackDefaultTimeStopDays: 10,
+    pullbackDefaultPullbackMax: -0.03,
+    pullbackDefaultPullbackMin: -0.06,
+    pullbackDefaultMinReturn50d: 0.08,
+    pullbackDefaultRequireAboveSma50: true,
+    pullbackDefaultKAtr: 2.0,
+    riskBasePerTradePct: 0.004,
+    riskDdHalfThreshold: -0.05,
+    riskDdHaltThreshold: -0.10,
+    bucketExposurePct: 0.30,
+  }),
+}))
+
+describe('GET /admin/backtest', () => {
+  let originalFetch: typeof fetch
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+  })
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('401s without Basic Auth', async () => {
+    const app = createApp()
+    const res = await app.request('/admin/backtest?symbol=AAPL&from=2024-01-01&to=2024-06-30', {}, baseEnv)
+    expect(res.status).toBe(401)
+  })
+
+  it('400s when symbol is missing', async () => {
+    const app = createApp()
+    const res = await app.request(
+      '/admin/backtest?from=2024-01-01&to=2024-06-30',
+      { headers: { ...authHeader } },
+      baseEnv,
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('400s when from > to', async () => {
+    const app = createApp()
+    const res = await app.request(
+      '/admin/backtest?symbol=AAPL&from=2024-12-31&to=2024-01-01',
+      { headers: { ...authHeader } },
+      baseEnv,
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('200s and returns BacktestResult shape on success', async () => {
+    // Build an uptrend-then-pullback synthetic series long enough for SMA50.
+    const warmup = buildBars(100, Array(80).fill(1.005), '2024-01-01')
+    const last = warmup[warmup.length - 1]!.close
+    const pullback: DailyBar = {
+      date: '2024-04-01',
+      open: last,
+      high: last,
+      low: last * 0.94,
+      close: last * 0.95,
+    }
+    const tail = buildBars(pullback.close, [1.05, 1.05, 1.02, 1.02], '2024-04-02')
+    const bars = [...warmup, pullback, ...tail]
+
+    // Stub the global fetch so YahooBarClient returns our synthetic series.
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify(buildYahooChart(bars)), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ) as unknown as typeof fetch
+
+    const app = createApp()
+    const res = await app.request(
+      '/admin/backtest?symbol=AAPL&from=2024-04-01&to=2024-04-10&initialCash=10000',
+      { headers: { ...authHeader } },
+      baseEnv,
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.params).toBeDefined()
+    expect(Array.isArray(body.trades)).toBe(true)
+    expect(Array.isArray(body.equityCurve)).toBe(true)
+    expect(typeof body.totalPnl).toBe('number')
+    expect(typeof body.totalReturn).toBe('number')
+    expect(typeof body.winRate).toBe('number')
+    expect(typeof body.sharpeRatio).toBe('number')
+    expect(typeof body.maxDrawdown).toBe('number')
+  })
+})

--- a/test/trading/backtest/runBacktest.test.ts
+++ b/test/trading/backtest/runBacktest.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from 'vitest'
+import {
+  computeMaxDrawdown,
+  computeSharpe,
+  runBacktest,
+  type BacktestParams,
+} from '../../../src/trading/backtest/runBacktest'
+import type { DailyBar } from '../../../src/trading/strategy/indicators'
+import { TEST_DEFAULT_RULE } from '../../../src/trading/strategy/strategies/PullbackUptrendStrategy'
+
+const BASE_PARAMS: BacktestParams = {
+  symbol: 'TEST',
+  from: '2025-01-01',
+  to: '2025-12-31',
+  initialCash: 10_000,
+  rule: TEST_DEFAULT_RULE,
+}
+
+/**
+ * Build a synthetic price series. Start at `start`, advance daily with the
+ * supplied multipliers (close = previous close * factor). High/low are close
+ * ±0.001% so ATR stays small but non-zero.
+ */
+function buildBars(start: number, factors: number[], startDate = '2025-01-01'): DailyBar[] {
+  const bars: DailyBar[] = []
+  let close = start
+  let date = new Date(`${startDate}T00:00:00.000Z`)
+  for (let i = 0; i < factors.length; i += 1) {
+    close = close * factors[i]!
+    bars.push({
+      date: date.toISOString().slice(0, 10),
+      open: close * 0.999,
+      high: close * 1.001,
+      low: close * 0.998,
+      close,
+    })
+    date = new Date(date.getTime() + 86_400_000)
+  }
+  return bars
+}
+
+/** 50 warmup bars at constant ~+1%/d so 50d return clears the trend filter. */
+function uptrendWarmup(start: number): DailyBar[] {
+  return buildBars(start, Array(60).fill(1.01))
+}
+
+describe('runBacktest', () => {
+  it('returns an empty result for empty bars', async () => {
+    const result = await runBacktest([], BASE_PARAMS)
+    expect(result.trades).toEqual([])
+    expect(result.totalPnl).toBe(0)
+    expect(result.totalReturn).toBe(0)
+    expect(result.equityCurve).toEqual([])
+    expect(result.totalTrades).toBe(0)
+  })
+
+  it('produces no trades when bars are pure downtrend (no BUY signal)', async () => {
+    // Constant 1% daily decline → 50d return < 0 → entry.trend_50d_return fails → HOLD.
+    const bars = buildBars(100, Array(120).fill(0.99))
+    const result = await runBacktest(bars, BASE_PARAMS)
+    expect(result.totalTrades).toBe(0)
+    expect(result.totalPnl).toBe(0)
+    // Equity should stay at initialCash because no position is ever opened.
+    expect(result.equityCurve.at(-1)?.equity).toBe(BASE_PARAMS.initialCash)
+  })
+
+  it('opens a position then closes via take-profit on a deep pullback + recovery', async () => {
+    // 60-day uptrend warmup, then a single ~-5% pullback day, then strong rally.
+    const warmup = buildBars(100, Array(60).fill(1.01))
+    const last = warmup[warmup.length - 1]!.close
+    const pullbackDay: DailyBar = {
+      date: '2025-04-01',
+      open: last,
+      high: last,
+      low: last * 0.94,
+      close: last * 0.95, // -5% pullback to trigger BUY (in [-6%, -3%])
+    }
+    // After BUY, simulate a +10% recovery over the next few days to trigger TP (>=7%).
+    const rally = buildBars(pullbackDay.close, [1.04, 1.04, 1.04], '2025-04-02')
+    const bars = [...warmup, pullbackDay, ...rally]
+    const result = await runBacktest(bars, BASE_PARAMS)
+    expect(result.totalTrades).toBeGreaterThanOrEqual(1)
+    const first = result.trades[0]!
+    expect(first.exitReason === 'TP' || first.exitReason === 'END_OF_DATA').toBe(true)
+  })
+
+  it('records STOP exit when price drops past stopPct after entry', async () => {
+    const warmup = buildBars(100, Array(60).fill(1.01))
+    const last = warmup[warmup.length - 1]!.close
+    const pullbackDay: DailyBar = {
+      date: '2025-04-01',
+      open: last,
+      high: last,
+      low: last * 0.94,
+      close: last * 0.95,
+    }
+    // Sharp -10% drop after entry to hit stopPct=-0.04.
+    const drop = buildBars(pullbackDay.close, [0.9, 0.95], '2025-04-02')
+    const bars = [...warmup, pullbackDay, ...drop]
+    const result = await runBacktest(bars, BASE_PARAMS)
+    expect(result.totalTrades).toBeGreaterThanOrEqual(1)
+    const first = result.trades[0]!
+    expect(first.exitReason).toBe('STOP')
+    expect(first.realizedPnl).toBeLessThan(0)
+  })
+
+  it('forces END_OF_DATA exit when position is still open at the last bar', async () => {
+    const warmup = buildBars(100, Array(60).fill(1.01))
+    const last = warmup[warmup.length - 1]!.close
+    const pullbackDay: DailyBar = {
+      date: '2025-04-01',
+      open: last,
+      high: last,
+      low: last * 0.94,
+      close: last * 0.95,
+    }
+    // After entry, hold flat (~+0.5% drift) so neither TP nor STOP fires before
+    // we run out of bars. timeStopDays=10 default is also avoided by a short
+    // tail.
+    const flat = buildBars(pullbackDay.close, [1.005, 1.005, 1.005], '2025-04-02')
+    const bars = [...warmup, pullbackDay, ...flat]
+    const result = await runBacktest(bars, BASE_PARAMS)
+    expect(result.totalTrades).toBeGreaterThanOrEqual(1)
+    expect(result.trades.at(-1)?.exitReason).toBe('END_OF_DATA')
+  })
+
+  it('totalPnl matches sum of trade pnls and equity ends at initialCash + totalPnl', async () => {
+    const warmup = buildBars(100, Array(60).fill(1.01))
+    const last = warmup[warmup.length - 1]!.close
+    const pullbackDay: DailyBar = {
+      date: '2025-04-01',
+      open: last,
+      high: last,
+      low: last * 0.94,
+      close: last * 0.95,
+    }
+    const rally = buildBars(pullbackDay.close, [1.04, 1.04, 1.04], '2025-04-02')
+    const bars = [...warmup, pullbackDay, ...rally]
+    const result = await runBacktest(bars, BASE_PARAMS)
+    const sum = result.trades.reduce((acc, t) => acc + t.realizedPnl, 0)
+    expect(result.totalPnl).toBeCloseTo(sum, 6)
+    // After all trades closed, ending equity should be roughly initialCash + totalPnl.
+    expect(result.equityCurve.at(-1)?.equity).toBeCloseTo(
+      BASE_PARAMS.initialCash + result.totalPnl,
+      4,
+    )
+  })
+
+  it('respects a SHORT timeStopDays rule by exiting via TIME_STOP', async () => {
+    const warmup = buildBars(100, Array(60).fill(1.01))
+    const last = warmup[warmup.length - 1]!.close
+    const pullbackDay: DailyBar = {
+      date: '2025-04-01',
+      open: last,
+      high: last,
+      low: last * 0.94,
+      close: last * 0.95,
+    }
+    // Hold flat for many bars so neither TP nor STOP fires. Use a very small
+    // timeStopDays=2 so TIME_STOP triggers before END_OF_DATA.
+    const flat = buildBars(pullbackDay.close, Array(15).fill(1.001), '2025-04-02')
+    const bars = [...warmup, pullbackDay, ...flat]
+    const result = await runBacktest(bars, {
+      ...BASE_PARAMS,
+      rule: { ...TEST_DEFAULT_RULE, timeStopDays: 2 },
+    })
+    expect(result.totalTrades).toBeGreaterThanOrEqual(1)
+    const reasons = result.trades.map((t) => t.exitReason)
+    expect(reasons.some((r) => r === 'TIME_STOP')).toBe(true)
+  })
+})
+
+describe('computeSharpe', () => {
+  it('returns 0 for empty input', () => {
+    expect(computeSharpe([])).toBe(0)
+  })
+
+  it('returns 0 for a single return (under-defined)', () => {
+    expect(computeSharpe([0.01])).toBe(0)
+  })
+
+  it('returns 0 when stdev is 0 (all returns identical)', () => {
+    expect(computeSharpe([0.01, 0.01, 0.01, 0.01])).toBe(0)
+  })
+
+  it('returns positive for a positive mean / non-zero variance', () => {
+    // Simulate ~+0.1%/d ± noise.
+    const returns = [0.001, 0.002, 0.0005, 0.0015, 0.001, 0.0005, 0.0012]
+    const sharpe = computeSharpe(returns)
+    expect(sharpe).toBeGreaterThan(0)
+    expect(Number.isFinite(sharpe)).toBe(true)
+  })
+
+  it('returns negative for a negative mean', () => {
+    const returns = [-0.001, -0.002, -0.0005, -0.0015, -0.001]
+    expect(computeSharpe(returns)).toBeLessThan(0)
+  })
+})
+
+describe('computeMaxDrawdown', () => {
+  it('returns zeros for empty input', () => {
+    expect(computeMaxDrawdown([])).toEqual({ maxDd: 0, maxDdPct: 0 })
+  })
+
+  it('returns zeros for a strictly increasing series', () => {
+    expect(computeMaxDrawdown([1, 2, 3, 4, 5])).toEqual({ maxDd: 0, maxDdPct: 0 })
+  })
+
+  it('captures the deepest peak-to-trough drop', () => {
+    const r = computeMaxDrawdown([100, 120, 90, 110, 80, 130])
+    // Peak 120 → trough 80 = -40 = -33.3%.
+    expect(r.maxDd).toBe(-40)
+    expect(r.maxDdPct).toBeCloseTo(-40 / 120, 6)
+  })
+
+  it('only counts the worst drawdown, not the cumulative', () => {
+    const r = computeMaxDrawdown([100, 90, 110, 80, 120])
+    // Worst is 110 → 80 = -30 (not 100→90 = -10).
+    expect(r.maxDd).toBe(-30)
+    expect(r.maxDdPct).toBeCloseTo(-30 / 110, 6)
+  })
+})


### PR DESCRIPTION
## 動機

issue #198: 過去 daily データで Pullback Uptrend 戦略をオフライン評価できるようにする。
POC で `pullback_default_*` パラメータの妥当性を data-driven に検証する手段を提供する。

## 実装概要

### Engine (`src/trading/backtest/runBacktest.ts`)

- `runBacktest(bars, params)` — 純粋関数。bars は warmup 込みで oldest-first。
- 各 bar 毎に直近 60 本で `computePullbackIndicators` → 既存 `PullbackUptrendStrategy.decide()` を呼ぶ。
  - 戦略本体は **一切変更していない**。backtest と live cron で同じ判定を出すため。
- BUY → `qty = floor(cash / close)` で全現金投下、1 ポジ持ち。
- SELL → 終値で全部クローズ、`exitReason` を `take-profit` / `stop-loss` / `time-stop` から分類。
- 期間末に持っていれば `END_OF_DATA` で強制クローズ。
- 集計: `totalPnl` / `totalReturn` / `winRate` / `avgWin` / `avgLoss` / `profitFactor` / `sharpeRatio` (252 営業日 annualized) / `maxDrawdown` / `avgHoldingDays` / `equityCurve`。
- `computeSharpe` / `computeMaxDrawdown` を export して unit test 可能に。

### Admin endpoint (`GET /admin/backtest`)

- query: `symbol` / `from` / `to` / `initialCash` (+ rule の各パラメータ optional)。
- global_config から既定 rule を読み、query で上書き可。
- Yahoo daily bars を `lookback = (to-from) * 5/7 + warmup_buffer` で fetch。
- 結果を `BacktestResult` JSON で返す (D1 保存は **別 PR**)。

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` 全 pass (531/531)
- [x] `runBacktest` unit tests (7 cases): 空入力 / 下落のみ → trade なし / pullback→TP / pullback→STOP / END_OF_DATA / pnl 整合性 / TIME_STOP
- [x] `computeSharpe` unit tests (5 cases): empty / single / zero-stdev / positive / negative
- [x] `computeMaxDrawdown` unit tests (4 cases): empty / monotonic up / standard / cumulative-vs-worst
- [x] admin endpoint smoke test (4 cases): 401 / 400 missing param / 400 from>to / 200 + JSON shape

## Out of scope (follow-up)

- D1 永続化 (`backtest_run` / `backtest_trade` テーブル) — issue #198 のチェックリストで別 PR 化。
- dashboard 表示 (equity curve / trade list 可視化)。
- Sweep / multi-param scan UI。
- Slippage / fees モデル化 (現状は close fill / 0 cost)。

## 注意

- backtest engine は live cron の判定ロジックを **そのまま** 再利用しており、`PullbackUptrendStrategy.ts` は変更していない。
- sizing は backtest 用の単純な「全現金投下」モデル。production の `computePullbackSizing` (risk-pct ベース + ATR floor + lot size) はバイパスしているので絶対 PnL は production と一致しない (= 戦略の **比較評価** 用 tool として使う)。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 管理画面にバックテスト機能を追加：シンボルと期間指定で履歴データを用いたシミュレーションを実行し、トレード一覧・エクイティ曲線・総損益、勝率、平均勝敗、プロフィットファクター、年率シャープ比、最大ドローダウン等を返す。

* **Bug Fixes / Validation**
  * クエリ引数の厳格な検証を追加し、期間不整合や範囲内データ不在時に適切なエラーを返すよう改善。

* **Tests**
  * エンドポイントとバックテストロジックの網羅的なテストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->