### PR TITLE
feat(notification): Slack/Discord webhook 通知実装 (#199)

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -30,3 +30,10 @@ SYMBOL_MAX_NOTIONAL={"SOXL":200,"SOXS":150}
 # #38-C risk knobs (optional, both default to sane values):
 # STALE_QUOTE_MS=900000
 # GAP_REJECT_PCT=0.03
+
+# Notification webhooks (#199, optional). 未設定なら通知 no-op。
+# Slack incoming webhook と Discord webhook はそれぞれ単独 / 両方設定可能。
+SLACK_WEBHOOK_URL=
+DISCORD_WEBHOOK_URL=
+# dashboard 通知 link の base URL (例: https://webull-trading.example.workers.dev)。
+DASHBOARD_BASE_URL=

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -297,3 +297,22 @@ export interface Env {
    */
   DB?: D1Database
 }
+
+// Notification webhook config (#199 append)
+export interface Env {
+  /**
+   * Slack incoming webhook URL。未設定なら Slack 通知無効。
+   * `wrangler secret put SLACK_WEBHOOK_URL` で設定する。
+   */
+  SLACK_WEBHOOK_URL?: string
+  /**
+   * Discord webhook URL。未設定なら Discord 通知無効。
+   * `wrangler secret put DISCORD_WEBHOOK_URL` で設定する。
+   */
+  DISCORD_WEBHOOK_URL?: string
+  /**
+   * 通知メッセージに付ける dashboard link の base URL
+   * (例: `https://webull-trading.example.workers.dev`)。未設定なら link 省略。
+   */
+  DASHBOARD_BASE_URL?: string
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { createApp } from './app'
 import type { Env } from './config/env'
 import { createDb, insertJournalRecord } from './infrastructure/db/tradeJournalRepo'
 import { setTradeJournalDbContext } from './infrastructure/logger/tradeJournal'
+import { createNotifier } from './infrastructure/notification/createNotifier'
 import { runQuoteFeed } from './trading/quotes/quoteScheduler'
 import { reconcileFills } from './trading/reconciliation/reconcileFills'
 import { runStrategyCron } from './trading/strategy/runStrategyCron'
@@ -61,13 +62,19 @@ export default {
             )
           },
           (error) => {
+            const message = error instanceof Error ? error.message : String(error)
             console.error(
               JSON.stringify({
                 event: 'strategy_cron_error',
                 requestId,
-                message: error instanceof Error ? error.message : String(error),
+                message,
               }),
             )
+            // cron 全体が落ちた時 (D1 失敗 / unexpected throw 等) も通知 (#199)。
+            // fire-and-forget。Notifier 実装側で silent fallback。
+            createNotifier(env)
+              .notify({ type: 'ERROR', message, cause: 'strategy_cron' })
+              .catch(() => undefined)
           },
         ),
       )

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,10 +71,13 @@ export default {
               }),
             )
             // cron 全体が落ちた時 (D1 失敗 / unexpected throw 等) も通知 (#199)。
-            // fire-and-forget。Notifier 実装側で silent fallback。
-            createNotifier(env)
-              .notify({ type: 'ERROR', message, cause: 'strategy_cron' })
-              .catch(() => undefined)
+            // ctx.waitUntil で wrap して isolate terminate 前に webhook fetch を
+            // 完了させる。Notifier 実装側は silent fallback なので catch は保険。
+            ctx.waitUntil(
+              createNotifier(env)
+                .notify({ type: 'ERROR', message, cause: 'strategy_cron' })
+                .catch(() => undefined),
+            )
           },
         ),
       )

--- a/src/infrastructure/notification/NoopNotifier.ts
+++ b/src/infrastructure/notification/NoopNotifier.ts
@@ -1,0 +1,12 @@
+import type { Notifier, NotificationEvent } from './Notifier'
+
+/**
+ * 何もしない Notifier。`SLACK_WEBHOOK_URL` / `DISCORD_WEBHOOK_URL` がいずれも
+ * 未設定な環境 (= 既定) で `createNotifier` から返される fallback。test 用
+ * stub としても使える。
+ */
+export class NoopNotifier implements Notifier {
+  async notify(_event: NotificationEvent): Promise<void> {
+    // 意図的に no-op。env 未設定 = 通知無効、を意味する。
+  }
+}

