### PR TITLE
fix(safety): cron と TradingService の per-symbol risk gate を unify (#138)

### DIFF
--- a/src/trading/application/TradingService.ts
+++ b/src/trading/application/TradingService.ts
@@ -4,13 +4,10 @@ import type { RiskDecision } from '../domain/RiskDecision'
 import type { Signal } from '../domain/Signal'
 import type { Execution } from '../execution/Execution'
 import type { RiskPolicy } from '../risk/RiskPolicy'
-import { isWithinJpPriceBand } from '../risk/jpPriceBand'
-import { computeSpreadPct } from '../risk/spreadGuard'
+import { evaluatePerSymbolRisk } from '../risk/perSymbolRiskGate'
 import type { PortfolioStore } from '../state/PortfolioStore'
 import type { PositionStore } from '../state/PositionStore'
-import type { QuoteSnapshot, SymbolState } from '../state/types'
 import type { Strategy, StrategyInput } from '../strategy/Strategy'
-import { inferWebullMarket } from '../../infrastructure/webull/mapper'
 import {
   logPostSubmit,
   logPreSubmit,
@@ -238,16 +235,10 @@ export class TradingService {
     const now = this.now()
     const state = await this.positionStore.getState(symbol)
 
-    if (state.cooldownUntil && new Date(state.cooldownUntil).getTime() > now.getTime()) {
-      return {
-        allowed: false,
-        riskDecision: appendReason(decision.riskDecision, `cooldown active until ${state.cooldownUntil}`),
-      }
-    }
-
-    // Portfolio-level drawdown kill switch. Fires before pending-lock acquisition
-    // so the lock is never taken when trading is disabled. Unseeded equity
-    // (0) is treated as fail-open so existing flows keep working.
+    // Portfolio-level drawdown kill switch & tradingDisabled は per-symbol gate
+    // ではなく account-wide なので applyStateGate に残す (issue #138 unify
+    // scope は per-symbol 側のみ)。pending-lock 取得前に評価して、kill
+    // 状態でロックが取られないようにする。
     if (this.portfolioStore) {
       const portfolio = await this.portfolioStore.getPortfolio()
       if (
@@ -278,89 +269,37 @@ export class TradingService {
       }
     }
 
-    if (
-      decision.orderIntent.side === 'BUY' &&
-      state.settledCash > 0 &&
-      decision.orderIntent.notional > state.settledCash
-    ) {
+    // Per-symbol gate を pure function に集約 (issue #138 — cron 側と unify)。
+    // inverse pair の SymbolState は同期 pure 関数で必要なので事前に fetch。
+    const inverseSymbol = decision.orderIntent.side === 'BUY'
+      ? this.inversePairs[symbol.toUpperCase()]
+      : undefined
+    const inverseState = inverseSymbol
+      ? await this.positionStore.getState(inverseSymbol)
+      : null
+
+    const perSymbol = evaluatePerSymbolRisk(
+      {
+        symbol,
+        side: decision.orderIntent.side,
+        intentPrice: decision.orderIntent.price,
+        intentNotional: decision.orderIntent.notional,
+        state,
+        inverseState,
+        now,
+      },
+      {
+        inversePairs: this.inversePairs,
+        spreadLimits: this.spreadLimits,
+        staleQuoteMs: this.staleQuoteMs,
+        gapRejectPct: this.gapRejectPct,
+        evaluateCooldown: true,
+      },
+    )
+    if (!perSymbol.approved) {
       return {
         allowed: false,
-        riskDecision: appendReason(
-          decision.riskDecision,
-          `insufficient settled cash: notional ${decision.orderIntent.notional} exceeds settledCash ${state.settledCash}`,
-        ),
-      }
-    }
-
-    if (decision.orderIntent.side === 'BUY') {
-      const inverse = this.inversePairs[symbol.toUpperCase()]
-      if (inverse) {
-        const inverseState = await this.positionStore.getState(inverse)
-        if (inverseState.position !== null && inverseState.position.qty > 0) {
-          return {
-            allowed: false,
-            riskDecision: appendReason(
-              decision.riskDecision,
-              `inverse-pair exposure: ${inverse} position (qty ${inverseState.position.qty}) blocks BUY ${symbol}`,
-            ),
-          }
-        }
-      }
-    }
-
-    // Halt detection (#38-C, freshness fallback): broker-side halt flag が UAT
-    // で確認できていないので quote freshness で代替。lastQuote が null のケース
-    // (quote feed まだ未シード) は POC 後方互換のためスキップ。先に halt を見る
-    // のは、stale な quote では下流の spread/gap/band が成立しないため。
-    // 注: `isQuoteStale` は future-quote ガードで diffMs<=0 も stale 扱いするが、
-    //   halt gate では「取得時刻と now がほぼ同時」(diffMs=0) を fresh として扱う。
-    if (state.lastQuote) {
-      const ageMs = now.getTime() - new Date(state.lastQuote.fetchedAt).getTime()
-      if (!Number.isFinite(ageMs) || ageMs > this.staleQuoteMs) {
-        return {
-          allowed: false,
-          riskDecision: appendReason(
-            decision.riskDecision,
-            `halt or stale quote: lastQuote ${state.lastQuote.fetchedAt} exceeds staleQuoteMs ${this.staleQuoteMs}`,
-          ),
-        }
-      }
-    }
-
-    // Spread guard (#38-D): wide spread at submit turns into slippage on market
-    // orders and stale fills on marketable limits. Fail-closed when bid/ask are
-    // missing once a quote has been seeded.
-    const spreadGate = this.evaluateSpreadGate(symbol, state.lastQuote)
-    if (spreadGate !== null) {
-      return {
-        allowed: false,
-        riskDecision: appendReason(decision.riskDecision, spreadGate),
-      }
-    }
-
-    // Gap re-eval (#38-C, simplified POC): avgPrice と現在 quote の gap が
-    // |gapRejectPct| を超えていれば 1 tick HOLD。open position が無いとき
-    // は比較対象が無いので gap check 自体をスキップする。
-    const gapReject = evaluateGap(state, this.gapRejectPct)
-    if (gapReject) {
-      return {
-        allowed: false,
-        riskDecision: appendReason(decision.riskDecision, gapReject),
-      }
-    }
-
-    // JP 値幅制限 (#38-C): 東証銘柄の指値が approximation band 外なら reject。
-    if (
-      inferWebullMarket(symbol) === 'JP' &&
-      state.lastQuote &&
-      !isWithinJpPriceBand(state.lastQuote.price, decision.orderIntent.price)
-    ) {
-      return {
-        allowed: false,
-        riskDecision: appendReason(
-          decision.riskDecision,
-          `JP price band: order price ${decision.orderIntent.price} outside band for reference ${state.lastQuote.price}`,
-        ),
+        riskDecision: appendReason(decision.riskDecision, perSymbol.reasons[0] ?? 'per-symbol risk reject'),
       }
     }
 
@@ -381,35 +320,6 @@ export class TradingService {
     return { allowed: true }
   }
 
-  /**
-   * Returns a rejection reason string when the spread gate blocks submit, or
-   * null when the gate passes. Fail-closed: missing bid or ask is a reject
-   * once a quote has been seeded.
-   */
-  private evaluateSpreadGate(
-    symbol: string,
-    lastQuote: QuoteSnapshot | null,
-  ): string | null {
-    if (lastQuote === null) return null
-
-    const bid = lastQuote.bid
-    const ask = lastQuote.ask
-    if (bid === undefined || ask === undefined) {
-      return 'spread unknown, bid/ask missing'
-    }
-
-    const market = inferWebullMarket(symbol)
-    const limit = market === 'JP' ? this.spreadLimits.JP : this.spreadLimits.US
-    const spreadPct = computeSpreadPct(bid, ask)
-    if (spreadPct === null) {
-      return 'spread invalid: crossed book, non-finite, or non-positive bid/ask'
-    }
-    if (spreadPct > limit) {
-      return `spread ${(spreadPct * 100).toFixed(3)}% exceeds ${market} limit ${(limit * 100).toFixed(3)}%`
-    }
-    return null
-  }
-
   private createOrderIntent(signal: Signal): OrderIntent | undefined {
     if (signal.action === 'HOLD') {
       return undefined
@@ -424,18 +334,6 @@ export class TradingService {
       clientOrderId: crypto.randomUUID().replaceAll('-', ''),
     }
   }
-}
-
-function evaluateGap(state: SymbolState, thresholdPct: number): string | null {
-  const position = state.position
-  const quote = state.lastQuote
-  if (!position || !quote) return null
-  if (!Number.isFinite(position.avgPrice) || position.avgPrice <= 0) return null
-  const gap = (quote.price - position.avgPrice) / position.avgPrice
-  if (Math.abs(gap) > thresholdPct) {
-    return `gap re-eval: |${gap.toFixed(4)}| > ${thresholdPct} (avgPrice ${position.avgPrice} vs quote ${quote.price})`
-  }
-  return null
 }
 
 function endOfUtcDay(now: Date): Date {

--- a/src/trading/risk/perSymbolRiskGate.ts
+++ b/src/trading/risk/perSymbolRiskGate.ts
@@ -1,0 +1,190 @@
+/**
+ * Per-symbol risk gate (pure).
+ *
+ * 7 つの per-symbol guard を一つの pure function に集約する。manual
+ * `/trade/execute` 経路 (TradingService) と cron (`runPullbackScheduler`) の
+ * 両方が同じ判定を通るよう unify する目的 (issue #138)。
+ *
+ * 含まれる gate:
+ *   1. settled cash (BUY only): notional > settledCash で reject
+ *   2. inverse pair (BUY only): inverse 銘柄の建玉が残っていれば reject
+ *   3. quote freshness (halt fallback): lastQuote.fetchedAt が staleQuoteMs を超えれば reject
+ *   4. spread guard: bid/ask 欠損 / 異常 / spread% が limit 超で reject
+ *   5. gap re-eval: avgPrice と lastQuote.price の |gap| > gapRejectPct で reject
+ *   6. JP 値幅制限: JP 銘柄かつ band 外 limit price で reject
+ *   7. (option) cooldown: state.cooldownUntil が未来なら reject
+ *
+ * 含まれない gate (orchestrator 層が直接持つ):
+ *   - portfolio-wide drawdown kill
+ *   - tradingDisabledUntil
+ *   - pending lock TTL (副作用持ちなので呼び出し側に残す)
+ *   - bucket cap (cron 側で pre-scan が必要)
+ *
+ * Inverse pair 評価は同期化のため、呼び出し側が事前に inverse 銘柄の SymbolState
+ * を読み出して `inverseState` として渡す責務を負う (cron は per-symbol loop の
+ * 中で fetch、TradingService は async wrapper で fetch)。
+ */
+import type { QuoteSnapshot, SymbolState } from '../state/types'
+import { inferWebullMarket } from '../../infrastructure/webull/mapper'
+import { isWithinJpPriceBand } from './jpPriceBand'
+import { computeSpreadPct } from './spreadGuard'
+
+export interface PerSymbolRiskInput {
+  symbol: string
+  side: 'BUY' | 'SELL'
+  /** Order limit price (used for JP price band). */
+  intentPrice: number
+  /** Order notional (qty × price), used for settled-cash gate. */
+  intentNotional: number
+  /** Latest known SymbolState for `symbol` (cooldown / position / lastQuote / settledCash). */
+  state: SymbolState
+  /**
+   * Pre-fetched SymbolState for the inverse symbol (per `config.inversePairs`).
+   * `null` when the symbol has no inverse mapping or fetch failed (fail-open
+   * for inverse only — fetch errors are not the gate's responsibility).
+   */
+  inverseState?: SymbolState | null
+  /** Wall clock for cooldown / freshness comparisons. */
+  now: Date
+}
+
+export interface PerSymbolRiskConfig {
+  /**
+   * Symbol → inverse symbol map (already upper-cased keys). When BUY is
+   * requested for `symbol` and `inverseState.position.qty > 0`, reject.
+   */
+  inversePairs: Record<string, string>
+  /** Per-market spread limits as fractions of mid (e.g. 0.0025 = 0.25%). */
+  spreadLimits: { US: number; JP: number }
+  /** lastQuote.fetchedAt より古い経過時間 (ms) を超えれば halt 扱い。 */
+  staleQuoteMs: number
+  /** position.avgPrice と lastQuote.price の |gap| 比率閾値。 */
+  gapRejectPct: number
+  /**
+   * `true` のとき state.cooldownUntil の評価も行う。manual TradingService 経路
+   * は従来 applyStateGate 内で評価していたので互換のため有効化、cron 経路は
+   * Strategy.decide() が同等判定を持つので冗長。両方 true でも behaviour 一致。
+   */
+  evaluateCooldown?: boolean
+}
+
+export interface PerSymbolRiskDecision {
+  approved: boolean
+  /**
+   * Approved=false のときの reject 理由。複数 gate が同時に reject しても
+   * **最初に当たった一つだけ** を返す (既存 TradingService の挙動と同じ:
+   * `appendReason` で 1 回 return)。cron 側 dashboard も先勝ちで表示する。
+   */
+  reasons: string[]
+}
+
+const APPROVED: PerSymbolRiskDecision = Object.freeze({ approved: true, reasons: [] })
+
+export function evaluatePerSymbolRisk(
+  input: PerSymbolRiskInput,
+  config: PerSymbolRiskConfig,
+): PerSymbolRiskDecision {
+  const { state, side, symbol, now, intentNotional, intentPrice } = input
+
+  // 1. cooldown (option): TradingService 互換のため最初に評価。
+  if (config.evaluateCooldown && state.cooldownUntil) {
+    const until = new Date(state.cooldownUntil).getTime()
+    if (Number.isFinite(until) && until > now.getTime()) {
+      return reject(`cooldown active until ${state.cooldownUntil}`)
+    }
+  }
+
+  // 2. settled cash (BUY only)。settledCash=0 は未 seed 扱いで skip。
+  if (side === 'BUY' && state.settledCash > 0 && intentNotional > state.settledCash) {
+    return reject(
+      `insufficient settled cash: notional ${intentNotional} exceeds settledCash ${state.settledCash}`,
+    )
+  }
+
+  // 3. inverse pair (BUY only)。呼び出し側が pre-fetch した inverseState を見る。
+  if (side === 'BUY') {
+    const inverseSymbol = config.inversePairs[symbol.toUpperCase()]
+    if (inverseSymbol && input.inverseState) {
+      const inversePos = input.inverseState.position
+      if (inversePos !== null && inversePos.qty > 0) {
+        return reject(
+          `inverse-pair exposure: ${inverseSymbol} position (qty ${inversePos.qty}) blocks BUY ${symbol}`,
+        )
+      }
+    }
+  }
+
+  // 4. halt / stale quote。lastQuote=null は未 seed 扱いで skip (POC 後方互換)。
+  if (state.lastQuote) {
+    const ageMs = now.getTime() - new Date(state.lastQuote.fetchedAt).getTime()
+    if (!Number.isFinite(ageMs) || ageMs > config.staleQuoteMs) {
+      return reject(
+        `halt or stale quote: lastQuote ${state.lastQuote.fetchedAt} exceeds staleQuoteMs ${config.staleQuoteMs}`,
+      )
+    }
+  }
+
+  // 5. spread guard: bid/ask 欠損は fail-closed (lastQuote 有り前提)。
+  const spreadReason = evaluateSpreadGate(symbol, state.lastQuote, config.spreadLimits)
+  if (spreadReason !== null) {
+    return reject(spreadReason)
+  }
+
+  // 6. gap re-eval。open position が無い / avgPrice が不正なら skip。
+  const gapReason = evaluateGap(state, config.gapRejectPct)
+  if (gapReason !== null) {
+    return reject(gapReason)
+  }
+
+  // 7. JP price band。JP 銘柄かつ lastQuote 有りで limit が band 外なら reject。
+  if (
+    inferWebullMarket(symbol) === 'JP' &&
+    state.lastQuote &&
+    !isWithinJpPriceBand(state.lastQuote.price, intentPrice)
+  ) {
+    return reject(
+      `JP price band: order price ${intentPrice} outside band for reference ${state.lastQuote.price}`,
+    )
+  }
+
+  return APPROVED
+}
+
+function reject(reason: string): PerSymbolRiskDecision {
+  return { approved: false, reasons: [reason] }
+}
+
+function evaluateSpreadGate(
+  symbol: string,
+  lastQuote: QuoteSnapshot | null,
+  limits: { US: number; JP: number },
+): string | null {
+  if (lastQuote === null) return null
+  const bid = lastQuote.bid
+  const ask = lastQuote.ask
+  if (bid === undefined || ask === undefined) {
+    return 'spread unknown, bid/ask missing'
+  }
+  const market = inferWebullMarket(symbol)
+  const limit = market === 'JP' ? limits.JP : limits.US
+  const spreadPct = computeSpreadPct(bid, ask)
+  if (spreadPct === null) {
+    return 'spread invalid: crossed book, non-finite, or non-positive bid/ask'
+  }
+  if (spreadPct > limit) {
+    return `spread ${(spreadPct * 100).toFixed(3)}% exceeds ${market} limit ${(limit * 100).toFixed(3)}%`
+  }
+  return null
+}
+
+function evaluateGap(state: SymbolState, thresholdPct: number): string | null {
+  const position = state.position
+  const quote = state.lastQuote
+  if (!position || !quote) return null
+  if (!Number.isFinite(position.avgPrice) || position.avgPrice <= 0) return null
+  const gap = (quote.price - position.avgPrice) / position.avgPrice
+  if (Math.abs(gap) > thresholdPct) {
+    return `gap re-eval: |${gap.toFixed(4)}| > ${thresholdPct} (avgPrice ${position.avgPrice} vs quote ${quote.price})`
+  }
+  return null
+}

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -5,6 +5,7 @@ import type { DecisionTraceStep } from '../domain/Signal'
 import { inferTradingMarket } from '../domain/tradingCalendar'
 import type { Execution } from '../execution/Execution'
 import type { PositionStore } from '../state/PositionStore'
+import type { SymbolState } from '../state/types'
 import {
   computeHoldBusinessDays,
   computePullbackIndicators,
@@ -19,6 +20,7 @@ import {
   type SymbolRule,
 } from './strategies/PullbackUptrendStrategy'
 import { decideBucketGate } from '../risk/bucketExposureGate'
+import { evaluatePerSymbolRisk } from '../risk/perSymbolRiskGate'
 
 const DEFAULT_BAR_LOOKBACK = 60
 
@@ -84,7 +86,25 @@ export interface PullbackSchedulerOptions {
    * scheduler 側は `.catch()` を付けるだけで cron を blocking しない。
    */
   notifier?: Notifier
+  /**
+   * Per-symbol risk gate config (issue #138 — TradingService と unify)。未指定で
+   * cron 経路を無 gate のままにできるよう、deps すべてが有効値なら gate 適用、
+   * 一つでも欠けると skip にして既存挙動を保つ (POC 後方互換)。production
+   * (`runStrategyCron`) は global_config / symbolUniverse から fully populate する。
+   */
+  perSymbolRisk?: PerSymbolRiskScheduleConfig
   now?: () => Date
+}
+
+export interface PerSymbolRiskScheduleConfig {
+  /**
+   * BUY symbol → inverse symbol map。production は symbol_universe.inversePairs。
+   * 大文字 key 前提で渡す。
+   */
+  inversePairs: Record<string, string>
+  spreadLimits: { US: number; JP: number }
+  staleQuoteMs: number
+  gapRejectPct: number
 }
 
 export interface PullbackRunSummary {
@@ -431,6 +451,59 @@ export async function runPullbackScheduler(
       intent = buildIntent(upper, 'SELL', state.position.qty, indicators.price)
     }
 
+    // Per-symbol risk gate (issue #138)。manual `/trade/execute` (TradingService)
+    // と同じ pure function を呼ぶことで gate parity を取る。perSymbolRisk が
+    // 未注入の場合は POC 後方互換で skip。Inverse pair の SymbolState は同期
+    // pure 関数で要求されるため、BUY のみ事前 fetch する。
+    if (options.perSymbolRisk) {
+      let inverseState: SymbolState | null = null
+      const inverseSymbol =
+        intent.side === 'BUY' ? options.perSymbolRisk.inversePairs[upper] : undefined
+      if (inverseSymbol) {
+        try {
+          inverseState = await options.positionStore.getState(inverseSymbol)
+        } catch {
+          // fetch 失敗は inverse gate fail-open。inverse 銘柄の state read 失敗
+          // で BUY ごと止めると universe 全体が連鎖 reject になり得るため、
+          // 他の gate (settled cash / spread / freshness など) に任せる。
+          inverseState = null
+        }
+      }
+      const riskDecision = evaluatePerSymbolRisk(
+        {
+          symbol: upper,
+          side: intent.side,
+          intentPrice: intent.price,
+          intentNotional: intent.notional,
+          state,
+          inverseState,
+          now: now(),
+        },
+        {
+          inversePairs: options.perSymbolRisk.inversePairs,
+          spreadLimits: options.perSymbolRisk.spreadLimits,
+          staleQuoteMs: options.perSymbolRisk.staleQuoteMs,
+          gapRejectPct: options.perSymbolRisk.gapRejectPct,
+          // Strategy.decide() が cooldown を既に評価しているので冗長 (両者
+          // 同義)。重複させても挙動は変わらないが、cron 経路では skip。
+          evaluateCooldown: false,
+        },
+      )
+      if (!riskDecision.approved) {
+        const reason = `risk: ${riskDecision.reasons.join(', ')}`
+        summary.rejected.push({ symbol: upper, reason })
+        await emitDecision({
+          symbol: upper,
+          decision: 'REJECT',
+          reason,
+          price: indicators.price,
+          indicatorsJson: JSON.stringify(indicators),
+          trace: appendTrace(signal.trace, traceStep('risk.per_symbol_gate', false, undefined, undefined, undefined, riskDecision.reasons.join(', '))),
+        })
+        continue
+      }
+    }
+
     const expiresAtMs = now().getTime() + pendingLockTtlMs
     if (!Number.isFinite(expiresAtMs) || expiresAtMs <= now().getTime()) {
       const reason = `invalid expiresAt computed from pendingLockTtlMs: ${pendingLockTtlMs}`
@@ -658,6 +731,7 @@ const TRACE_LABEL_JA: Record<string, string> = {
   'scheduler.pending_lock_expiry_valid': '注文ロック期限が有効',
   'scheduler.pending_lock_acquired': '注文ロックを取得できた',
   'risk.bucket_cap': '同グループ建玉上限内',
+  'risk.per_symbol_gate': '銘柄別リスクゲート',
   'broker.submit': '証券会社への発注送信',
 }
 

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -99,8 +99,9 @@ export interface StrategyCronAnalysis {
  *
  * Risk gate のうち **portfolio-wide な pre-flight 判定** (tradingDisabledUntil
  * と drawdown_kill) は本関数で適用する。per-symbol gate (spread / halt / gap /
- * JP band / inverse_pair / settled_cash) は TradingService 側が持っており、
- * 本 cron 経路では未統合 — follow-up で gate parity を取る予定。
+ * JP band / inverse_pair / settled_cash) は `evaluatePerSymbolRisk` を介して
+ * `runPullbackScheduler` に注入し、TradingService と判定が一致するよう unify
+ * 済み (issue #138)。
  *
  * JP 銘柄は 100 株ロットで round-down される。bar 取得は Yahoo Finance の
  * `<code>.T` サフィックス (YahooBarClient 内で自動付与)。
@@ -373,6 +374,18 @@ export async function runStrategyCron(
       riskPerTradePct: scaledRiskPerTradePct,
       requestId: options.requestId,
       notifier,
+      // Per-symbol risk gate (issue #138 — TradingService と unify)。
+      // global_config / symbol_universe から populate。manual route と同じ
+      // deps なので、cron / `/trade/execute` の判定が一致する。
+      perSymbolRisk: {
+        inversePairs: universe.inversePairs,
+        spreadLimits: {
+          US: global.spreadLimitPctUs,
+          JP: global.spreadLimitPctJp,
+        },
+        staleQuoteMs: global.staleQuoteMs,
+        gapRejectPct: global.gapRejectPct,
+      },
       onDecision: (record) =>
         logStrategyDecision(decisionDb, {
           timestamp: new Date().toISOString(),

--- a/test/trading/risk/perSymbolRiskGate.test.ts
+++ b/test/trading/risk/perSymbolRiskGate.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it } from 'vitest'
+import {
+  evaluatePerSymbolRisk,
+  type PerSymbolRiskConfig,
+} from '../../../src/trading/risk/perSymbolRiskGate'
+import {
+  emptySymbolState,
+  type QuoteSnapshot,
+  type SymbolState,
+} from '../../../src/trading/state/types'
+
+const now = new Date('2026-04-21T14:30:00.000Z')
+
+const baseConfig: PerSymbolRiskConfig = {
+  inversePairs: { SOXL: 'SOXS', SOXS: 'SOXL' },
+  spreadLimits: { US: 0.0025, JP: 0.006 },
+  staleQuoteMs: 15 * 60 * 1_000,
+  gapRejectPct: 0.03,
+}
+
+function quote(price: number, ageMs = 1_000, overrides: Partial<QuoteSnapshot> = {}): QuoteSnapshot {
+  // bid/ask seeded inside default spread envelope so non-spread tests do not
+  // trip the spread gate inadvertently。Override per-test as needed.
+  return {
+    price,
+    asOf: new Date(now.getTime() - ageMs).toISOString(),
+    fetchedAt: new Date(now.getTime() - ageMs).toISOString(),
+    source: 'test',
+    bid: price * 0.999,
+    ask: price * 1.001,
+    ...overrides,
+  }
+}
+
+describe('evaluatePerSymbolRisk — pass-through baseline', () => {
+  it('approves a clean BUY with empty state', () => {
+    const decision = evaluatePerSymbolRisk(
+      {
+        symbol: 'SOXL',
+        side: 'BUY',
+        intentPrice: 9,
+        intentNotional: 9,
+        state: emptySymbolState('SOXL', () => now),
+        inverseState: null,
+        now,
+      },
+      baseConfig,
+    )
+    expect(decision.approved).toBe(true)
+    expect(decision.reasons).toEqual([])
+  })
+})
+
+describe('evaluatePerSymbolRisk — settled cash', () => {
+  it('rejects BUY when notional exceeds settledCash', () => {
+    const state: SymbolState = { ...emptySymbolState('SOXL', () => now), settledCash: 20 }
+    const decision = evaluatePerSymbolRisk(
+      { symbol: 'SOXL', side: 'BUY', intentPrice: 9, intentNotional: 27, state, now },
+      baseConfig,
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reasons[0]).toContain('insufficient settled cash')
+  })
+
+  it('skips the gate for SELL', () => {
+    const state: SymbolState = { ...emptySymbolState('SOXL', () => now), settledCash: 20 }
+    const decision = evaluatePerSymbolRisk(
+      { symbol: 'SOXL', side: 'SELL', intentPrice: 9, intentNotional: 27, state, now },
+      baseConfig,
+    )
+    expect(decision.approved).toBe(true)
+  })
+
+  it('skips when settledCash=0 (unseeded)', () => {
+    const decision = evaluatePerSymbolRisk(
+      {
+        symbol: 'SOXL',
+        side: 'BUY',
+        intentPrice: 9,
+        intentNotional: 27,
+        state: emptySymbolState('SOXL', () => now),
+        now,
+      },
+      baseConfig,
+    )
+    expect(decision.approved).toBe(true)
+  })
+})
+
+describe('evaluatePerSymbolRisk — inverse pair', () => {
+  it('rejects BUY when inverseState shows an open position', () => {
+    const state = emptySymbolState('SOXL', () => now)
+    const inverseState: SymbolState = {
+      ...emptySymbolState('SOXS', () => now),
+      position: { qty: 5, avgPrice: 10, openedAt: now.toISOString() },
+    }
+    const decision = evaluatePerSymbolRisk(
+      { symbol: 'SOXL', side: 'BUY', intentPrice: 9, intentNotional: 9, state, inverseState, now },
+      baseConfig,
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reasons[0]).toContain('inverse-pair exposure')
+  })
+
+  it('approves BUY when inverseState has no position', () => {
+    const state = emptySymbolState('SOXL', () => now)
+    const inverseState = emptySymbolState('SOXS', () => now)
+    const decision = evaluatePerSymbolRisk(
+      { symbol: 'SOXL', side: 'BUY', intentPrice: 9, intentNotional: 9, state, inverseState, now },
+      baseConfig,
+    )
+    expect(decision.approved).toBe(true)
+  })
+
+  it('does not gate SELL on inverse exposure', () => {
+    const state: SymbolState = {
+      ...emptySymbolState('SOXL', () => now),
+      position: { qty: 1, avgPrice: 9, openedAt: now.toISOString() },
+    }
+    const inverseState: SymbolState = {
+      ...emptySymbolState('SOXS', () => now),
+      position: { qty: 5, avgPrice: 10, openedAt: now.toISOString() },
+    }
+    const decision = evaluatePerSymbolRisk(
+      { symbol: 'SOXL', side: 'SELL', intentPrice: 9, intentNotional: 9, state, inverseState, now },
+      baseConfig,
+    )
+    expect(decision.approved).toBe(true)
+  })
+})
+
+describe('evaluatePerSymbolRisk — stale quote / halt fallback', () => {
+  it('rejects when lastQuote.fetchedAt is older than staleQuoteMs', () => {
+    const state: SymbolState = {
+      ...emptySymbolState('SOXL', () => now),
+      lastQuote: quote(9, 16 * 60 * 1_000),
+    }
+    const decision = evaluatePerSymbolRisk(
+      { symbol: 'SOXL', side: 'BUY', intentPrice: 9, intentNotional: 9, state, now },
+      baseConfig,
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reasons[0]).toContain('halt or stale quote')
+  })
+
+  it('skips when lastQuote is null (unseeded)', () => {
+    const decision = evaluatePerSymbolRisk(
+      {
+        symbol: 'SOXL',
+        side: 'BUY',
+        intentPrice: 9,
+        intentNotional: 9,
+        state: emptySymbolState('SOXL', () => now),
+        now,
+      },
+      baseConfig,
+    )
+    expect(decision.approved).toBe(true)
+  })
+})
+
+describe('evaluatePerSymbolRisk — spread guard', () => {
+  it('rejects US BUY when spread > US limit', () => {
+    const state: SymbolState = {
+      ...emptySymbolState('SPY', () => now),
+      lastQuote: quote(100, 1_000, { bid: 99.85, ask: 100.15 }),
+    }
+    const decision = evaluatePerSymbolRisk(
+      { symbol: 'SPY', side: 'BUY', intentPrice: 100, intentNotional: 100, state, now },
+      baseConfig,
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reasons[0]).toContain('spread')
+  })
+
+  it('rejects when bid is missing (fail-closed)', () => {
+    const state: SymbolState = {
+      ...emptySymbolState('SPY', () => now),
+      lastQuote: quote(100, 1_000, { bid: undefined, ask: 100.1 }),
+    }
+    const decision = evaluatePerSymbolRisk(
+      { symbol: 'SPY', side: 'BUY', intentPrice: 100, intentNotional: 100, state, now },
+      baseConfig,
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reasons[0]).toContain('bid/ask missing')
+  })
+})
+
+describe('evaluatePerSymbolRisk — gap re-eval', () => {
+  it('rejects BUY when |gap| exceeds threshold', () => {
+    const state: SymbolState = {
+      ...emptySymbolState('SOXL', () => now),
+      position: { qty: 5, avgPrice: 10, openedAt: now.toISOString() },
+      lastQuote: quote(9),
+    }
+    const decision = evaluatePerSymbolRisk(
+      { symbol: 'SOXL', side: 'BUY', intentPrice: 9, intentNotional: 9, state, now },
+      baseConfig,
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reasons[0]).toContain('gap re-eval')
+  })
+
+  it('skips when no position is open', () => {
+    const state: SymbolState = {
+      ...emptySymbolState('SOXL', () => now),
+      lastQuote: quote(9),
+    }
+    const decision = evaluatePerSymbolRisk(
+      { symbol: 'SOXL', side: 'BUY', intentPrice: 9, intentNotional: 9, state, now },
+      baseConfig,
+    )
+    expect(decision.approved).toBe(true)
+  })
+})
+
+describe('evaluatePerSymbolRisk — JP price band', () => {
+  it('rejects JP limit priced outside the band', () => {
+    const state: SymbolState = {
+      ...emptySymbolState('7203', () => now),
+      lastQuote: quote(5_000),
+    }
+    const decision = evaluatePerSymbolRisk(
+      { symbol: '7203', side: 'BUY', intentPrice: 5_800, intentNotional: 5_800, state, now },
+      baseConfig,
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reasons[0]).toContain('JP price band')
+  })
+
+  it('does not apply the JP band to US symbols', () => {
+    const state: SymbolState = {
+      ...emptySymbolState('SOXL', () => now),
+      lastQuote: quote(9),
+    }
+    const decision = evaluatePerSymbolRisk(
+      { symbol: 'SOXL', side: 'BUY', intentPrice: 9, intentNotional: 9, state, now },
+      baseConfig,
+    )
+    expect(decision.approved).toBe(true)
+  })
+})
+
+describe('evaluatePerSymbolRisk — cooldown (option)', () => {
+  it('rejects when evaluateCooldown=true and cooldownUntil is in the future', () => {
+    const state: SymbolState = {
+      ...emptySymbolState('SOXL', () => now),
+      cooldownUntil: new Date(now.getTime() + 60_000).toISOString(),
+    }
+    const decision = evaluatePerSymbolRisk(
+      { symbol: 'SOXL', side: 'BUY', intentPrice: 9, intentNotional: 9, state, now },
+      { ...baseConfig, evaluateCooldown: true },
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reasons[0]).toContain('cooldown active')
+  })
+
+  it('ignores cooldown when evaluateCooldown=false (cron path)', () => {
+    const state: SymbolState = {
+      ...emptySymbolState('SOXL', () => now),
+      cooldownUntil: new Date(now.getTime() + 60_000).toISOString(),
+    }
+    const decision = evaluatePerSymbolRisk(
+      { symbol: 'SOXL', side: 'BUY', intentPrice: 9, intentNotional: 9, state, now },
+      baseConfig,
+    )
+    expect(decision.approved).toBe(true)
+  })
+})

--- a/test/trading/risk/perSymbolRiskGateParity.test.ts
+++ b/test/trading/risk/perSymbolRiskGateParity.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Parity test: same SymbolState + same risk config must yield the same
+ * pass/reject decision via TradingService.executeTrade() (manual route)
+ * AND via runPullbackScheduler (cron route). Anchors issue #138 — both
+ * call sites are wired to the shared `evaluatePerSymbolRisk` pure helper.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import type { BarClient } from '../../../src/infrastructure/quotes/BarClient'
+import {
+  TradingService,
+  type TradingConfig,
+} from '../../../src/trading/application/TradingService'
+import { MockExecution } from '../../../src/trading/execution/MockExecution'
+import { DefaultRiskPolicy } from '../../../src/trading/risk/DefaultRiskPolicy'
+import {
+  evaluatePerSymbolRisk,
+  type PerSymbolRiskConfig,
+} from '../../../src/trading/risk/perSymbolRiskGate'
+import type { Execution } from '../../../src/trading/execution/Execution'
+import type { PositionStore } from '../../../src/trading/state/PositionStore'
+import {
+  emptySymbolState,
+  type SymbolState,
+} from '../../../src/trading/state/types'
+import { FixedRuleStrategy } from '../../../src/trading/strategy/strategies/FixedRuleStrategy'
+import { runPullbackScheduler } from '../../../src/trading/strategy/pullbackScheduler'
+import type { DailyBar } from '../../../src/trading/strategy/indicators'
+
+const now = new Date('2026-04-21T14:30:00.000Z')
+
+const riskConfig: PerSymbolRiskConfig = {
+  inversePairs: { SOXL: 'SOXS' },
+  spreadLimits: { US: 0.0025, JP: 0.006 },
+  staleQuoteMs: 15 * 60 * 1_000,
+  gapRejectPct: 0.03,
+}
+
+function uptrendBars(): DailyBar[] {
+  const bars: DailyBar[] = []
+  for (let i = 0; i < 55; i += 1) bars.push(synth(i, 100 + i * 0.4))
+  bars.push(synth(55, 122))
+  bars.push(synth(56, 121))
+  bars.push(synth(57, 120))
+  bars.push(synth(58, 118))
+  bars.push(synth(59, 117.5))
+  return bars
+}
+
+function synth(i: number, close: number): DailyBar {
+  const date = new Date(Date.UTC(2026, 0, 1 + i)).toISOString().slice(0, 10)
+  return { date, open: close, high: close * 1.005, low: close * 0.995, close }
+}
+
+function makeStore(states: Record<string, SymbolState>): PositionStore {
+  return {
+    async getState(symbol) {
+      return states[symbol.toUpperCase()] ?? emptySymbolState(symbol, () => now)
+    },
+    async lockPendingOrder() {
+      return { ok: true, state: emptySymbolState('_', () => now) }
+    },
+    async clearPendingOrder(symbol) {
+      return emptySymbolState(symbol, () => now)
+    },
+    async recordFill(symbol) {
+      return emptySymbolState(symbol, () => now)
+    },
+    async addPendingSettlement(symbol) {
+      return emptySymbolState(symbol, () => now)
+    },
+    async setCooldown(symbol) {
+      return emptySymbolState(symbol, () => now)
+    },
+    async seedSettledCash(symbol) {
+      return emptySymbolState(symbol, () => now)
+    },
+  }
+}
+
+function mockBarClient(): BarClient {
+  return { getDailyBars: vi.fn(async () => uptrendBars()) }
+}
+
+function mockExecution(): Execution & { calls: unknown[] } {
+  const calls: unknown[] = []
+  return {
+    calls,
+    async execute(intent) {
+      calls.push(intent)
+      return { mode: 'DRY_RUN', submitted: true, brokerOrderId: 'dry-run-1' }
+    },
+  }
+}
+
+describe('per-symbol risk gate parity (TradingService vs runPullbackScheduler) — #138', () => {
+  // 各シナリオで:
+  //   1. pure helper の判定
+  //   2. TradingService.executeTrade() の `riskDecision`
+  //   3. runPullbackScheduler の REJECT decision
+  // が同じ reason で reject (or 同じく approve) することを確認する。
+
+  const tradingConfig: TradingConfig = {
+    dryRun: true,
+    tradingEnabled: true,
+    allowedSymbols: ['AAPL', 'SOXL'],
+    maxOrderNotional: 1_000_000,
+    symbolMaxNotional: {},
+    marketHoursCheck: false,
+  }
+
+  function tradingService(store: PositionStore) {
+    return new TradingService(
+      // FixedRuleStrategy: any input below 10000 → BUY
+      new FixedRuleStrategy(10_000, 20_000),
+      new DefaultRiskPolicy(),
+      new MockExecution(),
+      {
+        positionStore: store,
+        inversePairs: riskConfig.inversePairs,
+        spreadLimits: riskConfig.spreadLimits,
+        staleQuoteMs: riskConfig.staleQuoteMs,
+        gapRejectPct: riskConfig.gapRejectPct,
+        now: () => now,
+      },
+    )
+  }
+
+  it('stale quote rejects in all 3 evaluators with the same reason', async () => {
+    const state: SymbolState = {
+      ...emptySymbolState('AAPL', () => now),
+      lastQuote: {
+        price: 118,
+        asOf: new Date(now.getTime() - 16 * 60 * 1_000).toISOString(),
+        fetchedAt: new Date(now.getTime() - 16 * 60 * 1_000).toISOString(),
+        source: 'test',
+        bid: 117.9,
+        ask: 118.1,
+      },
+    }
+
+    // Pure helper
+    const pure = evaluatePerSymbolRisk(
+      { symbol: 'AAPL', side: 'BUY', intentPrice: 9, intentNotional: 9, state, now },
+      riskConfig,
+    )
+    expect(pure.approved).toBe(false)
+    expect(pure.reasons[0]).toContain('halt or stale quote')
+
+    // Manual / TradingService route
+    const store = makeStore({ AAPL: state })
+    const result = await tradingService(store).executeTrade(
+      { symbol: 'AAPL', price: 9, quantity: 1 },
+      tradingConfig,
+    )
+    expect(result.riskDecision.allowed).toBe(false)
+    expect(result.riskDecision.reasons.some((r) => r.includes('halt or stale quote'))).toBe(true)
+
+    // Cron / runPullbackScheduler route
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(),
+      positionStore: makeStore({ AAPL: state }),
+      execution: mockExecution(),
+      perSymbolRisk: riskConfig,
+      now: () => now,
+    })
+    expect(summary.buys).toBe(0)
+    const reject = summary.decisions.find((d) => d.decision === 'REJECT')
+    expect(reject?.reason).toContain('halt or stale quote')
+  })
+
+  it('inverse-pair exposure rejects in all 3 evaluators with the same reason', async () => {
+    const inverse: SymbolState = {
+      ...emptySymbolState('SOXS', () => now),
+      position: { qty: 5, avgPrice: 10, openedAt: now.toISOString() },
+    }
+    const subjectState = emptySymbolState('SOXL', () => now)
+
+    // Pure helper (caller must pre-fetch inverseState)
+    const pure = evaluatePerSymbolRisk(
+      {
+        symbol: 'SOXL',
+        side: 'BUY',
+        intentPrice: 9,
+        intentNotional: 9,
+        state: subjectState,
+        inverseState: inverse,
+        now,
+      },
+      riskConfig,
+    )
+    expect(pure.approved).toBe(false)
+    expect(pure.reasons[0]).toContain('inverse-pair exposure')
+
+    // Manual / TradingService route — store fetches inverse internally.
+    const tradingStore = makeStore({ SOXS: inverse, SOXL: subjectState })
+    const result = await tradingService(tradingStore).executeTrade(
+      { symbol: 'SOXL', price: 9, quantity: 1 },
+      tradingConfig,
+    )
+    expect(result.riskDecision.allowed).toBe(false)
+    expect(result.riskDecision.reasons.some((r) => r.includes('inverse-pair exposure'))).toBe(true)
+
+    // Cron / runPullbackScheduler — pre-fetches inverse symbol state.
+    const cronStore = makeStore({ SOXS: inverse, SOXL: subjectState })
+    const summary = await runPullbackScheduler({
+      symbols: ['SOXL'],
+      equity: 100_000,
+      barClient: mockBarClient(),
+      positionStore: cronStore,
+      execution: mockExecution(),
+      perSymbolRisk: riskConfig,
+      now: () => now,
+    })
+    expect(summary.buys).toBe(0)
+    const reject = summary.decisions.find((d) => d.decision === 'REJECT')
+    expect(reject?.reason).toContain('inverse-pair exposure')
+  })
+
+  it('clean state approves in all 3 evaluators', async () => {
+    const cleanState = emptySymbolState('AAPL', () => now)
+
+    const pure = evaluatePerSymbolRisk(
+      { symbol: 'AAPL', side: 'BUY', intentPrice: 9, intentNotional: 9, state: cleanState, now },
+      riskConfig,
+    )
+    expect(pure.approved).toBe(true)
+
+    const result = await tradingService(makeStore({ AAPL: cleanState })).executeTrade(
+      { symbol: 'AAPL', price: 9, quantity: 1 },
+      tradingConfig,
+    )
+    expect(result.riskDecision.allowed).toBe(true)
+
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(),
+      positionStore: makeStore({ AAPL: cleanState }),
+      execution: mockExecution(),
+      perSymbolRisk: riskConfig,
+      now: () => now,
+    })
+    expect(summary.buys).toBe(1)
+  })
+})

--- a/test/trading/strategy/pullbackScheduler.test.ts
+++ b/test/trading/strategy/pullbackScheduler.test.ts
@@ -304,3 +304,158 @@ describe('runPullbackScheduler', () => {
     expect(summary.buys).toBe(1)
   })
 })
+
+describe('runPullbackScheduler per-symbol risk gate (#138 parity)', () => {
+  // Default risk config matches global_config defaults; production wires this
+  // through runStrategyCron so cron / `/trade/execute` evaluate the same gates.
+  const baseRiskConfig = {
+    inversePairs: {} as Record<string, string>,
+    spreadLimits: { US: 0.0025, JP: 0.006 },
+    staleQuoteMs: 15 * 60 * 1_000,
+    gapRejectPct: 0.03,
+  }
+
+  it('rejects BUY when settledCash is insufficient (gate parity)', async () => {
+    const state: SymbolState = {
+      ...emptySymbolState('AAPL', () => now),
+      // tiny settledCash → uptrendBars BUY notional (qty>0 × ~$118) exceeds it
+      settledCash: 1,
+    }
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({ AAPL: state }),
+      execution,
+      perSymbolRisk: baseRiskConfig,
+      now: () => now,
+    })
+    expect(summary.buys).toBe(0)
+    expect(execution.calls).toHaveLength(0)
+    const reject = summary.decisions.find((d) => d.decision === 'REJECT')
+    expect(reject?.reason).toContain('insufficient settled cash')
+  })
+
+  it('rejects BUY when lastQuote is stale (halt fallback)', async () => {
+    const state: SymbolState = {
+      ...emptySymbolState('AAPL', () => now),
+      lastQuote: {
+        price: 118,
+        asOf: new Date(now.getTime() - 16 * 60 * 1_000).toISOString(),
+        fetchedAt: new Date(now.getTime() - 16 * 60 * 1_000).toISOString(),
+        source: 'test',
+        bid: 117.9,
+        ask: 118.1,
+      },
+    }
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({ AAPL: state }),
+      execution,
+      perSymbolRisk: baseRiskConfig,
+      now: () => now,
+    })
+    expect(summary.buys).toBe(0)
+    expect(execution.calls).toHaveLength(0)
+    const reject = summary.decisions.find((d) => d.decision === 'REJECT')
+    expect(reject?.reason).toContain('halt or stale quote')
+  })
+
+  it('rejects BUY when spread exceeds the US limit (fail-closed missing bid)', async () => {
+    const state: SymbolState = {
+      ...emptySymbolState('AAPL', () => now),
+      lastQuote: {
+        price: 118,
+        asOf: now.toISOString(),
+        fetchedAt: now.toISOString(),
+        source: 'test',
+        // bid missing → fail-closed reject
+        bid: undefined,
+        ask: 118.1,
+      },
+    }
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({ AAPL: state }),
+      execution,
+      perSymbolRisk: baseRiskConfig,
+      now: () => now,
+    })
+    expect(summary.buys).toBe(0)
+    expect(execution.calls).toHaveLength(0)
+    const reject = summary.decisions.find((d) => d.decision === 'REJECT')
+    expect(reject?.reason).toContain('bid/ask missing')
+  })
+
+  it('rejects BUY when inverseState shows an open position', async () => {
+    const inverse: SymbolState = {
+      ...emptySymbolState('SQQQ', () => now),
+      position: { qty: 5, avgPrice: 10, openedAt: now.toISOString() },
+    }
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['QQQ'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({ SQQQ: inverse }),
+      execution,
+      perSymbolRisk: { ...baseRiskConfig, inversePairs: { QQQ: 'SQQQ' } },
+      now: () => now,
+    })
+    expect(summary.buys).toBe(0)
+    expect(execution.calls).toHaveLength(0)
+    const reject = summary.decisions.find((d) => d.decision === 'REJECT')
+    expect(reject?.reason).toContain('inverse-pair exposure')
+  })
+
+  it('approves BUY when no per-symbol gate fires', async () => {
+    // settledCash 0 (unseeded) + lastQuote null (unseeded) → all gates skip;
+    // proves the gate is wired but does not block clean inputs.
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution,
+      perSymbolRisk: baseRiskConfig,
+      now: () => now,
+    })
+    expect(summary.buys).toBe(1)
+    expect(execution.calls).toHaveLength(1)
+  })
+
+  it('skips the gate when perSymbolRisk option is omitted (back-compat)', async () => {
+    // No perSymbolRisk → existing behaviour, even when state would trip
+    // the gate (stale quote here) the BUY proceeds.
+    const state: SymbolState = {
+      ...emptySymbolState('AAPL', () => now),
+      lastQuote: {
+        price: 118,
+        asOf: new Date(now.getTime() - 16 * 60 * 1_000).toISOString(),
+        fetchedAt: new Date(now.getTime() - 16 * 60 * 1_000).toISOString(),
+        source: 'test',
+        bid: 117.9,
+        ask: 118.1,
+      },
+    }
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({ AAPL: state }),
+      execution,
+      now: () => now,
+    })
+    expect(summary.buys).toBe(1)
+    expect(execution.calls).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Motivation

