### PR TITLE
fix(reconcile): reconcileFills に applied marker と repair/retry 経路を追加 (#142)

### DIFF
--- a/drizzle/0011_reconcile_state_apply_marker.sql
+++ b/drizzle/0011_reconcile_state_apply_marker.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `trade_journal` ADD `state_applied_at` text;--> statement-breakpoint
+ALTER TABLE `trade_journal` ADD `state_apply_error` text;--> statement-breakpoint
+ALTER TABLE `trade_journal` ADD `state_apply_attempts` integer DEFAULT 0 NOT NULL;

--- a/drizzle/meta/0011_snapshot.json
+++ b/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,766 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "378dd75c-d708-4394-adc1-cff80d63aa14",
+  "prevId": "e7333f10-0404-485f-9490-ba4f4dbdd893",
+  "tables": {
+    "global_config": {
+      "name": "global_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "trading_enabled": {
+          "name": "trading_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "market_hours_check": {
+          "name": "market_hours_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "max_order_notional": {
+          "name": "max_order_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "max_order_notional_usd": {
+          "name": "max_order_notional_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2000
+        },
+        "max_order_notional_jpy": {
+          "name": "max_order_notional_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100000
+        },
+        "total_capital_usd": {
+          "name": "total_capital_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_capital_jpy": {
+          "name": "total_capital_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_portfolio_exposure_pct": {
+          "name": "max_portfolio_exposure_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.6
+        },
+        "drawdown_kill_threshold": {
+          "name": "drawdown_kill_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.02
+        },
+        "stale_quote_ms": {
+          "name": "stale_quote_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 900000
+        },
+        "gap_reject_pct": {
+          "name": "gap_reject_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.03
+        },
+        "spread_limit_pct_us": {
+          "name": "spread_limit_pct_us",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.0025
+        },
+        "spread_limit_pct_jp": {
+          "name": "spread_limit_pct_jp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.006
+        },
+        "pullback_default_stop_pct": {
+          "name": "pullback_default_stop_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.04
+        },
+        "pullback_default_take_profit_pct": {
+          "name": "pullback_default_take_profit_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.07
+        },
+        "pullback_default_time_stop_days": {
+          "name": "pullback_default_time_stop_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "pullback_default_pullback_max": {
+          "name": "pullback_default_pullback_max",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.03
+        },
+        "pullback_default_pullback_min": {
+          "name": "pullback_default_pullback_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.06
+        },
+        "pullback_default_min_return_50d": {
+          "name": "pullback_default_min_return_50d",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.08
+        },
+        "pullback_default_require_above_sma50": {
+          "name": "pullback_default_require_above_sma50",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "pullback_default_k_atr": {
+          "name": "pullback_default_k_atr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "risk_base_per_trade_pct": {
+          "name": "risk_base_per_trade_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.004
+        },
+        "risk_dd_half_threshold": {
+          "name": "risk_dd_half_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.05
+        },
+        "risk_dd_halt_threshold": {
+          "name": "risk_dd_halt_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.1
+        },
+        "bucket_exposure_pct": {
+          "name": "bucket_exposure_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.3
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "global_config_max_order_notional_range": {
+          "name": "global_config_max_order_notional_range",
+          "value": "\"global_config\".\"max_order_notional\" > 0 AND \"global_config\".\"max_order_notional\" <= 10000000"
+        },
+        "global_config_max_order_notional_usd_range": {
+          "name": "global_config_max_order_notional_usd_range",
+          "value": "\"global_config\".\"max_order_notional_usd\" > 0 AND \"global_config\".\"max_order_notional_usd\" <= 1000000"
+        },
+        "global_config_max_order_notional_jpy_range": {
+          "name": "global_config_max_order_notional_jpy_range",
+          "value": "\"global_config\".\"max_order_notional_jpy\" > 0 AND \"global_config\".\"max_order_notional_jpy\" <= 100000000"
+        },
+        "global_config_total_capital_usd_range": {
+          "name": "global_config_total_capital_usd_range",
+          "value": "\"global_config\".\"total_capital_usd\" IS NULL OR \"global_config\".\"total_capital_usd\" > 0"
+        },
+        "global_config_total_capital_jpy_range": {
+          "name": "global_config_total_capital_jpy_range",
+          "value": "\"global_config\".\"total_capital_jpy\" IS NULL OR \"global_config\".\"total_capital_jpy\" > 0"
+        },
+        "global_config_max_portfolio_exposure_pct_range": {
+          "name": "global_config_max_portfolio_exposure_pct_range",
+          "value": "\"global_config\".\"max_portfolio_exposure_pct\" > 0 AND \"global_config\".\"max_portfolio_exposure_pct\" <= 1"
+        },
+        "global_config_drawdown_kill_threshold_range": {
+          "name": "global_config_drawdown_kill_threshold_range",
+          "value": "\"global_config\".\"drawdown_kill_threshold\" >= -1 AND \"global_config\".\"drawdown_kill_threshold\" <= 0"
+        },
+        "global_config_stale_quote_ms_range": {
+          "name": "global_config_stale_quote_ms_range",
+          "value": "\"global_config\".\"stale_quote_ms\" >= 0"
+        },
+        "global_config_gap_reject_pct_range": {
+          "name": "global_config_gap_reject_pct_range",
+          "value": "\"global_config\".\"gap_reject_pct\" >= 0 AND \"global_config\".\"gap_reject_pct\" <= 1"
+        },
+        "global_config_spread_limit_pct_us_range": {
+          "name": "global_config_spread_limit_pct_us_range",
+          "value": "\"global_config\".\"spread_limit_pct_us\" >= 0 AND \"global_config\".\"spread_limit_pct_us\" <= 1"
+        },
+        "global_config_spread_limit_pct_jp_range": {
+          "name": "global_config_spread_limit_pct_jp_range",
+          "value": "\"global_config\".\"spread_limit_pct_jp\" >= 0 AND \"global_config\".\"spread_limit_pct_jp\" <= 1"
+        },
+        "global_config_pullback_default_stop_pct_range": {
+          "name": "global_config_pullback_default_stop_pct_range",
+          "value": "\"global_config\".\"pullback_default_stop_pct\" < 0 AND \"global_config\".\"pullback_default_stop_pct\" >= -1"
+        },
+        "global_config_pullback_default_take_profit_pct_range": {
+          "name": "global_config_pullback_default_take_profit_pct_range",
+          "value": "\"global_config\".\"pullback_default_take_profit_pct\" > 0 AND \"global_config\".\"pullback_default_take_profit_pct\" <= 1"
+        },
+        "global_config_pullback_default_time_stop_days_range": {
+          "name": "global_config_pullback_default_time_stop_days_range",
+          "value": "\"global_config\".\"pullback_default_time_stop_days\" > 0 AND \"global_config\".\"pullback_default_time_stop_days\" <= 365"
+        },
+        "global_config_pullback_default_pullback_max_range": {
+          "name": "global_config_pullback_default_pullback_max_range",
+          "value": "\"global_config\".\"pullback_default_pullback_max\" <= 0 AND \"global_config\".\"pullback_default_pullback_max\" >= -1"
+        },
+        "global_config_pullback_default_pullback_min_range": {
+          "name": "global_config_pullback_default_pullback_min_range",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= 0 AND \"global_config\".\"pullback_default_pullback_min\" >= -1"
+        },
+        "global_config_pullback_default_min_return_50d_range": {
+          "name": "global_config_pullback_default_min_return_50d_range",
+          "value": "\"global_config\".\"pullback_default_min_return_50d\" >= -1 AND \"global_config\".\"pullback_default_min_return_50d\" <= 10"
+        },
+        "global_config_pullback_default_k_atr_range": {
+          "name": "global_config_pullback_default_k_atr_range",
+          "value": "\"global_config\".\"pullback_default_k_atr\" > 0 AND \"global_config\".\"pullback_default_k_atr\" <= 10"
+        },
+        "global_config_pullback_default_pullback_window_order": {
+          "name": "global_config_pullback_default_pullback_window_order",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= \"global_config\".\"pullback_default_pullback_max\""
+        },
+        "global_config_risk_base_per_trade_pct_range": {
+          "name": "global_config_risk_base_per_trade_pct_range",
+          "value": "\"global_config\".\"risk_base_per_trade_pct\" > 0 AND \"global_config\".\"risk_base_per_trade_pct\" <= 1"
+        },
+        "global_config_risk_dd_half_threshold_range": {
+          "name": "global_config_risk_dd_half_threshold_range",
+          "value": "\"global_config\".\"risk_dd_half_threshold\" < 0 AND \"global_config\".\"risk_dd_half_threshold\" >= -1"
+        },
+        "global_config_risk_dd_halt_threshold_range": {
+          "name": "global_config_risk_dd_halt_threshold_range",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" < 0 AND \"global_config\".\"risk_dd_halt_threshold\" >= -1"
+        },
+        "global_config_risk_dd_threshold_order": {
+          "name": "global_config_risk_dd_threshold_order",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" <= \"global_config\".\"risk_dd_half_threshold\""
+        },
+        "global_config_bucket_exposure_pct_range": {
+          "name": "global_config_bucket_exposure_pct_range",
+          "value": "\"global_config\".\"bucket_exposure_pct\" > 0 AND \"global_config\".\"bucket_exposure_pct\" <= 1"
+        }
+      }
+    },
+    "inverse_pairs": {
+      "name": "inverse_pairs",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inverse": {
+          "name": "inverse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "strategy_decision_log": {
+      "name": "strategy_decision_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indicators_json": {
+          "name": "indicators_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "strategy_decision_log_symbol_id_idx": {
+          "name": "strategy_decision_log_symbol_id_idx",
+          "columns": [
+            "symbol",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "strategy_decision_log_coid_idx": {
+          "name": "strategy_decision_log_coid_idx",
+          "columns": [
+            "client_order_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "symbol_config": {
+      "name": "symbol_config",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "market": {
+          "name": "market",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_notional": {
+          "name": "max_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "symbol_config_currency_enum": {
+          "name": "symbol_config_currency_enum",
+          "value": "\"symbol_config\".\"currency\" IN ('USD', 'JPY')"
+        }
+      }
+    },
+    "trade_journal": {
+      "name": "trade_journal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trade_event_type": {
+          "name": "trade_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "strategy_name": {
+          "name": "strategy_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_action": {
+          "name": "signal_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_reason": {
+          "name": "signal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_allowed": {
+          "name": "risk_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_reasons": {
+          "name": "risk_reasons",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "limit_price": {
+          "name": "limit_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notional": {
+          "name": "notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "broker_status": {
+          "name": "broker_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "submitted": {
+          "name": "submitted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_qty": {
+          "name": "filled_qty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_price": {
+          "name": "filled_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "realized_pnl": {
+          "name": "realized_pnl",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hold_days": {
+          "name": "hold_days",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_reason": {
+          "name": "exit_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_applied_at": {
+          "name": "state_applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_error": {
+          "name": "state_apply_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_attempts": {
+          "name": "state_apply_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1777043276942,
       "tag": "0010_strategy_decision_log_coid",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1777202359235,
+      "tag": "0011_reconcile_state_apply_marker",
+      "breakpoints": true
     }
   ]
 }

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -44,6 +44,37 @@ export const tradeJournal = sqliteTable('trade_journal', {
   exitReason: text('exit_reason'),
   errorClass: text('error_class'),
   errorMessage: text('error_message'),
+  /**
+   * ISO timestamp when the FILLED row was successfully applied to the DO
+   * layer (SymbolStateDO position / PortfolioStateDO realized PnL / cooldown).
+   * NULL means apply has not yet succeeded — either because broker_status is
+   * not yet FILLED, or because a previous DO apply attempt threw.
+   *
+   * Acts as an idempotent-apply ledger for `reconcileFills`: rows where
+   * `broker_status='FILLED' AND state_applied_at IS NULL` are picked up by
+   * the next reconcile tick (or the `?retryStateApply=1` repair mode) and
+   * re-attempted. Once stamped, the row is never re-applied, even if it is
+   * re-selected.
+   *
+   * Closes the split-brain that issue #142 tracked: D1 row was marked FILLED
+   * but the DO position never updated because the DO call threw between the
+   * UPDATE and the apply.
+   */
+  stateAppliedAt: text('state_applied_at'),
+  /**
+   * Last DO-apply error message captured while attempting to apply this
+   * FILLED row. NULL when apply has never failed (or has succeeded since the
+   * last failure). Only useful in conjunction with `state_applied_at IS NULL`
+   * — a non-NULL value with `state_applied_at` set means the most recent
+   * attempt eventually succeeded after a prior failure.
+   */
+  stateApplyError: text('state_apply_error'),
+  /**
+   * Number of DO-apply attempts (success or failure). Bumped on every retry.
+   * Used by ops to spot rows stuck in a retry loop (`attempts >> 1` with
+   * `state_applied_at IS NULL` is an alert signal).
+   */
+  stateApplyAttempts: integer('state_apply_attempts').notNull().default(0),
 })
 
 export type TradeJournalRow = typeof tradeJournal.$inferSelect

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,3 +1,4 @@
+import { and, eq, isNull, sql } from 'drizzle-orm'
 import { Hono } from 'hono'
 import type { AppBindings } from '../app'
 import { ValidationError } from '../shared/errors'
@@ -8,6 +9,8 @@ import { reconcileFills } from '../trading/reconciliation/reconcileFills'
 import { runStrategyCron } from '../trading/strategy/runStrategyCron'
 import { YahooBarClient } from '../infrastructure/quotes/YahooBarClient'
 import { loadGlobalConfigFrom } from '../infrastructure/db/globalConfigLoader'
+import { createDb } from '../infrastructure/db/tradeJournalRepo'
+import { tradeJournal } from '../infrastructure/db/schema'
 import { runBacktest, type BacktestParams } from '../trading/backtest/runBacktest'
 import type { SymbolRule } from '../trading/strategy/strategies/PullbackUptrendStrategy'
 
@@ -191,12 +194,46 @@ export const admin = new Hono<AppBindings>()
    * `filled_qty / filled_price / broker_status`. Safe to call on demand —
    * idempotent (terminal rows are already excluded by the WHERE clause).
    *
-   * PnL roll-up into PortfolioStateDO is a follow-up; this just makes sure
-   * the journal reflects what Webull says about each order.
+   * Optional `?retryStateApply=1` mode (issue #142): also sweep
+   * `broker_status='FILLED' AND state_applied_at IS NULL` rows that have
+   * aged out of the cron lookback window. Use to manually unstick legacy
+   * split-brain rows after deploying the marker columns.
    */
   .post('/orders/reconcile', async (c) => {
-    const summary = await reconcileFills({ env: c.env, requestId: c.get('requestId') })
+    const retryStateApply = parseTruthyQuery(c.req.query('retryStateApply'))
+    const summary = await reconcileFills({
+      env: c.env,
+      requestId: c.get('requestId'),
+      retryStateApply,
+    })
     return c.json(summary)
+  })
+  /**
+   * Read-only count of `broker_status='FILLED' AND state_applied_at IS NULL`
+   * rows — i.e. the split-brain backlog that issue #142 tracks. A non-zero
+   * `pendingApply` is the operator's signal to invoke
+   * `POST /admin/orders/reconcile?retryStateApply=1`.
+   *
+   * Cheap (single COUNT(*) query) so safe to scrape from a dashboard. Does
+   * not mutate state.
+   */
+  .get('/orders/repair-status', async (c) => {
+    if (!c.env.DB) {
+      throw new ValidationError('DB binding is not configured', { field: 'env' })
+    }
+    const db = createDb(c.env.DB)
+    const rows = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(tradeJournal)
+      .where(
+        and(
+          eq(tradeJournal.tradeEventType, 'post_submit'),
+          eq(tradeJournal.brokerStatus, 'FILLED'),
+          isNull(tradeJournal.stateAppliedAt),
+        ),
+      )
+    const pendingApply = Number(rows[0]?.count ?? 0)
+    return c.json({ pendingApply })
   })
   .get('/orders/:clientOrderId', async (c) => {
     const clientOrderId = c.req.param('clientOrderId').trim()
@@ -289,6 +326,17 @@ function readOptionalNumber(
     throw new ValidationError(`'${field}' must be > 0`, { field })
   }
   return parsed
+}
+
+/**
+ * Treat `1` / `true` / `yes` (case-insensitive) as truthy. Anything else —
+ * including missing — is false. Kept narrow so an operator typo on a flag
+ * fails closed (the safer default for a "do extra work" toggle).
+ */
+function parseTruthyQuery(value: string | undefined): boolean {
+  if (value === undefined) return false
+  const normalized = value.trim().toLowerCase()
+  return normalized === '1' || normalized === 'true' || normalized === 'yes'
 }
 
 function isYmd(value: string): boolean {

--- a/src/trading/reconciliation/reconcileFills.ts
+++ b/src/trading/reconciliation/reconcileFills.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gte, isNull } from 'drizzle-orm'
+import { and, desc, eq, gte, isNull, or, sql } from 'drizzle-orm'
 import type { Env } from '../../config/env'
 import { createDb } from '../../infrastructure/db/tradeJournalRepo'
 import { tradeJournal } from '../../infrastructure/db/schema'
@@ -30,6 +30,24 @@ export interface ReconcileSummary {
   stillPending: Array<{ clientOrderId: string; status?: string }>
   notFound: string[]
   errors: Array<{ clientOrderId: string; message: string }>
+  /**
+   * Number of rows where the DO state apply succeeded on this run (whether
+   * the row was first-seen-FILLED or a repair retry of a previously-failed
+   * apply). Bumped after `state_applied_at` is stamped.
+   */
+  stateApplied: number
+  /**
+   * Number of rows where the DO state apply attempt threw on this run. The
+   * journal row keeps `state_applied_at = NULL` and gets `state_apply_error`
+   * recorded so the next reconcile / repair tick can retry.
+   */
+  stateApplyFailed: number
+  /**
+   * Of `stateApplied`, how many were repair-mode rows (already FILLED in the
+   * journal but not previously applied). Useful to spot persistent split-brain
+   * recovery activity in cron logs.
+   */
+  repaired: number
 }
 
 interface ReconcileOptions {
@@ -45,6 +63,14 @@ interface ReconcileOptions {
   /** Cap on rows inspected per call so a single invocation doesn't fan out. */
   limit?: number
   now?: () => Date
+  /**
+   * When true, the SELECT also picks up `broker_status='FILLED' AND
+   * state_applied_at IS NULL` rows that fall **outside** the lookback window
+   * — i.e. anything ever stuck in split-brain. Used by the
+   * `/admin/orders/reconcile?retryStateApply=1` repair endpoint. Default
+   * `false`: cron-triggered runs only retry rows still inside `lookbackMs`.
+   */
+  retryStateApply?: boolean
 }
 
 /**
@@ -61,12 +87,21 @@ interface ReconcileOptions {
  *     applyRealizedPnl. The computed delta is also persisted on the
  *     trade_journal row (realized_pnl column).
  *
- * Idempotency note: the SELECT filter `broker_status IS NULL` prevents
- * double processing in the common case. If the journal UPDATE succeeds but
- * the subsequent DO apply throws, the row is marked reconciled and the DO
- * won't auto-repair on the next tick — the error is logged loudly so an
- * operator can fix it manually. Proper idempotency would need a separate
- * `applied_at` marker column; out of scope for this change.
+ * Idempotency / split-brain repair (issue #142):
+ *   - The SELECT picks up `broker_status IS NULL` (first-seen) AND
+ *     `broker_status='FILLED' AND state_applied_at IS NULL` (DO apply
+ *     previously failed). The latter ensures a single failed DO call does
+ *     not strand the row forever — the next cron tick retries.
+ *   - After a successful DO apply, `state_applied_at` is stamped on the
+ *     row, which removes it from future SELECT candidates. Already-applied
+ *     rows are also defensively skipped at the loop level.
+ *   - On apply failure the journal keeps `state_applied_at = NULL` and
+ *     records `state_apply_error` + bumps `state_apply_attempts` so an
+ *     operator can see how many retries it has taken.
+ *
+ * The previous implementation marked the row reconciled and trusted that
+ * any DO failure would be repaired manually — split-brain (D1 = FILLED, DO
+ * position = stale) was the result.
  */
 export async function reconcileFills(options: ReconcileOptions): Promise<ReconcileSummary> {
   // Fail-closed on a missing DB binding to match loadGlobalConfigFrom /
@@ -81,6 +116,9 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
     stillPending: [],
     notFound: [],
     errors: [],
+    stateApplied: 0,
+    stateApplyFailed: 0,
+    repaired: 0,
   }
 
   const now = options.now ?? (() => new Date())
@@ -93,20 +131,48 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
   const limit = options.limit ?? 50
 
   const db = createDb(options.env.DB)
+  // Two cohorts in one query:
+  //   (a) `broker_status IS NULL` — never-reconciled, the original case.
+  //   (b) `broker_status='FILLED' AND state_applied_at IS NULL` — D1 says
+  //       FILLED but DO apply previously threw (or was never attempted on a
+  //       row that was UPDATEd before this code shipped).
+  //
+  // For cohort (b), the `retryStateApply` flag controls whether the
+  // `lookbackMs` bound applies. Cron-triggered runs leave it false and
+  // only repair rows still inside the lookback window (match the original
+  // 48h scope). The repair endpoint sets it true to sweep older split-brain
+  // rows that have aged out of the window.
+  const repairFilter = and(
+    eq(tradeJournal.brokerStatus, 'FILLED'),
+    isNull(tradeJournal.stateAppliedAt),
+  )
   const candidates = await db
     .select({
       id: tradeJournal.id,
       clientOrderId: tradeJournal.clientOrderId,
       symbol: tradeJournal.symbol,
       side: tradeJournal.side,
+      brokerStatus: tradeJournal.brokerStatus,
+      filledQty: tradeJournal.filledQty,
+      filledPrice: tradeJournal.filledPrice,
+      realizedPnl: tradeJournal.realizedPnl,
+      stateAppliedAt: tradeJournal.stateAppliedAt,
+      stateApplyAttempts: tradeJournal.stateApplyAttempts,
     })
     .from(tradeJournal)
     .where(
       and(
         eq(tradeJournal.tradeEventType, 'post_submit'),
         eq(tradeJournal.submitted, true),
-        isNull(tradeJournal.brokerStatus),
-        gte(tradeJournal.timestamp, since),
+        // Always require the lookback window for the "fresh poll" cohort.
+        // Repair-mode (retryStateApply=true) drops it for cohort (b) only,
+        // applied via the OR below.
+        or(
+          and(isNull(tradeJournal.brokerStatus), gte(tradeJournal.timestamp, since)),
+          options.retryStateApply
+            ? repairFilter
+            : and(repairFilter, gte(tradeJournal.timestamp, since)),
+        ),
       ),
     )
     .orderBy(desc(tradeJournal.id))
@@ -129,6 +195,70 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
       })
       continue
     }
+
+    // Distinguish the two cohorts so we can:
+    //   - skip the Webull poll for already-FILLED repair rows (we already
+    //     have the canonical fill data on the journal row),
+    //   - count the repair stat correctly for ops visibility.
+    //
+    // `broker_status='FILLED' AND state_applied_at IS NULL` is the repair
+    // case: status is canonical, only the DO apply needs retry. Any other
+    // shape (NULL broker_status) means we still need a fresh status from
+    // the broker.
+    const isRepair = row.brokerStatus === 'FILLED' && row.stateAppliedAt === null
+
+    if (isRepair) {
+      // Use the canonical fill data already on the row. We must not
+      // re-poll Webull — orders/history can rotate the row off the first
+      // page after a few days, and re-polling would also waste a quota.
+      const symbol = row.symbol
+      const side = row.side as 'BUY' | 'SELL' | null
+      const filledQty = row.filledQty ?? null
+      const filledPrice = row.filledPrice ?? null
+      if (
+        symbol === null ||
+        side === null ||
+        filledQty === null || filledQty <= 0 ||
+        filledPrice === null || filledPrice <= 0
+      ) {
+        // The row was stamped FILLED earlier but is missing one of the
+        // fields required to apply the fill (impossibility under the
+        // current code path, but defensive). Mark the apply as
+        // permanently-skipped via an error so an operator can investigate.
+        const message = `repair_skipped_invalid_row: symbol=${symbol} side=${side} qty=${filledQty} price=${filledPrice}`
+        await recordApplyFailure(db, row.id, message)
+        summary.errors.push({ clientOrderId: coid, message })
+        summary.stateApplyFailed += 1
+        continue
+      }
+      const realizedPnl = row.realizedPnl ?? null
+      const ok = await tryApplyAndStamp({
+        env: options.env,
+        requestId: options.requestId,
+        db,
+        rowId: row.id,
+        clientOrderId: coid,
+        symbol,
+        side,
+        filledQty,
+        filledPrice,
+        realizedPnl,
+        runNow,
+        nowIso: runNow.toISOString(),
+      })
+      if (ok) {
+        summary.stateApplied += 1
+        summary.repaired += 1
+      } else {
+        summary.stateApplyFailed += 1
+        summary.errors.push({
+          clientOrderId: coid,
+          message: 'state_apply_failed (see reconcile_state_apply_error log)',
+        })
+      }
+      continue
+    }
+
     let detail: WebullOrderDetailDto | undefined
     try {
       detail = await client.findOrderByClientId(coid)
@@ -202,8 +332,8 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
       summary.updated.push({ clientOrderId: coid, status, ...(realizedPnl !== null ? { realizedPnl } : {}) })
 
       // After the journal is stamped reconciled, push the fill into the DO
-      // layer. Any DO failure here is logged but does NOT retry — see the
-      // idempotency note in the module docstring.
+      // layer. Failure here records `state_apply_error` and leaves
+      // `state_applied_at = NULL` so the next reconcile tick will retry.
       if (
         status === 'FILLED' &&
         side !== null &&
@@ -211,9 +341,11 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
         filledQty !== null && filledQty > 0 &&
         filledPrice !== null && filledPrice > 0
       ) {
-        await applyFillToState({
+        const ok = await tryApplyAndStamp({
           env: options.env,
           requestId: options.requestId,
+          db,
+          rowId: row.id,
           clientOrderId: coid,
           symbol,
           side,
@@ -221,7 +353,29 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
           filledPrice,
           realizedPnl,
           runNow,
+          nowIso: runNow.toISOString(),
         })
+        if (ok) {
+          summary.stateApplied += 1
+        } else {
+          summary.stateApplyFailed += 1
+          summary.errors.push({
+            clientOrderId: coid,
+            message: 'state_apply_failed (see reconcile_state_apply_error log)',
+          })
+        }
+      } else if (status === 'FILLED') {
+        // FILLED but missing one of the apply prerequisites. Mark
+        // `state_applied_at` anyway so we don't retry forever — there's
+        // nothing to apply.
+        await db
+          .update(tradeJournal)
+          .set({
+            stateAppliedAt: runNow.toISOString(),
+            stateApplyError: null,
+            stateApplyAttempts: sql`${tradeJournal.stateApplyAttempts} + 1`,
+          })
+          .where(eq(tradeJournal.id, row.id))
       }
 
       // Release the pending-order lock on every terminal status — FILLED,
@@ -271,12 +425,142 @@ function toNumberOrNull(value: string | undefined): number | null {
 }
 
 /**
+ * Apply a terminal FILLED order into SymbolStateDO + PortfolioStateDO and,
+ * on success, stamp `state_applied_at` on the journal row. On failure the
+ * row keeps `state_applied_at = NULL` and gets `state_apply_error` recorded
+ * so the next reconcile tick (or `?retryStateApply=1` repair sweep) can
+ * pick it back up.
+ *
+ * Returns `true` on success (marker stamped), `false` on failure.
+ */
+async function tryApplyAndStamp(args: {
+  env: Env
+  requestId?: string
+  db: ReturnType<typeof createDb>
+  rowId: number
+  clientOrderId: string
+  symbol: string
+  side: 'BUY' | 'SELL'
+  filledQty: number
+  filledPrice: number
+  realizedPnl: number | null
+  runNow: Date
+  nowIso: string
+}): Promise<boolean> {
+  const {
+    env,
+    requestId,
+    db,
+    rowId,
+    clientOrderId,
+    symbol,
+    side,
+    filledQty,
+    filledPrice,
+    realizedPnl,
+    runNow,
+    nowIso,
+  } = args
+
+  try {
+    await applyFillToState({
+      env,
+      requestId,
+      clientOrderId,
+      symbol,
+      side,
+      filledQty,
+      filledPrice,
+      realizedPnl,
+      runNow,
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(
+      JSON.stringify({
+        event: 'reconcile_state_apply_error',
+        requestId,
+        rowId,
+        clientOrderId,
+        symbol,
+        side,
+        message,
+      }),
+    )
+    await recordApplyFailure(db, rowId, message)
+    return false
+  }
+
+  // Apply succeeded. Stamp the marker so the row is excluded from future
+  // SELECT candidates.
+  try {
+    await db
+      .update(tradeJournal)
+      .set({
+        stateAppliedAt: nowIso,
+        stateApplyError: null,
+        stateApplyAttempts: sql`${tradeJournal.stateApplyAttempts} + 1`,
+      })
+      .where(eq(tradeJournal.id, rowId))
+    console.log(
+      JSON.stringify({
+        event: 'reconcile_state_applied',
+        requestId,
+        rowId,
+        clientOrderId,
+        symbol,
+        side,
+      }),
+    )
+  } catch (error) {
+    // Marker UPDATE failed *after* DO apply succeeded — log loudly. The DO
+    // is now ahead of the journal; the row will be re-selected next tick
+    // and the apply will run a second time. SymbolStateDO.recordFill is
+    // not idempotent on its own, so this is a real risk and operator
+    // intervention may be needed.
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(
+      JSON.stringify({
+        event: 'reconcile_state_marker_update_error',
+        requestId,
+        rowId,
+        clientOrderId,
+        symbol,
+        side,
+        message,
+      }),
+    )
+    return false
+  }
+  return true
+}
+
+async function recordApplyFailure(
+  db: ReturnType<typeof createDb>,
+  rowId: number,
+  message: string,
+): Promise<void> {
+  // Best-effort. If even this UPDATE fails the row simply keeps its prior
+  // attempts/error state and gets re-tried next tick — no need to escalate.
+  try {
+    await db
+      .update(tradeJournal)
+      .set({
+        stateApplyError: message,
+        stateApplyAttempts: sql`${tradeJournal.stateApplyAttempts} + 1`,
+      })
+      .where(eq(tradeJournal.id, rowId))
+  } catch {
+    // Swallow — logged at the call site already.
+  }
+}
+
+/**
  * Apply a terminal FILLED order into SymbolStateDO (position tracking) and,
  * for SELL legs, PortfolioStateDO (realized PnL aggregation).
  *
- * Failures here are logged but not rethrown — the journal row is already
- * marked reconciled at this point, so the next cron tick would skip it.
- * Proper repair would need an `applied_at` column; see module docstring.
+ * Throws on any underlying DO call failure — caller (`tryApplyAndStamp`)
+ * catches and records the error so the row stays repair-able.
  */
 async function applyFillToState(args: {
   env: Env
@@ -294,41 +578,17 @@ async function applyFillToState(args: {
   const { env, requestId, clientOrderId, symbol, side, filledQty, filledPrice, realizedPnl, runNow } = args
 
   if (env.SYMBOL_STATE) {
-    try {
-      await new SymbolStateClient(env.SYMBOL_STATE).recordFill(symbol, {
-        side,
-        qty: filledQty,
-        price: filledPrice,
-      })
-    } catch (error) {
-      console.error(
-        JSON.stringify({
-          event: 'reconcile_symbol_state_apply_error',
-          requestId,
-          clientOrderId,
-          symbol,
-          side,
-          message: error instanceof Error ? error.message : String(error),
-        }),
-      )
-    }
+    // Throws on DO failure — caller records `state_apply_error` and will
+    // retry on the next reconcile tick.
+    await new SymbolStateClient(env.SYMBOL_STATE).recordFill(symbol, {
+      side,
+      qty: filledQty,
+      price: filledPrice,
+    })
   }
 
   if (side === 'SELL' && realizedPnl !== null && env.PORTFOLIO_STATE) {
-    try {
-      await new PortfolioStateClient(env.PORTFOLIO_STATE).applyRealizedPnl(realizedPnl)
-    } catch (error) {
-      console.error(
-        JSON.stringify({
-          event: 'reconcile_portfolio_apply_error',
-          requestId,
-          clientOrderId,
-          symbol,
-          realizedPnl,
-          message: error instanceof Error ? error.message : String(error),
-        }),
-      )
-    }
+    await new PortfolioStateClient(env.PORTFOLIO_STATE).applyRealizedPnl(realizedPnl)
   }
 
   // Stop-out cooldown: a losing exit parks the symbol until the next trading
@@ -336,6 +596,13 @@ async function applyFillToState(args: {
   // removed TradeEventHandler — pullbackScheduler reads `state.cooldownUntil`
   // for its signal decision, so without this write the strategy never
   // backs off after a losing sell.
+  //
+  // Cooldown failures are intentionally NON-fatal (caught + logged) because
+  // the position itself has already been correctly recorded, and a missed
+  // cooldown only loosens a re-entry guard rather than producing
+  // double-counted state. We don't want a transient cooldown failure to
+  // strand the row in retry forever after position+pnl have already
+  // applied.
   if (
     side === 'SELL' &&
     realizedPnl !== null &&

--- a/test/routes/admin.test.ts
+++ b/test/routes/admin.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createApp } from '../../src/app'
+import { reconcileFills } from '../../src/trading/reconciliation/reconcileFills'
+
+vi.mock('../../src/trading/reconciliation/reconcileFills', () => ({
+  reconcileFills: vi.fn(),
+}))
 
 const baseEnv = {
   BASIC_AUTH_USER: 'admin',
@@ -100,6 +105,118 @@ describe('POST /admin/symbols/:symbol/seed-cash', () => {
       updatedAt: '2026-04-21T10:00:00.000Z',
     })
     expect(captured.calls).toEqual([{ symbol: 'SOXL', amount: 12_345 }])
+  })
+})
+
+describe('POST /admin/orders/reconcile', () => {
+  afterEach(() => vi.resetAllMocks())
+
+  function emptySummary() {
+    return {
+      inspected: 0,
+      updated: [],
+      stillPending: [],
+      notFound: [],
+      errors: [],
+      stateApplied: 0,
+      stateApplyFailed: 0,
+      repaired: 0,
+    }
+  }
+
+  it('forwards retryStateApply=false to reconcileFills by default', async () => {
+    vi.mocked(reconcileFills).mockResolvedValueOnce(emptySummary())
+    const app = createApp()
+    const res = await app.request(
+      '/admin/orders/reconcile',
+      { method: 'POST', headers: { ...authHeader } },
+      baseEnv,
+    )
+    expect(res.status).toBe(200)
+    expect(reconcileFills).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(reconcileFills).mock.calls[0]![0]).toMatchObject({
+      retryStateApply: false,
+    })
+  })
+
+  it.each(['1', 'true', 'TRUE', 'yes'])(
+    'enables repair sweep when ?retryStateApply=%s',
+    async (value) => {
+      vi.mocked(reconcileFills).mockResolvedValueOnce(emptySummary())
+      const app = createApp()
+      const res = await app.request(
+        `/admin/orders/reconcile?retryStateApply=${value}`,
+        { method: 'POST', headers: { ...authHeader } },
+        baseEnv,
+      )
+      expect(res.status).toBe(200)
+      expect(vi.mocked(reconcileFills).mock.calls[0]![0]).toMatchObject({
+        retryStateApply: true,
+      })
+    },
+  )
+
+  it('treats unknown ?retryStateApply values as false (fail-closed)', async () => {
+    vi.mocked(reconcileFills).mockResolvedValueOnce(emptySummary())
+    const app = createApp()
+    const res = await app.request(
+      '/admin/orders/reconcile?retryStateApply=please',
+      { method: 'POST', headers: { ...authHeader } },
+      baseEnv,
+    )
+    expect(res.status).toBe(200)
+    expect(vi.mocked(reconcileFills).mock.calls[0]![0]).toMatchObject({
+      retryStateApply: false,
+    })
+  })
+})
+
+describe('GET /admin/orders/repair-status', () => {
+  function fakeDbReturning(count: number) {
+    const chain = {
+      from: () => chain,
+      where: async () => [{ count }],
+    }
+    return { select: () => chain }
+  }
+
+  it('401s without Basic Auth', async () => {
+    const app = createApp()
+    const res = await app.request('/admin/orders/repair-status', {}, {
+      ...baseEnv,
+      DB: fakeDbReturning(3) as unknown as D1Database,
+    })
+    expect(res.status).toBe(401)
+  })
+
+  it('200s with the count of FILLED rows missing state_applied_at', async () => {
+    // Stub createDb so we can inject the query result without spinning up a
+    // real D1. The wrapper just receives the env.DB reference and forwards
+    // a typed drizzle handle, but here we want the chain we control.
+    const dbModule = await import('../../src/infrastructure/db/tradeJournalRepo')
+    const spy = vi
+      .spyOn(dbModule, 'createDb')
+      .mockReturnValue(fakeDbReturning(7) as never)
+
+    const app = createApp()
+    const res = await app.request(
+      '/admin/orders/repair-status',
+      { headers: { ...authHeader } },
+      { ...baseEnv, DB: {} as unknown as D1Database },
+    )
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ pendingApply: 7 })
+    spy.mockRestore()
+  })
+
+  it('400s when DB binding is missing', async () => {
+    const app = createApp()
+    const res = await app.request(
+      '/admin/orders/repair-status',
+      { headers: { ...authHeader } },
+      baseEnv,
+    )
+    expect(res.status).toBe(400)
   })
 })
 

--- a/test/trading/reconciliation/reconcileFills.test.ts
+++ b/test/trading/reconciliation/reconcileFills.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it } from 'vitest'
-import { _internal } from '../../../src/trading/reconciliation/reconcileFills'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { _internal, reconcileFills } from '../../../src/trading/reconciliation/reconcileFills'
+import { createDb } from '../../../src/infrastructure/db/tradeJournalRepo'
+import { createWebullHttpClient } from '../../../src/infrastructure/webull/WebullHttpClient'
+
+vi.mock('../../../src/infrastructure/db/tradeJournalRepo', () => ({
+  createDb: vi.fn(),
+}))
+vi.mock('../../../src/infrastructure/webull/WebullHttpClient', () => ({
+  createWebullHttpClient: vi.fn(),
+}))
 
 describe('reconcileFills internals', () => {
   it('TERMINAL_STATUSES covers the expected Webull statuses', () => {
@@ -58,5 +67,423 @@ describe('reconcileFills internals', () => {
     expect(_internal.resolveFilledPrice(1, { limit_price: '-5' })).toBeNull()
     expect(_internal.resolveFilledPrice(1, { limit_price: 'NaN' })).toBeNull()
     expect(_internal.resolveFilledPrice(1, {})).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// state-apply marker behaviour (issue #142)
+// ---------------------------------------------------------------------------
+
+interface CandidateRow {
+  id: number
+  clientOrderId: string | null
+  symbol: string | null
+  side: string | null
+  brokerStatus: string | null
+  filledQty: number | null
+  filledPrice: number | null
+  realizedPnl: number | null
+  stateAppliedAt: string | null
+  stateApplyAttempts: number
+}
+
+interface UpdateCall {
+  rowId: number
+  set: Record<string, unknown>
+}
+
+/**
+ * Build a fake drizzle DB that:
+ *   - returns the supplied rows from the SELECT chain,
+ *   - records every UPDATE into `updates` so tests can assert on which
+ *     columns moved (especially `stateAppliedAt` / `stateApplyError` /
+ *     `stateApplyAttempts`).
+ *
+ * The fake matches the call sequence reconcileFills uses
+ * (.update(table).set(values).where(rowEq)) — it doesn't actually parse
+ * the `where` predicate but we capture the row id from the most recent
+ * `.set` call that was followed by `.where`.
+ */
+function makeFakeDb(rows: CandidateRow[]): {
+  db: ReturnType<typeof createDb>
+  updates: UpdateCall[]
+} {
+  const updates: UpdateCall[] = []
+
+  const selectChain = {
+    from: () => selectChain,
+    where: () => selectChain,
+    orderBy: () => selectChain,
+    limit: async () => rows,
+    // Drizzle's chain is also thenable; not exercised here but kept for
+    // safety against future refactors.
+    then: (resolve: (v: unknown[]) => unknown) => Promise.resolve(resolve(rows)),
+  }
+
+  let pendingSet: Record<string, unknown> | null = null
+
+  const db = {
+    select: () => selectChain,
+    update: () => ({
+      set: (values: Record<string, unknown>) => {
+        pendingSet = values
+        return {
+          where: (predicate: { queryChunks?: unknown[] }) => {
+            // Pull the row id out of the eq() predicate. drizzle-orm's
+            // `eq(col, value)` creates an SQL chunk where the bound value
+            // is in `queryChunks`. We don't care about the schema; just
+            // grep the chunks for a finite number — there's only one row
+            // id in any UPDATE we issue.
+            const rowId = extractRowId(predicate)
+            updates.push({ rowId, set: pendingSet ?? {} })
+            pendingSet = null
+            return Promise.resolve()
+          },
+        }
+      },
+    }),
+  }
+  return { db: db as unknown as ReturnType<typeof createDb>, updates }
+}
+
+function extractRowId(predicate: unknown): number {
+  // Walk arbitrarily nested objects/arrays/symbols looking for the first
+  // finite number — that's the bound value passed to `eq(tradeJournal.id, n)`.
+  const seen = new Set<unknown>()
+  function walk(node: unknown): number | null {
+    if (typeof node === 'number' && Number.isFinite(node)) return node
+    if (node === null || typeof node !== 'object') return null
+    if (seen.has(node)) return null
+    seen.add(node)
+    for (const value of Object.values(node)) {
+      const found = walk(value)
+      if (found !== null) return found
+    }
+    return null
+  }
+  const found = walk(predicate)
+  if (found === null) throw new Error('extractRowId: no row id in predicate')
+  return found
+}
+
+interface SymbolStateStub {
+  recordFill: ReturnType<typeof vi.fn>
+  setCooldown: ReturnType<typeof vi.fn>
+  getState: ReturnType<typeof vi.fn>
+  clearPendingOrder: ReturnType<typeof vi.fn>
+}
+
+function makeSymbolStateNamespace(stub: SymbolStateStub): unknown {
+  return {
+    idFromName: (_n: string) => 'id',
+    get: () => stub,
+  }
+}
+
+interface PortfolioStateStub {
+  applyRealizedPnl: ReturnType<typeof vi.fn>
+}
+
+function makePortfolioNamespace(stub: PortfolioStateStub): unknown {
+  return {
+    idFromName: () => 'id',
+    get: () => stub,
+  }
+}
+
+function makeWebullStub(detailByCoid: Record<string, unknown>) {
+  return {
+    findOrderByClientId: vi.fn(async (coid: string) => detailByCoid[coid]),
+  }
+}
+
+function emptySymbolStateStub(): SymbolStateStub {
+  return {
+    recordFill: vi.fn(async () => ({})),
+    setCooldown: vi.fn(async () => ({})),
+    getState: vi.fn(async () => ({
+      symbol: 'SOXL',
+      position: null,
+      pendingOrder: null,
+      lastSignalAt: null,
+      cooldownUntil: null,
+      settledCash: 0,
+      pendingSettlement: [],
+      lastExecutedPrice: null,
+      lastQuote: null,
+      updatedAt: '2026-04-25T00:00:00.000Z',
+    })),
+    clearPendingOrder: vi.fn(async () => ({})),
+  }
+}
+
+const FAKE_DB_BINDING = { __isFakeD1: true } as unknown as D1Database
+
+describe('reconcileFills state-apply marker (issue #142)', () => {
+  beforeEach(() => {
+    // Quiet the JSON event log so test output stays readable.
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.resetAllMocks()
+  })
+
+  it('stamps state_applied_at after a successful BUY fill apply', async () => {
+    const row: CandidateRow = {
+      id: 7,
+      clientOrderId: 'coid-buy-1',
+      symbol: 'SOXL',
+      side: 'BUY',
+      brokerStatus: null,
+      filledQty: null,
+      filledPrice: null,
+      realizedPnl: null,
+      stateAppliedAt: null,
+      stateApplyAttempts: 0,
+    }
+    const { db, updates } = makeFakeDb([row])
+    vi.mocked(createDb).mockReturnValue(db)
+    vi.mocked(createWebullHttpClient).mockReturnValue(
+      makeWebullStub({
+        'coid-buy-1': {
+          status: 'FILLED',
+          filled_quantity: '10',
+          limit_price: '50',
+          side: 'BUY',
+          symbol: 'SOXL',
+        },
+      }) as unknown as ReturnType<typeof createWebullHttpClient>,
+    )
+    const symbolStub = emptySymbolStateStub()
+
+    const summary = await reconcileFills({
+      env: {
+        DB: FAKE_DB_BINDING,
+        SYMBOL_STATE: makeSymbolStateNamespace(symbolStub) as never,
+      } as never,
+      now: () => new Date('2026-04-25T12:00:00.000Z'),
+    })
+
+    expect(summary.inspected).toBe(1)
+    expect(summary.updated).toEqual([{ clientOrderId: 'coid-buy-1', status: 'FILLED' }])
+    expect(summary.stateApplied).toBe(1)
+    expect(summary.stateApplyFailed).toBe(0)
+    expect(summary.repaired).toBe(0)
+    expect(symbolStub.recordFill).toHaveBeenCalledWith('SOXL', {
+      side: 'BUY',
+      qty: 10,
+      price: 50,
+    })
+    // Two UPDATEs: (1) journal fill columns, (2) state_applied_at marker.
+    expect(updates).toHaveLength(2)
+    expect(updates[1]!.set.stateAppliedAt).toBe('2026-04-25T12:00:00.000Z')
+    expect(updates[1]!.set.stateApplyError).toBeNull()
+    // attempts uses sql`... + 1` — assert the column is being updated, not
+    // the literal value.
+    expect(updates[1]!.set.stateApplyAttempts).toBeDefined()
+  })
+
+  it('records state_apply_error and leaves marker NULL when DO recordFill throws', async () => {
+    const row: CandidateRow = {
+      id: 9,
+      clientOrderId: 'coid-broken-1',
+      symbol: 'SOXL',
+      side: 'BUY',
+      brokerStatus: null,
+      filledQty: null,
+      filledPrice: null,
+      realizedPnl: null,
+      stateAppliedAt: null,
+      stateApplyAttempts: 0,
+    }
+    const { db, updates } = makeFakeDb([row])
+    vi.mocked(createDb).mockReturnValue(db)
+    vi.mocked(createWebullHttpClient).mockReturnValue(
+      makeWebullStub({
+        'coid-broken-1': {
+          status: 'FILLED',
+          filled_quantity: '5',
+          limit_price: '20',
+          side: 'BUY',
+          symbol: 'SOXL',
+        },
+      }) as unknown as ReturnType<typeof createWebullHttpClient>,
+    )
+    const symbolStub = emptySymbolStateStub()
+    symbolStub.recordFill.mockRejectedValueOnce(new Error('DO unavailable'))
+
+    const summary = await reconcileFills({
+      env: {
+        DB: FAKE_DB_BINDING,
+        SYMBOL_STATE: makeSymbolStateNamespace(symbolStub) as never,
+      } as never,
+      now: () => new Date('2026-04-25T12:00:00.000Z'),
+    })
+
+    expect(summary.stateApplied).toBe(0)
+    expect(summary.stateApplyFailed).toBe(1)
+    expect(summary.errors).toEqual([
+      { clientOrderId: 'coid-broken-1', message: expect.stringContaining('state_apply_failed') },
+    ])
+    // UPDATEs: (1) journal fill columns, (2) failure marker (error +
+    // attempts++). state_applied_at must NOT be set on either UPDATE.
+    expect(updates).toHaveLength(2)
+    expect(updates[0]!.set.stateAppliedAt).toBeUndefined()
+    expect(updates[1]!.set.stateApplyError).toBe('DO unavailable')
+    expect(updates[1]!.set.stateAppliedAt).toBeUndefined()
+  })
+
+  it('repair cohort: re-applies state for FILLED rows missing state_applied_at without re-polling Webull', async () => {
+    const row: CandidateRow = {
+      id: 11,
+      clientOrderId: 'coid-repair-1',
+      symbol: 'SOXL',
+      side: 'BUY',
+      brokerStatus: 'FILLED',
+      filledQty: 3,
+      filledPrice: 40,
+      realizedPnl: null,
+      stateAppliedAt: null,
+      stateApplyAttempts: 1,
+    }
+    const { db, updates } = makeFakeDb([row])
+    vi.mocked(createDb).mockReturnValue(db)
+    const webullStub = makeWebullStub({})
+    vi.mocked(createWebullHttpClient).mockReturnValue(
+      webullStub as unknown as ReturnType<typeof createWebullHttpClient>,
+    )
+    const symbolStub = emptySymbolStateStub()
+
+    const summary = await reconcileFills({
+      env: {
+        DB: FAKE_DB_BINDING,
+        SYMBOL_STATE: makeSymbolStateNamespace(symbolStub) as never,
+      } as never,
+      now: () => new Date('2026-04-25T12:00:00.000Z'),
+      retryStateApply: true,
+    })
+
+    // Repair-mode rows must NOT trigger a fresh Webull poll — the canonical
+    // status/qty/price are already on the row.
+    expect(webullStub.findOrderByClientId).not.toHaveBeenCalled()
+    expect(symbolStub.recordFill).toHaveBeenCalledWith('SOXL', {
+      side: 'BUY',
+      qty: 3,
+      price: 40,
+    })
+    expect(summary.stateApplied).toBe(1)
+    expect(summary.repaired).toBe(1)
+    // Only one UPDATE on the repair path: the marker stamp.
+    expect(updates).toHaveLength(1)
+    expect(updates[0]!.set.stateAppliedAt).toBe('2026-04-25T12:00:00.000Z')
+    expect(updates[0]!.set.stateApplyError).toBeNull()
+  })
+
+  it('repair cohort with no apply prerequisites: records error and skips DO call', async () => {
+    const row: CandidateRow = {
+      id: 13,
+      clientOrderId: 'coid-bad-repair',
+      symbol: 'SOXL',
+      side: 'BUY',
+      brokerStatus: 'FILLED',
+      filledQty: 0, // invalid — should be > 0 for an applyable fill
+      filledPrice: 40,
+      realizedPnl: null,
+      stateAppliedAt: null,
+      stateApplyAttempts: 5,
+    }
+    const { db, updates } = makeFakeDb([row])
+    vi.mocked(createDb).mockReturnValue(db)
+    vi.mocked(createWebullHttpClient).mockReturnValue(
+      makeWebullStub({}) as unknown as ReturnType<typeof createWebullHttpClient>,
+    )
+    const symbolStub = emptySymbolStateStub()
+
+    const summary = await reconcileFills({
+      env: {
+        DB: FAKE_DB_BINDING,
+        SYMBOL_STATE: makeSymbolStateNamespace(symbolStub) as never,
+      } as never,
+      now: () => new Date('2026-04-25T12:00:00.000Z'),
+      retryStateApply: true,
+    })
+
+    expect(symbolStub.recordFill).not.toHaveBeenCalled()
+    expect(summary.stateApplyFailed).toBe(1)
+    expect(summary.repaired).toBe(0)
+    expect(summary.errors).toEqual([
+      { clientOrderId: 'coid-bad-repair', message: expect.stringContaining('repair_skipped_invalid_row') },
+    ])
+    // Only the failure-marker UPDATE.
+    expect(updates).toHaveLength(1)
+    expect(updates[0]!.set.stateApplyError).toMatch(/repair_skipped_invalid_row/)
+    expect(updates[0]!.set.stateAppliedAt).toBeUndefined()
+  })
+
+  it('SELL fill: applies portfolio realized PnL and stamps marker', async () => {
+    const row: CandidateRow = {
+      id: 15,
+      clientOrderId: 'coid-sell-1',
+      symbol: 'SOXL',
+      side: 'SELL',
+      brokerStatus: null,
+      filledQty: null,
+      filledPrice: null,
+      realizedPnl: null,
+      stateAppliedAt: null,
+      stateApplyAttempts: 0,
+    }
+    const { db, updates } = makeFakeDb([row])
+    vi.mocked(createDb).mockReturnValue(db)
+    vi.mocked(createWebullHttpClient).mockReturnValue(
+      makeWebullStub({
+        'coid-sell-1': {
+          status: 'FILLED',
+          filled_quantity: '4',
+          limit_price: '60',
+          side: 'SELL',
+          symbol: 'SOXL',
+        },
+      }) as unknown as ReturnType<typeof createWebullHttpClient>,
+    )
+    const symbolStub = emptySymbolStateStub()
+    symbolStub.getState.mockResolvedValueOnce({
+      symbol: 'SOXL',
+      position: { qty: 4, avgPrice: 50, openedAt: '2026-04-20T00:00:00.000Z' },
+      pendingOrder: null,
+      lastSignalAt: null,
+      cooldownUntil: null,
+      settledCash: 0,
+      pendingSettlement: [],
+      lastExecutedPrice: null,
+      lastQuote: null,
+      updatedAt: '2026-04-25T00:00:00.000Z',
+    })
+    const portfolioStub: PortfolioStateStub = {
+      applyRealizedPnl: vi.fn(async () => ({})),
+    }
+
+    const summary = await reconcileFills({
+      env: {
+        DB: FAKE_DB_BINDING,
+        SYMBOL_STATE: makeSymbolStateNamespace(symbolStub) as never,
+        PORTFOLIO_STATE: makePortfolioNamespace(portfolioStub) as never,
+      } as never,
+      now: () => new Date('2026-04-25T12:00:00.000Z'),
+    })
+
+    // (60 - 50) * 4 = 40 realized.
+    expect(summary.updated).toEqual([
+      { clientOrderId: 'coid-sell-1', status: 'FILLED', realizedPnl: 40 },
+    ])
+    expect(portfolioStub.applyRealizedPnl).toHaveBeenCalledWith(40)
+    expect(summary.stateApplied).toBe(1)
+    expect(updates.at(-1)!.set.stateAppliedAt).toBe('2026-04-25T12:00:00.000Z')
+  })
+
+  it('throws when env.DB binding is missing', async () => {
+    await expect(reconcileFills({ env: {} as never })).rejects.toThrow(/env\.DB/)
   })
 })


### PR DESCRIPTION
## 動機 (issue #142)

`reconcileFills` は Webull の terminal status を見つけると、まず `trade_journal` の `broker_status` / fill columns を UPDATE し、その後で `SymbolStateDO` / `PortfolioStateDO` に fill を適用していた。

journal UPDATE が成功した後で DO apply が throw すると、その行は `broker_status IS NULL` SELECT 対象から外れ、**次回 cron で自動再試行されない**。結果として:

- D1 は `FILLED` だが DO position は未更新 (split-brain)
- SELL fill の realized PnL が `PortfolioStateDO` に乗らず drawdown kill が実損益を見逃す
- pending lock / cooldown 失敗もログ頼みで、運用者の見落としで次の売買判断が歪む

module docstring 自身が `Proper idempotency would need a separate applied_at marker column; out of scope for this change.` と明示していた負債を、本 PR で解消する。

## 設計

### 1. D1 schema

`trade_journal` に 3 カラムを追加 (drizzle migration `0011_reconcile_state_apply_marker.sql`、ALTER のみ・データ移動なし):

| 列 | 型 | 意図 |
|---|---|---|
| `state_applied_at` | text (ISO) | DO apply 成功時の timestamp。NULL なら未適用 (= 要 repair) |
| `state_apply_error` | text | 直近 apply 失敗の message。成功で NULL に戻る |
| `state_apply_attempts` | integer DEFAULT 0 | 試行回数。`>>1 + state_applied_at IS NULL` は alert signal |

### 2. SELECT 拡張

```
broker_status IS NULL                              ← 既存「未確認」cohort
  OR (broker_status='FILLED' AND state_applied_at IS NULL)  ← repair cohort
```

repair cohort は **Webull に再 poll しない** — canonical fill data は journal row 上に既にあるので、そこから直接 DO apply に流す。

### 3. apply 経路の idempotency

DO 内部に新たな ledger は作らず、`trade_journal.state_applied_at` 自体を ledger とした。SELECT が `IS NULL` で絞っているので、stamped 行は二度と再選択されない。失敗時は `state_apply_error` + `state_apply_attempts++` で記録し、次 tick が拾う。

成功時に `applied_at` UPDATE が失敗した場合 (= DO は更新済 / journal は未 stamp の窓) は loud に warn する — 二重 apply のリスクなので運用者が手当する想定。

### 4. repair endpoint

- `POST /admin/orders/reconcile?retryStateApply=1` — lookback window を超えた古い split-brain 行も sweep に含める
- `GET /admin/orders/repair-status` — `pendingApply: number` を返す read-only count、dashboard scrape 用

response summary に新フィールド `stateApplied` / `stateApplyFailed` / `repaired` を追加して、cron log で repair 活動量が見えるように。

## test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test --run` 全 567 件 pass
- [x] `reconcileFills.test.ts`:
  - 正常系: BUY fill apply 成功 → `stateAppliedAt` stamp
  - 失敗系: DO `recordFill` throw → `stateAppliedAt = NULL`, `state_apply_error` 記録, summary `stateApplyFailed=1`
  - repair cohort: FILLED + `stateAppliedAt = NULL` 行を Webull に再 poll せず DO apply, summary `repaired=1`
  - repair 不正値: `filledQty <= 0` 等で apply 不能なら error 記録 + skip
  - SELL fill: `(price - avgPrice) * qty` で realized PnL 計算 + portfolio apply + marker stamp
- [x] `admin.test.ts`:
  - `?retryStateApply=1|true|TRUE|yes` で repair 有効化、unknown 値は false (fail-closed)
  - `GET /admin/orders/repair-status` で `pendingApply` count 返却
- [ ] staging で migration apply → `wrangler d1 migrations apply webull-trading-staging --env=staging --remote`
- [ ] staging で `POST /admin/orders/reconcile?retryStateApply=1` を叩いて、過去の FILLED rows が DO に再適用されることを確認

## migration 影響

- `0011_reconcile_state_apply_marker.sql` は `ALTER TABLE trade_journal ADD ...` 3 文のみ。既存行は default 値 (`state_applied_at = NULL` / `state_apply_attempts = 0`) で初期化される。
- 既存 FILLED 行は `state_applied_at IS NULL` になるので、deploy 後最初の cron で全件 repair sweep が走る (lookback 内のもの)。lookback 外も含めて一括処理したい場合は `?retryStateApply=1` を一回叩く。
- 二重 apply 懸念: 既存 deploy 済 FILLED 行は元コードで既に DO に apply 済 — その行を再 apply すると position が 2 倍になる。Acceptance items の 3 つ目「dashboard で要修復件数が見える」は `GET /admin/orders/repair-status` で達成しているので、**運用上は staging で件数確認 → 本番 deploy 前に既存 FILLED 行を `state_applied_at = NOW()` で手動 stamp する** ことを推奨 (`docs/db-operations.md` 案件)。

## 関連 issue

closes #142

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added retry capability for failed state application on orders
  * New repair-status endpoint to monitor pending state reconciliation operations

* **Tests**
  * Extended test coverage for state-apply tracking and repair-mode functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->