### PR TITLE
fix(webull): /webull/order/place を dry_run only に閉じる (#137)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ cd bridge && pnpm install && pnpm run typecheck
 | GET | `/health` | none | `{status, timestamp}` |
 | POST | `/trade/decide` | Basic | Signal + OrderIntent + RiskDecision を返す (発注しない) |
 | POST | `/trade/execute` | Basic | 上記 + ExecutionResult (`dry_run=1` で Mock、0 で Webull) |
-| POST | `/webull/order/place` | Basic | 低レベル疎通 endpoint (`dry_run=1` で synthetic response) |
+| POST | `/webull/order/place` | Basic | 低レベル疎通 endpoint (`dry_run=1` で synthetic response、`dry_run=0` は 403 で拒否。実発注は `/trade/execute` か `/admin/strategy/run` 経由) |
 | POST | `/events/trade` | secret header | bridge からの trade event ingest |
 | POST | `/admin/symbols/:symbol/seed-cash` | Basic | `settled_cash` の初期値投入 |
 | POST | `/admin/portfolio/seed-equity` | Basic | `daily_start_equity` 投入 |

--- a/src/routes/webull.ts
+++ b/src/routes/webull.ts
@@ -1,12 +1,20 @@
 import { Hono } from 'hono'
 import type { AppBindings } from '../app'
 import { loadGlobalConfigFrom } from '../infrastructure/db/globalConfigLoader'
-import { createWebullHttpClient } from '../infrastructure/webull/WebullHttpClient'
 import type { WebullPlaceOrderResponseDto } from '../infrastructure/webull/dto'
 import { logPostSubmit, logPreSubmit } from '../infrastructure/logger/tradeJournal'
 import { ValidationError } from '../shared/errors'
 import type { OrderIntent, OrderSide } from '../trading/domain/OrderIntent'
 
+/**
+ * Low-level Webull connectivity endpoint. Intentionally limited to dry-run
+ * mode so it cannot bypass the TradingService risk gate (allowed_symbols /
+ * max_order_notional / pending lock / spread / drawdown kill, etc).
+ *
+ * Live execution must go through `/trade/execute` or `/admin/strategy/run`,
+ * which run the full risk pipeline before talking to the broker. See
+ * issue #137 for the rationale.
+ */
 export const webull = new Hono<AppBindings>().post('/order/place', async (c) => {
   const intent = await parseOrderIntent(c.req.json())
   const requestId = c.get('requestId')
@@ -14,40 +22,44 @@ export const webull = new Hono<AppBindings>().post('/order/place', async (c) => 
   logPreSubmit({ requestId, clientOrderId: intent.clientOrderId, intent })
 
   const global = await loadGlobalConfigFrom(c.env)
-  if (global.dryRun) {
-    const dto = createDryRunResponse(intent)
+  if (!global.dryRun) {
     logPostSubmit({
       requestId,
       clientOrderId: intent.clientOrderId,
       symbol: intent.symbol,
-      result: { mode: 'DRY_RUN', submitted: true, brokerOrderId: dto.order_id },
+      result: { mode: 'LIVE', submitted: false, errorReason: 'webull_place_blocked_live' },
       latencyMs: 0,
     })
-    return c.json(dto)
+    console.log(
+      JSON.stringify({
+        event: 'webull_place_blocked_live',
+        request_id: requestId,
+        client_order_id: intent.clientOrderId,
+        symbol: intent.symbol,
+        side: intent.side,
+        quantity: intent.quantity,
+        notional: intent.notional,
+      }),
+    )
+    return c.json(
+      {
+        error: 'live_execution_forbidden',
+        message:
+          'low-level live execution is forbidden; use /trade/execute or /admin/strategy/run',
+      },
+      403,
+    )
   }
 
-  const client = createWebullHttpClient(c.env)
-  const startedAt = Date.now()
-  let dto: WebullPlaceOrderResponseDto | undefined
-  let error: Error | undefined
-  try {
-    dto = await client.placeOrder(intent)
-    return c.json(dto)
-  } catch (err) {
-    error = err instanceof Error ? err : new Error(String(err))
-    throw err
-  } finally {
-    logPostSubmit({
-      requestId,
-      clientOrderId: intent.clientOrderId,
-      symbol: intent.symbol,
-      result: dto
-        ? { mode: 'LIVE', submitted: !!dto.order_id, brokerOrderId: dto.order_id, errorReason: dto.message }
-        : undefined,
-      latencyMs: Date.now() - startedAt,
-      error,
-    })
-  }
+  const dto = createDryRunResponse(intent)
+  logPostSubmit({
+    requestId,
+    clientOrderId: intent.clientOrderId,
+    symbol: intent.symbol,
+    result: { mode: 'DRY_RUN', submitted: true, brokerOrderId: dto.order_id },
+    latencyMs: 0,
+  })
+  return c.json(dto)
 })
 
 async function parseOrderIntent(payload: Promise<unknown>): Promise<OrderIntent> {

--- a/test/routes/webull.test.ts
+++ b/test/routes/webull.test.ts
@@ -84,19 +84,11 @@ describe('webull routes', () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  it('calls Webull and returns the raw broker DTO when dryRun=false', async () => {
+  it('returns 403 and never contacts Webull when dryRun=false (issue #137)', async () => {
     vi.mocked(loadGlobalConfigFrom).mockResolvedValue(
       makeGlobalConfigSnapshot({ dryRun: false }),
     )
-    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          client_order_id: 'cli-123',
-          order_id: 'ord-123',
-        }),
-        { status: 200 },
-      ),
-    )
+    const fetchMock = vi.fn<typeof fetch>()
     vi.stubGlobal('fetch', fetchMock)
     const app = createApp()
 
@@ -119,16 +111,16 @@ describe('webull routes', () => {
         ...baseEnv,
         WEBULL_APP_KEY: 'app-key',
         WEBULL_APP_SECRET: 'app-secret',
-        
+
         WEBULL_ACCOUNT_ID_JP_CASH: 'acct-jp-1',
       },
     )
 
-    expect(response.status).toBe(200)
-    expect(await response.json()).toEqual({
-      client_order_id: 'cli-123',
-      order_id: 'ord-123',
-    })
-    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(response.status).toBe(403)
+    const body = (await response.json()) as { error: string; message: string }
+    expect(body.error).toBe('live_execution_forbidden')
+    expect(body.message).toMatch(/\/trade\/execute/)
+    expect(body.message).toMatch(/\/admin\/strategy\/run/)
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## 動機

[#137](https://github.com/ochanuco/webull-trading/issues/137) — `POST /webull/order/place` は Webull 疎通用の low-level endpoint だが、`global_config.dry_run` だけ参照して TradingService 経由の risk gate (allowed_symbols / max_order_notional / pending lock / spread / drawdown kill 等) を全て bypass する。dashboard / curl の誤操作で `dry_run=0` のまま叩くと broker まで実発注が届いてしまう risk があった。

## 採用方針 (issue 選択肢 A)

`dry_run=0` (live mode) では **403 で拒否**し、low-level live 発注を禁止する。実発注は `/trade/execute` か `/admin/strategy/run` の risk pipeline 経由のみに限定する。

- `dry_run=1` (= `true`): これまで通り synthetic `dry-run-*` response を返す (疎通確認用途は維持)
- `dry_run=0` (= `false`): `403 { error: "live_execution_forbidden", message: "..." }` を返し、broker は呼ばない
- 拒否ルートでは監査用に `webull_place_blocked_live` audit log を emit (request_id / client_order_id / symbol / side / quantity / notional)
- post_submit log には `mode: 'LIVE', submitted: false, errorReason: 'webull_place_blocked_live'` を残す

選択肢 B (TradingService に loop back) も考えたが、低レベル endpoint の役割 (raw broker 疎通) と risk gate の責務が混ざってしまうため、A の「閉じてしまう」方が責務が明確。

## 影響範囲

- production caller なし (この endpoint は疎通確認 / dashboard 経由の手動操作のみ)。dry_run の synthetic response 利用は維持されるので回帰なし。
- 旧テスト `'calls Webull and returns the raw broker DTO when dryRun=false'` は live mode を期待していたので、新挙動 (403 / fetch 未呼び出し) を assert する形に書き換え。

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test --run` 552/552 pass
  - `dryRun=true` で 200 + `dry-run-*` response (既存)
  - `dryRun=false` で 403 + `live_execution_forbidden` + fetch 未呼び出し (新規)
  - 認証なしで 401 (既存)

## 関連

- Issue: #137
- 触ったファイル: `src/routes/webull.ts`, `test/routes/webull.test.ts`, `README.md` (endpoint 表 dry_run only 注記)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 低レベルの注文配置エンドポイント（`/webull/order/place`）での本番実行をブロック。エラーコード `live_execution_forbidden` を返すようになりました。

* **ドキュメント**
  * エンドポイント仕様を更新。本番環境での注文執行は、より高レベルのルート（`/trade/execute` または `/admin/strategy/run`）を使用するよう明示しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->