### PR TITLE
feat(observability): critical event push notification + alerts dashboard (#141 partial)

### DIFF
--- a/drizzle/0012_observability_alerts.sql
+++ b/drizzle/0012_observability_alerts.sql
@@ -16,5 +16,6 @@ CREATE TABLE `notification_emit_log` (
 	`message` text NOT NULL
 );
 --> statement-breakpoint
-CREATE INDEX `notification_emit_log_severity_id_idx` ON `notification_emit_log` (`severity`,`id`);--> statement-breakpoint
-CREATE INDEX `notification_emit_log_event_type_id_idx` ON `notification_emit_log` (`event_type`,`id`);
+CREATE INDEX `notification_emit_log_timestamp_id_idx` ON `notification_emit_log` (`timestamp`,`id`);--> statement-breakpoint
+CREATE INDEX `notification_emit_log_severity_timestamp_id_idx` ON `notification_emit_log` (`severity`,`timestamp`,`id`);--> statement-breakpoint
+CREATE INDEX `notification_emit_log_event_type_timestamp_id_idx` ON `notification_emit_log` (`event_type`,`timestamp`,`id`);

--- a/drizzle/0012_observability_alerts.sql
+++ b/drizzle/0012_observability_alerts.sql
@@ -1,0 +1,20 @@
+CREATE TABLE `config_state_snapshot` (
+	`key` text PRIMARY KEY NOT NULL,
+	`value` text NOT NULL,
+	`snapshot_at` text NOT NULL,
+	`request_id` text
+);
+--> statement-breakpoint
+CREATE TABLE `notification_emit_log` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`timestamp` text NOT NULL,
+	`request_id` text,
+	`event_type` text NOT NULL,
+	`severity` text NOT NULL,
+	`symbol` text,
+	`cause` text,
+	`message` text NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `notification_emit_log_severity_id_idx` ON `notification_emit_log` (`severity`,`id`);--> statement-breakpoint
+CREATE INDEX `notification_emit_log_event_type_id_idx` ON `notification_emit_log` (`event_type`,`id`);

--- a/drizzle/meta/0012_snapshot.json
+++ b/drizzle/meta/0012_snapshot.json
@@ -461,18 +461,28 @@
         }
       },
       "indexes": {
-        "notification_emit_log_severity_id_idx": {
-          "name": "notification_emit_log_severity_id_idx",
+        "notification_emit_log_timestamp_id_idx": {
+          "name": "notification_emit_log_timestamp_id_idx",
           "columns": [
-            "severity",
+            "timestamp",
             "id"
           ],
           "isUnique": false
         },
-        "notification_emit_log_event_type_id_idx": {
-          "name": "notification_emit_log_event_type_id_idx",
+        "notification_emit_log_severity_timestamp_id_idx": {
+          "name": "notification_emit_log_severity_timestamp_id_idx",
+          "columns": [
+            "severity",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "notification_emit_log_event_type_timestamp_id_idx": {
+          "name": "notification_emit_log_event_type_timestamp_id_idx",
           "columns": [
             "event_type",
+            "timestamp",
             "id"
           ],
           "isUnique": false

--- a/drizzle/meta/0012_snapshot.json
+++ b/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,887 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "db1f5cfc-13af-4a93-9aa8-e354bdb4c11f",
+  "prevId": "378dd75c-d708-4394-adc1-cff80d63aa14",
+  "tables": {
+    "config_state_snapshot": {
+      "name": "config_state_snapshot",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "global_config": {
+      "name": "global_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "trading_enabled": {
+          "name": "trading_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "market_hours_check": {
+          "name": "market_hours_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "max_order_notional": {
+          "name": "max_order_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "max_order_notional_usd": {
+          "name": "max_order_notional_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2000
+        },
+        "max_order_notional_jpy": {
+          "name": "max_order_notional_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100000
+        },
+        "total_capital_usd": {
+          "name": "total_capital_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_capital_jpy": {
+          "name": "total_capital_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_portfolio_exposure_pct": {
+          "name": "max_portfolio_exposure_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.6
+        },
+        "drawdown_kill_threshold": {
+          "name": "drawdown_kill_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.02
+        },
+        "stale_quote_ms": {
+          "name": "stale_quote_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 900000
+        },
+        "gap_reject_pct": {
+          "name": "gap_reject_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.03
+        },
+        "spread_limit_pct_us": {
+          "name": "spread_limit_pct_us",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.0025
+        },
+        "spread_limit_pct_jp": {
+          "name": "spread_limit_pct_jp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.006
+        },
+        "pullback_default_stop_pct": {
+          "name": "pullback_default_stop_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.04
+        },
+        "pullback_default_take_profit_pct": {
+          "name": "pullback_default_take_profit_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.07
+        },
+        "pullback_default_time_stop_days": {
+          "name": "pullback_default_time_stop_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "pullback_default_pullback_max": {
+          "name": "pullback_default_pullback_max",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.03
+        },
+        "pullback_default_pullback_min": {
+          "name": "pullback_default_pullback_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.06
+        },
+        "pullback_default_min_return_50d": {
+          "name": "pullback_default_min_return_50d",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.08
+        },
+        "pullback_default_require_above_sma50": {
+          "name": "pullback_default_require_above_sma50",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "pullback_default_k_atr": {
+          "name": "pullback_default_k_atr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "risk_base_per_trade_pct": {
+          "name": "risk_base_per_trade_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.004
+        },
+        "risk_dd_half_threshold": {
+          "name": "risk_dd_half_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.05
+        },
+        "risk_dd_halt_threshold": {
+          "name": "risk_dd_halt_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.1
+        },
+        "bucket_exposure_pct": {
+          "name": "bucket_exposure_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.3
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "global_config_max_order_notional_range": {
+          "name": "global_config_max_order_notional_range",
+          "value": "\"global_config\".\"max_order_notional\" > 0 AND \"global_config\".\"max_order_notional\" <= 10000000"
+        },
+        "global_config_max_order_notional_usd_range": {
+          "name": "global_config_max_order_notional_usd_range",
+          "value": "\"global_config\".\"max_order_notional_usd\" > 0 AND \"global_config\".\"max_order_notional_usd\" <= 1000000"
+        },
+        "global_config_max_order_notional_jpy_range": {
+          "name": "global_config_max_order_notional_jpy_range",
+          "value": "\"global_config\".\"max_order_notional_jpy\" > 0 AND \"global_config\".\"max_order_notional_jpy\" <= 100000000"
+        },
+        "global_config_total_capital_usd_range": {
+          "name": "global_config_total_capital_usd_range",
+          "value": "\"global_config\".\"total_capital_usd\" IS NULL OR \"global_config\".\"total_capital_usd\" > 0"
+        },
+        "global_config_total_capital_jpy_range": {
+          "name": "global_config_total_capital_jpy_range",
+          "value": "\"global_config\".\"total_capital_jpy\" IS NULL OR \"global_config\".\"total_capital_jpy\" > 0"
+        },
+        "global_config_max_portfolio_exposure_pct_range": {
+          "name": "global_config_max_portfolio_exposure_pct_range",
+          "value": "\"global_config\".\"max_portfolio_exposure_pct\" > 0 AND \"global_config\".\"max_portfolio_exposure_pct\" <= 1"
+        },
+        "global_config_drawdown_kill_threshold_range": {
+          "name": "global_config_drawdown_kill_threshold_range",
+          "value": "\"global_config\".\"drawdown_kill_threshold\" >= -1 AND \"global_config\".\"drawdown_kill_threshold\" <= 0"
+        },
+        "global_config_stale_quote_ms_range": {
+          "name": "global_config_stale_quote_ms_range",
+          "value": "\"global_config\".\"stale_quote_ms\" >= 0"
+        },
+        "global_config_gap_reject_pct_range": {
+          "name": "global_config_gap_reject_pct_range",
+          "value": "\"global_config\".\"gap_reject_pct\" >= 0 AND \"global_config\".\"gap_reject_pct\" <= 1"
+        },
+        "global_config_spread_limit_pct_us_range": {
+          "name": "global_config_spread_limit_pct_us_range",
+          "value": "\"global_config\".\"spread_limit_pct_us\" >= 0 AND \"global_config\".\"spread_limit_pct_us\" <= 1"
+        },
+        "global_config_spread_limit_pct_jp_range": {
+          "name": "global_config_spread_limit_pct_jp_range",
+          "value": "\"global_config\".\"spread_limit_pct_jp\" >= 0 AND \"global_config\".\"spread_limit_pct_jp\" <= 1"
+        },
+        "global_config_pullback_default_stop_pct_range": {
+          "name": "global_config_pullback_default_stop_pct_range",
+          "value": "\"global_config\".\"pullback_default_stop_pct\" < 0 AND \"global_config\".\"pullback_default_stop_pct\" >= -1"
+        },
+        "global_config_pullback_default_take_profit_pct_range": {
+          "name": "global_config_pullback_default_take_profit_pct_range",
+          "value": "\"global_config\".\"pullback_default_take_profit_pct\" > 0 AND \"global_config\".\"pullback_default_take_profit_pct\" <= 1"
+        },
+        "global_config_pullback_default_time_stop_days_range": {
+          "name": "global_config_pullback_default_time_stop_days_range",
+          "value": "\"global_config\".\"pullback_default_time_stop_days\" > 0 AND \"global_config\".\"pullback_default_time_stop_days\" <= 365"
+        },
+        "global_config_pullback_default_pullback_max_range": {
+          "name": "global_config_pullback_default_pullback_max_range",
+          "value": "\"global_config\".\"pullback_default_pullback_max\" <= 0 AND \"global_config\".\"pullback_default_pullback_max\" >= -1"
+        },
+        "global_config_pullback_default_pullback_min_range": {
+          "name": "global_config_pullback_default_pullback_min_range",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= 0 AND \"global_config\".\"pullback_default_pullback_min\" >= -1"
+        },
+        "global_config_pullback_default_min_return_50d_range": {
+          "name": "global_config_pullback_default_min_return_50d_range",
+          "value": "\"global_config\".\"pullback_default_min_return_50d\" >= -1 AND \"global_config\".\"pullback_default_min_return_50d\" <= 10"
+        },
+        "global_config_pullback_default_k_atr_range": {
+          "name": "global_config_pullback_default_k_atr_range",
+          "value": "\"global_config\".\"pullback_default_k_atr\" > 0 AND \"global_config\".\"pullback_default_k_atr\" <= 10"
+        },
+        "global_config_pullback_default_pullback_window_order": {
+          "name": "global_config_pullback_default_pullback_window_order",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= \"global_config\".\"pullback_default_pullback_max\""
+        },
+        "global_config_risk_base_per_trade_pct_range": {
+          "name": "global_config_risk_base_per_trade_pct_range",
+          "value": "\"global_config\".\"risk_base_per_trade_pct\" > 0 AND \"global_config\".\"risk_base_per_trade_pct\" <= 1"
+        },
+        "global_config_risk_dd_half_threshold_range": {
+          "name": "global_config_risk_dd_half_threshold_range",
+          "value": "\"global_config\".\"risk_dd_half_threshold\" < 0 AND \"global_config\".\"risk_dd_half_threshold\" >= -1"
+        },
+        "global_config_risk_dd_halt_threshold_range": {
+          "name": "global_config_risk_dd_halt_threshold_range",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" < 0 AND \"global_config\".\"risk_dd_halt_threshold\" >= -1"
+        },
+        "global_config_risk_dd_threshold_order": {
+          "name": "global_config_risk_dd_threshold_order",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" <= \"global_config\".\"risk_dd_half_threshold\""
+        },
+        "global_config_bucket_exposure_pct_range": {
+          "name": "global_config_bucket_exposure_pct_range",
+          "value": "\"global_config\".\"bucket_exposure_pct\" > 0 AND \"global_config\".\"bucket_exposure_pct\" <= 1"
+        }
+      }
+    },
+    "inverse_pairs": {
+      "name": "inverse_pairs",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inverse": {
+          "name": "inverse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_emit_log": {
+      "name": "notification_emit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cause": {
+          "name": "cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notification_emit_log_severity_id_idx": {
+          "name": "notification_emit_log_severity_id_idx",
+          "columns": [
+            "severity",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "notification_emit_log_event_type_id_idx": {
+          "name": "notification_emit_log_event_type_id_idx",
+          "columns": [
+            "event_type",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "strategy_decision_log": {
+      "name": "strategy_decision_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indicators_json": {
+          "name": "indicators_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "strategy_decision_log_symbol_id_idx": {
+          "name": "strategy_decision_log_symbol_id_idx",
+          "columns": [
+            "symbol",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "strategy_decision_log_coid_idx": {
+          "name": "strategy_decision_log_coid_idx",
+          "columns": [
+            "client_order_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "symbol_config": {
+      "name": "symbol_config",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "market": {
+          "name": "market",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_notional": {
+          "name": "max_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "symbol_config_currency_enum": {
+          "name": "symbol_config_currency_enum",
+          "value": "\"symbol_config\".\"currency\" IN ('USD', 'JPY')"
+        }
+      }
+    },
+    "trade_journal": {
+      "name": "trade_journal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trade_event_type": {
+          "name": "trade_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "strategy_name": {
+          "name": "strategy_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_action": {
+          "name": "signal_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_reason": {
+          "name": "signal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_allowed": {
+          "name": "risk_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_reasons": {
+          "name": "risk_reasons",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "limit_price": {
+          "name": "limit_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notional": {
+          "name": "notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "broker_status": {
+          "name": "broker_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "submitted": {
+          "name": "submitted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_qty": {
+          "name": "filled_qty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_price": {
+          "name": "filled_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "realized_pnl": {
+          "name": "realized_pnl",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hold_days": {
+          "name": "hold_days",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_reason": {
+          "name": "exit_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_applied_at": {
+          "name": "state_applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_error": {
+          "name": "state_apply_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_attempts": {
+          "name": "state_apply_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1777202359235,
       "tag": "0011_reconcile_state_apply_marker",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "6",
+      "when": 1777206141621,
+      "tag": "0012_observability_alerts",
+      "breakpoints": true
     }
   ]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,12 +81,17 @@ export default {
                 message,
               }),
             )
-            // cron 全体が落ちた時 (D1 失敗 / unexpected throw 等) も通知 (#199)。
-            // ctx.waitUntil で wrap して isolate terminate 前に webhook fetch を
-            // 完了させる。Notifier 実装側は silent fallback なので catch は保険。
+            // cron 全体が落ちた時 (D1 失敗 / unexpected throw 等) も通知 (#199 → #141)。
+            // severity: critical で push する。waitUntil で wrap して isolate
+            // terminate 前に webhook fetch を完了させる。
             ctx.waitUntil(
-              createNotifier(env)
-                .notify({ type: 'ERROR', message, cause: 'strategy_cron' })
+              createNotifier(env, { requestId })
+                .notify({
+                  type: 'ERROR',
+                  message,
+                  cause: 'strategy_cron',
+                  severity: 'critical',
+                })
                 .catch(() => undefined),
             )
           },
@@ -96,6 +101,8 @@ export default {
     }
 
     // default: CRON_QUOTE_RECONCILE (`*/5 * * * *`) — quote feed + fill reconcile.
+    // 5 分 cron は quote と reconcile が独立に走るので、片方の error 経路で
+    // notifier を 1 回ずつ作る (overhead は無視できる: createNotifier は薄い)。
     ctx.waitUntil(
       runQuoteFeed({ env }).then(
         (summary) => {
@@ -111,12 +118,25 @@ export default {
           )
         },
         (error) => {
+          const message = error instanceof Error ? error.message : String(error)
           console.error(
             JSON.stringify({
               event: 'quote_feed_error',
               requestId,
-              message: error instanceof Error ? error.message : String(error),
+              message,
             }),
+          )
+          // quote feed の global throw は warning (per-symbol skip と区別)。
+          // 連続 fail で operator が気付けるよう push 通知 (#141)。
+          ctx.waitUntil(
+            createNotifier(env, { requestId })
+              .notify({
+                type: 'ERROR',
+                message,
+                cause: 'quote_feed',
+                severity: 'warning',
+              })
+              .catch(() => undefined),
           )
         },
       ),
@@ -141,14 +161,41 @@ export default {
               errorCount: summary.errors.length,
             }),
           )
+          // reconcile の per-row error が出ていれば 1 件まとめて通知 (#141)。
+          // 1 row 1 通知だと polling tick で連発するので summary 単位で 1 件。
+          if (summary.errors.length > 0) {
+            ctx.waitUntil(
+              createNotifier(env, { requestId })
+                .notify({
+                  type: 'ERROR',
+                  message: `reconcile fills had ${summary.errors.length} error(s) across ${summary.inspected} row(s)`,
+                  cause: 'reconcile_fills_partial',
+                  severity: 'warning',
+                })
+                .catch(() => undefined),
+            )
+          }
         },
         (error) => {
+          const message = error instanceof Error ? error.message : String(error)
           console.error(
             JSON.stringify({
               event: 'reconcile_fills_error',
               requestId,
-              message: error instanceof Error ? error.message : String(error),
+              message,
             }),
+          )
+          // reconcile 全体 throw は critical (split-brain リスク、#142 系列の
+          // 修復が走らない)。
+          ctx.waitUntil(
+            createNotifier(env, { requestId })
+              .notify({
+                type: 'ERROR',
+                message,
+                cause: 'reconcile_fills',
+                severity: 'critical',
+              })
+              .catch(() => undefined),
           )
         },
       ),

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -387,11 +387,22 @@ export const notificationEmitLog = sqliteTable(
     message: text('message').notNull(),
   },
   (t) => ({
-    // dashboard `/dashboard/alerts` は WHERE severity IN ('critical','warning')
-    // ORDER BY id DESC で読む。
-    severityIdIdx: index('notification_emit_log_severity_id_idx').on(t.severity, t.id),
+    // dashboard `/dashboard/alerts` は ORDER BY timestamp DESC, id DESC で読む。
+    // `waitUntil` 配下の INSERT が前後して id 順と発生順がずれるケースを
+    // tiebreak で吸収するため、timestamp を first key にする (CodeRabbit #210)。
+    timestampIdIdx: index('notification_emit_log_timestamp_id_idx').on(t.timestamp, t.id),
+    // severity フィルタ + timestamp DESC ソートを 1 本でカバー。
+    severityTimestampIdIdx: index('notification_emit_log_severity_timestamp_id_idx').on(
+      t.severity,
+      t.timestamp,
+      t.id,
+    ),
     // event type 別フィルタ ('strategy_cron_error' のような cause も同 index で覆える)。
-    eventTypeIdIdx: index('notification_emit_log_event_type_id_idx').on(t.eventType, t.id),
+    eventTypeTimestampIdIdx: index('notification_emit_log_event_type_timestamp_id_idx').on(
+      t.eventType,
+      t.timestamp,
+      t.id,
+    ),
   }),
 )
 

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -354,3 +354,67 @@ export const strategyDecisionLog = sqliteTable(
 
 export type StrategyDecisionLogRow = typeof strategyDecisionLog.$inferSelect
 export type StrategyDecisionLogInsert = typeof strategyDecisionLog.$inferInsert
+
+/**
+ * `Notifier.notify()` で push 通知を送った全イベントを書き出す append-only
+ * ログ (#141)。dashboard `/dashboard/alerts` の active alerts view が
+ * `severity = 'critical' | 'warning'` を timestamp DESC で読む。
+ *
+ * 役割:
+ *   - operator が dashboard を見れば「直近 100 件の critical / warning」を
+ *     一覧できる
+ *   - Webhook が落ちていた / 未設定でも D1 だけは残る (audit trail)
+ *   - Workers Logs retention を超える長期保全までは expectation しない (POC)。
+ *     長期保全は Logpush to R2 (follow-up) でカバー想定。
+ *
+ * `severity` は free-form text にしておく (DB CHECK 制約は drizzle-kit で
+ * 後から追加可能)。production の値域は `NotificationSeverity` 型で縛る。
+ */
+export const notificationEmitLog = sqliteTable(
+  'notification_emit_log',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    timestamp: text('timestamp').notNull(),
+    requestId: text('request_id'),
+    /** 'TRADE' / 'ERROR' / 'STATE_CHANGE' (NotificationEvent.type と一致) */
+    eventType: text('event_type').notNull(),
+    /** 'critical' / 'warning' / 'info' (NotificationSeverity と一致)。TRADE は 'info'。 */
+    severity: text('severity').notNull(),
+    symbol: text('symbol'),
+    /** ERROR の cause (例: `bar fetch`, `broker submit`)。STATE_CHANGE は field 名。 */
+    cause: text('cause'),
+    /** WebhookNotifier formatter が組み立てた text (Slack/Discord に送ったのと同じ)。 */
+    message: text('message').notNull(),
+  },
+  (t) => ({
+    // dashboard `/dashboard/alerts` は WHERE severity IN ('critical','warning')
+    // ORDER BY id DESC で読む。
+    severityIdIdx: index('notification_emit_log_severity_id_idx').on(t.severity, t.id),
+    // event type 別フィルタ ('strategy_cron_error' のような cause も同 index で覆える)。
+    eventTypeIdIdx: index('notification_emit_log_event_type_id_idx').on(t.eventType, t.id),
+  }),
+)
+
+export type NotificationEmitLogRow = typeof notificationEmitLog.$inferSelect
+export type NotificationEmitLogInsert = typeof notificationEmitLog.$inferInsert
+
+/**
+ * `global_config` の重要 field の前回値スナップショット (#141)。
+ * cron tick で global_config を読む際にこの table と比較し、
+ * `dry_run` true→false や `trading_enabled` false→true 等の遷移を検知して
+ * STATE_CHANGE 通知を出す。
+ *
+ * `key` PRIMARY KEY 1 行 / field なので `INSERT OR REPLACE` で更新する。
+ * 値は JSON.stringify で保存 (boolean / number / string / null を一律扱う)。
+ */
+export const configStateSnapshot = sqliteTable('config_state_snapshot', {
+  /** field 名 (例: `dry_run`, `trading_enabled`). */
+  key: text('key').primaryKey(),
+  /** `JSON.stringify(value)` 形式。比較は文字列等価で行う。 */
+  value: text('value').notNull(),
+  snapshotAt: text('snapshot_at').notNull(),
+  requestId: text('request_id'),
+})
+
+export type ConfigStateSnapshotRow = typeof configStateSnapshot.$inferSelect
+export type ConfigStateSnapshotInsert = typeof configStateSnapshot.$inferInsert

--- a/src/infrastructure/notification/LoggingNotifier.ts
+++ b/src/infrastructure/notification/LoggingNotifier.ts
@@ -1,0 +1,107 @@
+import { insertNotificationEmit } from './notificationEmitLog'
+import type {
+  Notifier,
+  NotificationEvent,
+  NotificationSeverity,
+} from './Notifier'
+
+/**
+ * `Notifier` decorator that ALSO appends every notify() into D1
+ * `notification_emit_log` (#141).
+ *
+ * Wrap any concrete `Notifier` (typically `WebhookNotifier`) so a single
+ * notify() call:
+ *   1. Forwards to the inner notifier (Slack/Discord webhook send)
+ *   2. INSERTs a row into `notification_emit_log` for the dashboard alerts view
+ *
+ * Both are fire-and-forget from the caller's perspective: this class always
+ * resolves, never throws. D1 INSERT failures are caught + logged so a flaky
+ * D1 cannot block webhook delivery (and vice-versa).
+ *
+ * `formatMessage` is a callback so we can record the same string the inner
+ * notifier displayed (single source of truth for "what the operator saw").
+ */
+export interface LoggingNotifierOptions {
+  inner: Notifier
+  db: D1Database
+  /**
+   * 通知 message を組み立てる callback。`WebhookNotifier` の formatter と
+   * 同じ実装を使う想定 (factory 側で wiring)。失敗したら event.type に
+   * fallback。
+   */
+  formatMessage: (event: NotificationEvent) => string
+  /**
+   * cron fire 単位の correlation id。`notification_emit_log.request_id` に書く。
+   */
+  requestId?: string
+  /** test 用に固定可能。 */
+  now?: () => Date
+}
+
+export class LoggingNotifier implements Notifier {
+  private readonly inner: Notifier
+  private readonly db: D1Database
+  private readonly formatMessage: (event: NotificationEvent) => string
+  private readonly requestId?: string
+  private readonly now?: () => Date
+
+  constructor(options: LoggingNotifierOptions) {
+    this.inner = options.inner
+    this.db = options.db
+    this.formatMessage = options.formatMessage
+    this.requestId = options.requestId
+    this.now = options.now
+  }
+
+  async notify(event: NotificationEvent): Promise<void> {
+    // Webhook と D1 INSERT は独立。片方の失敗で他方を止めない (silent fallback)。
+    const message = this.safeFormatMessage(event)
+    const severity = pickSeverity(event)
+    const innerP = this.inner.notify(event).catch((err) => {
+      console.warn(
+        JSON.stringify({
+          event: 'logging_notifier_inner_failed',
+          requestId: this.requestId ?? null,
+          eventType: event.type,
+          message: err instanceof Error ? err.message : String(err),
+        }),
+      )
+    })
+    const dbP = insertNotificationEmit(this.db, {
+      event,
+      message,
+      severity,
+      requestId: this.requestId,
+      now: this.now,
+    }).catch((err) => {
+      console.warn(
+        JSON.stringify({
+          event: 'logging_notifier_db_failed',
+          requestId: this.requestId ?? null,
+          eventType: event.type,
+          message: err instanceof Error ? err.message : String(err),
+        }),
+      )
+    })
+    await Promise.allSettled([innerP, dbP])
+  }
+
+  private safeFormatMessage(event: NotificationEvent): string {
+    try {
+      return this.formatMessage(event)
+    } catch {
+      return event.type
+    }
+  }
+}
+
+/**
+ * Event の native severity を抽出。TRADE は POC では `info` 扱い (ledger
+ * としての行を残す目的)、ERROR は未指定なら `warning`、STATE_CHANGE は
+ * 必須なので素直に取る。
+ */
+export function pickSeverity(event: NotificationEvent): NotificationSeverity {
+  if (event.type === 'TRADE') return 'info'
+  if (event.type === 'STATE_CHANGE') return event.severity
+  return event.severity ?? 'warning'
+}

--- a/src/infrastructure/notification/Notifier.ts
+++ b/src/infrastructure/notification/Notifier.ts
@@ -1,5 +1,5 @@
 /**
- * Notifier — Slack/Discord webhook 通知用 thin port (#199)。
+ * Notifier — Slack/Discord webhook 通知用 thin port (#199 → #141 拡張)。
  *
  * 様子見フェーズで dashboard を能動的に開かなくても DRY_RUN BUY/SELL や cron
  * error に気付けるようにするための shallow event sink。意図的に薄い:
@@ -10,6 +10,12 @@
  * Production wiring は `createNotifier(env)` で env から組み立てる。
  * env 未設定 (SLACK_WEBHOOK_URL も DISCORD_WEBHOOK_URL も無し) なら
  * `NoopNotifier` が返り、cron 経路は何もしない。
+ *
+ * Issue #141 — 通知 event の taxonomy を critical events に拡張:
+ *   - `severity` を ERROR / STATE_CHANGE に追加 (critical / warning / info)
+ *   - cron skip (portfolio_halted / drawdown_kill / no_bridge_state) や
+ *     reconcile error / quote feed error も `Notifier.notify()` 経由で push 通知
+ *   - `dry_run=0 && trading_enabled=1` 等の状態遷移は STATE_CHANGE で通知
  */
 export interface Notifier {
   /**
@@ -23,6 +29,17 @@ export interface Notifier {
 export type NotificationEvent =
   | TradeNotificationEvent
   | ErrorNotificationEvent
+  | StateChangeNotificationEvent
+
+/**
+ * Severity tier for ERROR / STATE_CHANGE events (#141)。
+ *   - `critical`: ops が即対応すべき (trading 停止 / 状態異常)。赤系 icon。
+ *   - `warning` : 注意して見るべき (cron skip / quote feed エラー)。黄系 icon。
+ *   - `info`    : 状態遷移ログとしての通知 (運用判断には影響しない)。青系 icon。
+ *
+ * TRADE event は POC では severity を付けない (BUY/SELL は side で色分け済み)。
+ */
+export type NotificationSeverity = 'critical' | 'warning' | 'info'
 
 export interface TradeNotificationEvent {
   type: 'TRADE'
@@ -42,4 +59,35 @@ export interface ErrorNotificationEvent {
   message: string
   /** 例外の root cause / context (例: `bar fetch`, `broker submit`). */
   cause?: string
+  /**
+   * 通知の重要度。未指定なら `warning` (#199 の既定挙動を保つ)。critical は
+   * `strategy_cron_error` / `dry_run=0 && trading_enabled=1` 切替の trading
+   * 停止リスクの高い経路だけに付ける。
+   */
+  severity?: NotificationSeverity
+}
+
+/**
+ * 状態遷移通知 (#141)。`global_config` の dry_run / trading_enabled 等が
+ * cron tick 間で変化した時に出る。1 tick で複数 field が変わる場合は
+ * field ごとに 1 件ずつ送る (formatter が message を自動生成)。
+ *
+ * `from` / `to` は arbitrary primitive を取れるよう unknown だが、JSON
+ * stringify 可能であること (Slack/Discord に表示するため)。
+ */
+export interface StateChangeNotificationEvent {
+  type: 'STATE_CHANGE'
+  /** 変化した config field 名 (例: `dry_run`, `trading_enabled`). */
+  field: string
+  from: unknown
+  to: unknown
+  /**
+   * `dry_run: true→false` や `trading_enabled: false→true` 等の「実発注に
+   * 近づく」遷移は critical。逆方向 (実発注を止める向き) は info。
+   */
+  severity: NotificationSeverity
+  /**
+   * 補足 (例: `requestId`)。formatter が末尾に付ける。
+   */
+  note?: string
 }

--- a/src/infrastructure/notification/WebhookNotifier.ts
+++ b/src/infrastructure/notification/WebhookNotifier.ts
@@ -1,4 +1,8 @@
-import type { Notifier, NotificationEvent } from './Notifier'
+import type {
+  Notifier,
+  NotificationEvent,
+  NotificationSeverity,
+} from './Notifier'
 
 export interface WebhookNotifierOptions {
   /** Slack incoming webhook URL。空 / undefined なら Slack には送らない。 */
@@ -95,7 +99,12 @@ export class WebhookNotifier implements Notifier {
     }
   }
 
-  private formatMessage(event: NotificationEvent): string {
+  /**
+   * Slack/Discord に送るのと同じ message 文字列を組み立てる。`LoggingNotifier`
+   * が D1 `notification_emit_log.message` 列に同じ表現を残すために public に
+   * 露出している (#141)。テスト用にも便利。
+   */
+  formatMessage(event: NotificationEvent): string {
     if (event.type === 'TRADE') {
       const head =
         event.side === 'BUY'
@@ -106,10 +115,18 @@ export class WebhookNotifier implements Notifier {
       const link = this.dashboardLinkFor(event.symbol)
       return link ? `${head}\n${link}` : head
     }
+    if (event.type === 'STATE_CHANGE') {
+      // `from → to` を表示し、severity icon で実発注に近づく遷移を強調する。
+      const head = `${severityIcon(event.severity)} state change: ${event.field} ${formatValue(event.from)} → ${formatValue(event.to)}`
+      const note = event.note ? `\n${event.note}` : ''
+      return `${head}${note}`
+    }
     // ERROR
     const sym = event.symbol ?? 'global'
     const causePart = event.cause ? ` (${event.cause})` : ''
-    const head = `⚠️ cron error: ${sym} — ${event.message}${causePart}`
+    const icon = severityIcon(event.severity ?? 'warning')
+    const label = event.severity === 'critical' ? 'CRITICAL' : 'cron error'
+    const head = `${icon} ${label}: ${sym} — ${event.message}${causePart}`
     const link = event.symbol ? this.dashboardLinkFor(event.symbol) : undefined
     return link ? `${head}\n${link}` : head
   }
@@ -136,4 +153,38 @@ function formatPnl(pnl: number): string {
   // pnl は正負ありうる。読みやすさで小数 2 桁固定 + 符号明示。
   const sign = pnl > 0 ? '+' : ''
   return `${sign}${pnl.toFixed(2)}`
+}
+
+/**
+ * Severity を icon に対応付ける (#141)。Slack/Discord 共通で render される
+ * unicode emoji。critical = 赤、warning = 黄、info = 青を採用。BUY/SELL の
+ * 緑/赤と差別化するため critical は警告マーク (🚨) を使う。
+ */
+function severityIcon(severity: NotificationSeverity): string {
+  switch (severity) {
+    case 'critical':
+      return '🚨'
+    case 'info':
+      return 'ℹ️'
+    case 'warning':
+    default:
+      return '⚠️'
+  }
+}
+
+/**
+ * STATE_CHANGE event の `from` / `to` を 1 行表記に。primitive はそのまま、
+ * object は JSON 化する。null/undefined は明示文字列で出して「値が消えた」と
+ * 区別できるようにする。
+ */
+function formatValue(value: unknown): string {
+  if (value === null) return 'null'
+  if (value === undefined) return 'undefined'
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return String(value)
+  }
 }

--- a/src/infrastructure/notification/configStateChange.ts
+++ b/src/infrastructure/notification/configStateChange.ts
@@ -1,0 +1,241 @@
+import { eq, inArray } from 'drizzle-orm'
+import { configStateSnapshot } from '../db/schema'
+import { createDb } from '../db/tradeJournalRepo'
+import type { Notifier, NotificationSeverity } from './Notifier'
+
+/**
+ * `global_config` の重要 field の前回値を D1 `config_state_snapshot` に
+ * 保存し、cron tick ごとに diff を取って STATE_CHANGE 通知する (#141)。
+ *
+ * 検知対象は **trading の安全性に直結する** 4 つに絞る:
+ *   - `dry_run`            (true → false: 実発注 ON、危険)
+ *   - `trading_enabled`    (false → true: 実発注 ON、危険)
+ *   - `market_hours_check` (false → true: 取引時間外 reject、運用変更)
+ *   - `drawdown_kill_threshold` (絶対値が緩む方向は危険)
+ *
+ * 「実発注に近づく方向」の遷移は `severity: critical`、逆方向は `info`。
+ * 初回 (snapshot 行なし) は通知を出さず単に snapshot を作る (false alert
+ * 防止)。
+ *
+ * fail-silent: D1 read / write が落ちても cron 本体には影響させない (caller
+ * が try/catch する想定 + emit は fire-and-forget)。
+ */
+export interface WatchedConfig {
+  dryRun: boolean
+  tradingEnabled: boolean
+  marketHoursCheck: boolean
+  drawdownKillThreshold: number
+}
+
+export const WATCHED_KEYS: ReadonlyArray<keyof WatchedConfig> = [
+  'dryRun',
+  'tradingEnabled',
+  'marketHoursCheck',
+  'drawdownKillThreshold',
+]
+
+export interface DetectedStateChange {
+  field: keyof WatchedConfig
+  from: WatchedConfig[keyof WatchedConfig] | null
+  to: WatchedConfig[keyof WatchedConfig]
+  severity: NotificationSeverity
+}
+
+/**
+ * D1 から前回 snapshot を読む。table 未 migration 等で落ちても caller を
+ * 落とさないよう、空 Map を返して「初回扱い」にフォールバックする。
+ */
+export async function loadConfigSnapshots(
+  db: D1Database,
+): Promise<Map<string, string>> {
+  try {
+    const drizzle = createDb(db)
+    const rows = await drizzle
+      .select({ key: configStateSnapshot.key, value: configStateSnapshot.value })
+      .from(configStateSnapshot)
+      .where(inArray(configStateSnapshot.key, [...WATCHED_KEYS]))
+    return new Map(rows.map((r) => [r.key, r.value] as const))
+  } catch (error) {
+    console.warn(
+      JSON.stringify({
+        event: 'config_state_snapshot_load_failed',
+        message: error instanceof Error ? error.message : String(error),
+      }),
+    )
+    return new Map()
+  }
+}
+
+/**
+ * 現在値と前回 snapshot を diff して、変化した field だけ列挙する。前回
+ * 値が無い field は「初回」扱いで diff には含めない (false alert 防止)。
+ */
+export function diffConfigState(
+  current: WatchedConfig,
+  previous: Map<string, string>,
+): DetectedStateChange[] {
+  const changes: DetectedStateChange[] = []
+  for (const key of WATCHED_KEYS) {
+    const currentValue = current[key]
+    const currentJson = JSON.stringify(currentValue)
+    const previousJson = previous.get(key)
+    if (previousJson === undefined) continue // 初回 — 通知しない
+    if (previousJson === currentJson) continue
+    const previousValue = parseSafe(previousJson)
+    changes.push({
+      field: key,
+      from: previousValue as WatchedConfig[keyof WatchedConfig] | null,
+      to: currentValue,
+      severity: classifySeverity(key, previousValue, currentValue),
+    })
+  }
+  return changes
+}
+
+/**
+ * 「実発注に近づく方向」かどうかで severity を決める。基準:
+ *   - `dry_run: true → false`        critical
+ *   - `trading_enabled: false → true` critical
+ *   - `market_hours_check: true → false` critical (時間外 fence が外れる)
+ *   - `drawdown_kill_threshold` が緩む (より 0 に近い負値、または 0 以上) critical
+ *   - 逆方向 (停止に向かう) は info
+ *   - 上記以外の遷移 (型崩れ等) は warning
+ */
+export function classifySeverity(
+  field: keyof WatchedConfig,
+  from: unknown,
+  to: unknown,
+): NotificationSeverity {
+  if (field === 'dryRun') {
+    if (from === true && to === false) return 'critical'
+    if (from === false && to === true) return 'info'
+    return 'warning'
+  }
+  if (field === 'tradingEnabled') {
+    if (from === false && to === true) return 'critical'
+    if (from === true && to === false) return 'info'
+    return 'warning'
+  }
+  if (field === 'marketHoursCheck') {
+    if (from === true && to === false) return 'critical'
+    if (from === false && to === true) return 'info'
+    return 'warning'
+  }
+  if (field === 'drawdownKillThreshold') {
+    if (typeof from === 'number' && typeof to === 'number') {
+      // 閾値が「より 0 に近い / 正方向」へ動くと kill が発動しづらくなる = 危険
+      if (to > from) return 'critical'
+      if (to < from) return 'info'
+    }
+    return 'warning'
+  }
+  return 'warning'
+}
+
+/**
+ * 現在値で snapshot table を upsert する。caller は `loadConfigSnapshots`
+ * → `diffConfigState` → `notifyChanges` → `persistSnapshots` の順で呼ぶ。
+ *
+ * 失敗は throw しない (caller が握りつぶす)。snapshot 書き込みが落ちても
+ * 次 tick で「変わらなかった」誤検知が増えるだけで実害は小さい。
+ */
+export async function persistSnapshots(
+  db: D1Database,
+  current: WatchedConfig,
+  requestId: string | undefined,
+  now: Date,
+): Promise<void> {
+  const drizzle = createDb(db)
+  const snapshotAt = now.toISOString()
+  // Drizzle has no portable upsert for sqlite without ON CONFLICT — emulate
+  // with delete + insert per key. Each key is independent so a single
+  // failure doesn't lose the others.
+  for (const key of WATCHED_KEYS) {
+    const value = JSON.stringify(current[key])
+    try {
+      await drizzle.delete(configStateSnapshot).where(eq(configStateSnapshot.key, key))
+      await drizzle.insert(configStateSnapshot).values({
+        key,
+        value,
+        snapshotAt,
+        requestId: requestId ?? null,
+      })
+    } catch (error) {
+      console.warn(
+        JSON.stringify({
+          event: 'config_state_snapshot_persist_failed',
+          key,
+          message: error instanceof Error ? error.message : String(error),
+        }),
+      )
+    }
+  }
+}
+
+/**
+ * 検出した change を Notifier に流す helper。fire-and-forget (caller は
+ * await 不要) — エラーは内部で log するだけ。
+ */
+export function notifyConfigStateChanges(
+  notifier: Notifier,
+  changes: DetectedStateChange[],
+  requestId: string | undefined,
+): void {
+  for (const change of changes) {
+    const note = requestId ? `requestId=${requestId}` : undefined
+    notifier
+      .notify({
+        type: 'STATE_CHANGE',
+        field: change.field,
+        from: change.from,
+        to: change.to,
+        severity: change.severity,
+        ...(note !== undefined ? { note } : {}),
+      })
+      .catch((err) => {
+        console.warn(
+          JSON.stringify({
+            event: 'config_state_change_notify_failed',
+            field: change.field,
+            message: err instanceof Error ? err.message : String(err),
+          }),
+        )
+      })
+  }
+}
+
+/**
+ * cron tick から呼ばれる top-level helper。
+ *
+ *   1. snapshot を読む (失敗 → 空 Map)
+ *   2. diff を取る (初回 = 空)
+ *   3. notifier に diff を流す (fire-and-forget)
+ *   4. snapshot を upsert (await する: 次 tick の比較に必要)
+ *
+ * `env.DB` が無いと state change 検知は成立しないので、caller 側で
+ * skip するか、ここで noop fallback する。後者を採用 (caller の if 分岐を
+ * 減らす)。
+ */
+export async function detectAndNotifyConfigStateChanges(args: {
+  db: D1Database | undefined
+  notifier: Notifier
+  current: WatchedConfig
+  requestId?: string
+  now?: () => Date
+}): Promise<DetectedStateChange[]> {
+  if (!args.db) return []
+  const previous = await loadConfigSnapshots(args.db)
+  const changes = diffConfigState(args.current, previous)
+  notifyConfigStateChanges(args.notifier, changes, args.requestId)
+  const now = (args.now ?? (() => new Date()))()
+  await persistSnapshots(args.db, args.current, args.requestId, now)
+  return changes
+}
+
+function parseSafe(json: string): unknown {
+  try {
+    return JSON.parse(json)
+  } catch {
+    return json
+  }
+}

--- a/src/infrastructure/notification/createNotifier.ts
+++ b/src/infrastructure/notification/createNotifier.ts
@@ -1,22 +1,79 @@
 import type { Env } from '../../config/env'
+import { LoggingNotifier } from './LoggingNotifier'
 import { NoopNotifier } from './NoopNotifier'
-import type { Notifier } from './Notifier'
+import type { Notifier, NotificationEvent } from './Notifier'
 import { WebhookNotifier } from './WebhookNotifier'
 
 /**
- * Env から `Notifier` を組み立てる factory (#199)。
+ * Env から `Notifier` を組み立てる factory (#199 → #141 拡張)。
  *
- * Slack/Discord webhook URL がいずれも未設定なら `NoopNotifier` を返し、
- * cron 経路は完全に no-op になる。env の typo / 抜け落ちで通知が飛ばないだけで
- * cron 自体は止めない (fail-open ではなく **fail-silent**)。
+ * 組み立てルール:
+ *   - Slack/Discord webhook URL がいずれも未設定 → `NoopNotifier`
+ *     - ただし `env.DB` があれば「webhook 無し / D1 ログのみ」の `LoggingNotifier`
+ *       を返す。dashboard alerts view が動くため。
+ *   - URL 設定あり → `WebhookNotifier` を作る
+ *     - `env.DB` があればさらに `LoggingNotifier` で wrap (D1 INSERT も走る)
+ *     - `env.DB` 不在なら WebhookNotifier 単体 (POC 後方互換)
+ *
+ * fail-silent 方針は変えない: env の typo / 抜け落ちで通知が飛ばないだけで
+ * cron 自体は止めない。
  */
-export function createNotifier(env: Env): Notifier {
+export interface CreateNotifierOptions {
+  /**
+   * cron fire 単位の correlation id (`scheduled()` の `crypto.randomUUID()`)。
+   * `notification_emit_log.request_id` に書き込むために伝搬させる。
+   */
+  requestId?: string
+  /**
+   * 通知 message を組み立てる関数の override (test 用)。production は
+   * `WebhookNotifier.formatMessage` を使う。
+   */
+  formatMessage?: (event: NotificationEvent) => string
+}
+
+export function createNotifier(env: Env, options: CreateNotifierOptions = {}): Notifier {
   const slack = env.SLACK_WEBHOOK_URL?.trim()
   const discord = env.DISCORD_WEBHOOK_URL?.trim()
-  if (!slack && !discord) return new NoopNotifier()
-  return new WebhookNotifier({
+
+  // Webhook 単体 (D1 ログ無し) — `env.DB` 未 bind の old fixture / minimal env
+  // を破壊しないため、`createNotifier` を flat に保つ。
+  if (!slack && !discord) {
+    if (!env.DB) return new NoopNotifier()
+    // webhook 無し + D1 あり: ログだけ残す Notifier。NoopNotifier を inner に
+    // 据えて LoggingNotifier で wrap する (D1 INSERT 専用パス)。
+    return new LoggingNotifier({
+      inner: new NoopNotifier(),
+      db: env.DB,
+      formatMessage: options.formatMessage ?? createDefaultFormatter(env),
+      requestId: options.requestId,
+    })
+  }
+
+  const webhook = new WebhookNotifier({
     slackUrl: slack,
     discordUrl: discord,
     dashboardBaseUrl: env.DASHBOARD_BASE_URL,
   })
+  if (!env.DB) return webhook
+  return new LoggingNotifier({
+    inner: webhook,
+    db: env.DB,
+    formatMessage: options.formatMessage ?? webhook.formatMessage.bind(webhook),
+    requestId: options.requestId,
+  })
+}
+
+/**
+ * D1 ログのみで使う message formatter。Slack/Discord に出すのと同じ表現を
+ * 出すために WebhookNotifier の formatter をそのまま借りる。webhook URL が
+ * 全く無い場合でもこのインスタンスは format 専用に使い、fetch は呼ばれない
+ * (notify path の中に出てこない)。
+ */
+function createDefaultFormatter(env: Env): (event: NotificationEvent) => string {
+  const formatter = new WebhookNotifier({
+    slackUrl: undefined,
+    discordUrl: undefined,
+    dashboardBaseUrl: env.DASHBOARD_BASE_URL,
+  })
+  return (event) => formatter.formatMessage(event)
 }

--- a/src/infrastructure/notification/notificationEmitLog.ts
+++ b/src/infrastructure/notification/notificationEmitLog.ts
@@ -1,0 +1,110 @@
+import { desc, eq, inArray } from 'drizzle-orm'
+import {
+  notificationEmitLog,
+  type NotificationEmitLogInsert,
+  type NotificationEmitLogRow,
+} from '../db/schema'
+import { createDb } from '../db/tradeJournalRepo'
+import type { NotificationEvent, NotificationSeverity } from './Notifier'
+
+/**
+ * `notification_emit_log` table の R/W (#141)。
+ *
+ * `LoggingNotifier` (notify するたびに 1 行 INSERT する notifier 装飾) と
+ * dashboard `/dashboard/alerts` view の SELECT で使う。
+ *
+ * ここは pure な D1 アクセス層なので env binding 自体の有無は呼び出し側の
+ * 責務 (`env.DB` 不在時は呼ばない / NoopNotifier に委譲する)。
+ */
+export interface NotificationEmitLogParams {
+  event: NotificationEvent
+  /** WebhookNotifier formatter が組み立てた送信文字列。 */
+  message: string
+  severity: NotificationSeverity
+  requestId?: string
+  /** test 用に固定可能。未指定なら `new Date().toISOString()`. */
+  now?: () => Date
+}
+
+/**
+ * D1 への 1 行 INSERT。失敗は throw しない (caller が握りつぶす)。
+ *
+ * 通知ログは「あれば便利」レイヤなので、D1 が一時的に落ちても webhook 送信
+ * 自体は成功させたい — caller が必ず try/catch する前提で設計している。
+ */
+export async function insertNotificationEmit(
+  db: D1Database,
+  params: NotificationEmitLogParams,
+): Promise<void> {
+  const now = (params.now ?? (() => new Date()))().toISOString()
+  const row = toInsertRow(params, now)
+  await createDb(db).insert(notificationEmitLog).values(row)
+}
+
+function toInsertRow(
+  params: NotificationEmitLogParams,
+  timestamp: string,
+): NotificationEmitLogInsert {
+  const { event } = params
+  return {
+    timestamp,
+    requestId: params.requestId ?? null,
+    eventType: event.type,
+    severity: params.severity,
+    symbol: pickSymbol(event),
+    cause: pickCause(event),
+    message: params.message,
+  }
+}
+
+function pickSymbol(event: NotificationEvent): string | null {
+  if (event.type === 'TRADE') return event.symbol
+  if (event.type === 'ERROR') return event.symbol ?? null
+  return null
+}
+
+function pickCause(event: NotificationEvent): string | null {
+  if (event.type === 'ERROR') return event.cause ?? null
+  if (event.type === 'STATE_CHANGE') return event.field
+  return null
+}
+
+export interface LoadAlertOptions {
+  /**
+   * 表示上限。dashboard 既定 100。最大 500 (D1 query を爆発させない)。
+   */
+  limit?: number
+  /**
+   * severity フィルタ (例: `['critical', 'warning']`)。空配列 / undefined なら全件。
+   */
+  severities?: NotificationSeverity[]
+  /** event_type フィルタ ('TRADE' / 'ERROR' / 'STATE_CHANGE')。空なら全件。 */
+  eventType?: NotificationEvent['type']
+}
+
+export type AlertRow = NotificationEmitLogRow
+
+/**
+ * dashboard `/dashboard/alerts` 用 SELECT。timestamp DESC で最新から limit
+ * 件返す。severity / eventType フィルタは複合 index がカバーする方を優先
+ * (severity 単独 / event_type 単独 のみ index あり)。
+ */
+export async function loadRecentAlerts(
+  db: D1Database,
+  options: LoadAlertOptions = {},
+): Promise<AlertRow[]> {
+  const limit = clampLimit(options.limit)
+  const drizzle = createDb(db)
+  let query = drizzle.select().from(notificationEmitLog).$dynamic()
+  if (options.eventType) {
+    query = query.where(eq(notificationEmitLog.eventType, options.eventType))
+  } else if (options.severities && options.severities.length > 0) {
+    query = query.where(inArray(notificationEmitLog.severity, options.severities))
+  }
+  return await query.orderBy(desc(notificationEmitLog.id)).limit(limit)
+}
+
+function clampLimit(raw: number | undefined): number {
+  if (raw === undefined || !Number.isFinite(raw) || raw <= 0) return 100
+  return Math.min(Math.floor(raw), 500)
+}

--- a/src/infrastructure/notification/notificationEmitLog.ts
+++ b/src/infrastructure/notification/notificationEmitLog.ts
@@ -1,4 +1,4 @@
-import { desc, eq, inArray } from 'drizzle-orm'
+import { and, desc, eq, inArray, type SQL } from 'drizzle-orm'
 import {
   notificationEmitLog,
   type NotificationEmitLogInsert,
@@ -86,8 +86,9 @@ export type AlertRow = NotificationEmitLogRow
 
 /**
  * dashboard `/dashboard/alerts` 用 SELECT。timestamp DESC で最新から limit
- * 件返す。severity / eventType フィルタは複合 index がカバーする方を優先
- * (severity 単独 / event_type 単独 のみ index あり)。
+ * 件返す。severity と eventType は両方指定された場合 AND で組み合わせる
+ * (CodeRabbit #210): UI 側で両 filter の同時選択 URL が成立可能なため、
+ * data 側でも両方を反映して silently drop しないようにする。
  */
 export async function loadRecentAlerts(
   db: D1Database,
@@ -96,10 +97,15 @@ export async function loadRecentAlerts(
   const limit = clampLimit(options.limit)
   const drizzle = createDb(db)
   let query = drizzle.select().from(notificationEmitLog).$dynamic()
+  const conditions: SQL[] = []
   if (options.eventType) {
-    query = query.where(eq(notificationEmitLog.eventType, options.eventType))
-  } else if (options.severities && options.severities.length > 0) {
-    query = query.where(inArray(notificationEmitLog.severity, options.severities))
+    conditions.push(eq(notificationEmitLog.eventType, options.eventType))
+  }
+  if (options.severities && options.severities.length > 0) {
+    conditions.push(inArray(notificationEmitLog.severity, options.severities))
+  }
+  if (conditions.length > 0) {
+    query = query.where(conditions.length === 1 ? conditions[0] : and(...conditions))
   }
   // `waitUntil` 配下の INSERT が前後すると id 順は実発生順とずれることが
   // ある。timestamp (ISO 文字列) DESC を first key にし、同 timestamp は

--- a/src/infrastructure/notification/notificationEmitLog.ts
+++ b/src/infrastructure/notification/notificationEmitLog.ts
@@ -101,7 +101,12 @@ export async function loadRecentAlerts(
   } else if (options.severities && options.severities.length > 0) {
     query = query.where(inArray(notificationEmitLog.severity, options.severities))
   }
-  return await query.orderBy(desc(notificationEmitLog.id)).limit(limit)
+  // `waitUntil` 配下の INSERT が前後すると id 順は実発生順とずれることが
+  // ある。timestamp (ISO 文字列) DESC を first key にし、同 timestamp は
+  // id DESC で tiebreak する (CodeRabbit #210)。
+  return await query
+    .orderBy(desc(notificationEmitLog.timestamp), desc(notificationEmitLog.id))
+    .limit(limit)
 }
 
 function clampLimit(raw: number | undefined): number {

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -339,7 +339,8 @@ export const dashboard = new Hono<AppBindings>()
     const options: LoadAlertOptions = { limit }
     if (eventTypeFilter) {
       options.eventType = eventTypeFilter
-    } else if (severityFilter.length > 0) {
+    }
+    if (severityFilter.length > 0) {
       options.severities = severityFilter
     }
     try {

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -335,6 +335,7 @@ export const dashboard = new Hono<AppBindings>()
     const limit = clampAlertLimit(c.req.query('limit'))
     const severityFilter = parseSeverityFilter(c.req.query('severity'))
     const eventTypeFilter = parseEventTypeFilter(c.req.query('eventType'))
+    const currentQuery = parseAlertsQuery(c.req.url)
     const options: LoadAlertOptions = { limit }
     if (eventTypeFilter) {
       options.eventType = eventTypeFilter
@@ -346,7 +347,7 @@ export const dashboard = new Hono<AppBindings>()
       return c.html(
         layout(
           'アラート',
-          alertsBody({ rows, limit, severityFilter, eventTypeFilter }),
+          alertsBody({ rows, limit, severityFilter, eventTypeFilter, currentQuery }),
         ),
       )
     } catch (err) {
@@ -1113,6 +1114,20 @@ function clampAlertLimit(raw: string | undefined): number {
   return Math.min(n, 500)
 }
 
+/**
+ * `c.req.url` から `URLSearchParams` を取り出す。filter pill が他の query
+ * (例: `limit=500`) を保持するために使う (CodeRabbit #210)。
+ *
+ * URL 構築失敗時は空 URLSearchParams にフォールバック。
+ */
+function parseAlertsQuery(rawUrl: string): URLSearchParams {
+  try {
+    return new URL(rawUrl).searchParams
+  } catch {
+    return new URLSearchParams()
+  }
+}
+
 const SEVERITY_VALUES: ReadonlyArray<NotificationSeverity> = ['critical', 'warning', 'info']
 
 function parseSeverityFilter(raw: string | undefined): NotificationSeverity[] {
@@ -1142,6 +1157,8 @@ interface AlertsBodyArgs {
   limit: number
   severityFilter: NotificationSeverity[]
   eventTypeFilter: NotificationEvent['type'] | undefined
+  /** 現在の query string。filter pill が他の param (limit 等) を保持するために使う。 */
+  currentQuery: URLSearchParams
 }
 
 /**
@@ -1153,7 +1170,7 @@ interface AlertsBodyArgs {
  *   - 行クリックで Slack/Discord に出したのと同じ message を JST 時刻と一緒に確認
  */
 function alertsBody(args: AlertsBodyArgs): string {
-  const { rows, limit, severityFilter, eventTypeFilter } = args
+  const { rows, limit, severityFilter, eventTypeFilter, currentQuery } = args
   const filterDescription =
     severityFilter.length === 0 && eventTypeFilter === undefined
       ? '全件'
@@ -1164,7 +1181,7 @@ function alertsBody(args: AlertsBodyArgs): string {
           .filter((s): s is string => s !== null)
           .join(' / ')
   const header = `<p class="muted">直近 ${rows.length} 件のアラート (${esc(filterDescription)}, limit=${limit}, max 500)。Webhook が未設定でも D1 には記録されています。</p>`
-  const filterPills = renderAlertFilterPills(severityFilter, eventTypeFilter)
+  const filterPills = renderAlertFilterPills(severityFilter, eventTypeFilter, currentQuery)
   if (rows.length === 0) {
     return `${header}${filterPills}<p class="muted">該当するアラートは見つかりませんでした。</p>`
   }
@@ -1199,26 +1216,56 @@ function alertsBody(args: AlertsBodyArgs): string {
   </table>`
 }
 
-function renderAlertFilterPills(
+/**
+ * `/dashboard/alerts` の severity / eventType filter ピルを描画する。
+ *
+ * `currentQuery` の他 param (例: `limit=500`) は preserve したまま、対象 key
+ * のみを差し替える / 削除する (CodeRabbit #210)。
+ *
+ * Exported for unit test (URL preservation).
+ */
+export function renderAlertFilterPills(
   active: NotificationSeverity[],
   activeEventType: NotificationEvent['type'] | undefined,
+  currentQuery: URLSearchParams,
 ): string {
-  const sevPill = (label: string, query: string, isActive: boolean): string =>
-    `<a href="/dashboard/alerts${query}" style="margin-right:6px;${isActive ? 'background:#1d1d1f;color:#fff;' : ''}">${esc(label)}</a>`
+  const buildHref = (updatedKey: string, updatedValue: string | null): string => {
+    const next = new URLSearchParams(currentQuery)
+    if (updatedValue === null) next.delete(updatedKey)
+    else next.set(updatedKey, updatedValue)
+    const qs = next.toString()
+    return qs.length === 0 ? '/dashboard/alerts' : `/dashboard/alerts?${qs}`
+  }
+  const pill = (label: string, href: string, isActive: boolean): string =>
+    `<a href="${esc(href)}" style="margin-right:6px;${isActive ? 'background:#1d1d1f;color:#fff;' : ''}">${esc(label)}</a>`
   const sev = [
-    sevPill('全 severity', '', active.length === 0),
-    sevPill('critical', '?severity=critical', active.length === 1 && active[0] === 'critical'),
-    sevPill('warning', '?severity=warning', active.length === 1 && active[0] === 'warning'),
-    sevPill('critical+warning', '?severity=critical,warning', active.length === 2 && active.includes('critical') && active.includes('warning')),
-    sevPill('info', '?severity=info', active.length === 1 && active[0] === 'info'),
+    pill('全 severity', buildHref('severity', null), active.length === 0),
+    pill(
+      'critical',
+      buildHref('severity', 'critical'),
+      active.length === 1 && active[0] === 'critical',
+    ),
+    pill(
+      'warning',
+      buildHref('severity', 'warning'),
+      active.length === 1 && active[0] === 'warning',
+    ),
+    pill(
+      'critical+warning',
+      buildHref('severity', 'critical,warning'),
+      active.length === 2 && active.includes('critical') && active.includes('warning'),
+    ),
+    pill('info', buildHref('severity', 'info'), active.length === 1 && active[0] === 'info'),
   ].join('')
-  const evPill = (label: string, query: string, isActive: boolean): string =>
-    `<a href="/dashboard/alerts${query}" style="margin-right:6px;${isActive ? 'background:#1d1d1f;color:#fff;' : ''}">${esc(label)}</a>`
   const ev = [
-    evPill('全 type', '', activeEventType === undefined),
-    evPill('ERROR', '?eventType=ERROR', activeEventType === 'ERROR'),
-    evPill('TRADE', '?eventType=TRADE', activeEventType === 'TRADE'),
-    evPill('STATE_CHANGE', '?eventType=STATE_CHANGE', activeEventType === 'STATE_CHANGE'),
+    pill('全 type', buildHref('eventType', null), activeEventType === undefined),
+    pill('ERROR', buildHref('eventType', 'ERROR'), activeEventType === 'ERROR'),
+    pill('TRADE', buildHref('eventType', 'TRADE'), activeEventType === 'TRADE'),
+    pill(
+      'STATE_CHANGE',
+      buildHref('eventType', 'STATE_CHANGE'),
+      activeEventType === 'STATE_CHANGE',
+    ),
   ].join('')
   return `<nav style="margin-bottom:12px">${sev}<span class="muted" style="margin:0 8px">|</span>${ev}</nav>`
 }

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -5,6 +5,12 @@ import { loadGlobalConfigFrom } from '../infrastructure/db/globalConfigLoader'
 import { loadSymbolUniverse } from '../infrastructure/db/symbolUniverse'
 import { createDb } from '../infrastructure/db/tradeJournalRepo'
 import { MAX_TIME_STOP_DAYS, strategyDecisionLog, tradeJournal } from '../infrastructure/db/schema'
+import {
+  loadRecentAlerts,
+  type AlertRow,
+  type LoadAlertOptions,
+} from '../infrastructure/notification/notificationEmitLog'
+import type { NotificationSeverity, NotificationEvent } from '../infrastructure/notification/Notifier'
 import { and, asc, desc, eq } from 'drizzle-orm'
 import { PortfolioStateClient } from '../trading/state/PortfolioStateClient'
 import { SymbolStateClient } from '../trading/state/SymbolStateClient'
@@ -322,6 +328,33 @@ export const dashboard = new Hono<AppBindings>()
       return c.html(layout('Cron 判定', unavailable(messageOf(err))))
     }
   })
+  .get('/alerts', async (c) => {
+    if (!c.env.DB) {
+      return c.html(layout('アラート', unavailable('DB not bound')))
+    }
+    const limit = clampAlertLimit(c.req.query('limit'))
+    const severityFilter = parseSeverityFilter(c.req.query('severity'))
+    const eventTypeFilter = parseEventTypeFilter(c.req.query('eventType'))
+    const options: LoadAlertOptions = { limit }
+    if (eventTypeFilter) {
+      options.eventType = eventTypeFilter
+    } else if (severityFilter.length > 0) {
+      options.severities = severityFilter
+    }
+    try {
+      const rows = await loadRecentAlerts(c.env.DB, options)
+      return c.html(
+        layout(
+          'アラート',
+          alertsBody({ rows, limit, severityFilter, eventTypeFilter }),
+        ),
+      )
+    } catch (err) {
+      // 0012 migration 未適用 (= notification_emit_log テーブル無し) を
+      // 500 にせず unavailable に落とす。段階的デプロイ時の自己保護。
+      return c.html(layout('アラート', unavailable(messageOf(err))))
+    }
+  })
 
 function messageOf(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
@@ -424,6 +457,7 @@ function layout(title: string, body: string): string {
   <a href="/dashboard/config">設定</a>
   <a href="/dashboard/cron">Cron</a>
   <a href="/dashboard/charts">チャート</a>
+  <a href="/dashboard/alerts">アラート</a>
 </nav>
 ${body}
 <div class="footer">画面生成時刻: ${esc(fmtJst(new Date()))}</div>
@@ -460,6 +494,7 @@ function indexBody(): string {
   <li><a href="/dashboard/config">設定</a> — <code>global_config</code> + 有効な <code>symbol_config</code></li>
   <li><a href="/dashboard/cron">Cron 判定</a> — <code>strategy_decision_log</code> 直近 (<code>?symbol=SOXL</code> で絞り込み可)</li>
   <li><a href="/dashboard/charts">チャート</a> — 概要 (エクイティカーブ + ドローダウン) / 取引品質 (PnL 分布 + 統計 + Decision breakdown) / 個別銘柄 (price + SMA50 + entry/exit) を tab 切替</li>
+  <li><a href="/dashboard/alerts">アラート</a> — Slack/Discord に push 通知した critical / warning / info の直近 (#141)。webhook 未設定でも D1 に記録される。</li>
 </ul>`
 }
 
@@ -1066,6 +1101,126 @@ export function localizeReason(en: string | null | undefined): string {
     'データ不足: 同グループ発注金額が無効 ($1 の金額 $2)',
   )
   return s
+}
+
+/**
+ * `?limit=N` を 1〜500 の範囲に丸める。`/dashboard/alerts` 専用 (cron 系の
+ * `clampLimit` は既定 50 / max 200 で別ロール)。
+ */
+function clampAlertLimit(raw: string | undefined): number {
+  const n = raw === undefined ? 100 : Number.parseInt(raw, 10)
+  if (!Number.isFinite(n) || n <= 0) return 100
+  return Math.min(n, 500)
+}
+
+const SEVERITY_VALUES: ReadonlyArray<NotificationSeverity> = ['critical', 'warning', 'info']
+
+function parseSeverityFilter(raw: string | undefined): NotificationSeverity[] {
+  if (!raw) return []
+  return raw
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter((s): s is NotificationSeverity =>
+      (SEVERITY_VALUES as readonly string[]).includes(s),
+    )
+}
+
+const EVENT_TYPE_VALUES: ReadonlyArray<NotificationEvent['type']> = [
+  'TRADE',
+  'ERROR',
+  'STATE_CHANGE',
+]
+
+function parseEventTypeFilter(raw: string | undefined): NotificationEvent['type'] | undefined {
+  if (!raw) return undefined
+  const upper = raw.trim().toUpperCase() as NotificationEvent['type']
+  return (EVENT_TYPE_VALUES as readonly string[]).includes(upper) ? upper : undefined
+}
+
+interface AlertsBodyArgs {
+  rows: AlertRow[]
+  limit: number
+  severityFilter: NotificationSeverity[]
+  eventTypeFilter: NotificationEvent['type'] | undefined
+}
+
+/**
+ * `/dashboard/alerts` の HTML 本文 (#141)。
+ *
+ *   - severity ピル (critical / warning / info / 全件) で絞り込み
+ *   - event type ピル (TRADE / ERROR / STATE_CHANGE / 全件) で絞り込み
+ *   - 表示は最新 100 件 (`?limit=N` で 1〜500)
+ *   - 行クリックで Slack/Discord に出したのと同じ message を JST 時刻と一緒に確認
+ */
+function alertsBody(args: AlertsBodyArgs): string {
+  const { rows, limit, severityFilter, eventTypeFilter } = args
+  const filterDescription =
+    severityFilter.length === 0 && eventTypeFilter === undefined
+      ? '全件'
+      : [
+          severityFilter.length > 0 ? `severity=${severityFilter.join(',')}` : null,
+          eventTypeFilter ? `eventType=${eventTypeFilter}` : null,
+        ]
+          .filter((s): s is string => s !== null)
+          .join(' / ')
+  const header = `<p class="muted">直近 ${rows.length} 件のアラート (${esc(filterDescription)}, limit=${limit}, max 500)。Webhook が未設定でも D1 には記録されています。</p>`
+  const filterPills = renderAlertFilterPills(severityFilter, eventTypeFilter)
+  if (rows.length === 0) {
+    return `${header}${filterPills}<p class="muted">該当するアラートは見つかりませんでした。</p>`
+  }
+  const tbody = rows
+    .map((r) => {
+      const cls =
+        r.severity === 'critical'
+          ? 'err'
+          : r.severity === 'warning'
+            ? 'warn'
+            : 'muted'
+      const symbolCell = r.symbol
+        ? `<a href="/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(r.symbol)}">${esc(r.symbol)}</a>`
+        : '<span class="muted">-</span>'
+      return `<tr>
+        <td class="muted">${esc(fmtJst(r.timestamp))}</td>
+        <td class="${cls}"><strong>${esc(r.severity)}</strong></td>
+        <td>${esc(r.eventType)}</td>
+        <td>${symbolCell}</td>
+        <td>${esc(r.cause ?? '-')}</td>
+        <td><code style="white-space:pre-wrap">${esc(r.message)}</code></td>
+        <td class="muted"><code>${esc(r.requestId ?? '-')}</code></td>
+      </tr>`
+    })
+    .join('')
+  return `${header}${filterPills}
+  <table>
+    <thead><tr>
+      <th>timestamp (JST)</th><th>severity</th><th>event</th><th>symbol</th><th>cause / field</th><th>message</th><th>requestId</th>
+    </tr></thead>
+    <tbody>${tbody}</tbody>
+  </table>`
+}
+
+function renderAlertFilterPills(
+  active: NotificationSeverity[],
+  activeEventType: NotificationEvent['type'] | undefined,
+): string {
+  const sevPill = (label: string, query: string, isActive: boolean): string =>
+    `<a href="/dashboard/alerts${query}" style="margin-right:6px;${isActive ? 'background:#1d1d1f;color:#fff;' : ''}">${esc(label)}</a>`
+  const sev = [
+    sevPill('全 severity', '', active.length === 0),
+    sevPill('critical', '?severity=critical', active.length === 1 && active[0] === 'critical'),
+    sevPill('warning', '?severity=warning', active.length === 1 && active[0] === 'warning'),
+    sevPill('critical+warning', '?severity=critical,warning', active.length === 2 && active.includes('critical') && active.includes('warning')),
+    sevPill('info', '?severity=info', active.length === 1 && active[0] === 'info'),
+  ].join('')
+  const evPill = (label: string, query: string, isActive: boolean): string =>
+    `<a href="/dashboard/alerts${query}" style="margin-right:6px;${isActive ? 'background:#1d1d1f;color:#fff;' : ''}">${esc(label)}</a>`
+  const ev = [
+    evPill('全 type', '', activeEventType === undefined),
+    evPill('ERROR', '?eventType=ERROR', activeEventType === 'ERROR'),
+    evPill('TRADE', '?eventType=TRADE', activeEventType === 'TRADE'),
+    evPill('STATE_CHANGE', '?eventType=STATE_CHANGE', activeEventType === 'STATE_CHANGE'),
+  ].join('')
+  return `<nav style="margin-bottom:12px">${sev}<span class="muted" style="margin:0 8px">|</span>${ev}</nav>`
 }
 
 function cronBody(

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -3,7 +3,12 @@ import { YahooBarClient } from '../../infrastructure/quotes/YahooBarClient'
 import { loadGlobalConfigFrom } from '../../infrastructure/db/globalConfigLoader'
 import { loadSymbolUniverse } from '../../infrastructure/db/symbolUniverse'
 import type { SymbolCurrency } from '../../infrastructure/db/symbolConfigRepo'
+import {
+  detectAndNotifyConfigStateChanges,
+  type WatchedConfig,
+} from '../../infrastructure/notification/configStateChange'
 import { createNotifier } from '../../infrastructure/notification/createNotifier'
+import type { Notifier } from '../../infrastructure/notification/Notifier'
 import { createWebullHttpClient } from '../../infrastructure/webull/WebullHttpClient'
 import { MockExecution } from '../execution/MockExecution'
 import { WebullExecution } from '../execution/WebullExecution'
@@ -130,6 +135,36 @@ export async function runStrategyCron(
     loadSymbolUniverse(env),
   ])
 
+  // Notifier は cron tick の最序盤で組み立てる: 後続の skipReason 通知や
+  // state change 検知が同じ instance を使う (#141)。requestId を伝搬させる
+  // ことで `notification_emit_log.request_id` に紐付く。
+  const notifier = createNotifier(env, { requestId: options.requestId })
+
+  // global_config の watched field 遷移を検知 (#141)。await して snapshot を
+  // 確実に書き終えてから次の処理に進む — 1 cron tick 中に複数の通知 path が
+  // STATE_CHANGE を出すと重複するので、ここで 1 回だけ走らせる。失敗しても
+  // 内部で握りつぶされる (caller は気にしなくて良い)。
+  const watchedNow: WatchedConfig = {
+    dryRun: global.dryRun,
+    tradingEnabled: global.tradingEnabled,
+    marketHoursCheck: global.marketHoursCheck,
+    drawdownKillThreshold: global.drawdownKillThreshold,
+  }
+  await detectAndNotifyConfigStateChanges({
+    db: env.DB,
+    notifier,
+    current: watchedNow,
+    requestId: options.requestId,
+  }).catch((err) => {
+    console.warn(
+      JSON.stringify({
+        event: 'config_state_change_detect_failed',
+        requestId: options.requestId,
+        message: err instanceof Error ? err.message : String(err),
+      }),
+    )
+  })
+
   const defaultRule = {
     stopPct: global.pullbackDefaultStopPct,
     takeProfitPct: global.pullbackDefaultTakeProfitPct,
@@ -171,6 +206,9 @@ export async function runStrategyCron(
     decisions: [],
   })
 
+  // Critical な cron skip は #141 で push 通知化する。`trading_disabled` /
+  // `no_tradable_symbols` は「設定通り」なので noisy にしないよう **通知しない**
+  // (operator は意図的に切ってる場合が多い)。
   if (!global.tradingEnabled) {
     return { summary: emptySummary(), symbols: [], analysis: analysisBase(), skipReason: 'trading_disabled' }
   }
@@ -180,6 +218,7 @@ export async function runStrategyCron(
   }
 
   if (!env.SYMBOL_STATE) {
+    emitSkipReasonNotify(notifier, 'no_bridge_state', options.requestId, 'critical')
     return {
       summary: emptySummary(),
       symbols: universe.allowedSymbols,
@@ -195,6 +234,7 @@ export async function runStrategyCron(
   // - tradingDisabledUntil が有効 & 未来 → halt
   // - drawdown 閾値超過 → halt
   if (!env.PORTFOLIO_STATE) {
+    emitSkipReasonNotify(notifier, 'portfolio_halted', options.requestId, 'critical', 'PORTFOLIO_STATE binding missing')
     return {
       summary: emptySummary(),
       symbols: universe.allowedSymbols,
@@ -229,6 +269,13 @@ export async function runStrategyCron(
     if (portfolioSnapshot.tradingDisabledUntil) {
       const disabledUntilMs = new Date(portfolioSnapshot.tradingDisabledUntil).getTime()
       if (!Number.isFinite(disabledUntilMs) || disabledUntilMs > now) {
+        emitSkipReasonNotify(
+          notifier,
+          'portfolio_halted',
+          options.requestId,
+          'critical',
+          `tradingDisabledUntil=${portfolioSnapshot.tradingDisabledUntil}`,
+        )
         return {
           summary: emptySummary(),
           symbols: universe.allowedSymbols,
@@ -240,6 +287,13 @@ export async function runStrategyCron(
     if (portfolioSnapshot.dailyStartEquity > 0) {
       const ratio = portfolioSnapshot.dailyRealizedPnl / portfolioSnapshot.dailyStartEquity
       if (ratio <= global.drawdownKillThreshold) {
+        emitSkipReasonNotify(
+          notifier,
+          'drawdown_kill',
+          options.requestId,
+          'critical',
+          `ratio=${ratio.toFixed(4)} <= threshold=${global.drawdownKillThreshold}`,
+        )
         return {
           summary: emptySummary(),
           symbols: universe.allowedSymbols,
@@ -248,7 +302,14 @@ export async function runStrategyCron(
         }
       }
     }
-  } catch {
+  } catch (error) {
+    emitSkipReasonNotify(
+      notifier,
+      'portfolio_halted',
+      options.requestId,
+      'critical',
+      `getPortfolio threw: ${error instanceof Error ? error.message : String(error)}`,
+    )
     return {
       summary: emptySummary(),
       symbols: universe.allowedSymbols,
@@ -311,8 +372,9 @@ export async function runStrategyCron(
   const execution = global.dryRun
     ? new MockExecution()
     : new WebullExecution(createWebullHttpClient(env))
-  // Slack/Discord webhook 通知 (#199)。env 未設定なら NoopNotifier。
-  const notifier = createNotifier(env)
+  // notifier は関数冒頭で組み立て済み (#141)。BUY/SELL emit / per-symbol
+  // bar fetch error / broker submit error は scheduler 内で注入された
+  // notifier を使う (#199 経路のまま)。
   // Yahoo Finance /v8/finance/chart is free, no auth, covers US + JP (7267.T
   // style) in one endpoint — chosen over Webull's JP-subscription-gated
   // market-data API (see #84). Webull is still the order-execution path.
@@ -509,4 +571,39 @@ export function emitStaleRollWarningIfNeeded(args: {
       }),
     )
   }
+}
+
+/**
+ * cron tick の skip reason を Notifier に push する (#141)。fire-and-forget
+ * + silent fallback。`portfolio_halted` / `drawdown_kill` / `no_bridge_state`
+ * の 3 種を critical として通知する。
+ *
+ * 既存の `strategy_cron_run.skipReason` ログ列はそのまま (後方互換)。
+ */
+function emitSkipReasonNotify(
+  notifier: Notifier,
+  reason: 'portfolio_halted' | 'drawdown_kill' | 'no_bridge_state',
+  requestId: string | undefined,
+  severity: 'critical' | 'warning' = 'critical',
+  detail?: string,
+): void {
+  const note = requestId ? ` requestId=${requestId}` : ''
+  const message = detail ? `cron skipped: ${reason} — ${detail}${note}` : `cron skipped: ${reason}${note}`
+  notifier
+    .notify({
+      type: 'ERROR',
+      message,
+      cause: reason,
+      severity,
+    })
+    .catch((err) => {
+      console.warn(
+        JSON.stringify({
+          event: 'cron_skip_notify_failed',
+          requestId,
+          reason,
+          message: err instanceof Error ? err.message : String(err),
+        }),
+      )
+    })
 }

--- a/test/infrastructure/notification/LoggingNotifier.test.ts
+++ b/test/infrastructure/notification/LoggingNotifier.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  LoggingNotifier,
+  pickSeverity,
+} from '../../../src/infrastructure/notification/LoggingNotifier'
+import type {
+  Notifier,
+  NotificationEvent,
+} from '../../../src/infrastructure/notification/Notifier'
+
+/**
+ * D1 binding を最小限 mock する: drizzle-orm の `insert(...).values(...)` を
+ * 通すだけで良い。createDb → drizzle(d1) は drizzle-orm/d1 が呼ぶので、
+ * ここでは prepare → first/all を呼ばない経路 (insert のみ) をスタブする。
+ */
+function fakeD1(opts: { onInsert?: () => void; throwOnInsert?: Error } = {}): D1Database {
+  const stmt = {
+    bind: () => stmt,
+    first: async () => null,
+    all: async () => ({ results: [], success: true, meta: {} as never }),
+    run: async () => {
+      if (opts.throwOnInsert) throw opts.throwOnInsert
+      opts.onInsert?.()
+      return { success: true, meta: {} as never }
+    },
+    raw: async () => [],
+  }
+  const db = {
+    prepare: () => stmt,
+    batch: async () => [],
+    exec: async () => ({ count: 0, duration: 0 } as never),
+    dump: async () => new ArrayBuffer(0),
+  } as unknown as D1Database
+  return db
+}
+
+function fakeInner(): { notifier: Notifier; calls: NotificationEvent[] } {
+  const calls: NotificationEvent[] = []
+  return {
+    notifier: {
+      async notify(event) {
+        calls.push(event)
+      },
+    },
+    calls,
+  }
+}
+
+describe('LoggingNotifier', () => {
+  it('forwards event to inner Notifier and INSERTs into D1', async () => {
+    const inner = fakeInner()
+    let inserted = false
+    const db = fakeD1({ onInsert: () => (inserted = true) })
+    const lg = new LoggingNotifier({
+      inner: inner.notifier,
+      db,
+      formatMessage: () => 'fmt',
+    })
+
+    await lg.notify({
+      type: 'TRADE',
+      side: 'BUY',
+      symbol: 'AAPL',
+      qty: 1,
+      price: 100,
+      mode: 'DRY_RUN',
+    })
+
+    expect(inner.calls).toHaveLength(1)
+    expect(inner.calls[0]?.type).toBe('TRADE')
+    expect(inserted).toBe(true)
+  })
+
+  it('still resolves when inner Notifier throws (silent fallback)', async () => {
+    const innerThrowing: Notifier = {
+      async notify() {
+        throw new Error('webhook down')
+      },
+    }
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const db = fakeD1()
+    const lg = new LoggingNotifier({
+      inner: innerThrowing,
+      db,
+      formatMessage: () => 'fmt',
+    })
+
+    await expect(
+      lg.notify({ type: 'ERROR', message: 'x', severity: 'critical' }),
+    ).resolves.toBeUndefined()
+    expect(warnSpy).toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
+  it('still resolves when D1 INSERT throws (silent fallback)', async () => {
+    const inner = fakeInner()
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const db = fakeD1({ throwOnInsert: new Error('D1 timeout') })
+    const lg = new LoggingNotifier({
+      inner: inner.notifier,
+      db,
+      formatMessage: () => 'fmt',
+    })
+
+    await expect(
+      lg.notify({ type: 'ERROR', message: 'x', severity: 'warning' }),
+    ).resolves.toBeUndefined()
+    // 内部で warn が出る (DB 失敗の log)
+    expect(warnSpy).toHaveBeenCalled()
+    // inner notifier は呼ばれている
+    expect(inner.calls).toHaveLength(1)
+    warnSpy.mockRestore()
+  })
+})
+
+describe('pickSeverity', () => {
+  it('maps TRADE → info', () => {
+    expect(
+      pickSeverity({
+        type: 'TRADE',
+        side: 'BUY',
+        symbol: 'X',
+        qty: 1,
+        price: 1,
+        mode: 'DRY_RUN',
+      }),
+    ).toBe('info')
+  })
+  it('takes ERROR.severity, defaulting to warning', () => {
+    expect(pickSeverity({ type: 'ERROR', message: 'm' })).toBe('warning')
+    expect(pickSeverity({ type: 'ERROR', message: 'm', severity: 'critical' })).toBe('critical')
+  })
+  it('takes STATE_CHANGE.severity', () => {
+    expect(
+      pickSeverity({
+        type: 'STATE_CHANGE',
+        field: 'dryRun',
+        from: true,
+        to: false,
+        severity: 'critical',
+      }),
+    ).toBe('critical')
+  })
+})

--- a/test/infrastructure/notification/WebhookNotifier.test.ts
+++ b/test/infrastructure/notification/WebhookNotifier.test.ts
@@ -203,4 +203,88 @@ describe('WebhookNotifier', () => {
     const body = JSON.parse(String(calls[0]?.init.body))
     expect(body.text).not.toContain('/dashboard/charts')
   })
+
+  // #141: severity / STATE_CHANGE 拡張
+  it('renders ERROR with severity=critical using a critical icon and CRITICAL label', async () => {
+    const { fn, calls } = makeFetch()
+    const notifier = new WebhookNotifier({ slackUrl: 'https://hooks.slack.test/x', fetchImpl: fn })
+
+    await notifier.notify({
+      type: 'ERROR',
+      message: 'cron skipped: portfolio_halted',
+      cause: 'portfolio_halted',
+      severity: 'critical',
+    })
+
+    const body = JSON.parse(String(calls[0]?.init.body))
+    expect(body.text).toContain('🚨')
+    expect(body.text).toContain('CRITICAL')
+    expect(body.text).toContain('portfolio_halted')
+  })
+
+  it('renders ERROR with default severity=warning using ⚠️ icon (back-compat)', async () => {
+    const { fn, calls } = makeFetch()
+    const notifier = new WebhookNotifier({ slackUrl: 'https://hooks.slack.test/x', fetchImpl: fn })
+
+    await notifier.notify({
+      type: 'ERROR',
+      symbol: 'NVDA',
+      message: 'upstream 500',
+      cause: 'bar fetch',
+    })
+
+    const body = JSON.parse(String(calls[0]?.init.body))
+    expect(body.text).toContain('⚠️')
+    expect(body.text).toContain('cron error')
+    expect(body.text).not.toContain('CRITICAL')
+  })
+
+  it('renders STATE_CHANGE event with critical icon and field/from/to', async () => {
+    const { fn, calls } = makeFetch()
+    const notifier = new WebhookNotifier({ slackUrl: 'https://hooks.slack.test/x', fetchImpl: fn })
+
+    await notifier.notify({
+      type: 'STATE_CHANGE',
+      field: 'dryRun',
+      from: true,
+      to: false,
+      severity: 'critical',
+      note: 'requestId=abc',
+    })
+
+    const body = JSON.parse(String(calls[0]?.init.body))
+    expect(body.text).toContain('🚨')
+    expect(body.text).toContain('state change: dryRun true → false')
+    expect(body.text).toContain('requestId=abc')
+  })
+
+  it('renders STATE_CHANGE with info severity using ℹ️ icon', async () => {
+    const { fn, calls } = makeFetch()
+    const notifier = new WebhookNotifier({ slackUrl: 'https://hooks.slack.test/x', fetchImpl: fn })
+
+    await notifier.notify({
+      type: 'STATE_CHANGE',
+      field: 'tradingEnabled',
+      from: true,
+      to: false,
+      severity: 'info',
+    })
+
+    const body = JSON.parse(String(calls[0]?.init.body))
+    expect(body.text).toContain('ℹ️')
+    expect(body.text).toContain('state change: tradingEnabled true → false')
+  })
+
+  it('formatMessage is exposed for LoggingNotifier reuse (#141)', () => {
+    const notifier = new WebhookNotifier({ slackUrl: 'https://hooks.slack.test/x' })
+    const text = notifier.formatMessage({
+      type: 'ERROR',
+      message: 'reconcile fails',
+      cause: 'reconcile_fills',
+      severity: 'critical',
+    })
+    expect(text).toContain('🚨')
+    expect(text).toContain('CRITICAL')
+    expect(text).toContain('reconcile fails')
+  })
 })

--- a/test/infrastructure/notification/configStateChange.test.ts
+++ b/test/infrastructure/notification/configStateChange.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  classifySeverity,
+  diffConfigState,
+  notifyConfigStateChanges,
+  type WatchedConfig,
+} from '../../../src/infrastructure/notification/configStateChange'
+import type {
+  Notifier,
+  NotificationEvent,
+} from '../../../src/infrastructure/notification/Notifier'
+
+const baseCurrent: WatchedConfig = {
+  dryRun: true,
+  tradingEnabled: false,
+  marketHoursCheck: false,
+  drawdownKillThreshold: -0.02,
+}
+
+describe('classifySeverity', () => {
+  it('dry_run true → false is critical', () => {
+    expect(classifySeverity('dryRun', true, false)).toBe('critical')
+  })
+  it('dry_run false → true is info', () => {
+    expect(classifySeverity('dryRun', false, true)).toBe('info')
+  })
+  it('trading_enabled false → true is critical', () => {
+    expect(classifySeverity('tradingEnabled', false, true)).toBe('critical')
+  })
+  it('trading_enabled true → false is info', () => {
+    expect(classifySeverity('tradingEnabled', true, false)).toBe('info')
+  })
+  it('drawdown_kill_threshold loosening (closer to 0) is critical', () => {
+    expect(classifySeverity('drawdownKillThreshold', -0.05, -0.02)).toBe('critical')
+  })
+  it('drawdown_kill_threshold tightening (further from 0) is info', () => {
+    expect(classifySeverity('drawdownKillThreshold', -0.02, -0.05)).toBe('info')
+  })
+})
+
+describe('diffConfigState', () => {
+  it('returns empty when no previous snapshots exist (initial run)', () => {
+    const changes = diffConfigState(baseCurrent, new Map())
+    expect(changes).toEqual([])
+  })
+
+  it('returns empty when values match the snapshots', () => {
+    const previous = new Map<string, string>([
+      ['dryRun', JSON.stringify(true)],
+      ['tradingEnabled', JSON.stringify(false)],
+      ['marketHoursCheck', JSON.stringify(false)],
+      ['drawdownKillThreshold', JSON.stringify(-0.02)],
+    ])
+    const changes = diffConfigState(baseCurrent, previous)
+    expect(changes).toEqual([])
+  })
+
+  it('detects dry_run true → false as critical', () => {
+    const previous = new Map<string, string>([['dryRun', JSON.stringify(true)]])
+    const current: WatchedConfig = { ...baseCurrent, dryRun: false }
+    const changes = diffConfigState(current, previous)
+    expect(changes).toHaveLength(1)
+    expect(changes[0]).toMatchObject({
+      field: 'dryRun',
+      from: true,
+      to: false,
+      severity: 'critical',
+    })
+  })
+
+  it('detects trading_enabled false → true as critical', () => {
+    const previous = new Map<string, string>([['tradingEnabled', JSON.stringify(false)]])
+    const current: WatchedConfig = { ...baseCurrent, tradingEnabled: true }
+    const changes = diffConfigState(current, previous)
+    expect(changes).toHaveLength(1)
+    expect(changes[0]).toMatchObject({
+      field: 'tradingEnabled',
+      from: false,
+      to: true,
+      severity: 'critical',
+    })
+  })
+
+  it('detects multiple changes in one tick', () => {
+    const previous = new Map<string, string>([
+      ['dryRun', JSON.stringify(true)],
+      ['tradingEnabled', JSON.stringify(false)],
+    ])
+    const current: WatchedConfig = { ...baseCurrent, dryRun: false, tradingEnabled: true }
+    const changes = diffConfigState(current, previous)
+    expect(changes).toHaveLength(2)
+    const fields = changes.map((c) => c.field).sort()
+    expect(fields).toEqual(['dryRun', 'tradingEnabled'])
+  })
+})
+
+describe('notifyConfigStateChanges', () => {
+  it('emits one STATE_CHANGE event per detected change', () => {
+    const calls: NotificationEvent[] = []
+    const notifier: Notifier = {
+      async notify(event) {
+        calls.push(event)
+      },
+    }
+    notifyConfigStateChanges(
+      notifier,
+      [
+        {
+          field: 'dryRun',
+          from: true,
+          to: false,
+          severity: 'critical',
+        },
+      ],
+      'req-1',
+    )
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toMatchObject({
+      type: 'STATE_CHANGE',
+      field: 'dryRun',
+      from: true,
+      to: false,
+      severity: 'critical',
+      note: 'requestId=req-1',
+    })
+  })
+
+  it('does not throw when notifier rejects (fire-and-forget)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const notifier: Notifier = {
+      async notify() {
+        throw new Error('webhook down')
+      },
+    }
+    expect(() =>
+      notifyConfigStateChanges(
+        notifier,
+        [
+          {
+            field: 'dryRun',
+            from: true,
+            to: false,
+            severity: 'critical',
+          },
+        ],
+        undefined,
+      ),
+    ).not.toThrow()
+    warnSpy.mockRestore()
+  })
+})

--- a/test/infrastructure/notification/createNotifier.test.ts
+++ b/test/infrastructure/notification/createNotifier.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { Env } from '../../../src/config/env'
 import { createNotifier } from '../../../src/infrastructure/notification/createNotifier'
+import { LoggingNotifier } from '../../../src/infrastructure/notification/LoggingNotifier'
 import { NoopNotifier } from '../../../src/infrastructure/notification/NoopNotifier'
 import { WebhookNotifier } from '../../../src/infrastructure/notification/WebhookNotifier'
 
@@ -14,29 +15,29 @@ function makeEnv(overrides: Partial<Env> = {}): Env {
 }
 
 describe('createNotifier', () => {
-  it('returns NoopNotifier when no webhook URLs are configured', () => {
+  it('returns NoopNotifier when no webhook URLs and no DB are configured', () => {
     const n = createNotifier(makeEnv())
     expect(n).toBeInstanceOf(NoopNotifier)
   })
 
-  it('returns NoopNotifier when both URLs are blank strings', () => {
+  it('returns NoopNotifier when both URLs are blank strings and no DB', () => {
     const n = createNotifier(
       makeEnv({ SLACK_WEBHOOK_URL: '   ', DISCORD_WEBHOOK_URL: '' }),
     )
     expect(n).toBeInstanceOf(NoopNotifier)
   })
 
-  it('returns WebhookNotifier when only Slack is set', () => {
+  it('returns WebhookNotifier when only Slack is set (no DB)', () => {
     const n = createNotifier(makeEnv({ SLACK_WEBHOOK_URL: 'https://hooks.slack.test/x' }))
     expect(n).toBeInstanceOf(WebhookNotifier)
   })
 
-  it('returns WebhookNotifier when only Discord is set', () => {
+  it('returns WebhookNotifier when only Discord is set (no DB)', () => {
     const n = createNotifier(makeEnv({ DISCORD_WEBHOOK_URL: 'https://discord.test/webhooks/abc' }))
     expect(n).toBeInstanceOf(WebhookNotifier)
   })
 
-  it('returns WebhookNotifier when both are set', () => {
+  it('returns WebhookNotifier when both are set (no DB)', () => {
     const n = createNotifier(
       makeEnv({
         SLACK_WEBHOOK_URL: 'https://hooks.slack.test/x',
@@ -44,5 +45,21 @@ describe('createNotifier', () => {
       }),
     )
     expect(n).toBeInstanceOf(WebhookNotifier)
+  })
+
+  // #141: env.DB あり = LoggingNotifier で wrap される (D1 ログ用)
+  it('returns LoggingNotifier wrapping NoopNotifier when only DB is bound (#141)', () => {
+    const n = createNotifier(makeEnv({ DB: {} as D1Database }))
+    expect(n).toBeInstanceOf(LoggingNotifier)
+  })
+
+  it('returns LoggingNotifier wrapping WebhookNotifier when DB + URLs are set (#141)', () => {
+    const n = createNotifier(
+      makeEnv({
+        DB: {} as D1Database,
+        SLACK_WEBHOOK_URL: 'https://hooks.slack.test/x',
+      }),
+    )
+    expect(n).toBeInstanceOf(LoggingNotifier)
   })
 })

--- a/test/infrastructure/notification/notificationEmitLog.test.ts
+++ b/test/infrastructure/notification/notificationEmitLog.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest'
+import { loadRecentAlerts } from '../../../src/infrastructure/notification/notificationEmitLog'
+import { createDb } from '../../../src/infrastructure/db/tradeJournalRepo'
+import type { AlertRow } from '../../../src/infrastructure/notification/notificationEmitLog'
+
+vi.mock('../../../src/infrastructure/db/tradeJournalRepo', () => ({
+  createDb: vi.fn(),
+}))
+
+/**
+ * `loadRecentAlerts` の filter 適用テスト (CodeRabbit #210)。
+ *
+ * drizzle-orm の SQL 生成自体は信頼するが、
+ *   - `eventType` のみ指定 → eq 1 つ
+ *   - `severities` のみ指定 → inArray 1 つ
+ *   - 両方指定 → AND で結合 (silently drop しない)
+ *   - 何も指定なし → where 呼び出しなし
+ * を build chain spy で検証する。
+ */
+function fakeDrizzleChain(rows: AlertRow[]) {
+  const query = {
+    from: vi.fn(() => query),
+    $dynamic: vi.fn(() => query),
+    where: vi.fn((_arg: unknown) => query),
+    orderBy: vi.fn((..._args: unknown[]) => query),
+    limit: vi.fn(async (_n: number) => rows),
+  }
+  return {
+    query,
+    db: {
+      select: vi.fn(() => query),
+    },
+  }
+}
+
+const fakeD1 = {} as D1Database
+
+describe('loadRecentAlerts', () => {
+  it('applies eventType-only filter via eq()', async () => {
+    const { db, query } = fakeDrizzleChain([])
+    vi.mocked(createDb).mockReturnValue(db as unknown as ReturnType<typeof createDb>)
+
+    await loadRecentAlerts(fakeD1, { eventType: 'TRADE' })
+
+    expect(query.where).toHaveBeenCalledTimes(1)
+    // eq() returns a SQL chunk — we only assert that exactly 1 condition
+    // was passed (i.e. not wrapped in and()).
+    const arg = query.where.mock.calls[0]![0]
+    expect(arg).toBeDefined()
+  })
+
+  it('applies severities-only filter via inArray()', async () => {
+    const { db, query } = fakeDrizzleChain([])
+    vi.mocked(createDb).mockReturnValue(db as unknown as ReturnType<typeof createDb>)
+
+    await loadRecentAlerts(fakeD1, { severities: ['critical'] })
+
+    expect(query.where).toHaveBeenCalledTimes(1)
+    const arg = query.where.mock.calls[0]![0]
+    expect(arg).toBeDefined()
+  })
+
+  it('AND-combines eventType + severities when both are present (#210)', async () => {
+    const { db, query } = fakeDrizzleChain([])
+    vi.mocked(createDb).mockReturnValue(db as unknown as ReturnType<typeof createDb>)
+
+    await loadRecentAlerts(fakeD1, {
+      eventType: 'TRADE',
+      severities: ['critical'],
+    })
+
+    expect(query.where).toHaveBeenCalledTimes(1)
+    const condition = query.where.mock.calls[0]![0] as { queryChunks?: unknown[] } | undefined
+    expect(condition).toBeDefined()
+    // drizzle-orm の and() は SQL オブジェクトを返し、内部に複数の SQL chunk を
+    // 持つ。ここでは `queryChunks` 配列の存在 (= 単一条件ではなく結合) を
+    // 軽く確認するに留める。
+    expect(condition && 'queryChunks' in condition).toBe(true)
+  })
+
+  it('omits where() when no filter is given', async () => {
+    const { db, query } = fakeDrizzleChain([])
+    vi.mocked(createDb).mockReturnValue(db as unknown as ReturnType<typeof createDb>)
+
+    await loadRecentAlerts(fakeD1, {})
+
+    expect(query.where).not.toHaveBeenCalled()
+  })
+
+  it('orders by timestamp DESC, id DESC and clamps limit', async () => {
+    const { db, query } = fakeDrizzleChain([])
+    vi.mocked(createDb).mockReturnValue(db as unknown as ReturnType<typeof createDb>)
+
+    await loadRecentAlerts(fakeD1, { limit: 9999 })
+
+    expect(query.orderBy).toHaveBeenCalledTimes(1)
+    expect(query.limit).toHaveBeenCalledWith(500)
+  })
+})

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -1686,3 +1686,33 @@ describe('renderLastRolledCell (issue #140)', () => {
     expect(html).toContain('parse 不能')
   })
 })
+
+import { renderAlertFilterPills } from '../../src/routes/dashboard'
+
+describe('renderAlertFilterPills', () => {
+  it('preserves unrelated query params (e.g. limit) when switching severity', () => {
+    const current = new URLSearchParams('limit=500&severity=warning')
+    const html = renderAlertFilterPills(['warning'], undefined, current)
+    // critical pill should switch severity but keep limit=500.
+    expect(html).toContain('href="/dashboard/alerts?limit=500&amp;severity=critical"')
+    // warning pill should be the active one (currently selected).
+    expect(html).toContain('href="/dashboard/alerts?limit=500&amp;severity=warning"')
+    // 全 severity pill drops the severity key but keeps limit.
+    expect(html).toContain('href="/dashboard/alerts?limit=500"')
+  })
+
+  it('drops severity entirely when 全 severity is selected (no stale severity param)', () => {
+    const current = new URLSearchParams('severity=info')
+    const html = renderAlertFilterPills(['info'], undefined, current)
+    expect(html).toContain('href="/dashboard/alerts"')
+  })
+
+  it('includes both severity and eventType keys when current url already has both', () => {
+    const current = new URLSearchParams('limit=200&severity=critical&eventType=ERROR')
+    const html = renderAlertFilterPills(['critical'], 'ERROR', current)
+    // Switching to TRADE event type should keep limit and severity.
+    expect(html).toContain(
+      'href="/dashboard/alerts?limit=200&amp;severity=critical&amp;eventType=TRADE"',
+    )
+  })
+})

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -3,6 +3,7 @@ import { createApp } from '../../src/app'
 import { loadGlobalConfigFrom } from '../../src/infrastructure/db/globalConfigLoader'
 import { createDb } from '../../src/infrastructure/db/tradeJournalRepo'
 import { loadSymbolUniverse } from '../../src/infrastructure/db/symbolUniverse'
+import { loadRecentAlerts } from '../../src/infrastructure/notification/notificationEmitLog'
 import { makeGlobalConfigSnapshot, makeSymbolUniverse } from '../helpers/configFixtures'
 
 vi.mock('../../src/infrastructure/db/globalConfigLoader', () => ({
@@ -13,6 +14,9 @@ vi.mock('../../src/infrastructure/db/symbolUniverse', () => ({
 }))
 vi.mock('../../src/infrastructure/db/tradeJournalRepo', () => ({
   createDb: vi.fn(),
+}))
+vi.mock('../../src/infrastructure/notification/notificationEmitLog', () => ({
+  loadRecentAlerts: vi.fn(),
 }))
 
 const baseEnv = {
@@ -299,6 +303,69 @@ describe('dashboard', () => {
   it('cron page requires basic auth', async () => {
     const app = createApp()
     const res = await app.request('/dashboard/cron', {}, baseEnv)
+    expect(res.status).toBe(401)
+  })
+
+  // #141: dashboard alerts view
+  it('renders /dashboard/alerts unavailable when DB is not bound', async () => {
+    const app = createApp()
+    const res = await app.request('/dashboard/alerts', { headers: authHeader }, baseEnv)
+    expect(res.status).toBe(200)
+    expect(await res.text()).toContain('利用不可')
+  })
+
+  it('renders rows from notification_emit_log on /dashboard/alerts (#141)', async () => {
+    vi.mocked(loadRecentAlerts).mockResolvedValue([
+      {
+        id: 1,
+        timestamp: '2026-04-23T00:00:00.000Z',
+        requestId: 'req-1',
+        eventType: 'ERROR',
+        severity: 'critical',
+        symbol: 'SOXL',
+        cause: 'portfolio_halted',
+        message: '🚨 CRITICAL: SOXL — cron skipped: portfolio_halted',
+      },
+      {
+        id: 2,
+        timestamp: '2026-04-23T00:01:00.000Z',
+        requestId: 'req-2',
+        eventType: 'STATE_CHANGE',
+        severity: 'critical',
+        symbol: null,
+        cause: 'dryRun',
+        message: '🚨 state change: dryRun true → false',
+      },
+    ])
+    const app = createApp()
+    const res = await app.request(
+      '/dashboard/alerts',
+      { headers: authHeader },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    expect(body).toContain('CRITICAL: SOXL')
+    expect(body).toContain('dryRun true → false')
+    expect(body).toContain('portfolio_halted')
+    expect(body).toContain('req-1')
+  })
+
+  it('falls back to unavailable when loadRecentAlerts throws (e.g. migration not applied)', async () => {
+    vi.mocked(loadRecentAlerts).mockRejectedValue(new Error('no such table: notification_emit_log'))
+    const app = createApp()
+    const res = await app.request(
+      '/dashboard/alerts',
+      { headers: authHeader },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    expect(res.status).toBe(200)
+    expect(await res.text()).toContain('利用不可')
+  })
+
+  it('alerts page requires basic auth', async () => {
+    const app = createApp()
+    const res = await app.request('/dashboard/alerts', {}, baseEnv)
     expect(res.status).toBe(401)
   })
 })

--- a/test/trading/strategy/runStrategyCron.test.ts
+++ b/test/trading/strategy/runStrategyCron.test.ts
@@ -21,12 +21,18 @@ const env = {
 } as unknown as Parameters<typeof runStrategyCron>[0]
 
 describe('runStrategyCron', () => {
+  // 0012 migration の new tables (config_state_snapshot / notification_emit_log)
+  // を mock D1 が知らないので、`this.client.prepare is not a function` 系の
+  // warn が大量に出る。挙動には影響しない (silent fallback) ので suppress。
+  let warnSpy: ReturnType<typeof vi.spyOn>
   beforeEach(() => {
     vi.mocked(loadGlobalConfigFrom).mockResolvedValue(makeGlobalConfigSnapshot())
     vi.mocked(loadSymbolUniverse).mockResolvedValue(makeSymbolUniverse())
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
   })
 
   afterEach(() => {
+    warnSpy.mockRestore()
     vi.resetAllMocks()
   })
 
@@ -140,6 +146,42 @@ describe('runStrategyCron', () => {
     } as unknown as Parameters<typeof runStrategyCron>[0]
     const result = await runStrategyCron(envWithBrokenPortfolio)
     expect(result.skipReason).toBe('portfolio_halted')
+  })
+
+  // #141: critical な skip reason は Notifier 経由で push 通知される。
+  // env.SLACK_WEBHOOK_URL を設定して fetch を spy し、webhook 行きの POST が
+  // 1 回入ることだけ確認する (formatter は WebhookNotifier.test に分離済み)。
+  it('pushes notify() when skipReason=portfolio_halted (#141)', async () => {
+    const fetchSpy = vi
+      .fn(async () => new Response('ok', { status: 200 }))
+      .mockName('fetchSpy')
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = fetchSpy as unknown as typeof fetch
+    try {
+      const envWithBrokenPortfolio = {
+        DB: {} as D1Database,
+        SYMBOL_STATE: {} as DurableObjectNamespace<never>,
+        // Webhook URL を設定 → notifier が fetch を叩く
+        SLACK_WEBHOOK_URL: 'https://hooks.slack.test/x',
+        PORTFOLIO_STATE: {
+          idFromName: () => ({}),
+          get: () => ({
+            getPortfolio: vi.fn().mockRejectedValue(new Error('DO unreachable')),
+          }),
+        },
+      } as unknown as Parameters<typeof runStrategyCron>[0]
+      const result = await runStrategyCron(envWithBrokenPortfolio, { requestId: 'req-x' })
+      expect(result.skipReason).toBe('portfolio_halted')
+      // notify は fire-and-forget なので microtask flush 待ち
+      await new Promise((r) => setTimeout(r, 0))
+      expect(fetchSpy).toHaveBeenCalled()
+      const calls = fetchSpy.mock.calls as unknown as Array<[string, RequestInit]>
+      const body = JSON.parse(String(calls[0]?.[1]?.body))
+      expect(body.text).toContain('CRITICAL')
+      expect(body.text).toContain('portfolio_halted')
+    } finally {
+      globalThis.fetch = originalFetch
+    }
   })
 
 })


### PR DESCRIPTION
## 動機

[#141](https://github.com/ochanuco/webull-trading/issues/141) — operator が dashboard を能動的に見に行かなくても、自動売買の「止まるべき時に止まった / 止まってはいけないところで止まった / reconcile が壊れている」を push 型で検知できるようにする。

PR #201 で導入した \`Notifier\` (Slack/Discord webhook) を critical events まで対象拡張し、危険な状態遷移と dashboard alerts view を追加した。

## Scope

### 実装範囲 (この PR)

- **Notifier event taxonomy 拡張**
  - \`severity\` (critical / warning / info) を ERROR / STATE_CHANGE に追加
  - \`STATE_CHANGE\` type を追加 (config field の state 遷移通知)
  - WebhookNotifier formatter が severity icon を出し分け (🚨 / ⚠️ / ℹ️)、CRITICAL ラベル
  - \`formatMessage\` を public 化して LoggingNotifier から再利用
- **LoggingNotifier 装飾**
  - 全 \`notify()\` 呼出を D1 \`notification_emit_log\` table にも記録
  - webhook と D1 INSERT は独立 (片方の失敗で他方を止めない silent fallback)
- **critical event の push 化**
  - \`runStrategyCron\` で \`skipReason=portfolio_halted/drawdown_kill/no_bridge_state\` を critical で通知 (\`strategy_cron_run.skipReason\` ログは後方互換維持)
  - \`scheduled()\` handler で \`reconcile_fills_error\` (critical) / \`quote_feed_error\` (warning) / partial reconcile errors (warning) を通知
  - 既存 \`strategy_cron_error\` 通知に \`severity: critical\` を付与
- **state change 検知**
  - \`config_state_snapshot\` table に \`global_config\` の watched field 前回値を保存
  - cron tick で diff を取って STATE_CHANGE event 発火
  - \`dry_run: true→false\` / \`trading_enabled: false→true\` / \`market_hours_check: true→false\` / \`drawdown_kill_threshold\` 緩和 = critical
  - 逆方向 = info、初回は通知しない
- **dashboard \`/dashboard/alerts\` view**
  - \`notification_emit_log\` を timestamp DESC で最新 100 件 (\`?limit=N\` で 1〜500)
  - severity / eventType ピルフィルタ
  - 既存 dashboard table style 踏襲
- **migration 0012**: \`notification_emit_log\` + \`config_state_snapshot\` テーブル追加

### Out of scope (follow-up issue)

- **#207** Logpush to R2 設定 (Cloudflare 管理画面操作、code 変更なし)
- **#208** \`docs/review-queries.md\` 拡張 (運用 docs)
- **#209** broker 4xx/5xx / 429 急増検知 (lookback / window logic + dedup の別 PR が clean)

## 安全性

- 全通知経路は **fire-and-forget + silent fallback** (PR #201 の方針継承)
- 状態遷移検知の D1 read/write 失敗は内部で握りつぶし、cron 本体を落とさない
- env.DB が未 bind なら \`detectAndNotifyConfigStateChanges\` は no-op で skip
- LoggingNotifier 内 webhook と D1 INSERT は独立 (\`Promise.allSettled\`)
- 0012 migration は **新規テーブル追加のみ** (既存 table の ALTER なし)

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test --run\` — 638/638 pass (新規 31 件)
  - WebhookNotifier 拡張: severity icon、CRITICAL label、STATE_CHANGE format、formatMessage 公開
  - LoggingNotifier: forward + D1 INSERT、inner throw silent、D1 throw silent、severity 抽出
  - configStateChange: classifySeverity / diffConfigState / notifyConfigStateChanges
  - createNotifier: env.DB 有無で LoggingNotifier wrap
  - runStrategyCron: \`portfolio_halted\` 経路で webhook fetch 1 件入る
  - dashboard: \`/dashboard/alerts\` smoke (DB 未 bind / rows / migration 未適用 / 401)
- [ ] 手動: \`wrangler d1 migrations apply\` で 0012 流して、\`global_config\` の \`dry_run\` を \`UPDATE\` した次 cron tick で Slack に \`STATE_CHANGE: dryRun true → false\` が出るか確認 (運用 user)

## 関連

- 元 issue: #141
- 通知基盤: #199 / PR #201
- follow-up: #207 / #208 / #209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * アラートダッシュボード（/dashboard/alerts）を追加、フィルタ・表示が可能
  * 通知の永続化テーブルと履歴APIを追加しダッシュボードから参照可能に
  * LoggingNotifier導入で通知送信をDBに記録（フォーマット再利用可）
  * 設定スナップショット差分検出でSTATE_CHANGE通知を自動発行
  * 通知重み付け（critical/warning/info）とリクエストID伝播を追加

* **テスト**
  * 通知周りの単体テストを拡充（フォーマット／永続化／耐障害性検証）
<!-- end of auto-generated comment: release notes by coderabbit.ai -->