--- a/src/infrastructure/notification/Notifier.ts
+++ b/src/infrastructure/notification/Notifier.ts
@@ -1,0 +1,45 @@
+/**
+ * Notifier — Slack/Discord webhook 通知用 thin port (#199)。
+ *
+ * 様子見フェーズで dashboard を能動的に開かなくても DRY_RUN BUY/SELL や cron
+ * error に気付けるようにするための shallow event sink。意図的に薄い:
+ *   - retry / dedup / rate-limit はしない (POC の通知漏れ許容)
+ *   - 呼び出し側は **fire-and-forget** で叩く (await しない)
+ *   - 実装は失敗を握りつぶす責務を持つ (silent fallback)
+ *
+ * Production wiring は `createNotifier(env)` で env から組み立てる。
+ * env 未設定 (SLACK_WEBHOOK_URL も DISCORD_WEBHOOK_URL も無し) なら
+ * `NoopNotifier` が返り、cron 経路は何もしない。
+ */
+export interface Notifier {
+  /**
+   * イベント 1 件を送信する。実装は **必ず resolve** する (fetch 失敗 / 4xx /
+   * 5xx / network error は内部で catch + log)。 caller が `.catch()` を
+   * 忘れても cron が落ちないようにするため。
+   */
+  notify(event: NotificationEvent): Promise<void>
+}
+
+export type NotificationEvent =
+  | TradeNotificationEvent
+  | ErrorNotificationEvent
+
+export interface TradeNotificationEvent {
+  type: 'TRADE'
+  side: 'BUY' | 'SELL'
+  symbol: string
+  qty: number
+  price: number
+  /** SELL のみ。BUY 時は undefined。 */
+  realizedPnl?: number
+  mode: 'DRY_RUN' | 'LIVE'
+}
+
+export interface ErrorNotificationEvent {
+  type: 'ERROR'
+  /** symbol 単位で失敗した時のみ。global 失敗 (D1 等) は undefined。 */
+  symbol?: string
+  message: string
+  /** 例外の root cause / context (例: `bar fetch`, `broker submit`). */
+  cause?: string
+}