Closes #138.

`runPullbackScheduler` was calling `Execution.execute(intent)` directly and bypassing **all 7 per-symbol gates** that `TradingService.executeTrade()` runs for the manual `/trade/execute` route:

1. settled cash (BUY only)
2. inverse pair (BUY only — anti-correlated exposure)
3. quote freshness (halt fallback)
4. spread guard
5. gap re-eval (avgPrice vs lastQuote)
6. JP 値幅制限 (price band)
7. (cooldown — strategy already evaluates this for cron, kept as opt-in)

The asymmetry meant a manual order could be rejected while the cron submitted the equivalent intent unchecked — fail-open in the path that runs every 15 minutes.

## Design

- New pure helper `src/trading/risk/perSymbolRiskGate.ts` exporting `evaluatePerSymbolRisk(input, config)`. No I/O — caller pre-fetches `inverseState` so the helper stays sync.
- `TradingService.applyStateGate` refactored to call the helper (drawdown / `tradingDisabledUntil` / pending-lock TTL stay in `TradingService` because they touch `PortfolioStore` or have side effects).
- `runPullbackScheduler` accepts a new `perSymbolRisk?` option. When provided, the gate runs after intent build and bucket cap, before pending-lock acquisition, with a structured `risk: <reason>` REJECT decision sink emit.
- `runStrategyCron` wires the helper config from `global_config` (`spreadLimitPctUs/Jp`, `staleQuoteMs`, `gapRejectPct`) and `symbol_universe.inversePairs` — the same deps the manual route uses, which is what makes the parity guarantee real.
- `perSymbolRisk` is optional on the scheduler so existing test call sites keep working without change (back-compat).

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test --run` — 607 / 607 passing (581 baseline + 26 new)
- [x] New unit tests for the pure helper covering each gate and the cooldown opt-in (`test/trading/risk/perSymbolRiskGate.test.ts`)
- [x] New parity tests showing the same `SymbolState` → same approve/reject decision via pure helper, `TradingService.executeTrade()`, and `runPullbackScheduler` (`test/trading/risk/perSymbolRiskGateParity.test.ts`)
- [x] New cron-side scheduler tests for stale quote / spread fail-closed / inverse pair / settled cash REJECT routes (`test/trading/strategy/pullbackScheduler.test.ts`)
- [x] Existing `tradingService*.test.ts` (settlement / spread / halt / gap / band / state / drawdown / correlation) all green — TradingService external behaviour unchanged

## Impact

- Cron may now produce additional REJECT decisions in `strategy_decision_log` with `reason` prefixed `risk: …`. Operator dashboards already render `reason`, no schema change.
- Manual `/trade/execute` behaviour is preserved — same gates, same wording, same first-reason-wins semantics.
- No DB / wrangler binding changes. All config flows through existing `global_config` rows.

## Notes

- Per-PR scope: issue #138 only. portfolio-wide drawdown kill / `tradingDisabledUntil` / pending-lock TTL stay in `TradingService` and `runStrategyCron` because they need `PortfolioStore` or have side effects (separate gates, not in scope).
- `evaluateCooldown` is opt-in: `TradingService` keeps `true` for byte-for-byte parity with prior behaviour; cron leaves it `false` because `PullbackUptrendStrategy.decide()` already gates cooldown via `guard.cooldown_inactive`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * スケジュール実行による自動取引にシンボル毎のリスク評価が適用されるようになりました。

* **改善**
  * リスク管理ロジックが統一され、全ての取引パスで一貫した評価が行われます。

* **テスト**
  * リスク評価機能の包括的なテストスイートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->