### PR TITLE
feat(risk): earnings calendar gate 実装 (#196 1/3)

### DIFF
--- a/drizzle/0013_earnings_calendar.sql
+++ b/drizzle/0013_earnings_calendar.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `earnings_calendar` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`symbol` text NOT NULL,
+	`earnings_date` text NOT NULL,
+	`notes` text,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `earnings_calendar_symbol_date_unique` ON `earnings_calendar` (`symbol`,`earnings_date`);

--- a/drizzle/meta/0013_snapshot.json
+++ b/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,952 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b427c35a-42b5-4397-9912-90ab6f1414d4",
+  "prevId": "db1f5cfc-13af-4a93-9aa8-e354bdb4c11f",
+  "tables": {
+    "config_state_snapshot": {
+      "name": "config_state_snapshot",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "earnings_calendar": {
+      "name": "earnings_calendar",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "earnings_date": {
+          "name": "earnings_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "earnings_calendar_symbol_date_unique": {
+          "name": "earnings_calendar_symbol_date_unique",
+          "columns": [
+            "symbol",
+            "earnings_date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "global_config": {
+      "name": "global_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "trading_enabled": {
+          "name": "trading_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "market_hours_check": {
+          "name": "market_hours_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "max_order_notional": {
+          "name": "max_order_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "max_order_notional_usd": {
+          "name": "max_order_notional_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2000
+        },
+        "max_order_notional_jpy": {
+          "name": "max_order_notional_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100000
+        },
+        "total_capital_usd": {
+          "name": "total_capital_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_capital_jpy": {
+          "name": "total_capital_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_portfolio_exposure_pct": {
+          "name": "max_portfolio_exposure_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.6
+        },
+        "drawdown_kill_threshold": {
+          "name": "drawdown_kill_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.02
+        },
+        "stale_quote_ms": {
+          "name": "stale_quote_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 900000
+        },
+        "gap_reject_pct": {
+          "name": "gap_reject_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.03
+        },
+        "spread_limit_pct_us": {
+          "name": "spread_limit_pct_us",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.0025
+        },
+        "spread_limit_pct_jp": {
+          "name": "spread_limit_pct_jp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.006
+        },
+        "pullback_default_stop_pct": {
+          "name": "pullback_default_stop_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.04
+        },
+        "pullback_default_take_profit_pct": {
+          "name": "pullback_default_take_profit_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.07
+        },
+        "pullback_default_time_stop_days": {
+          "name": "pullback_default_time_stop_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "pullback_default_pullback_max": {
+          "name": "pullback_default_pullback_max",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.03
+        },
+        "pullback_default_pullback_min": {
+          "name": "pullback_default_pullback_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.06
+        },
+        "pullback_default_min_return_50d": {
+          "name": "pullback_default_min_return_50d",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.08
+        },
+        "pullback_default_require_above_sma50": {
+          "name": "pullback_default_require_above_sma50",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "pullback_default_k_atr": {
+          "name": "pullback_default_k_atr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "risk_base_per_trade_pct": {
+          "name": "risk_base_per_trade_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.004
+        },
+        "risk_dd_half_threshold": {
+          "name": "risk_dd_half_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.05
+        },
+        "risk_dd_halt_threshold": {
+          "name": "risk_dd_halt_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.1
+        },
+        "bucket_exposure_pct": {
+          "name": "bucket_exposure_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.3
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "global_config_max_order_notional_range": {
+          "name": "global_config_max_order_notional_range",
+          "value": "\"global_config\".\"max_order_notional\" > 0 AND \"global_config\".\"max_order_notional\" <= 10000000"
+        },
+        "global_config_max_order_notional_usd_range": {
+          "name": "global_config_max_order_notional_usd_range",
+          "value": "\"global_config\".\"max_order_notional_usd\" > 0 AND \"global_config\".\"max_order_notional_usd\" <= 1000000"
+        },
+        "global_config_max_order_notional_jpy_range": {
+          "name": "global_config_max_order_notional_jpy_range",
+          "value": "\"global_config\".\"max_order_notional_jpy\" > 0 AND \"global_config\".\"max_order_notional_jpy\" <= 100000000"
+        },
+        "global_config_total_capital_usd_range": {
+          "name": "global_config_total_capital_usd_range",
+          "value": "\"global_config\".\"total_capital_usd\" IS NULL OR \"global_config\".\"total_capital_usd\" > 0"
+        },
+        "global_config_total_capital_jpy_range": {
+          "name": "global_config_total_capital_jpy_range",
+          "value": "\"global_config\".\"total_capital_jpy\" IS NULL OR \"global_config\".\"total_capital_jpy\" > 0"
+        },
+        "global_config_max_portfolio_exposure_pct_range": {
+          "name": "global_config_max_portfolio_exposure_pct_range",
+          "value": "\"global_config\".\"max_portfolio_exposure_pct\" > 0 AND \"global_config\".\"max_portfolio_exposure_pct\" <= 1"
+        },
+        "global_config_drawdown_kill_threshold_range": {
+          "name": "global_config_drawdown_kill_threshold_range",
+          "value": "\"global_config\".\"drawdown_kill_threshold\" >= -1 AND \"global_config\".\"drawdown_kill_threshold\" <= 0"
+        },
+        "global_config_stale_quote_ms_range": {
+          "name": "global_config_stale_quote_ms_range",
+          "value": "\"global_config\".\"stale_quote_ms\" >= 0"
+        },
+        "global_config_gap_reject_pct_range": {
+          "name": "global_config_gap_reject_pct_range",
+          "value": "\"global_config\".\"gap_reject_pct\" >= 0 AND \"global_config\".\"gap_reject_pct\" <= 1"
+        },
+        "global_config_spread_limit_pct_us_range": {
+          "name": "global_config_spread_limit_pct_us_range",
+          "value": "\"global_config\".\"spread_limit_pct_us\" >= 0 AND \"global_config\".\"spread_limit_pct_us\" <= 1"
+        },
+        "global_config_spread_limit_pct_jp_range": {
+          "name": "global_config_spread_limit_pct_jp_range",
+          "value": "\"global_config\".\"spread_limit_pct_jp\" >= 0 AND \"global_config\".\"spread_limit_pct_jp\" <= 1"
+        },
+        "global_config_pullback_default_stop_pct_range": {
+          "name": "global_config_pullback_default_stop_pct_range",
+          "value": "\"global_config\".\"pullback_default_stop_pct\" < 0 AND \"global_config\".\"pullback_default_stop_pct\" >= -1"
+        },
+        "global_config_pullback_default_take_profit_pct_range": {
+          "name": "global_config_pullback_default_take_profit_pct_range",
+          "value": "\"global_config\".\"pullback_default_take_profit_pct\" > 0 AND \"global_config\".\"pullback_default_take_profit_pct\" <= 1"
+        },
+        "global_config_pullback_default_time_stop_days_range": {
+          "name": "global_config_pullback_default_time_stop_days_range",
+          "value": "\"global_config\".\"pullback_default_time_stop_days\" > 0 AND \"global_config\".\"pullback_default_time_stop_days\" <= 365"
+        },
+        "global_config_pullback_default_pullback_max_range": {
+          "name": "global_config_pullback_default_pullback_max_range",
+          "value": "\"global_config\".\"pullback_default_pullback_max\" <= 0 AND \"global_config\".\"pullback_default_pullback_max\" >= -1"
+        },
+        "global_config_pullback_default_pullback_min_range": {
+          "name": "global_config_pullback_default_pullback_min_range",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= 0 AND \"global_config\".\"pullback_default_pullback_min\" >= -1"
+        },
+        "global_config_pullback_default_min_return_50d_range": {
+          "name": "global_config_pullback_default_min_return_50d_range",
+          "value": "\"global_config\".\"pullback_default_min_return_50d\" >= -1 AND \"global_config\".\"pullback_default_min_return_50d\" <= 10"
+        },
+        "global_config_pullback_default_k_atr_range": {
+          "name": "global_config_pullback_default_k_atr_range",
+          "value": "\"global_config\".\"pullback_default_k_atr\" > 0 AND \"global_config\".\"pullback_default_k_atr\" <= 10"
+        },
+        "global_config_pullback_default_pullback_window_order": {
+          "name": "global_config_pullback_default_pullback_window_order",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= \"global_config\".\"pullback_default_pullback_max\""
+        },
+        "global_config_risk_base_per_trade_pct_range": {
+          "name": "global_config_risk_base_per_trade_pct_range",
+          "value": "\"global_config\".\"risk_base_per_trade_pct\" > 0 AND \"global_config\".\"risk_base_per_trade_pct\" <= 1"
+        },
+        "global_config_risk_dd_half_threshold_range": {
+          "name": "global_config_risk_dd_half_threshold_range",
+          "value": "\"global_config\".\"risk_dd_half_threshold\" < 0 AND \"global_config\".\"risk_dd_half_threshold\" >= -1"
+        },
+        "global_config_risk_dd_halt_threshold_range": {
+          "name": "global_config_risk_dd_halt_threshold_range",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" < 0 AND \"global_config\".\"risk_dd_halt_threshold\" >= -1"
+        },
+        "global_config_risk_dd_threshold_order": {
+          "name": "global_config_risk_dd_threshold_order",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" <= \"global_config\".\"risk_dd_half_threshold\""
+        },
+        "global_config_bucket_exposure_pct_range": {
+          "name": "global_config_bucket_exposure_pct_range",
+          "value": "\"global_config\".\"bucket_exposure_pct\" > 0 AND \"global_config\".\"bucket_exposure_pct\" <= 1"
+        }
+      }
+    },
+    "inverse_pairs": {
+      "name": "inverse_pairs",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inverse": {
+          "name": "inverse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_emit_log": {
+      "name": "notification_emit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cause": {
+          "name": "cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notification_emit_log_timestamp_id_idx": {
+          "name": "notification_emit_log_timestamp_id_idx",
+          "columns": [
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "notification_emit_log_severity_timestamp_id_idx": {
+          "name": "notification_emit_log_severity_timestamp_id_idx",
+          "columns": [
+            "severity",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "notification_emit_log_event_type_timestamp_id_idx": {
+          "name": "notification_emit_log_event_type_timestamp_id_idx",
+          "columns": [
+            "event_type",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "strategy_decision_log": {
+      "name": "strategy_decision_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indicators_json": {
+          "name": "indicators_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "strategy_decision_log_symbol_id_idx": {
+          "name": "strategy_decision_log_symbol_id_idx",
+          "columns": [
+            "symbol",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "strategy_decision_log_coid_idx": {
+          "name": "strategy_decision_log_coid_idx",
+          "columns": [
+            "client_order_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "symbol_config": {
+      "name": "symbol_config",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "market": {
+          "name": "market",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_notional": {
+          "name": "max_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "symbol_config_currency_enum": {
+          "name": "symbol_config_currency_enum",
+          "value": "\"symbol_config\".\"currency\" IN ('USD', 'JPY')"
+        }
+      }
+    },
+    "trade_journal": {
+      "name": "trade_journal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trade_event_type": {
+          "name": "trade_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "strategy_name": {
+          "name": "strategy_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_action": {
+          "name": "signal_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_reason": {
+          "name": "signal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_allowed": {
+          "name": "risk_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_reasons": {
+          "name": "risk_reasons",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "limit_price": {
+          "name": "limit_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notional": {
+          "name": "notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "broker_status": {
+          "name": "broker_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "submitted": {
+          "name": "submitted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_qty": {
+          "name": "filled_qty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_price": {
+          "name": "filled_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "realized_pnl": {
+          "name": "realized_pnl",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hold_days": {
+          "name": "hold_days",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_reason": {
+          "name": "exit_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_applied_at": {
+          "name": "state_applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_error": {
+          "name": "state_apply_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_attempts": {
+          "name": "state_apply_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,13 +99,6 @@
       "when": 1777210015055,
       "tag": "0013_earnings_calendar",
       "breakpoints": true
-    },
-    {
-      "idx": 14,
-      "version": "6",
-      "when": 1777210084921,
-      "tag": "0014_gigantic_true_believers",
-      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -92,6 +92,20 @@
       "when": 1777206141621,
       "tag": "0012_observability_alerts",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "6",
+      "when": 1777210015055,
+      "tag": "0013_earnings_calendar",
+      "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "6",
+      "when": 1777210084921,
+      "tag": "0014_gigantic_true_believers",
+      "breakpoints": true
     }
   ]
 }

--- a/src/infrastructure/calendar/earningsCalendarRepo.ts
+++ b/src/infrastructure/calendar/earningsCalendarRepo.ts
@@ -1,0 +1,111 @@
+/**
+ * `earnings_calendar` テーブルへの薄い repo。issue #196 の earnings gate 専用。
+ *
+ * - `fetchByRange` は gate (`evaluateEarningsGate`) からの read。range 指定で
+ *   返すので、gate 側が ±N 営業日窓を計算して渡す。
+ * - `bulkUpsert` は admin endpoint (POC では手動 seed) からの write。同一
+ *   `(symbol, earnings_date)` は `INSERT OR IGNORE` で skip — operator が
+ *   何度 seed しても安全。
+ * - 結果は read 時に DB から戻った row そのまま (symbol は upper-case 正規化を
+ *   write 側で済ませる方針)。
+ *
+ * 結果の dummy 化は repo 層では行わない。gate 層が「fetch 失敗 → fail-closed
+ * (entry block)」を担う (POC fail-closed 原則)。
+ */
+import { and, asc, eq, gte, lte } from 'drizzle-orm'
+import { drizzle, type DrizzleD1Database } from 'drizzle-orm/d1'
+import { earningsCalendar, type EarningsCalendarRow } from '../db/schema'
+
+export type EarningsCalendarDb = DrizzleD1Database
+
+export interface EarningsCalendarRepo {
+  /**
+   * `[fromYmd, toYmd]` 両端を含む範囲で `symbol` の earnings 日を返す
+   * (date asc)。throws on D1 read failure — caller がここで fail-closed する。
+   */
+  fetchByRange(symbol: string, fromYmd: string, toYmd: string): Promise<EarningsCalendarRow[]>
+  /** `symbol` の row 全件 (operator inspect 用)。 */
+  fetchBySymbol(symbol: string): Promise<EarningsCalendarRow[]>
+  /**
+   * Upsert (実際は `INSERT OR IGNORE`) 配列。POC 段階では既存 row の更新は
+   * 行わない (operator が DELETE → INSERT で対応する想定)。重複 skip 数を返す。
+   */
+  bulkUpsert(records: EarningsCalendarSeedInput[]): Promise<{ inserted: number; skipped: number }>
+  /** id 指定で 1 row 削除。存在しない id は false を返す。 */
+  deleteById(id: number): Promise<boolean>
+}
+
+export interface EarningsCalendarSeedInput {
+  symbol: string
+  /** ISO date "YYYY-MM-DD"。caller が validation 済みである前提。 */
+  earningsDate: string
+  notes?: string | null
+}
+
+/** Wraps a Worker `env.DB` into a drizzle-typed client (other repos と同形式)。 */
+export function createEarningsCalendarDb(d1: D1Database): EarningsCalendarDb {
+  return drizzle(d1)
+}
+
+export function createEarningsCalendarRepo(db: EarningsCalendarDb): EarningsCalendarRepo {
+  return {
+    async fetchByRange(symbol, fromYmd, toYmd) {
+      const upper = symbol.toUpperCase()
+      return db
+        .select()
+        .from(earningsCalendar)
+        .where(
+          and(
+            eq(earningsCalendar.symbol, upper),
+            gte(earningsCalendar.earningsDate, fromYmd),
+            lte(earningsCalendar.earningsDate, toYmd),
+          ),
+        )
+        .orderBy(asc(earningsCalendar.earningsDate))
+    },
+
+    async fetchBySymbol(symbol) {
+      const upper = symbol.toUpperCase()
+      return db
+        .select()
+        .from(earningsCalendar)
+        .where(eq(earningsCalendar.symbol, upper))
+        .orderBy(asc(earningsCalendar.earningsDate))
+    },
+
+    async bulkUpsert(records) {
+      let inserted = 0
+      let skipped = 0
+      // drizzle d1 driver の `.onConflictDoNothing()` を使う。bulk values で
+      // 1 statement にまとめても良いが、UNIQUE 違反 row だけ skip して残りを
+      // insert する挙動は drizzle 側で吸収してくれる。
+      for (const r of records) {
+        const result = await db
+          .insert(earningsCalendar)
+          .values({
+            symbol: r.symbol.toUpperCase(),
+            earningsDate: r.earningsDate,
+            notes: r.notes ?? null,
+          })
+          .onConflictDoNothing({
+            target: [earningsCalendar.symbol, earningsCalendar.earningsDate],
+          })
+          .returning({ id: earningsCalendar.id })
+        if (result.length > 0) {
+          inserted += 1
+        } else {
+          skipped += 1
+        }
+      }
+      return { inserted, skipped }
+    },
+
+    async deleteById(id) {
+      const result = await db
+        .delete(earningsCalendar)
+        .where(eq(earningsCalendar.id, id))
+        .returning({ id: earningsCalendar.id })
+      return result.length > 0
+    },
+  }
+}

--- a/src/infrastructure/calendar/earningsCalendarRepo.ts
+++ b/src/infrastructure/calendar/earningsCalendarRepo.ts
@@ -74,28 +74,33 @@ export function createEarningsCalendarRepo(db: EarningsCalendarDb): EarningsCale
     },
 
     async bulkUpsert(records) {
+      // CodeRabbit #196 review: 1 row 1 INSERT は 1000 行で 1000 D1 writes/req
+      // 相当の subrequest を発生させ Worker 制限に当たる。`db.insert().values([...])`
+      // で multi-row INSERT (chunk) にまとめ、`onConflictDoNothing()` で UNIQUE
+      // 違反 row のみ skip する挙動は維持。drizzle d1 driver は VALUES (?,?), (?,?), ...
+      // の prepared statement を 1 statement で送るため、chunk あたり 1 subrequest。
       let inserted = 0
       let skipped = 0
-      // drizzle d1 driver の `.onConflictDoNothing()` を使う。bulk values で
-      // 1 statement にまとめても良いが、UNIQUE 違反 row だけ skip して残りを
-      // insert する挙動は drizzle 側で吸収してくれる。
-      for (const r of records) {
+      if (records.length === 0) return { inserted, skipped }
+      const CHUNK = 50
+      for (let i = 0; i < records.length; i += CHUNK) {
+        const chunk = records.slice(i, i + CHUNK)
+        const values = chunk.map((r) => ({
+          symbol: r.symbol.toUpperCase(),
+          earningsDate: r.earningsDate,
+          notes: r.notes ?? null,
+        }))
         const result = await db
           .insert(earningsCalendar)
-          .values({
-            symbol: r.symbol.toUpperCase(),
-            earningsDate: r.earningsDate,
-            notes: r.notes ?? null,
-          })
+          .values(values)
           .onConflictDoNothing({
             target: [earningsCalendar.symbol, earningsCalendar.earningsDate],
           })
           .returning({ id: earningsCalendar.id })
-        if (result.length > 0) {
-          inserted += 1
-        } else {
-          skipped += 1
-        }
+        // `result.length` = 実際に INSERT された row 数。差分が UNIQUE 違反 skip。
+        const insertedInChunk = result.length
+        inserted += insertedInChunk
+        skipped += chunk.length - insertedInChunk
       }
       return { inserted, skipped }
     },

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -1,5 +1,5 @@
 import { sql } from 'drizzle-orm'
-import { check, index, integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { check, index, integer, real, sqliteTable, text, uniqueIndex } from 'drizzle-orm/sqlite-core'
 
 /**
  * Schema-level max for pullbackDefaultTimeStopDays. Exported so chart window
@@ -429,3 +429,39 @@ export const configStateSnapshot = sqliteTable('config_state_snapshot', {
 
 export type ConfigStateSnapshotRow = typeof configStateSnapshot.$inferSelect
 export type ConfigStateSnapshotInsert = typeof configStateSnapshot.$inferInsert
+
+/**
+ * Per-symbol earnings calendar (issue #196 1/3)。entry を avoid させる用途
+ * の risk gate ソース。`earningsGate` が evalDate ± freezeBusinessDays を
+ * 範囲で読み、該当日があれば BUY を reject する (シグナル源ではなく avoid 用)。
+ *
+ * POC では外部 API 取得は別 issue で、`/admin/earnings/seed` 経由で operator が
+ * 手動 seed する想定。`UNIQUE (symbol, earnings_date)` で重複 insert は弾く。
+ */
+export const earningsCalendar = sqliteTable(
+  'earnings_calendar',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    /** 銘柄コード (例: 'AAPL', '7203')。upper-case 前提で repo 側が正規化する。 */
+    symbol: text('symbol').notNull(),
+    /**
+     * 決算発表日 ISO date "YYYY-MM-DD"。BMO (Before Market Open) / AMC
+     * (After Market Close) の区別は POC では持たない (±N 営業日窓で十分粗い)。
+     */
+    earningsDate: text('earnings_date').notNull(),
+    /** 自由 text。'Q2 2026' / 'BMO' / news source 等を operator が任意で残す。 */
+    notes: text('notes'),
+    createdAt: text('created_at')
+      .notNull()
+      .default(sql`(datetime('now'))`),
+  },
+  (t) => ({
+    // 同一銘柄 × 同一日の重複を物理的に防ぐ。bulk seed は INSERT OR IGNORE で skip。
+    // unique index は gate の (symbol, earnings_date) range read もカバーするので
+    // 通常の index は別建てしない (drop-in covering)。
+    symbolDateUnique: uniqueIndex('earnings_calendar_symbol_date_unique').on(t.symbol, t.earningsDate),
+  }),
+)
+
+export type EarningsCalendarRow = typeof earningsCalendar.$inferSelect
+export type EarningsCalendarInsert = typeof earningsCalendar.$inferInsert

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -11,6 +11,11 @@ import { YahooBarClient } from '../infrastructure/quotes/YahooBarClient'
 import { loadGlobalConfigFrom } from '../infrastructure/db/globalConfigLoader'
 import { createDb } from '../infrastructure/db/tradeJournalRepo'
 import { tradeJournal } from '../infrastructure/db/schema'
+import {
+  createEarningsCalendarDb,
+  createEarningsCalendarRepo,
+  type EarningsCalendarSeedInput,
+} from '../infrastructure/calendar/earningsCalendarRepo'
 import { runBacktest, type BacktestParams } from '../trading/backtest/runBacktest'
 import type { SymbolRule } from '../trading/strategy/strategies/PullbackUptrendStrategy'
 
@@ -294,6 +299,104 @@ export const admin = new Hono<AppBindings>()
       updatedAt: state.updatedAt,
     })
   })
+  /**
+   * Bulk seed `earnings_calendar` rows (issue #196 1/3)。POC では外部 API 連携を
+   * 持たず、operator が手動で curl 経由で seed する。重複 (symbol × earnings_date)
+   * は `INSERT OR IGNORE` で skip し、件数を返す。
+   *
+   * Body: `[{ symbol: "AAPL", earnings_date: "2026-04-30", notes?: "Q2" }, ...]`
+   */
+  .post('/earnings/seed', async (c) => {
+    if (!c.env.DB) {
+      throw new ValidationError('DB binding is not configured', { field: 'env' })
+    }
+    const body = (await c.req.json().catch(() => null)) as unknown
+    if (!Array.isArray(body)) {
+      throw new ValidationError('body must be an array of { symbol, earnings_date, notes? }', { field: 'body' })
+    }
+    if (body.length === 0) {
+      throw new ValidationError('body must contain at least one entry', { field: 'body' })
+    }
+    if (body.length > 1000) {
+      // 桁違いの誤入力を弾く。1 cron 環境で扱う universe は十数銘柄 × 4 半期分
+      // (せいぜい 100 行) を想定。
+      throw new ValidationError('body cannot exceed 1000 entries per request', { field: 'body' })
+    }
+    const records: EarningsCalendarSeedInput[] = []
+    body.forEach((raw, idx) => {
+      records.push(parseEarningsSeedRow(raw, idx))
+    })
+    const repo = createEarningsCalendarRepo(createEarningsCalendarDb(c.env.DB))
+    const result = await repo.bulkUpsert(records)
+    return c.json({ inserted: result.inserted, skipped: result.skipped, total: records.length })
+  })
+  /**
+   * Read `earnings_calendar` rows for a symbol (operator inspect)。`?symbol=AAPL`
+   * 必須。NULL / 0 件でも 200 を返す (空配列)。
+   */
+  .get('/earnings', async (c) => {
+    if (!c.env.DB) {
+      throw new ValidationError('DB binding is not configured', { field: 'env' })
+    }
+    const symbol = readRequiredParam(c.req.query('symbol'), 'symbol').toUpperCase()
+    const repo = createEarningsCalendarRepo(createEarningsCalendarDb(c.env.DB))
+    const rows = await repo.fetchBySymbol(symbol)
+    return c.json({ symbol, rows })
+  })
+  /**
+   * Delete a single earnings row by `id`。誤 seed の取り消し用。404 if not found。
+   */
+  .delete('/earnings/:id', async (c) => {
+    if (!c.env.DB) {
+      throw new ValidationError('DB binding is not configured', { field: 'env' })
+    }
+    const idRaw = c.req.param('id').trim()
+    const id = Number(idRaw)
+    if (!Number.isInteger(id) || id <= 0) {
+      throw new ValidationError("'id' must be a positive integer path param", { field: 'id' })
+    }
+    const repo = createEarningsCalendarRepo(createEarningsCalendarDb(c.env.DB))
+    const ok = await repo.deleteById(id)
+    if (!ok) {
+      return c.json({ error: 'earnings_row_not_found', id }, 404)
+    }
+    return c.json({ deleted: true, id })
+  })
+
+function parseEarningsSeedRow(raw: unknown, idx: number): EarningsCalendarSeedInput {
+  if (raw === null || typeof raw !== 'object') {
+    throw new ValidationError(`entry [${idx}]: must be an object`, { field: `body[${idx}]` })
+  }
+  const obj = raw as { symbol?: unknown; earnings_date?: unknown; notes?: unknown }
+  const symbol = typeof obj.symbol === 'string' ? obj.symbol.trim() : ''
+  if (symbol.length === 0 || symbol.length > 16) {
+    throw new ValidationError(`entry [${idx}]: 'symbol' must be a non-empty string <= 16 chars`, {
+      field: `body[${idx}].symbol`,
+    })
+  }
+  const earningsDate = typeof obj.earnings_date === 'string' ? obj.earnings_date.trim() : ''
+  if (!isYmd(earningsDate)) {
+    throw new ValidationError(
+      `entry [${idx}]: 'earnings_date' must be ISO 'YYYY-MM-DD'`,
+      { field: `body[${idx}].earnings_date` },
+    )
+  }
+  let notes: string | null = null
+  if (obj.notes !== undefined && obj.notes !== null) {
+    if (typeof obj.notes !== 'string') {
+      throw new ValidationError(`entry [${idx}]: 'notes' must be string when present`, {
+        field: `body[${idx}].notes`,
+      })
+    }
+    if (obj.notes.length > 256) {
+      throw new ValidationError(`entry [${idx}]: 'notes' must be <= 256 chars`, {
+        field: `body[${idx}].notes`,
+      })
+    }
+    notes = obj.notes
+  }
+  return { symbol: symbol.toUpperCase(), earningsDate, notes }
+}
 
 function readAmount(body: unknown): number {
   if (body === null || typeof body !== 'object') {

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -444,8 +444,18 @@ function parseTruthyQuery(value: string | undefined): boolean {
   return normalized === '1' || normalized === 'true' || normalized === 'yes'
 }
 
+/**
+ * `YYYY-MM-DD` の文法チェック + **実在しない日付の弾き**。`Date` の自動
+ * normalize ('2026-02-30' → '2026-03-02') を逆手に取り、parse 後の Date を
+ * 同じ形式で書き戻して入力と一致するか比較する。これで `2026-02-30` や
+ * `2026-13-01` が DB に保存される事故を防ぐ (CodeRabbit #196 review)。
+ */
 function isYmd(value: string): boolean {
-  return /^\d{4}-\d{2}-\d{2}$/.test(value) && Number.isFinite(Date.parse(`${value}T00:00:00.000Z`))
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false
+  const ms = Date.parse(`${value}T00:00:00.000Z`)
+  if (!Number.isFinite(ms)) return false
+  const roundTrip = new Date(ms).toISOString().slice(0, 10)
+  return roundTrip === value
 }
 
 /**

--- a/src/trading/risk/earningsGate.ts
+++ b/src/trading/risk/earningsGate.ts
@@ -1,0 +1,165 @@
+/**
+ * Earnings calendar gate (issue #196 1/3)。
+ *
+ * 決算発表 ±N 営業日のエントリ (BUY) を凍結する **avoid 用 risk gate**。
+ * - シグナル源ではない (BUY を出す根拠にしない、BUY を *止める* だけ)
+ * - 計算コストはゼロに近い (D1 read 1 本)
+ * - DB read 失敗 → fail-closed (entry block) で safe 側に倒す
+ * - `freezeBusinessDays` 単位は **営業日** (土日 + 取引所休日 skip)。
+ *   `tradingCalendar.isTradingDay` を使うので JP / US 両対応。
+ *
+ * scope:
+ *   - in: BUY を ±N 営業日内に earnings がある銘柄について止める
+ *   - out: SELL は止めない (既存 position 保護のため決算前売却は許容)
+ *   - out: FOMC / CPI macro gate, VIX regime filter は別 PR で
+ *
+ * 呼び出し側 (`pullbackScheduler` 経由) は gate decision の `reason` を
+ * `risk: earnings_within_1bd: 2026-04-30` 形式で `strategy_decision_log.reason`
+ * に書く。dashboard `localizeReason` で日本語化。
+ */
+import {
+  inferTradingMarket,
+  isTradingDay,
+  type TradingMarket,
+} from '../domain/tradingCalendar'
+import type { EarningsCalendarRepo } from '../../infrastructure/calendar/earningsCalendarRepo'
+
+export interface EarningsGateInput {
+  symbol: string
+  /**
+   * 評価日 ISO date "YYYY-MM-DD"。cron tick が走った日付を渡す。time-of-day
+   * は持たない (1 日粒度の gate)。
+   */
+  evalDate: string
+  /**
+   * 評価対象の side。BUY のみ gate を効かせる。SELL は既存 position の
+   * 撤退 / cleanup を妨げないように常に approve。
+   */
+  side: 'BUY' | 'SELL'
+}
+
+export interface EarningsGateConfig {
+  /**
+   * ±N 営業日凍結。default 1 (issue #196 — 「earnings 翌日」までを含む)。
+   * 0 を渡せば当日のみ凍結。
+   */
+  freezeBusinessDays: number
+}
+
+export interface EarningsGateDecision {
+  approved: boolean
+  /**
+   * Approved=false のときの reject 理由。形式:
+   *   `earnings_within_${freezeBusinessDays}bd: ${earningsDate}`
+   * 複数該当する場合は最も近い earnings 日 1 件のみ載せる (operator UI 表示用)。
+   */
+  reason?: string
+}
+
+const DEFAULT_CONFIG: EarningsGateConfig = { freezeBusinessDays: 1 }
+
+/**
+ * Pure-ish gate evaluator (`repo.fetchByRange` のみ side-effect)。
+ *
+ * 振る舞い:
+ *  1. SELL → 常に approve (gate scope 外)
+ *  2. evalDate parse 失敗 → fail-closed reject
+ *  3. evalDate を中心に ±freezeBusinessDays 営業日窓を計算 (Date 範囲 string)
+ *  4. repo.fetchByRange で該当 earnings_calendar 行を取得
+ *  5. fetch throw → fail-closed reject (D1 read failure を silent pass させない)
+ *  6. 行があれば最初 (= 範囲開始日に最も近い) を理由に載せて reject
+ *  7. 行がなければ approve
+ */
+export async function evaluateEarningsGate(
+  input: EarningsGateInput,
+  repo: EarningsCalendarRepo,
+  config: EarningsGateConfig = DEFAULT_CONFIG,
+): Promise<EarningsGateDecision> {
+  if (input.side === 'SELL') return { approved: true }
+
+  const evalDay = parseYmdUtc(input.evalDate)
+  if (evalDay === null) {
+    return {
+      approved: false,
+      reason: `earnings_gate_invalid_eval_date: ${input.evalDate}`,
+    }
+  }
+
+  const freeze = sanitizeFreezeDays(config.freezeBusinessDays)
+  const market = inferTradingMarket(input.symbol)
+  const fromDay = shiftBusinessDays(evalDay, -freeze, market)
+  const toDay = shiftBusinessDays(evalDay, freeze, market)
+  const fromYmd = toYmd(fromDay)
+  const toYmd_ = toYmd(toDay)
+
+  let rows: Awaited<ReturnType<EarningsCalendarRepo['fetchByRange']>>
+  try {
+    rows = await repo.fetchByRange(input.symbol, fromYmd, toYmd_)
+  } catch (err) {
+    // D1 read failure は fail-closed。entry を止めて他 cron tick / 復旧後に
+    // 再判定。reason は dashboard で operator が原因に気付ける程度に残す。
+    const msg = err instanceof Error ? err.message : String(err)
+    return {
+      approved: false,
+      reason: `earnings_gate_fetch_failed: ${msg}`,
+    }
+  }
+
+  if (rows.length === 0) return { approved: true }
+
+  // earnings_calendar.earnings_date は ISO YYYY-MM-DD なので文字列比較で OK。
+  // repo は asc で返す前提だが、念のため最小日付を選ぶ。
+  let nearest = rows[0]!.earningsDate
+  for (const r of rows) {
+    if (r.earningsDate < nearest) nearest = r.earningsDate
+  }
+
+  return {
+    approved: false,
+    reason: `earnings_within_${freeze}bd: ${nearest}`,
+  }
+}
+
+/**
+ * 0 / 負値 / 非有限 / 巨大値の `freezeBusinessDays` を default に倒す。
+ * 上限 30 営業日 (= 約 6 週間) は POC 運用上の sane bound。
+ */
+function sanitizeFreezeDays(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return DEFAULT_CONFIG.freezeBusinessDays
+  if (value < 0) return DEFAULT_CONFIG.freezeBusinessDays
+  if (value > 30) return 30
+  return Math.floor(value)
+}
+
+const MS_PER_DAY = 86_400_000
+const MAX_SHIFT_ITER = 90
+
+/**
+ * `from` を起点に営業日 `count` 日分前後にシフト。`count > 0` で未来、`< 0` で
+ * 過去。`from` 自身は count に含めない (= count=0 はそのまま、count=1 は翌営業日)。
+ * 連続休日で無限ループを避けるため上限 90 日でガード。
+ */
+function shiftBusinessDays(from: Date, count: number, market: TradingMarket): Date {
+  if (count === 0) return from
+  const direction = count > 0 ? 1 : -1
+  const remaining = Math.abs(count)
+  let cursor = new Date(from.getTime())
+  let shifted = 0
+  for (let i = 0; i < MAX_SHIFT_ITER && shifted < remaining; i += 1) {
+    cursor = new Date(cursor.getTime() + direction * MS_PER_DAY)
+    if (isTradingDay(cursor, market)) shifted += 1
+  }
+  return cursor
+}
+
+/** "YYYY-MM-DD" → Date (UTC midnight)。形式不一致は null。 */
+function parseYmdUtc(ymd: string): Date | null {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(ymd)) return null
+  const ms = Date.parse(`${ymd}T00:00:00.000Z`)
+  if (!Number.isFinite(ms)) return null
+  return new Date(ms)
+}
+
+function toYmd(d: Date): string {
+  return d.toISOString().slice(0, 10)
+}

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -333,6 +333,12 @@ export async function runPullbackScheduler(
     }
 
     let intent: OrderIntent
+    // BUY 経路で bucketCap check が pass した場合のみ set される pending update。
+    // 後続 gate (earnings / perSymbolRisk) が reject すると未 commit のまま破棄、
+    // pass で初めて bucketExposure に反映する (CodeRabbit #196 review)。
+    // 過去仕様では check 直後に commit していたため、reject された BUY が同一
+    // bucket の後続銘柄に「占有済」とみなされる over-counting bug があった。
+    let pendingBucketUpdate: { bucket: string; newExposure: number } | null = null
     if (signal.action === 'BUY') {
       const rule = strategy.resolveRule(upper)
       const sizing = computePullbackSizing({
@@ -407,8 +413,11 @@ export async function runPullbackScheduler(
         })
         continue
       }
+      // bucketExposure の commit はまだ行わない。後続の earnings / perSymbolRisk
+      // gate が reject する可能性があり、その場合に同 bucket 後続銘柄の判定を
+      // over-count させてはいけない。実 commit は全 gate pass 後に下で行う。
       if (bucket && bucketDecision.newExposure !== undefined) {
-        bucketExposure[bucket] = bucketDecision.newExposure
+        pendingBucketUpdate = { bucket, newExposure: bucketDecision.newExposure }
       }
       intent = buildIntent(upper, 'BUY', sizing.quantity, indicators.price)
     } else {
@@ -546,6 +555,14 @@ export async function runPullbackScheduler(
         })
         continue
       }
+    }
+
+    // 全 gate (bucket / earnings / perSymbolRisk) を通過したので、ここで初めて
+    // bucketExposure を新 exposure に置き換える。これより前 (= bucket gate 直後)
+    // で commit すると、reject された BUY が同 bucket の後続銘柄を誤って弾く
+    // (CodeRabbit #196 review)。
+    if (pendingBucketUpdate) {
+      bucketExposure[pendingBucketUpdate.bucket] = pendingBucketUpdate.newExposure
     }
 
     const expiresAtMs = now().getTime() + pendingLockTtlMs

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -20,6 +20,8 @@ import {
   type SymbolRule,
 } from './strategies/PullbackUptrendStrategy'
 import { decideBucketGate } from '../risk/bucketExposureGate'
+import { evaluateEarningsGate } from '../risk/earningsGate'
+import type { EarningsCalendarRepo } from '../../infrastructure/calendar/earningsCalendarRepo'
 import { evaluatePerSymbolRisk } from '../risk/perSymbolRiskGate'
 
 const DEFAULT_BAR_LOOKBACK = 60
@@ -93,7 +95,19 @@ export interface PullbackSchedulerOptions {
    * (`runStrategyCron`) は global_config / symbolUniverse から fully populate する。
    */
   perSymbolRisk?: PerSymbolRiskScheduleConfig
+  /**
+   * Earnings calendar gate (issue #196 1/3)。±N 営業日で BUY を凍結。
+   * `repo` 未注入なら gate skip (POC 後方互換)。production
+   * (`runStrategyCron`) が D1 から repo を作って渡す。
+   */
+  earningsGate?: EarningsScheduleConfig
   now?: () => Date
+}
+
+export interface EarningsScheduleConfig {
+  repo: EarningsCalendarRepo
+  /** ±N 営業日。default 1。 */
+  freezeBusinessDays?: number
 }
 
 export interface PerSymbolRiskScheduleConfig {
@@ -451,6 +465,36 @@ export async function runPullbackScheduler(
       intent = buildIntent(upper, 'SELL', state.position.qty, indicators.price)
     }
 
+    // Earnings calendar gate (issue #196 1/3)。BUY の場合のみ評価し、
+    // ±N 営業日内に earnings_calendar 行があれば reject。SELL は撤退路を
+    // 妨げないよう gate 対象外。`earningsGate` 未注入なら skip (POC 後方互換)。
+    // perSymbolRisk より先に評価することで、broker / spread 系より上位の
+    // 「そもそもエントリしない」判断として cron 経路から見える。
+    if (options.earningsGate && intent.side === 'BUY') {
+      const evalDate = now().toISOString().slice(0, 10)
+      const earningsDecision = await evaluateEarningsGate(
+        { symbol: upper, evalDate, side: 'BUY' },
+        options.earningsGate.repo,
+        { freezeBusinessDays: options.earningsGate.freezeBusinessDays ?? 1 },
+      )
+      if (!earningsDecision.approved) {
+        const reason = `risk: ${earningsDecision.reason ?? 'earnings_gate'}`
+        summary.rejected.push({ symbol: upper, reason })
+        await emitDecision({
+          symbol: upper,
+          decision: 'REJECT',
+          reason,
+          price: indicators.price,
+          indicatorsJson: JSON.stringify(indicators),
+          trace: appendTrace(
+            signal.trace,
+            traceStep('risk.earnings_calendar', false, undefined, undefined, undefined, earningsDecision.reason),
+          ),
+        })
+        continue
+      }
+    }
+
     // Per-symbol risk gate (issue #138)。manual `/trade/execute` (TradingService)
     // と同じ pure function を呼ぶことで gate parity を取る。perSymbolRisk が
     // 未注入の場合は POC 後方互換で skip。Inverse pair の SymbolState は同期
@@ -731,6 +775,7 @@ const TRACE_LABEL_JA: Record<string, string> = {
   'scheduler.pending_lock_expiry_valid': '注文ロック期限が有効',
   'scheduler.pending_lock_acquired': '注文ロックを取得できた',
   'risk.bucket_cap': '同グループ建玉上限内',
+  'risk.earnings_calendar': '決算日カレンダーゲート',
   'risk.per_symbol_gate': '銘柄別リスクゲート',
   'broker.submit': '証券会社への発注送信',
 }

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -19,6 +19,10 @@ import {
   logStrategyDecision,
   strategyDecisionDbOrUndefined,
 } from '../../infrastructure/logger/strategyDecisionLog'
+import {
+  createEarningsCalendarDb,
+  createEarningsCalendarRepo,
+} from '../../infrastructure/calendar/earningsCalendarRepo'
 import { runPullbackScheduler, type PullbackDecisionTrace, type PullbackRunSummary } from './pullbackScheduler'
 
 const DEFAULT_EQUITY_USD = 10_000
@@ -448,6 +452,17 @@ export async function runStrategyCron(
         staleQuoteMs: global.staleQuoteMs,
         gapRejectPct: global.gapRejectPct,
       },
+      // Earnings calendar gate (issue #196 1/3)。env.DB が無ければ skip
+      // (POC 後方互換)。freezeBusinessDays は POC 段階では default 1 固定。
+      // 将来 global_config に出すなら別 PR (#196 follow-up)。
+      ...(env.DB
+        ? {
+            earningsGate: {
+              repo: createEarningsCalendarRepo(createEarningsCalendarDb(env.DB)),
+              freezeBusinessDays: 1,
+            },
+          }
+        : {}),
       onDecision: (record) =>
         logStrategyDecision(decisionDb, {
           timestamp: new Date().toISOString(),

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -384,6 +384,22 @@ export async function runStrategyCron(
   // market-data API (see #84). Webull is still the order-execution path.
   const barClient = new YahooBarClient()
 
+  // Earnings calendar gate (issue #196 1/3): table 未 migrate な環境で
+  // `fetchByRange()` が `no such table` を吐くと fail-closed で全 BUY が
+  // `earnings_gate_fetch_failed` reject になる。新環境 / preview deploy 等で
+  // 0013 未適用の状態を許容するため、起動時に 1 回 sqlite_master を見て
+  // table の有無を判定し、無ければ gate を 注入しない (= 過去挙動 = 全通過)
+  // (CodeRabbit #196 review)。
+  const earningsGateReady = env.DB ? await isEarningsCalendarReady(env.DB) : false
+  if (env.DB && !earningsGateReady) {
+    console.warn(
+      JSON.stringify({
+        event: 'earnings_gate_disabled_table_missing',
+        requestId: options.requestId,
+      }),
+    )
+  }
+
   // Pullback デフォルト rule は D1 global_config に寄せた (#118)。
   // 実運用中の tuning は `UPDATE global_config SET ...` で即反映可能。
   const summary = emptySummary()
@@ -452,10 +468,11 @@ export async function runStrategyCron(
         staleQuoteMs: global.staleQuoteMs,
         gapRejectPct: global.gapRejectPct,
       },
-      // Earnings calendar gate (issue #196 1/3)。env.DB が無ければ skip
-      // (POC 後方互換)。freezeBusinessDays は POC 段階では default 1 固定。
-      // 将来 global_config に出すなら別 PR (#196 follow-up)。
-      ...(env.DB
+      // Earnings calendar gate (issue #196 1/3)。env.DB が無い OR table 未
+      // migrate なら skip (POC 後方互換 / CodeRabbit #196 review)。
+      // freezeBusinessDays は POC 段階では default 1 固定。将来 global_config に
+      // 出すなら別 PR (#196 follow-up)。
+      ...(env.DB && earningsGateReady
         ? {
             earningsGate: {
               repo: createEarningsCalendarRepo(createEarningsCalendarDb(env.DB)),
@@ -585,6 +602,32 @@ export function emitStaleRollWarningIfNeeded(args: {
         thresholdHours: STALE_ROLL_WARNING_HOURS,
       }),
     )
+  }
+}
+
+/**
+ * 0013 migration (`earnings_calendar`) が当該 D1 で適用済みかを判定する。
+ *
+ * 新環境 / preview deploy 等で 0013 未適用の状態に対し earnings gate を有効化
+ * すると、`fetchByRange()` が `no such table` を吐き fail-closed で全 BUY が
+ * reject される (CodeRabbit #196 review)。それを避けるため、cron 起動時に
+ * `sqlite_master` を 1 回参照し、table が存在しなければ gate を **注入しない**
+ * (過去挙動 = 全通過 へ fallback)。
+ *
+ * クエリ自体が throw した場合 (DB 接続失敗 / corruption 等) も「未 ready」
+ * 扱い。これは「earnings 評価ができない壊れた D1 で gate を有効化しない」
+ * という選択で、安全側の fallback として bucket / perSymbolRisk gate に任せる。
+ */
+async function isEarningsCalendarReady(db: D1Database): Promise<boolean> {
+  try {
+    const row = await db
+      .prepare(
+        "SELECT 1 AS ok FROM sqlite_master WHERE type='table' AND name='earnings_calendar' LIMIT 1",
+      )
+      .first<{ ok: number }>()
+    return row?.ok === 1
+  } catch {
+    return false
   }
 }
 

--- a/test/infrastructure/calendar/earningsCalendarRepo.test.ts
+++ b/test/infrastructure/calendar/earningsCalendarRepo.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createEarningsCalendarRepo,
+  type EarningsCalendarDb,
+  type EarningsCalendarSeedInput,
+} from '../../../src/infrastructure/calendar/earningsCalendarRepo'
+
+/**
+ * `bulkUpsert` の chunk insert 動作テスト (CodeRabbit #196 review)。
+ *
+ * 過去仕様は 1 row につき 1 INSERT 文を発行 (records.length 回 await) → 1000 行
+ * で D1 subrequest 制限に達する。修正後は 50 行 chunk で multi-row VALUES に
+ * まとめる (drizzle `.values([...])`)。`.onConflictDoNothing()` の挙動 (UNIQUE
+ * 違反 row だけ skip)、`.returning()` の戻り行数による inserted/skipped カウントも
+ * 維持する。
+ */
+
+function makeFakeDb(opts: {
+  /** chunk index → returning rows (id) */
+  insertedPerChunk: Array<Array<{ id: number }>>
+}) {
+  const calls: Array<{ values: Array<EarningsCalendarSeedInput & { symbol: string }> }> = []
+  let chunkIdx = 0
+  const builder = {
+    values(values: Array<EarningsCalendarSeedInput & { symbol: string }>) {
+      calls.push({ values })
+      return {
+        onConflictDoNothing(_args: unknown) {
+          return {
+            returning(_cols: unknown) {
+              const rows = opts.insertedPerChunk[chunkIdx] ?? []
+              chunkIdx += 1
+              return Promise.resolve(rows)
+            },
+          }
+        },
+      }
+    },
+  }
+  const db = {
+    insert: vi.fn(() => builder),
+  } as unknown as EarningsCalendarDb
+  return { db, calls }
+}
+
+describe('createEarningsCalendarRepo.bulkUpsert', () => {
+  it('returns inserted=0 / skipped=0 when records is empty', async () => {
+    const { db } = makeFakeDb({ insertedPerChunk: [] })
+    const repo = createEarningsCalendarRepo(db)
+    const result = await repo.bulkUpsert([])
+    expect(result).toEqual({ inserted: 0, skipped: 0 })
+  })
+
+  it('chunks 50 rows per multi-row INSERT (single subrequest per chunk)', async () => {
+    const records: EarningsCalendarSeedInput[] = Array.from({ length: 120 }, (_, i) => ({
+      symbol: `S${i}`,
+      earningsDate: '2026-04-30',
+      notes: null,
+    }))
+    // chunk 0 (50 rows): all inserted, chunk 1 (50): 1 conflict skipped,
+    // chunk 2 (20): all inserted.
+    const insertedPerChunk = [
+      Array.from({ length: 50 }, (_, i) => ({ id: i + 1 })),
+      Array.from({ length: 49 }, (_, i) => ({ id: 50 + i + 1 })),
+      Array.from({ length: 20 }, (_, i) => ({ id: 100 + i + 1 })),
+    ]
+    const { db, calls } = makeFakeDb({ insertedPerChunk })
+    const repo = createEarningsCalendarRepo(db)
+    const result = await repo.bulkUpsert(records)
+    // 3 chunks → 3 INSERT statements。1 行あたり 1 INSERT ではないことを保証。
+    expect(calls).toHaveLength(3)
+    expect(calls[0]!.values).toHaveLength(50)
+    expect(calls[1]!.values).toHaveLength(50)
+    expect(calls[2]!.values).toHaveLength(20)
+    // inserted は returning() の合計、skipped は chunk size との差分。
+    expect(result).toEqual({ inserted: 50 + 49 + 20, skipped: 1 })
+  })
+
+  it('upper-cases symbol and applies notes ?? null per row', async () => {
+    const records: EarningsCalendarSeedInput[] = [
+      { symbol: 'aapl', earningsDate: '2026-04-30', notes: 'Q2' },
+      { symbol: 'msft', earningsDate: '2026-04-29' }, // notes omitted
+    ]
+    const { db, calls } = makeFakeDb({
+      insertedPerChunk: [[{ id: 1 }, { id: 2 }]],
+    })
+    const repo = createEarningsCalendarRepo(db)
+    const result = await repo.bulkUpsert(records)
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.values).toEqual([
+      { symbol: 'AAPL', earningsDate: '2026-04-30', notes: 'Q2' },
+      { symbol: 'MSFT', earningsDate: '2026-04-29', notes: null },
+    ])
+    expect(result).toEqual({ inserted: 2, skipped: 0 })
+  })
+
+  it('attributes UNIQUE-violation skips correctly within a single chunk', async () => {
+    const records: EarningsCalendarSeedInput[] = [
+      { symbol: 'AAPL', earningsDate: '2026-04-30' },
+      { symbol: 'AAPL', earningsDate: '2026-04-30' }, // duplicate
+      { symbol: 'MSFT', earningsDate: '2026-04-29' },
+    ]
+    // returning() returns only the 2 actually-inserted rows (1 was a conflict).
+    const { db } = makeFakeDb({ insertedPerChunk: [[{ id: 1 }, { id: 2 }]] })
+    const repo = createEarningsCalendarRepo(db)
+    const result = await repo.bulkUpsert(records)
+    expect(result).toEqual({ inserted: 2, skipped: 1 })
+  })
+})

--- a/test/routes/admin.test.ts
+++ b/test/routes/admin.test.ts
@@ -266,3 +266,213 @@ describe('POST /admin/symbols/:symbol/clear-cooldown', () => {
     expect(captured.calls).toEqual([{ symbol: 'SOXL', untilIso: '1970-01-01T00:00:00.000Z' }])
   })
 })
+
+describe('Earnings calendar admin endpoints (#196)', () => {
+  type EarningsRow = {
+    id: number
+    symbol: string
+    earningsDate: string
+    notes: string | null
+    createdAt: string
+  }
+  function fakeRepo() {
+    return {
+      bulkUpsert: vi.fn<(records: unknown) => Promise<{ inserted: number; skipped: number }>>(
+        async () => ({ inserted: 0, skipped: 0 }),
+      ),
+      fetchBySymbol: vi.fn<(symbol: string) => Promise<EarningsRow[]>>(async () => []),
+      fetchByRange: vi.fn<(symbol: string, from: string, to: string) => Promise<EarningsRow[]>>(
+        async () => [],
+      ),
+      deleteById: vi.fn<(id: number) => Promise<boolean>>(async () => false),
+    }
+  }
+
+  async function withFakeRepo<T>(repo: ReturnType<typeof fakeRepo>, fn: () => Promise<T>): Promise<T> {
+    const mod = await import('../../src/infrastructure/calendar/earningsCalendarRepo')
+    const spy = vi.spyOn(mod, 'createEarningsCalendarRepo').mockReturnValue(repo as never)
+    try {
+      return await fn()
+    } finally {
+      spy.mockRestore()
+    }
+  }
+
+  describe('POST /admin/earnings/seed', () => {
+    it('401s without Basic Auth', async () => {
+      const app = createApp()
+      const res = await app.request(
+        '/admin/earnings/seed',
+        {
+          method: 'POST',
+          body: JSON.stringify([{ symbol: 'AAPL', earnings_date: '2026-04-30' }]),
+        },
+        { ...baseEnv, DB: {} as unknown as D1Database },
+      )
+      expect(res.status).toBe(401)
+    })
+
+    it('400s when DB binding is missing', async () => {
+      const app = createApp()
+      const res = await app.request(
+        '/admin/earnings/seed',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', ...authHeader },
+          body: JSON.stringify([{ symbol: 'AAPL', earnings_date: '2026-04-30' }]),
+        },
+        baseEnv,
+      )
+      expect(res.status).toBe(400)
+    })
+
+    it('400s when body is not an array', async () => {
+      const app = createApp()
+      const res = await app.request(
+        '/admin/earnings/seed',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', ...authHeader },
+          body: JSON.stringify({ symbol: 'AAPL' }),
+        },
+        { ...baseEnv, DB: {} as unknown as D1Database },
+      )
+      expect(res.status).toBe(400)
+    })
+
+    it('400s on invalid earnings_date format', async () => {
+      const app = createApp()
+      const res = await app.request(
+        '/admin/earnings/seed',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', ...authHeader },
+          body: JSON.stringify([{ symbol: 'AAPL', earnings_date: '04/30/2026' }]),
+        },
+        { ...baseEnv, DB: {} as unknown as D1Database },
+      )
+      expect(res.status).toBe(400)
+    })
+
+    it('400s on empty body array', async () => {
+      const app = createApp()
+      const res = await app.request(
+        '/admin/earnings/seed',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', ...authHeader },
+          body: JSON.stringify([]),
+        },
+        { ...baseEnv, DB: {} as unknown as D1Database },
+      )
+      expect(res.status).toBe(400)
+    })
+
+    it('200s and forwards entries (uppercased) to bulkUpsert', async () => {
+      const repo = fakeRepo()
+      repo.bulkUpsert.mockResolvedValueOnce({ inserted: 2, skipped: 0 })
+      const res = await withFakeRepo(repo, async () => {
+        const app = createApp()
+        return app.request(
+          '/admin/earnings/seed',
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', ...authHeader },
+            body: JSON.stringify([
+              { symbol: 'aapl', earnings_date: '2026-04-30', notes: 'Q2' },
+              { symbol: 'MSFT', earnings_date: '2026-04-29' },
+            ]),
+          },
+          { ...baseEnv, DB: {} as unknown as D1Database },
+        )
+      })
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as { inserted: number; skipped: number; total: number }
+      expect(body).toEqual({ inserted: 2, skipped: 0, total: 2 })
+      expect(repo.bulkUpsert).toHaveBeenCalledWith([
+        { symbol: 'AAPL', earningsDate: '2026-04-30', notes: 'Q2' },
+        { symbol: 'MSFT', earningsDate: '2026-04-29', notes: null },
+      ])
+    })
+  })
+
+  describe('GET /admin/earnings', () => {
+    it('400s when symbol query param missing', async () => {
+      const app = createApp()
+      const res = await app.request(
+        '/admin/earnings',
+        { headers: { ...authHeader } },
+        { ...baseEnv, DB: {} as unknown as D1Database },
+      )
+      expect(res.status).toBe(400)
+    })
+
+    it('200s with rows for the symbol', async () => {
+      const repo = fakeRepo()
+      repo.fetchBySymbol.mockResolvedValueOnce([
+        {
+          id: 1,
+          symbol: 'AAPL',
+          earningsDate: '2026-04-30',
+          notes: null,
+          createdAt: '2026-04-21T00:00:00.000Z',
+        },
+      ])
+      const res = await withFakeRepo(repo, async () => {
+        const app = createApp()
+        return app.request(
+          '/admin/earnings?symbol=aapl',
+          { headers: { ...authHeader } },
+          { ...baseEnv, DB: {} as unknown as D1Database },
+        )
+      })
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as { symbol: string; rows: Array<{ symbol: string }> }
+      expect(body.symbol).toBe('AAPL')
+      expect(body.rows).toHaveLength(1)
+      expect(repo.fetchBySymbol).toHaveBeenCalledWith('AAPL')
+    })
+  })
+
+  describe('DELETE /admin/earnings/:id', () => {
+    it('400s on non-numeric id', async () => {
+      const app = createApp()
+      const res = await app.request(
+        '/admin/earnings/abc',
+        { method: 'DELETE', headers: { ...authHeader } },
+        { ...baseEnv, DB: {} as unknown as D1Database },
+      )
+      expect(res.status).toBe(400)
+    })
+
+    it('404 when row does not exist', async () => {
+      const repo = fakeRepo()
+      repo.deleteById.mockResolvedValueOnce(false)
+      const res = await withFakeRepo(repo, async () => {
+        const app = createApp()
+        return app.request(
+          '/admin/earnings/42',
+          { method: 'DELETE', headers: { ...authHeader } },
+          { ...baseEnv, DB: {} as unknown as D1Database },
+        )
+      })
+      expect(res.status).toBe(404)
+    })
+
+    it('200 and forwards id when deletion succeeds', async () => {
+      const repo = fakeRepo()
+      repo.deleteById.mockResolvedValueOnce(true)
+      const res = await withFakeRepo(repo, async () => {
+        const app = createApp()
+        return app.request(
+          '/admin/earnings/9',
+          { method: 'DELETE', headers: { ...authHeader } },
+          { ...baseEnv, DB: {} as unknown as D1Database },
+        )
+      })
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ deleted: true, id: 9 })
+      expect(repo.deleteById).toHaveBeenCalledWith(9)
+    })
+  })
+})

--- a/test/routes/admin.test.ts
+++ b/test/routes/admin.test.ts
@@ -354,6 +354,26 @@ describe('Earnings calendar admin endpoints (#196)', () => {
       expect(res.status).toBe(400)
     })
 
+    it.each(['2026-02-30', '2026-13-01', '2026-00-15', '2026-04-31', '2025-02-29'])(
+      'rejects calendar-impossible date %s (round-trip validation)',
+      async (badDate) => {
+        // CodeRabbit #196 review: 単純な regex + Date.parse() では
+        // `2026-02-30` が `2026-03-02` に normalize されて DB に保存される。
+        // round-trip で実在日付のみ通すよう validator が直っていることを確認。
+        const app = createApp()
+        const res = await app.request(
+          '/admin/earnings/seed',
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', ...authHeader },
+            body: JSON.stringify([{ symbol: 'AAPL', earnings_date: badDate }]),
+          },
+          { ...baseEnv, DB: {} as unknown as D1Database },
+        )
+        expect(res.status).toBe(400)
+      },
+    )
+
     it('400s on empty body array', async () => {
       const app = createApp()
       const res = await app.request(

--- a/test/trading/risk/earningsGate.test.ts
+++ b/test/trading/risk/earningsGate.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  evaluateEarningsGate,
+  type EarningsGateConfig,
+} from '../../../src/trading/risk/earningsGate'
+import type {
+  EarningsCalendarRepo,
+  EarningsCalendarSeedInput,
+} from '../../../src/infrastructure/calendar/earningsCalendarRepo'
+import type { EarningsCalendarRow } from '../../../src/infrastructure/db/schema'
+
+/**
+ * Tests for the earnings calendar gate (#196 1/3).
+ *
+ * 観点:
+ *   - ±1 営業日以内 → reject (BUY)
+ *   - 範囲外 → approve
+ *   - 該当 row なし → approve
+ *   - SELL → 常に approve (撤退路を妨げない)
+ *   - DB read 失敗 → fail-closed reject
+ *   - 営業日計算 (土日/祝日 skip) が正しく窓に効いている
+ */
+
+const baseConfig: EarningsGateConfig = { freezeBusinessDays: 1 }
+
+function row(symbol: string, date: string, id = 1): EarningsCalendarRow {
+  return {
+    id,
+    symbol: symbol.toUpperCase(),
+    earningsDate: date,
+    notes: null,
+    createdAt: '2026-04-21T00:00:00.000Z',
+  }
+}
+
+function fakeRepo(rows: EarningsCalendarRow[]): EarningsCalendarRepo & {
+  calls: Array<{ symbol: string; from: string; to: string }>
+} {
+  const calls: Array<{ symbol: string; from: string; to: string }> = []
+  return {
+    calls,
+    async fetchByRange(symbol, from, to) {
+      calls.push({ symbol: symbol.toUpperCase(), from, to })
+      return rows.filter(
+        (r) => r.symbol === symbol.toUpperCase() && r.earningsDate >= from && r.earningsDate <= to,
+      )
+    },
+    async fetchBySymbol(symbol) {
+      return rows.filter((r) => r.symbol === symbol.toUpperCase())
+    },
+    async bulkUpsert(_records: EarningsCalendarSeedInput[]) {
+      return { inserted: 0, skipped: 0 }
+    },
+    async deleteById(_id: number) {
+      return false
+    },
+  }
+}
+
+describe('evaluateEarningsGate — base behaviour', () => {
+  it('approves when no earnings row exists for the symbol', async () => {
+    const repo = fakeRepo([])
+    const decision = await evaluateEarningsGate(
+      { symbol: 'AAPL', evalDate: '2026-04-20', side: 'BUY' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(true)
+    expect(decision.reason).toBeUndefined()
+    expect(repo.calls).toHaveLength(1)
+  })
+
+  it('always approves SELL regardless of earnings proximity', async () => {
+    const repo = fakeRepo([row('AAPL', '2026-04-20')])
+    const decision = await evaluateEarningsGate(
+      { symbol: 'AAPL', evalDate: '2026-04-20', side: 'SELL' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(true)
+    expect(repo.calls).toHaveLength(0)
+  })
+})
+
+describe('evaluateEarningsGate — within window', () => {
+  it('rejects on the earnings day itself', async () => {
+    const repo = fakeRepo([row('AAPL', '2026-04-20')])
+    const decision = await evaluateEarningsGate(
+      { symbol: 'AAPL', evalDate: '2026-04-20', side: 'BUY' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reason).toBe('earnings_within_1bd: 2026-04-20')
+  })
+
+  it('rejects 1 business day before earnings', async () => {
+    // earnings on Tue 2026-04-21, evaluating on Mon 2026-04-20 (1 BD ahead)
+    const repo = fakeRepo([row('AAPL', '2026-04-21')])
+    const decision = await evaluateEarningsGate(
+      { symbol: 'AAPL', evalDate: '2026-04-20', side: 'BUY' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reason).toBe('earnings_within_1bd: 2026-04-21')
+  })
+
+  it('rejects 1 business day after earnings', async () => {
+    // earnings on Mon 2026-04-20, evaluating on Tue 2026-04-21
+    const repo = fakeRepo([row('AAPL', '2026-04-20')])
+    const decision = await evaluateEarningsGate(
+      { symbol: 'AAPL', evalDate: '2026-04-21', side: 'BUY' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reason).toBe('earnings_within_1bd: 2026-04-20')
+  })
+
+  it('rejects across a weekend (Friday earnings, Monday eval = 1 BD)', async () => {
+    // Friday earnings 2026-04-17, Monday eval 2026-04-20 — 3 calendar days but
+    // 1 business day with weekend skip, must reject under freezeBusinessDays=1.
+    const repo = fakeRepo([row('AAPL', '2026-04-17')])
+    const decision = await evaluateEarningsGate(
+      { symbol: 'AAPL', evalDate: '2026-04-20', side: 'BUY' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reason).toContain('2026-04-17')
+  })
+})
+
+describe('evaluateEarningsGate — outside window', () => {
+  it('approves 2 business days before earnings (range exclusive)', async () => {
+    // Friday earnings 2026-04-24, eval Tuesday 2026-04-21 — 2 business days
+    // gap (Wed and Thu) under freezeBusinessDays=1.
+    const repo = fakeRepo([row('AAPL', '2026-04-24')])
+    const decision = await evaluateEarningsGate(
+      { symbol: 'AAPL', evalDate: '2026-04-21', side: 'BUY' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(true)
+  })
+
+  it('approves 2 business days after earnings', async () => {
+    // earnings Mon 2026-04-20, eval Wed 2026-04-22 — 2 business days gap.
+    const repo = fakeRepo([row('AAPL', '2026-04-20')])
+    const decision = await evaluateEarningsGate(
+      { symbol: 'AAPL', evalDate: '2026-04-22', side: 'BUY' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(true)
+  })
+
+  it('does not match a different symbol with a same-day earnings row', async () => {
+    const repo = fakeRepo([row('MSFT', '2026-04-20')])
+    const decision = await evaluateEarningsGate(
+      { symbol: 'AAPL', evalDate: '2026-04-20', side: 'BUY' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(true)
+  })
+})
+
+describe('evaluateEarningsGate — fail-closed paths', () => {
+  it('rejects when D1 read throws (fail-closed)', async () => {
+    const repo: EarningsCalendarRepo = {
+      async fetchByRange() {
+        throw new Error('d1 connection lost')
+      },
+      async fetchBySymbol() {
+        return []
+      },
+      async bulkUpsert() {
+        return { inserted: 0, skipped: 0 }
+      },
+      async deleteById() {
+        return false
+      },
+    }
+    const decision = await evaluateEarningsGate(
+      { symbol: 'AAPL', evalDate: '2026-04-20', side: 'BUY' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reason).toContain('earnings_gate_fetch_failed')
+    expect(decision.reason).toContain('d1 connection lost')
+  })
+
+  it('rejects on invalid evalDate', async () => {
+    const repo = fakeRepo([])
+    const decision = await evaluateEarningsGate(
+      { symbol: 'AAPL', evalDate: 'not-a-date', side: 'BUY' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reason).toContain('earnings_gate_invalid_eval_date')
+  })
+
+  it('reports the nearest earnings date when multiple rows are within window', async () => {
+    const repo = fakeRepo([row('AAPL', '2026-04-19', 1), row('AAPL', '2026-04-21', 2)])
+    const decision = await evaluateEarningsGate(
+      { symbol: 'AAPL', evalDate: '2026-04-20', side: 'BUY' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(false)
+    // both within ±1 BD; reason picks the earliest deterministically
+    expect(decision.reason).toBe('earnings_within_1bd: 2026-04-19')
+  })
+})
+
+describe('evaluateEarningsGate — config sanitisation', () => {
+  it('clamps negative freezeBusinessDays to default 1', async () => {
+    const repo = fakeRepo([row('AAPL', '2026-04-21')])
+    const decision = await evaluateEarningsGate(
+      { symbol: 'AAPL', evalDate: '2026-04-20', side: 'BUY' },
+      repo,
+      { freezeBusinessDays: -3 },
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reason).toBe('earnings_within_1bd: 2026-04-21')
+  })
+
+  it('clamps absurdly large freezeBusinessDays to 30', async () => {
+    const repo = fakeRepo([row('AAPL', '2026-04-21')])
+    const fetchSpy = vi.spyOn(repo, 'fetchByRange')
+    await evaluateEarningsGate(
+      { symbol: 'AAPL', evalDate: '2026-04-20', side: 'BUY' },
+      repo,
+      { freezeBusinessDays: 9999 },
+    )
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    const call = fetchSpy.mock.calls[0]!
+    // window expanded to ±30 BD around 2026-04-20 — `from` should be well
+    // before, `to` well after.
+    expect(call[1] < '2026-04-01').toBe(true)
+    expect(call[2] > '2026-05-01').toBe(true)
+  })
+})

--- a/test/trading/strategy/pullbackScheduler.test.ts
+++ b/test/trading/strategy/pullbackScheduler.test.ts
@@ -459,3 +459,91 @@ describe('runPullbackScheduler per-symbol risk gate (#138 parity)', () => {
     expect(execution.calls).toHaveLength(1)
   })
 })
+
+describe('runPullbackScheduler earnings calendar gate (#196)', () => {
+  it('rejects BUY when an earnings_calendar row is within ±1 BD', async () => {
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution,
+      earningsGate: {
+        repo: {
+          async fetchByRange() {
+            // Always returns one row whose date matches the eval day.
+            return [
+              {
+                id: 1,
+                symbol: 'AAPL',
+                earningsDate: now.toISOString().slice(0, 10),
+                notes: null,
+                createdAt: now.toISOString(),
+              },
+            ]
+          },
+          async fetchBySymbol() {
+            return []
+          },
+          async bulkUpsert() {
+            return { inserted: 0, skipped: 0 }
+          },
+          async deleteById() {
+            return false
+          },
+        },
+        freezeBusinessDays: 1,
+      },
+      now: () => now,
+    })
+    expect(summary.buys).toBe(0)
+    expect(execution.calls).toHaveLength(0)
+    const reject = summary.decisions.find((d) => d.decision === 'REJECT')
+    expect(reject?.reason).toContain('risk: earnings_within_1bd')
+  })
+
+  it('approves BUY when earnings repo returns no rows', async () => {
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution,
+      earningsGate: {
+        repo: {
+          async fetchByRange() {
+            return []
+          },
+          async fetchBySymbol() {
+            return []
+          },
+          async bulkUpsert() {
+            return { inserted: 0, skipped: 0 }
+          },
+          async deleteById() {
+            return false
+          },
+        },
+        freezeBusinessDays: 1,
+      },
+      now: () => now,
+    })
+    expect(summary.buys).toBe(1)
+    expect(execution.calls).toHaveLength(1)
+  })
+
+  it('skips the earnings gate when option is omitted (back-compat)', async () => {
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution,
+      now: () => now,
+    })
+    expect(summary.buys).toBe(1)
+  })
+})

--- a/test/trading/strategy/pullbackScheduler.test.ts
+++ b/test/trading/strategy/pullbackScheduler.test.ts
@@ -546,4 +546,82 @@ describe('runPullbackScheduler earnings calendar gate (#196)', () => {
     })
     expect(summary.buys).toBe(1)
   })
+
+  it('does not commit bucketExposure when earnings gate rejects the BUY (#196 review)', async () => {
+    // CodeRabbit #196 review: bucketExposure は bucket cap check 直後ではなく
+    // 全 gate (earnings + perSymbolRisk) 通過後に commit する。同 bucket の
+    // 後続銘柄が、reject された BUY の notional を「占有済」と誤解しないように。
+    //
+    // Setup: 2 銘柄 (AAPL, MSFT) を同 'tech' bucket に置き、bucketCap を
+    // 「BUY 1 件分の notional × 1.5」に設定。AAPL は earnings reject、
+    // MSFT は通常通過。修正後は MSFT が 1 件 BUY 成立する (cap 余裕あり)。
+    // 修正前 (バグ) は AAPL の notional が exposure に積まれて MSFT も bucket
+    // cap reject になる。
+    const repo = {
+      async fetchByRange(symbol: string) {
+        if (symbol === 'AAPL') {
+          return [
+            {
+              id: 1,
+              symbol: 'AAPL',
+              earningsDate: now.toISOString().slice(0, 10),
+              notes: null,
+              createdAt: now.toISOString(),
+            },
+          ]
+        }
+        return []
+      },
+      async fetchBySymbol() {
+        return []
+      },
+      async bulkUpsert() {
+        return { inserted: 0, skipped: 0 }
+      },
+      async deleteById() {
+        return false
+      },
+    }
+
+    // Probe: 単一 BUY の notional を確定値で取得し、bucketCap を 1.5× にする。
+    // uptrendBars + equity 100k の qty / price は決定的なので probe → cap 算出。
+    const probeExecution = mockExecution()
+    const probe = await runPullbackScheduler({
+      symbols: ['MSFT'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution: probeExecution,
+      now: () => now,
+    })
+    expect(probe.buys).toBe(1)
+    const probeNotional = probe.decisions[0]?.order?.notional ?? 0
+    expect(probeNotional).toBeGreaterThan(0)
+    const bucketCap = Math.floor(probeNotional * 1.5)
+
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL', 'MSFT'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution,
+      symbolBucketMap: { AAPL: 'tech', MSFT: 'tech' },
+      bucketCapMap: { tech: bucketCap },
+      earningsGate: { repo, freezeBusinessDays: 1 },
+      now: () => now,
+    })
+
+    // AAPL は earnings reject、MSFT は bucket pass + execute。
+    expect(summary.buys).toBe(1)
+    expect(execution.calls).toHaveLength(1)
+    expect((execution.calls[0] as { symbol: string }).symbol).toBe('MSFT')
+
+    const aaplDecision = summary.decisions.find((d) => d.symbol === 'AAPL')
+    expect(aaplDecision?.decision).toBe('REJECT')
+    expect(aaplDecision?.reason).toContain('earnings_within_1bd')
+
+    const msftDecision = summary.decisions.find((d) => d.symbol === 'MSFT')
+    expect(msftDecision?.decision).toBe('BUY')
+  })
 })

--- a/test/trading/strategy/runStrategyCron.test.ts
+++ b/test/trading/strategy/runStrategyCron.test.ts
@@ -148,6 +148,60 @@ describe('runStrategyCron', () => {
     expect(result.skipReason).toBe('portfolio_halted')
   })
 
+  // CodeRabbit #196 review: 0013 未 migrate な D1 で earnings gate を有効化すると
+  // `fetchByRange()` が `no such table` を吐き全 BUY が fail-closed reject される。
+  // 起動時 sqlite_master チェックで table 不在を検知し、gate 自体を **注入しない**
+  // ことを確認する (= 過去挙動 / approve all へ fallback)。`tradingDisabledUntil`
+  // を未来時刻にして scheduler は起動させず、probe + warn だけ評価する。
+  it('disables earnings gate when earnings_calendar table is missing (#196 review)', async () => {
+    // sqlite_master を SELECT してくる prepare 呼び出し用 fake D1。
+    // - SELECT 1 ... sqlite_master ... earnings_calendar → first() が null
+    //   (table 未存在) → earningsGateReady=false で gate skip
+    const firstSpy = vi.fn(async () => null)
+    const fakeDb = {
+      prepare: vi.fn(() => ({
+        first: firstSpy,
+      })),
+    } as unknown as D1Database
+    const warnSpy2 = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    try {
+      const envWithMissingTable = {
+        DB: fakeDb,
+        SYMBOL_STATE: {} as DurableObjectNamespace<never>,
+        PORTFOLIO_STATE: {
+          idFromName: () => ({}),
+          get: () => ({
+            getPortfolio: vi.fn().mockResolvedValue({
+              dailyStartEquity: 10_000,
+              dailyRealizedPnl: 0,
+              tradingDisabledUntil: null,
+              updatedAt: new Date().toISOString(),
+            }),
+          }),
+        },
+      } as unknown as Parameters<typeof runStrategyCron>[0]
+
+      await runStrategyCron(envWithMissingTable, { requestId: 'req-no-table' }).catch(
+        // scheduler 内部 (bar fetch / DO etc.) は本テストのスコープ外なので
+        // 例外は握りつぶす。重要なのは sqlite_master probe + warn ログ。
+        () => undefined,
+      )
+
+      const calls = (fakeDb.prepare as ReturnType<typeof vi.fn>).mock.calls as Array<[string]>
+      const probedSqliteMaster = calls.some(
+        (c) => c[0].includes('sqlite_master') && c[0].includes('earnings_calendar'),
+      )
+      expect(probedSqliteMaster).toBe(true)
+      // table 不在の warn ログが出る (operator が追跡できるよう)。
+      const warnLines = warnSpy2.mock.calls.map((c) => String(c[0]))
+      expect(
+        warnLines.some((l) => l.includes('earnings_gate_disabled_table_missing')),
+      ).toBe(true)
+    } finally {
+      warnSpy2.mockRestore()
+    }
+  })
+
   // #141: critical な skip reason は Notifier 経由で push 通知される。
   // env.SLACK_WEBHOOK_URL を設定して fetch を spy し、webhook 行きの POST が
   // 1 回入ることだけ確認する (formatter は WebhookNotifier.test に分離済み)。


### PR DESCRIPTION
## 動機

Issue #196 の 3 sub-feature のうちの **1 つ目: earnings calendar gate**。

決算発表 ±1 営業日に被る BUY エントリを機械的に凍結する avoid 用 risk gate を導入。シグナル源ではなく、決算ボラを跨ぐ建玉を避けるための guard。

残り 2 つ (FOMC / CPI macro gate, VIX regime filter) は **別 PR で続ける** (本 PR の scope 外)。

## 実装概要

- D1 schema 追加 (`drizzle/0013_earnings_calendar.sql`):
  - `earnings_calendar(id, symbol, earnings_date, notes, created_at)`
  - UNIQUE INDEX `(symbol, earnings_date)` で重複 seed を物理的に弾く
  - `src/infrastructure/db/schema.ts` に Drizzle entry 追加
- repo (`src/infrastructure/calendar/earningsCalendarRepo.ts`):
  - `fetchByRange` (gate read) / `fetchBySymbol` (operator inspect) / `bulkUpsert` (`INSERT OR IGNORE`) / `deleteById`
- gate 本体 (`src/trading/risk/earningsGate.ts`):
  - `evaluateEarningsGate(input, repo, config)`: 評価日 ± freezeBusinessDays 営業日内に earnings 行があれば reject
  - 営業日計算は既存 `tradingCalendar.isTradingDay` (土日 + 取引所休日 skip) を再利用
  - SELL は常に approve (撤退路は妨げない)
  - **fail-closed**: D1 read 失敗 / 不正 evalDate → reject (entry block) で safe 側
- cron への配線 (`pullbackScheduler` / `runStrategyCron`):
  - `runPullbackScheduler` に `earningsGate?` option を追加。BUY 経路で perSymbolRisk より先に評価
  - reject reason は `risk: earnings_within_1bd: 2026-04-30` 形式で `strategy_decision_log.reason` に書く
  - decision trace に `risk.earnings_calendar` step を追加 (label_ja: `決算日カレンダーゲート`)
  - `runStrategyCron` は `env.DB` があれば repo を組み立てて gate 注入。なければ skip (POC 後方互換 / `freezeBusinessDays = 1` 固定)
- admin endpoints (`src/routes/admin.ts`):
  - `POST /admin/earnings/seed` — bulk seed (`[{symbol, earnings_date, notes?}]`)
  - `GET /admin/earnings?symbol=X` — operator inspect
  - `DELETE /admin/earnings/:id` — 誤 seed の取り消し

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test --run` 全 pass (60 files / 700 tests)
- [x] 新規 unit test `test/trading/risk/earningsGate.test.ts`:
  - 当日 / -1 BD / +1 BD → reject
  - -2 BD / +2 BD → approve
  - 別 symbol の earnings → approve (素通り)
  - 金曜決算 → 月曜評価で reject (土日跨ぎの営業日換算)
  - SELL → 常に approve
  - DB read throw → fail-closed reject
  - 不正 evalDate → fail-closed reject
  - 複数該当時は最近接 (= 最早) を reason に載せる
  - freezeBusinessDays の負値 → default 1、巨大値 → 30 にクランプ
- [x] `runPullbackScheduler` の earnings reject / approve / 未注入 (back-compat) 3 ケース
- [x] admin endpoint:
  - 401 (no auth) / 400 (no DB / not array / bad date / empty / non-numeric id) / 200 (success forward to repo) / 404 (delete miss)

## Out of scope (別 PR で対応)

- FOMC / CPI macro gate (#196 2/3)
- VIX regime filter (#196 3/3)
- 外部 API からの earnings 自動 seed (今回は admin 経由の手動 seed)
- dashboard `/dashboard/charts` 上の earnings 近接バッジ (運用 UI 改善は後続)
- BMO / AMC (寄付前 / 引け後) の区別 (POC では ±N 営業日窓で十分粗い)

## 運用上の seed 手順

```sh
curl -u admin:$ADMIN_PASS https://<host>/admin/earnings/seed \
  -H 'content-type: application/json' \
  -d '[
    {"symbol":"AAPL","earnings_date":"2026-04-30","notes":"Q2 2026"},
    {"symbol":"MSFT","earnings_date":"2026-04-29"}
  ]'
```

inspect:
```sh
curl -u admin:$ADMIN_PASS 'https://<host>/admin/earnings?symbol=AAPL'
```

## Notes

- `freezeBusinessDays` は POC 段階では default 1 固定 (config 化は #196 follow-up)
- `INSERT OR IGNORE` で既存 row は skip するので運用上 idempotent
- 既存の global_config / drizzle 状態には触れていない (drizzle-kit が pre-existing な `MAX_TIME_STOP_DAYS` 定数の placeholder noise を出すが、main にも同症があり本 PR の対象外)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 決算日カレンダー機能を追加：管理者向けに一括登録・取得・削除できるAPIを提供。
  * 決算日リスクゲートを追加：指定の取引日幅内に決算がある銘柄の買いシグナルをブロック。
  * スケジューラー統合：売買スケジュールで決算ゲートを参照し、BUYの処理を条件付け。

* **Tests**
  * 管理API、リスクゲート、スケジューラー周りの包括的なテストを追加。

* **Chores**
  * データベーススキーマ追加と移行スナップショットを導入。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->