--- a/src/infrastructure/notification/WebhookNotifier.ts
+++ b/src/infrastructure/notification/WebhookNotifier.ts
@@ -1,0 +1,136 @@
+import type { Notifier, NotificationEvent } from './Notifier'
+
+export interface WebhookNotifierOptions {
+  /** Slack incoming webhook URL。空 / undefined なら Slack には送らない。 */
+  slackUrl?: string
+  /** Discord webhook URL。空 / undefined なら Discord には送らない。 */
+  discordUrl?: string
+  /**
+   * dashboard の base URL (例: `https://webull-trading.example.workers.dev`)。
+   * 設定されていれば各メッセージ末尾に `/dashboard/charts?...` link を付ける。
+   * 未設定なら link 省略 (deploy 環境固有なので env 任せ)。
+   */
+  dashboardBaseUrl?: string
+  /**
+   * 注入可能な fetch (test 用)。未指定ならグローバル `fetch`。
+   */
+  fetchImpl?: typeof fetch
+}
+
+/**
+ * Slack / Discord webhook 通知の concrete 実装 (#199)。
+ *
+ * 設計:
+ *   - Slack POST body: `{ text: "..." }`
+ *   - Discord POST body: `{ content: "..." }` (key 名が違う点に注意)
+ *   - 両方の URL が設定されていれば **両方に並列送信**
+ *   - 個別 POST が失敗しても他方は止めない (Promise.allSettled)
+ *   - 全失敗でも throw しない (`silent fallback`、cron を fail させない)
+ *
+ * dedup / retry / batching は意図的に持たない (POC、頻度は cron 15 分粒度の範囲)。
+ */
+export class WebhookNotifier implements Notifier {
+  private readonly slackUrl?: string
+  private readonly discordUrl?: string
+  private readonly dashboardBaseUrl?: string
+  private readonly fetchImpl: typeof fetch
+
+  constructor(options: WebhookNotifierOptions) {
+    // 空文字列も「未設定」扱い。env loader が `?? ''` した時に静かに無効化する。
+    this.slackUrl = options.slackUrl?.trim() ? options.slackUrl : undefined
+    this.discordUrl = options.discordUrl?.trim() ? options.discordUrl : undefined
+    this.dashboardBaseUrl = options.dashboardBaseUrl?.trim()
+      ? stripTrailingSlash(options.dashboardBaseUrl)
+      : undefined
+    this.fetchImpl = options.fetchImpl ?? globalThis.fetch.bind(globalThis)
+  }
+
+  async notify(event: NotificationEvent): Promise<void> {
+    const message = this.formatMessage(event)
+    const tasks: Array<Promise<unknown>> = []
+    if (this.slackUrl) {
+      tasks.push(this.postSafe(this.slackUrl, { text: message }, 'slack'))
+    }
+    if (this.discordUrl) {
+      tasks.push(this.postSafe(this.discordUrl, { content: message }, 'discord'))
+    }
+    if (tasks.length === 0) return
+    // allSettled で握りつぶす (silent fallback)。caller には常に resolve を返す。
+    await Promise.allSettled(tasks)
+  }
+
+  private async postSafe(
+    url: string,
+    body: Record<string, unknown>,
+    target: 'slack' | 'discord',
+  ): Promise<void> {
+    try {
+      const response = await this.fetchImpl(url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      if (!response.ok) {
+        // 4xx / 5xx は webhook URL 設定ミス / Slack 側の問題。log だけ残して続行。
+        console.warn(
+          JSON.stringify({
+            event: 'notifier_webhook_non_ok',
+            target,
+            status: response.status,
+          }),
+        )
+      }
+    } catch (error) {
+      // network failure 等。やはり throw しない (silent fallback)。
+      console.warn(
+        JSON.stringify({
+          event: 'notifier_webhook_failed',
+          target,
+          message: error instanceof Error ? error.message : String(error),
+        }),
+      )
+    }
+  }
+
+  private formatMessage(event: NotificationEvent): string {
+    if (event.type === 'TRADE') {
+      const head =
+        event.side === 'BUY'
+          ? `🟢 BUY ${event.symbol} qty=${event.qty} @ $${formatPrice(event.price)} (${event.mode})`
+          : `🔴 SELL ${event.symbol} qty=${event.qty} @ $${formatPrice(event.price)}${
+              event.realizedPnl !== undefined ? ` pnl=${formatPnl(event.realizedPnl)}` : ''
+            } (${event.mode})`
+      const link = this.dashboardLinkFor(event.symbol)
+      return link ? `${head}\n${link}` : head
+    }
+    // ERROR
+    const sym = event.symbol ?? 'global'
+    const causePart = event.cause ? ` (${event.cause})` : ''
+    const head = `⚠️ cron error: ${sym} — ${event.message}${causePart}`
+    const link = event.symbol ? this.dashboardLinkFor(event.symbol) : undefined
+    return link ? `${head}\n${link}` : head
+  }
+
+  private dashboardLinkFor(symbol: string): string | undefined {
+    if (!this.dashboardBaseUrl) return undefined
+    // chart UI の deep link。dashboard route は src/routes/dashboard 配下に存在。
+    const encoded = encodeURIComponent(symbol)
+    return `${this.dashboardBaseUrl}/dashboard/charts?tab=symbol&symbol=${encoded}`
+  }
+}
+
+function stripTrailingSlash(url: string): string {
+  return url.endsWith('/') ? url.slice(0, -1) : url
+}
+
+function formatPrice(price: number): string {
+  if (!Number.isFinite(price)) return String(price)
+  return price.toFixed(2)
+}
+
+function formatPnl(pnl: number): string {
+  if (!Number.isFinite(pnl)) return String(pnl)
+  // pnl は正負ありうる。読みやすさで小数 2 桁固定 + 符号明示。
+  const sign = pnl > 0 ? '+' : ''
+  return `${sign}${pnl.toFixed(2)}`
+}

--- a/src/infrastructure/notification/WebhookNotifier.ts
+++ b/src/infrastructure/notification/WebhookNotifier.ts
@@ -36,12 +36,15 @@ export class WebhookNotifier implements Notifier {
   private readonly fetchImpl: typeof fetch
 
   constructor(options: WebhookNotifierOptions) {
-    // 空文字列も「未設定」扱い。env loader が `?? ''` した時に静かに無効化する。
-    this.slackUrl = options.slackUrl?.trim() ? options.slackUrl : undefined
-    this.discordUrl = options.discordUrl?.trim() ? options.discordUrl : undefined
-    this.dashboardBaseUrl = options.dashboardBaseUrl?.trim()
-      ? stripTrailingSlash(options.dashboardBaseUrl)
-      : undefined
+    // 空文字列 / 空白のみ も「未設定」扱い。env loader が `?? ''` した時に静かに
+    // 無効化する。trim 値を保存することで、前後空白付き URL が webhook fetch を
+    // 失敗させてサイレントに通知が落ちる事故を防ぐ。
+    const slack = options.slackUrl?.trim()
+    const discord = options.discordUrl?.trim()
+    const dashboard = options.dashboardBaseUrl?.trim()
+    this.slackUrl = slack ? slack : undefined
+    this.discordUrl = discord ? discord : undefined
+    this.dashboardBaseUrl = dashboard ? stripTrailingSlash(dashboard) : undefined
     this.fetchImpl = options.fetchImpl ?? globalThis.fetch.bind(globalThis)
   }
 

--- a/src/infrastructure/notification/createNotifier.ts
+++ b/src/infrastructure/notification/createNotifier.ts
@@ -1,0 +1,22 @@
+import type { Env } from '../../config/env'
+import { NoopNotifier } from './NoopNotifier'
+import type { Notifier } from './Notifier'
+import { WebhookNotifier } from './WebhookNotifier'
+
+/**
+ * Env から `Notifier` を組み立てる factory (#199)。
+ *
+ * Slack/Discord webhook URL がいずれも未設定なら `NoopNotifier` を返し、
+ * cron 経路は完全に no-op になる。env の typo / 抜け落ちで通知が飛ばないだけで
+ * cron 自体は止めない (fail-open ではなく **fail-silent**)。
+ */
+export function createNotifier(env: Env): Notifier {
+  const slack = env.SLACK_WEBHOOK_URL?.trim()
+  const discord = env.DISCORD_WEBHOOK_URL?.trim()
+  if (!slack && !discord) return new NoopNotifier()
+  return new WebhookNotifier({
+    slackUrl: slack,
+    discordUrl: discord,
+    dashboardBaseUrl: env.DASHBOARD_BASE_URL,
+  })
+}

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -1,5 +1,6 @@
 import type { BarClient } from '../../infrastructure/quotes/BarClient'
 import { logPostSubmit, logPreSubmit } from '../../infrastructure/logger/tradeJournal'
+import type { Notifier } from '../../infrastructure/notification/Notifier'
 import type { DecisionTraceStep } from '../domain/Signal'
 import { inferTradingMarket } from '../domain/tradingCalendar'
 import type { Execution } from '../execution/Execution'
@@ -77,6 +78,12 @@ export interface PullbackSchedulerOptions {
    * `crypto.randomUUID()` を渡す。
    */
   requestId?: string
+  /**
+   * Slack/Discord webhook 通知用 sink (#199)。BUY/SELL emit 時と cron error 時に
+   * fire-and-forget で叩く。実装は失敗を握りつぶす責務 (silent fallback) なので
+   * scheduler 側は `.catch()` を付けるだけで cron を blocking しない。
+   */
+  notifier?: Notifier
   now?: () => Date
 }
 
@@ -138,6 +145,34 @@ export async function runPullbackScheduler(
     rejected: [],
     errors: [],
     decisions: [],
+  }
+
+  // Notifier helper: fire-and-forget。Notifier 実装側で silent fallback する
+  // 約束だが、念のため二重 catch して cron を絶対に落とさない (#199)。
+  const emitNotify = (event: Parameters<NonNullable<typeof options.notifier>['notify']>[0]): void => {
+    if (!options.notifier) return
+    try {
+      const p = options.notifier.notify(event)
+      if (p && typeof (p as Promise<unknown>).catch === 'function') {
+        ;(p as Promise<unknown>).catch((err) => {
+          console.warn(
+            JSON.stringify({
+              event: 'notifier_emit_failed',
+              requestId: options.requestId ?? null,
+              message: err instanceof Error ? err.message : String(err),
+            }),
+          )
+        })
+      }
+    } catch (err) {
+      console.warn(
+        JSON.stringify({
+          event: 'notifier_emit_failed',
+          requestId: options.requestId ?? null,
+          message: err instanceof Error ? err.message : String(err),
+        }),
+      )
+    }
   }
 
   // Logging helper: sink が投げても本体を落とさない (logging failure isolation)。
@@ -222,6 +257,7 @@ export async function runPullbackScheduler(
     } catch (error) {
       summary.errors.push({ symbol: upper, message: messageOf(error) })
       await emitDecision({ symbol: upper, decision: 'ERROR', reason: `bar fetch: ${messageOf(error)}` })
+      emitNotify({ type: 'ERROR', symbol: upper, message: messageOf(error), cause: 'bar fetch' })
       continue
     }
 
@@ -467,6 +503,12 @@ export async function runPullbackScheduler(
         price: indicators.price,
         trace: appendTrace(signal.trace, traceStep('broker.submit', false, messageOf(error), '==', 'submitted')),
       })
+      emitNotify({
+        type: 'ERROR',
+        symbol: upper,
+        message: messageOf(error),
+        cause: 'broker submit',
+      })
       try {
         logPostSubmit({
           clientOrderId: intent.clientOrderId,
@@ -524,6 +566,23 @@ export async function runPullbackScheduler(
         quantity: intent.quantity,
         notional: intent.notional,
       },
+    })
+
+    // SELL の realizedPnl は state.position.avgPrice (existing) と
+    // intent.price (exit) の差から推定。BUY 時は undefined。avgPrice が無い
+    // SELL は不正経路 (上で reject 済) なので発生しないはずだが defensive。
+    const realizedPnl =
+      intent.side === 'SELL' && state.position && Number.isFinite(state.position.avgPrice)
+        ? (intent.price - state.position.avgPrice) * intent.quantity
+        : undefined
+    emitNotify({
+      type: 'TRADE',
+      side: intent.side,
+      symbol: upper,
+      qty: intent.quantity,
+      price: intent.price,
+      ...(realizedPnl !== undefined ? { realizedPnl } : {}),
+      mode: result.mode,
     })
 
     if (result.mode === 'DRY_RUN') {

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -3,6 +3,7 @@ import { YahooBarClient } from '../../infrastructure/quotes/YahooBarClient'
 import { loadGlobalConfigFrom } from '../../infrastructure/db/globalConfigLoader'
 import { loadSymbolUniverse } from '../../infrastructure/db/symbolUniverse'
 import type { SymbolCurrency } from '../../infrastructure/db/symbolConfigRepo'
+import { createNotifier } from '../../infrastructure/notification/createNotifier'
 import { createWebullHttpClient } from '../../infrastructure/webull/WebullHttpClient'
 import { MockExecution } from '../execution/MockExecution'
 import { WebullExecution } from '../execution/WebullExecution'
@@ -299,6 +300,8 @@ export async function runStrategyCron(
   const execution = global.dryRun
     ? new MockExecution()
     : new WebullExecution(createWebullHttpClient(env))
+  // Slack/Discord webhook 通知 (#199)。env 未設定なら NoopNotifier。
+  const notifier = createNotifier(env)
   // Yahoo Finance /v8/finance/chart is free, no auth, covers US + JP (7267.T
   // style) in one endpoint — chosen over Webull's JP-subscription-gated
   // market-data API (see #84). Webull is still the order-execution path.
@@ -359,6 +362,7 @@ export async function runStrategyCron(
       defaultRule,
       riskPerTradePct: scaledRiskPerTradePct,
       requestId: options.requestId,
+      notifier,
       onDecision: (record) =>
         logStrategyDecision(decisionDb, {
           timestamp: new Date().toISOString(),

--- a/test/infrastructure/notification/NoopNotifier.test.ts
+++ b/test/infrastructure/notification/NoopNotifier.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { NoopNotifier } from '../../../src/infrastructure/notification/NoopNotifier'
+
+describe('NoopNotifier', () => {
+  it('resolves without doing anything for TRADE events', async () => {
+    const n = new NoopNotifier()
+    await expect(
+      n.notify({ type: 'TRADE', side: 'BUY', symbol: 'AAPL', qty: 1, price: 1, mode: 'DRY_RUN' }),
+    ).resolves.toBeUndefined()
+  })
+
+  it('resolves without doing anything for ERROR events', async () => {
+    const n = new NoopNotifier()
+    await expect(n.notify({ type: 'ERROR', message: 'oops' })).resolves.toBeUndefined()
+  })
+})

--- a/test/infrastructure/notification/WebhookNotifier.test.ts
+++ b/test/infrastructure/notification/WebhookNotifier.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi } from 'vitest'
+import { WebhookNotifier } from '../../../src/infrastructure/notification/WebhookNotifier'
+
+function okResponse(): Response {
+  return new Response('ok', { status: 200 })
+}
+
+function makeFetch() {
+  const calls: Array<{ url: string; init: RequestInit }> = []
+  const fn = vi.fn(async (url: string, init: RequestInit) => {
+    calls.push({ url, init })
+    return okResponse()
+  }) as unknown as typeof fetch
+  return { fn, calls }
+}
+
+describe('WebhookNotifier', () => {
+  it('POSTs Slack-shape body when only slackUrl is set', async () => {
+    const { fn, calls } = makeFetch()
+    const notifier = new WebhookNotifier({ slackUrl: 'https://hooks.slack.test/x', fetchImpl: fn })
+
+    await notifier.notify({
+      type: 'TRADE',
+      side: 'BUY',
+      symbol: 'AAPL',
+      qty: 5,
+      price: 200.123,
+      mode: 'DRY_RUN',
+    })
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.url).toBe('https://hooks.slack.test/x')
+    expect(calls[0]?.init.method).toBe('POST')
+    const body = JSON.parse(String(calls[0]?.init.body))
+    expect(body).toHaveProperty('text')
+    expect(body.text).toContain('BUY AAPL')
+    expect(body.text).toContain('qty=5')
+    expect(body.text).toContain('200.12')
+    expect(body.text).toContain('DRY_RUN')
+  })
+
+  it('POSTs Discord-shape body when only discordUrl is set', async () => {
+    const { fn, calls } = makeFetch()
+    const notifier = new WebhookNotifier({
+      discordUrl: 'https://discord.test/webhooks/abc',
+      fetchImpl: fn,
+    })
+
+    await notifier.notify({
+      type: 'TRADE',
+      side: 'SELL',
+      symbol: 'SOXL',
+      qty: 10,
+      price: 30,
+      realizedPnl: 12.5,
+      mode: 'DRY_RUN',
+    })
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.url).toBe('https://discord.test/webhooks/abc')
+    const body = JSON.parse(String(calls[0]?.init.body))
+    // Discord uses `content` (not `text`).
+    expect(body).toHaveProperty('content')
+    expect(body).not.toHaveProperty('text')
+    expect(body.content).toContain('SELL SOXL')
+    expect(body.content).toContain('pnl=+12.50')
+  })
+
+  it('POSTs to both targets when both URLs are set', async () => {
+    const { fn, calls } = makeFetch()
+    const notifier = new WebhookNotifier({
+      slackUrl: 'https://hooks.slack.test/x',
+      discordUrl: 'https://discord.test/webhooks/abc',
+      fetchImpl: fn,
+    })
+
+    await notifier.notify({
+      type: 'ERROR',
+      symbol: 'NVDA',
+      message: 'upstream 500',
+      cause: 'bar fetch',
+    })
+
+    const urls = calls.map((c) => c.url).sort()
+    expect(urls).toEqual([
+      'https://discord.test/webhooks/abc',
+      'https://hooks.slack.test/x',
+    ])
+  })
+
+  it('does nothing (no fetch) when both URLs are missing/empty', async () => {
+    const { fn, calls } = makeFetch()
+    const notifier = new WebhookNotifier({ slackUrl: '', discordUrl: undefined, fetchImpl: fn })
+    await notifier.notify({ type: 'ERROR', message: 'oops' })
+    expect(calls).toHaveLength(0)
+  })
+
+  it('resolves silently when fetch rejects (network failure)', async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('network down')
+    }) as unknown as typeof fetch
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const notifier = new WebhookNotifier({ slackUrl: 'https://hooks.slack.test/x', fetchImpl })
+
+    await expect(
+      notifier.notify({
+        type: 'TRADE',
+        side: 'BUY',
+        symbol: 'AAPL',
+        qty: 1,
+        price: 100,
+        mode: 'DRY_RUN',
+      }),
+    ).resolves.toBeUndefined()
+
+    expect(warnSpy).toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
+  it('resolves silently on non-OK HTTP status (4xx/5xx)', async () => {
+    const fetchImpl = vi.fn(async () => new Response('bad', { status: 500 })) as unknown as typeof fetch
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const notifier = new WebhookNotifier({
+      discordUrl: 'https://discord.test/webhooks/abc',
+      fetchImpl,
+    })
+
+    await expect(
+      notifier.notify({ type: 'ERROR', symbol: 'AAPL', message: 'boom' }),
+    ).resolves.toBeUndefined()
+
+    expect(warnSpy).toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
+  it('appends dashboard link when DASHBOARD_BASE_URL is set', async () => {
+    const { fn, calls } = makeFetch()
+    const notifier = new WebhookNotifier({
+      slackUrl: 'https://hooks.slack.test/x',
+      dashboardBaseUrl: 'https://dash.example.com/',
+      fetchImpl: fn,
+    })
+
+    await notifier.notify({
+      type: 'TRADE',
+      side: 'BUY',
+      symbol: 'AAPL',
+      qty: 1,
+      price: 100,
+      mode: 'DRY_RUN',
+    })
+
+    const body = JSON.parse(String(calls[0]?.init.body))
+    // trailing slash should be stripped, link should target chart UI.
+    expect(body.text).toContain('https://dash.example.com/dashboard/charts?tab=symbol&symbol=AAPL')
+  })
+
+  it('omits dashboard link when DASHBOARD_BASE_URL is unset', async () => {
+    const { fn, calls } = makeFetch()
+    const notifier = new WebhookNotifier({
+      slackUrl: 'https://hooks.slack.test/x',
+      fetchImpl: fn,
+    })
+
+    await notifier.notify({
+      type: 'TRADE',
+      side: 'BUY',
+      symbol: 'AAPL',
+      qty: 1,
+      price: 100,
+      mode: 'DRY_RUN',
+    })
+
+    const body = JSON.parse(String(calls[0]?.init.body))
+    expect(body.text).not.toContain('/dashboard/charts')
+  })
+})

--- a/test/infrastructure/notification/WebhookNotifier.test.ts
+++ b/test/infrastructure/notification/WebhookNotifier.test.ts
@@ -155,6 +155,35 @@ describe('WebhookNotifier', () => {
     expect(body.text).toContain('https://dash.example.com/dashboard/charts?tab=symbol&symbol=AAPL')
   })
 
+  it('trims leading/trailing whitespace from URLs before POSTing', async () => {
+    const { fn, calls } = makeFetch()
+    const notifier = new WebhookNotifier({
+      slackUrl: '  https://hooks.slack.test/x  \n',
+      discordUrl: '\thttps://discord.test/webhooks/abc ',
+      dashboardBaseUrl: '  https://dash.example.com/  ',
+      fetchImpl: fn,
+    })
+
+    await notifier.notify({
+      type: 'TRADE',
+      side: 'BUY',
+      symbol: 'AAPL',
+      qty: 1,
+      price: 100,
+      mode: 'DRY_RUN',
+    })
+
+    const urls = calls.map((c) => c.url).sort()
+    expect(urls).toEqual([
+      'https://discord.test/webhooks/abc',
+      'https://hooks.slack.test/x',
+    ])
+    // dashboard link も trim 済みの base から組み立てられること。
+    const slackCall = calls.find((c) => c.url === 'https://hooks.slack.test/x')
+    const slackBody = JSON.parse(String(slackCall?.init.body))
+    expect(slackBody.text).toContain('https://dash.example.com/dashboard/charts?tab=symbol&symbol=AAPL')
+  })
+
   it('omits dashboard link when DASHBOARD_BASE_URL is unset', async () => {
     const { fn, calls } = makeFetch()
     const notifier = new WebhookNotifier({

--- a/test/infrastructure/notification/createNotifier.test.ts
+++ b/test/infrastructure/notification/createNotifier.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import type { Env } from '../../../src/config/env'
+import { createNotifier } from '../../../src/infrastructure/notification/createNotifier'
+import { NoopNotifier } from '../../../src/infrastructure/notification/NoopNotifier'
+import { WebhookNotifier } from '../../../src/infrastructure/notification/WebhookNotifier'
+
+function makeEnv(overrides: Partial<Env> = {}): Env {
+  return {
+    BASIC_AUTH_USER: 'u',
+    BASIC_AUTH_PASSWORD: 'p',
+    SYMBOL_STATE: undefined as never,
+    ...overrides,
+  } as Env
+}
+
+describe('createNotifier', () => {
+  it('returns NoopNotifier when no webhook URLs are configured', () => {
+    const n = createNotifier(makeEnv())
+    expect(n).toBeInstanceOf(NoopNotifier)
+  })
+
+  it('returns NoopNotifier when both URLs are blank strings', () => {
+    const n = createNotifier(
+      makeEnv({ SLACK_WEBHOOK_URL: '   ', DISCORD_WEBHOOK_URL: '' }),
+    )
+    expect(n).toBeInstanceOf(NoopNotifier)
+  })
+
+  it('returns WebhookNotifier when only Slack is set', () => {
+    const n = createNotifier(makeEnv({ SLACK_WEBHOOK_URL: 'https://hooks.slack.test/x' }))
+    expect(n).toBeInstanceOf(WebhookNotifier)
+  })
+
+  it('returns WebhookNotifier when only Discord is set', () => {
+    const n = createNotifier(makeEnv({ DISCORD_WEBHOOK_URL: 'https://discord.test/webhooks/abc' }))
+    expect(n).toBeInstanceOf(WebhookNotifier)
+  })
+
+  it('returns WebhookNotifier when both are set', () => {
+    const n = createNotifier(
+      makeEnv({
+        SLACK_WEBHOOK_URL: 'https://hooks.slack.test/x',
+        DISCORD_WEBHOOK_URL: 'https://discord.test/webhooks/abc',
+      }),
+    )
+    expect(n).toBeInstanceOf(WebhookNotifier)
+  })
+})

--- a/test/trading/strategy/pullbackScheduler.test.ts
+++ b/test/trading/strategy/pullbackScheduler.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { BarClient, IntradayBar } from '../../../src/infrastructure/quotes/BarClient'
+import type { Notifier, NotificationEvent } from '../../../src/infrastructure/notification/Notifier'
 import type { Execution } from '../../../src/trading/execution/Execution'
 import type { PositionStore } from '../../../src/trading/state/PositionStore'
 import { emptySymbolState, type SymbolState } from '../../../src/trading/state/types'
@@ -207,5 +208,99 @@ describe('runPullbackScheduler', () => {
     expect(summary.buys).toBe(1)
     const intent = execution.calls[0] as { side: string; price: number }
     expect(intent.price).toBe(117.5)
+  })
+
+  it('fires notifier with TRADE event on a successful BUY (#199)', async () => {
+    const events: NotificationEvent[] = []
+    const notifier: Notifier = {
+      async notify(event) {
+        events.push(event)
+      },
+    }
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution: mockExecution(),
+      notifier,
+      now: () => now,
+    })
+
+    expect(summary.buys).toBe(1)
+    // microtask drain so fire-and-forget notify は test 完了前に reach する
+    await Promise.resolve()
+    const trade = events.find((e) => e.type === 'TRADE') as Extract<NotificationEvent, { type: 'TRADE' }> | undefined
+    expect(trade).toBeDefined()
+    expect(trade?.side).toBe('BUY')
+    expect(trade?.symbol).toBe('AAPL')
+    expect(trade?.mode).toBe('DRY_RUN')
+    expect(trade?.realizedPnl).toBeUndefined()
+  })
+
+  it('fires notifier with ERROR event on bar fetch failure (#199)', async () => {
+    const events: NotificationEvent[] = []
+    const notifier: Notifier = {
+      async notify(event) {
+        events.push(event)
+      },
+    }
+    const crashingClient: BarClient = {
+      async getDailyBars() {
+        throw new Error('upstream 500')
+      },
+    }
+    await runPullbackScheduler({
+      symbols: ['BROKEN'],
+      equity: 100_000,
+      barClient: crashingClient,
+      positionStore: makeStore({}),
+      execution: mockExecution(),
+      notifier,
+      now: () => now,
+    })
+
+    await Promise.resolve()
+    const err = events.find((e) => e.type === 'ERROR') as Extract<NotificationEvent, { type: 'ERROR' }> | undefined
+    expect(err).toBeDefined()
+    expect(err?.symbol).toBe('BROKEN')
+    expect(err?.cause).toBe('bar fetch')
+    expect(err?.message).toContain('upstream 500')
+  })
+
+  it('does not let a throwing notifier break the scheduler (silent fallback) (#199)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const notifier: Notifier = {
+      async notify() {
+        throw new Error('notifier exploded')
+      },
+    }
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution: mockExecution(),
+      notifier,
+      now: () => now,
+    })
+
+    // notifier failure must not block the BUY path.
+    expect(summary.buys).toBe(1)
+    await Promise.resolve()
+    warnSpy.mockRestore()
+  })
+
+  it('does not call notifier when one is not provided (back-compat) (#199)', async () => {
+    // Sanity: existing call sites without `notifier` keep working.
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution: mockExecution(),
+      now: () => now,
+    })
+    expect(summary.buys).toBe(1)
   })
 })


### PR DESCRIPTION
## 動機

[#199](https://github.com/ochanuco/webull-trading/issues/199) — 様子見フェーズで DRY_RUN cron が `strategy_decision_log` / `trade_journal` に記録されていても、dashboard を能動的に開かないと「想定通り押し目で BUY、TP/stop で SELL が出ているか」が見えない。Slack/Discord webhook で能動通知して気付けるようにする。

## 設計概要

- `src/infrastructure/notification/` 配下に薄い port を新設
  - `Notifier` interface: `notify(NotificationEvent): Promise<void>` のみ
  - `NotificationEvent` = `TRADE` (BUY/SELL) | `ERROR` (cron 失敗)
  - `WebhookNotifier`: Slack (`{text}`) / Discord (`{content}`) の body shape 差異を吸収。両方設定なら並列送信
  - `NoopNotifier`: env 未設定時の fallback
  - `createNotifier(env)`: env から組み立てる factory
- Env 拡張 (append): `SLACK_WEBHOOK_URL?` / `DISCORD_WEBHOOK_URL?` / `DASHBOARD_BASE_URL?`
- `pullbackScheduler` に optional `notifier` を追加し以下の経路で **fire-and-forget**:
  - bar fetch ERROR → `ERROR` 通知 (cause: `bar fetch`)
  - broker submit ERROR → `ERROR` 通知 (cause: `broker submit`)
  - 成功 BUY/SELL emit → `TRADE` 通知 (mode = `result.mode`、SELL は `realizedPnl` 推定値付き)
- HOLD / REJECT / risk gate block は仕様通り通知しない
- `runStrategyCron` で `createNotifier(env)` を組み立てて scheduler に渡す
- `index.ts` の `scheduled()` で cron 全体が throw した時 (`strategy_cron_error`) も通知

## 安全性

- **fire-and-forget**: scheduler は `await` しない (cron を block しない)
- **silent fallback**: `WebhookNotifier` が fetch reject / 4xx / 5xx を内部で catch + log
- **二重 catch**: scheduler 側の `emitNotify` も try/catch + Promise.catch を重ねて、Notifier 実装のバグでも cron を絶対に落とさない
- env 未設定 → `NoopNotifier` で完全 no-op
- secrets は repo に commit せず `.dev.vars.example` にキーのみ追加 (空文字列)

## Out of scope (#199 で意図的に切ったもの)

- 通知 dedup / cooldown / batch
- 通知 ack / 既読管理
- email / LINE Notify

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test --run` — 530/530 pass (新規 16 含む)
  - `WebhookNotifier` 7 cases: Slack only / Discord only / both / neither / fetch reject silent / non-OK silent / dashboard link
  - `NoopNotifier` 2 cases: TRADE / ERROR resolve no-op
  - `createNotifier` 5 cases: env 分岐 (Noop / Slack / Discord / both / 空白文字列)
  - `pullbackScheduler` 4 cases追加: TRADE 通知 / ERROR 通知 / throwing notifier silent / 未設定で back-compat
- [ ] 手動: `wrangler secret put SLACK_WEBHOOK_URL` 後、cron 走行で Slack に届くか実機確認 (運用 user の責務)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Slack/Discord のウェブフック通知を追加。トレード実行（買い/売り）や戦略エラー時に通知送信。
  * 通知にダッシュボードのチャート深堀リンクを付与可能。
  * 環境変数でウェブフックURLとダッシュボードURLを設定可能。未設定時は通知を行わないフォールバックあり。

* **テスト**
  * 通知ロジックとフォールバックのユニットテストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->