### PR TITLE
feat(risk): macro event gate 実装 (#196 2/3)

### DIFF
--- a/drizzle/0014_macro_event_calendar.sql
+++ b/drizzle/0014_macro_event_calendar.sql
@@ -1,0 +1,11 @@
+CREATE TABLE `macro_event_calendar` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`event_type` text NOT NULL,
+	`event_date` text NOT NULL,
+	`event_time` text,
+	`notes` text,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `macro_event_calendar_type_date_unique` ON `macro_event_calendar` (`event_type`,`event_date`);--> statement-breakpoint
+CREATE INDEX `macro_event_calendar_date_idx` ON `macro_event_calendar` (`event_date`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1777210015055,
       "tag": "0013_earnings_calendar",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "6",
+      "when": 1777901600000,
+      "tag": "0014_macro_event_calendar",
+      "breakpoints": true
     }
   ]
 }

--- a/src/infrastructure/calendar/macroEventCalendarRepo.ts
+++ b/src/infrastructure/calendar/macroEventCalendarRepo.ts
@@ -1,0 +1,137 @@
+/**
+ * `macro_event_calendar` テーブルへの薄い repo (issue #196 2/3)。
+ *
+ * - `fetchByDateRange` は gate (`evaluateMacroEventGate`) からの read。range
+ *   指定で返すので、gate 側が ±N 時間窓に対応する **日付** 範囲 (ET base) を
+ *   計算して渡す。時刻 fine-grained 比較は gate 側で行う。
+ * - `bulkUpsert` は admin endpoint (POC では手動 seed) からの write。同一
+ *   `(event_type, event_date)` は `INSERT OR IGNORE` 相当で skip。
+ * - `fetchAll` は admin の `?type` / `?from` / `?to` filter 付き inspect 用。
+ *
+ * 結果の dummy 化は repo 層では行わない。gate 層が「fetch 失敗 → fail-closed
+ * (entry block)」を担う (POC fail-closed 原則 — `earningsCalendarRepo` と同形)。
+ */
+import { and, asc, eq, gte, lte, type SQL } from 'drizzle-orm'
+import { drizzle, type DrizzleD1Database } from 'drizzle-orm/d1'
+import { macroEventCalendar, type MacroEventCalendarRow } from '../db/schema'
+
+export type MacroEventCalendarDb = DrizzleD1Database
+
+export interface MacroEventCalendarRepo {
+  /**
+   * `[fromYmd, toYmd]` 両端を含む範囲で event を返す (event_date asc → 同日内
+   * は event_type asc)。`eventType` を渡すとさらに絞り込み。throws on D1 read
+   * failure — caller がここで fail-closed する。
+   */
+  fetchByDateRange(
+    fromYmd: string,
+    toYmd: string,
+    eventType?: string,
+  ): Promise<MacroEventCalendarRow[]>
+  /** admin inspect 用。`type` / `from` / `to` 全てが optional。 */
+  fetchAll(filter: {
+    fromYmd?: string
+    toYmd?: string
+    eventType?: string
+  }): Promise<MacroEventCalendarRow[]>
+  /**
+   * Upsert (実体は drizzle `.onConflictDoNothing()`)。chunk insert で D1 の
+   * subrequest 制限を避ける (`earningsCalendarRepo` と同パターン、CodeRabbit
+   * #196 review)。重複 skip 数を返す。
+   */
+  bulkUpsert(records: MacroEventCalendarSeedInput[]): Promise<{ inserted: number; skipped: number }>
+  /** id 指定で 1 row 削除。存在しない id は false を返す。 */
+  deleteById(id: number): Promise<boolean>
+}
+
+export interface MacroEventCalendarSeedInput {
+  /** Event 種別。caller が upper-case 化済み前提だが repo 側でも upper-case 化。 */
+  eventType: string
+  /** ISO date "YYYY-MM-DD"。caller が round-trip validation 済みである前提。 */
+  eventDate: string
+  /**
+   * 発表時刻 "HH:MM" (24h ET)。`null` で全日凍結扱い。caller が validation 済み。
+   */
+  eventTime: string | null
+  notes?: string | null
+}
+
+/** Wraps a Worker `env.DB` into a drizzle-typed client (other repos と同形式)。 */
+export function createMacroEventCalendarDb(d1: D1Database): MacroEventCalendarDb {
+  return drizzle(d1)
+}
+
+export function createMacroEventCalendarRepo(
+  db: MacroEventCalendarDb,
+): MacroEventCalendarRepo {
+  return {
+    async fetchByDateRange(fromYmd, toYmd, eventType) {
+      const conditions: SQL[] = [
+        gte(macroEventCalendar.eventDate, fromYmd),
+        lte(macroEventCalendar.eventDate, toYmd),
+      ]
+      if (eventType !== undefined) {
+        conditions.push(eq(macroEventCalendar.eventType, eventType.toUpperCase()))
+      }
+      return db
+        .select()
+        .from(macroEventCalendar)
+        .where(and(...conditions))
+        .orderBy(asc(macroEventCalendar.eventDate), asc(macroEventCalendar.eventType))
+    },
+
+    async fetchAll(filter) {
+      const conditions: SQL[] = []
+      if (filter.fromYmd !== undefined) {
+        conditions.push(gte(macroEventCalendar.eventDate, filter.fromYmd))
+      }
+      if (filter.toYmd !== undefined) {
+        conditions.push(lte(macroEventCalendar.eventDate, filter.toYmd))
+      }
+      if (filter.eventType !== undefined) {
+        conditions.push(eq(macroEventCalendar.eventType, filter.eventType.toUpperCase()))
+      }
+      const base = db.select().from(macroEventCalendar)
+      const filtered = conditions.length > 0 ? base.where(and(...conditions)) : base
+      return filtered.orderBy(asc(macroEventCalendar.eventDate), asc(macroEventCalendar.eventType))
+    },
+
+    async bulkUpsert(records) {
+      // CodeRabbit #196 review: 1 row 1 INSERT は D1 subrequest を浪費するため
+      // chunk multi-row INSERT (`.values([...])`) にまとめる。`.onConflictDoNothing()`
+      // で UNIQUE (event_type, event_date) 違反 row のみ skip。
+      let inserted = 0
+      let skipped = 0
+      if (records.length === 0) return { inserted, skipped }
+      const CHUNK = 50
+      for (let i = 0; i < records.length; i += CHUNK) {
+        const chunk = records.slice(i, i + CHUNK)
+        const values = chunk.map((r) => ({
+          eventType: r.eventType.toUpperCase(),
+          eventDate: r.eventDate,
+          eventTime: r.eventTime,
+          notes: r.notes ?? null,
+        }))
+        const result = await db
+          .insert(macroEventCalendar)
+          .values(values)
+          .onConflictDoNothing({
+            target: [macroEventCalendar.eventType, macroEventCalendar.eventDate],
+          })
+          .returning({ id: macroEventCalendar.id })
+        const insertedInChunk = result.length
+        inserted += insertedInChunk
+        skipped += chunk.length - insertedInChunk
+      }
+      return { inserted, skipped }
+    },
+
+    async deleteById(id) {
+      const result = await db
+        .delete(macroEventCalendar)
+        .where(eq(macroEventCalendar.id, id))
+        .returning({ id: macroEventCalendar.id })
+      return result.length > 0
+    },
+  }
+}

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -465,3 +465,54 @@ export const earningsCalendar = sqliteTable(
 
 export type EarningsCalendarRow = typeof earningsCalendar.$inferSelect
 export type EarningsCalendarInsert = typeof earningsCalendar.$inferInsert
+
+/**
+ * Macro economic event calendar (issue #196 2/3)。`earningsCalendar` と
+ * 同じく avoid 用 risk gate のソース。FOMC / CPI / NFP / PCE / GDP / ISM 等の
+ * 重要発表 当日 ±N 時間に被る BUY エントリを `macroEventGate` が凍結する
+ * (シグナル源ではない、BUY を *止める* だけ)。
+ *
+ * POC では外部 API 取得は別 issue で、`/admin/macro-events/seed` 経由で
+ * operator が手動 seed する想定。`UNIQUE (event_type, event_date)` で同一
+ * event の重複 insert を物理的に弾く。
+ *
+ * `event_time` (HH:MM ET) は optional — 未設定なら「当日全日凍結」、設定
+ * されていれば 発表時刻 ± N 時間で window 判定 (簡略 ET tz: `Intl.DateTimeFormat`
+ * with `America/New_York`)。
+ */
+export const macroEventCalendar = sqliteTable(
+  'macro_event_calendar',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    /**
+     * Event 種別 (例: 'FOMC' / 'CPI' / 'NFP' / 'PCE' / 'GDP' / 'ISM')。
+     * upper-case 前提で repo 側が正規化する。reason 文字列に含めるので
+     * operator が dashboard で読みやすい短い記号を使う。
+     */
+    eventType: text('event_type').notNull(),
+    /** 発表日 ISO date "YYYY-MM-DD" (ET base — 米国経済指標の慣習)。 */
+    eventDate: text('event_date').notNull(),
+    /**
+     * 発表時刻 ISO time "HH:MM" (ET base、24h)。NULL なら時刻不明 = 当日全日
+     * 凍結扱い (例: 一部 ISM / GDP の正確な分単位が事前未確定なケース)。
+     * 例: CPI '08:30', FOMC '14:00', NFP '08:30'。
+     */
+    eventTime: text('event_time'),
+    /** 自由 text。'June FOMC' / 'June CPI release' / source 等。 */
+    notes: text('notes'),
+    createdAt: text('created_at')
+      .notNull()
+      .default(sql`(datetime('now'))`),
+  },
+  (t) => ({
+    // 同一 event_type × 同一日の重複を物理的に防ぐ。bulk seed は
+    // INSERT OR IGNORE (drizzle `.onConflictDoNothing()`) で skip。
+    typeDateUnique: uniqueIndex('macro_event_calendar_type_date_unique').on(t.eventType, t.eventDate),
+    // gate 側の range read (event_date 範囲) を加速する。type_date_unique は
+    // (type, date) の複合 index なので date 単独 prefix では使えない。
+    dateIdx: index('macro_event_calendar_date_idx').on(t.eventDate),
+  }),
+)
+
+export type MacroEventCalendarRow = typeof macroEventCalendar.$inferSelect
+export type MacroEventCalendarInsert = typeof macroEventCalendar.$inferInsert

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -16,6 +16,11 @@ import {
   createEarningsCalendarRepo,
   type EarningsCalendarSeedInput,
 } from '../infrastructure/calendar/earningsCalendarRepo'
+import {
+  createMacroEventCalendarDb,
+  createMacroEventCalendarRepo,
+  type MacroEventCalendarSeedInput,
+} from '../infrastructure/calendar/macroEventCalendarRepo'
 import { runBacktest, type BacktestParams } from '../trading/backtest/runBacktest'
 import type { SymbolRule } from '../trading/strategy/strategies/PullbackUptrendStrategy'
 
@@ -362,6 +367,192 @@ export const admin = new Hono<AppBindings>()
     }
     return c.json({ deleted: true, id })
   })
+  /**
+   * Bulk seed `macro_event_calendar` rows (issue #196 2/3)。POC では外部 API
+   * 連携を持たず、operator が手動で curl 経由で seed する。重複 (event_type ×
+   * event_date) は `INSERT OR IGNORE` で skip し、件数を返す。
+   *
+   * Body: `[{ event_type: "FOMC", event_date: "2026-06-17",
+   *           event_time?: "14:00", notes?: "June FOMC" }, ...]`
+   */
+  .post('/macro-events/seed', async (c) => {
+    if (!c.env.DB) {
+      throw new ValidationError('DB binding is not configured', { field: 'env' })
+    }
+    const body = (await c.req.json().catch(() => null)) as unknown
+    if (!Array.isArray(body)) {
+      throw new ValidationError(
+        'body must be an array of { event_type, event_date, event_time?, notes? }',
+        { field: 'body' },
+      )
+    }
+    if (body.length === 0) {
+      throw new ValidationError('body must contain at least one entry', { field: 'body' })
+    }
+    if (body.length > 1000) {
+      // POC では年 50 件 (FOMC + CPI + NFP + ...) × 数年で十分上限。桁違いの
+      // 誤入力を弾く目的。
+      throw new ValidationError('body cannot exceed 1000 entries per request', { field: 'body' })
+    }
+    const records: MacroEventCalendarSeedInput[] = []
+    body.forEach((raw, idx) => {
+      records.push(parseMacroEventSeedRow(raw, idx))
+    })
+    const repo = createMacroEventCalendarRepo(createMacroEventCalendarDb(c.env.DB))
+    const result = await repo.bulkUpsert(records)
+    return c.json({ inserted: result.inserted, skipped: result.skipped, total: records.length })
+  })
+  /**
+   * Read `macro_event_calendar` rows (operator inspect)。`?from`/`?to` は
+   * いずれも YYYY-MM-DD で optional。`?type` で event_type filter (大文字化)。
+   */
+  .get('/macro-events', async (c) => {
+    if (!c.env.DB) {
+      throw new ValidationError('DB binding is not configured', { field: 'env' })
+    }
+    const fromRaw = c.req.query('from')?.trim()
+    const toRaw = c.req.query('to')?.trim()
+    const typeRaw = c.req.query('type')?.trim()
+    if (fromRaw !== undefined && fromRaw !== '' && !isYmd(fromRaw)) {
+      throw new ValidationError("'from' must be ISO 'YYYY-MM-DD'", { field: 'from' })
+    }
+    if (toRaw !== undefined && toRaw !== '' && !isYmd(toRaw)) {
+      throw new ValidationError("'to' must be ISO 'YYYY-MM-DD'", { field: 'to' })
+    }
+    if (typeRaw !== undefined && typeRaw !== '' && !isMacroEventType(typeRaw)) {
+      throw new ValidationError("'type' must be 1-32 chars [A-Z0-9_]", { field: 'type' })
+    }
+    const repo = createMacroEventCalendarRepo(createMacroEventCalendarDb(c.env.DB))
+    const rows = await repo.fetchAll({
+      ...(fromRaw && fromRaw !== '' ? { fromYmd: fromRaw } : {}),
+      ...(toRaw && toRaw !== '' ? { toYmd: toRaw } : {}),
+      ...(typeRaw && typeRaw !== '' ? { eventType: typeRaw.toUpperCase() } : {}),
+    })
+    return c.json({
+      filter: {
+        from: fromRaw ?? null,
+        to: toRaw ?? null,
+        type: typeRaw ? typeRaw.toUpperCase() : null,
+      },
+      rows,
+    })
+  })
+  /**
+   * Delete a single macro event row by `id`。誤 seed の取り消し用。
+   */
+  .delete('/macro-events/:id', async (c) => {
+    if (!c.env.DB) {
+      throw new ValidationError('DB binding is not configured', { field: 'env' })
+    }
+    const idRaw = c.req.param('id').trim()
+    const id = Number(idRaw)
+    if (!Number.isInteger(id) || id <= 0) {
+      throw new ValidationError("'id' must be a positive integer path param", { field: 'id' })
+    }
+    const repo = createMacroEventCalendarRepo(createMacroEventCalendarDb(c.env.DB))
+    const ok = await repo.deleteById(id)
+    if (!ok) {
+      return c.json({ error: 'macro_event_row_not_found', id }, 404)
+    }
+    return c.json({ deleted: true, id })
+  })
+
+/**
+ * Validate a single `/admin/macro-events/seed` body entry。
+ *
+ *   - `event_type`: 1〜32 chars, `[A-Z0-9_]` のみ (大文字化前提) — operator が
+ *     'FOMC' / 'CPI' / 'NFP_REV' のような短い記号で seed する想定
+ *   - `event_date`: ISO 'YYYY-MM-DD' で round-trip validation (`isYmd`)
+ *   - `event_time` (optional): `HH:MM` (00:00〜23:59 のみ受理)。null / 省略 OK
+ *   - `notes` (optional): 256 chars 上限
+ */
+function parseMacroEventSeedRow(raw: unknown, idx: number): MacroEventCalendarSeedInput {
+  if (raw === null || typeof raw !== 'object') {
+    throw new ValidationError(`entry [${idx}]: must be an object`, { field: `body[${idx}]` })
+  }
+  const obj = raw as {
+    event_type?: unknown
+    event_date?: unknown
+    event_time?: unknown
+    notes?: unknown
+  }
+  const eventTypeRaw = typeof obj.event_type === 'string' ? obj.event_type.trim() : ''
+  if (!isMacroEventType(eventTypeRaw)) {
+    throw new ValidationError(
+      `entry [${idx}]: 'event_type' must be 1-32 chars [A-Z0-9_]`,
+      { field: `body[${idx}].event_type` },
+    )
+  }
+  const eventDate = typeof obj.event_date === 'string' ? obj.event_date.trim() : ''
+  if (!isYmd(eventDate)) {
+    throw new ValidationError(
+      `entry [${idx}]: 'event_date' must be ISO 'YYYY-MM-DD'`,
+      { field: `body[${idx}].event_date` },
+    )
+  }
+  let eventTime: string | null = null
+  if (obj.event_time !== undefined && obj.event_time !== null) {
+    if (typeof obj.event_time !== 'string') {
+      throw new ValidationError(
+        `entry [${idx}]: 'event_time' must be string when present`,
+        { field: `body[${idx}].event_time` },
+      )
+    }
+    const trimmed = obj.event_time.trim()
+    if (trimmed === '') {
+      eventTime = null
+    } else if (!isHourMinute(trimmed)) {
+      throw new ValidationError(
+        `entry [${idx}]: 'event_time' must be 'HH:MM' (24h)`,
+        { field: `body[${idx}].event_time` },
+      )
+    } else {
+      eventTime = trimmed
+    }
+  }
+  let notes: string | null = null
+  if (obj.notes !== undefined && obj.notes !== null) {
+    if (typeof obj.notes !== 'string') {
+      throw new ValidationError(`entry [${idx}]: 'notes' must be string when present`, {
+        field: `body[${idx}].notes`,
+      })
+    }
+    if (obj.notes.length > 256) {
+      throw new ValidationError(`entry [${idx}]: 'notes' must be <= 256 chars`, {
+        field: `body[${idx}].notes`,
+      })
+    }
+    notes = obj.notes
+  }
+  return {
+    eventType: eventTypeRaw.toUpperCase(),
+    eventDate,
+    eventTime,
+    notes,
+  }
+}
+
+/**
+ * 'FOMC' / 'CPI' / 'NFP' 等の短い event_type 記号として受理可能か。
+ * 1〜32 chars、`[A-Za-z0-9_]` のみ (大文字化は呼び出し側で行う)。
+ */
+function isMacroEventType(value: string): boolean {
+  return /^[A-Za-z0-9_]{1,32}$/.test(value)
+}
+
+/**
+ * 'HH:MM' (00:00〜23:59) として受理可能か。秒は持たない (POC では分単位で十分)。
+ */
+function isHourMinute(value: string): boolean {
+  if (!/^\d{2}:\d{2}$/.test(value)) return false
+  const [hh, mm] = value.split(':') as [string, string]
+  const h = Number(hh)
+  const m = Number(mm)
+  if (!Number.isInteger(h) || !Number.isInteger(m)) return false
+  if (h < 0 || h > 23) return false
+  if (m < 0 || m > 59) return false
+  return true
+}
 
 function parseEarningsSeedRow(raw: unknown, idx: number): EarningsCalendarSeedInput {
   if (raw === null || typeof raw !== 'object') {

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -419,6 +419,17 @@ export const admin = new Hono<AppBindings>()
     if (toRaw !== undefined && toRaw !== '' && !isYmd(toRaw)) {
       throw new ValidationError("'to' must be ISO 'YYYY-MM-DD'", { field: 'to' })
     }
+    if (
+      fromRaw !== undefined &&
+      fromRaw !== '' &&
+      toRaw !== undefined &&
+      toRaw !== '' &&
+      fromRaw > toRaw
+    ) {
+      // `?from=2026-07-10&to=2026-07-01` のような operator 入力ミスを 400 で
+      // 弾く (空配列 200 だと「データなし」と区別がつかないため)。
+      throw new ValidationError("'from' must be <= 'to'", { field: 'from' })
+    }
     if (typeRaw !== undefined && typeRaw !== '' && !isMacroEventType(typeRaw)) {
       throw new ValidationError("'type' must be 1-32 chars [A-Z0-9_]", { field: 'type' })
     }

--- a/src/trading/risk/macroEventGate.ts
+++ b/src/trading/risk/macroEventGate.ts
@@ -232,7 +232,7 @@ function shiftYmd(ymd: string, days: number): string {
  *   3. `naive UTC ms - offset` が真の UTC ms
  *
  * DST 境界の 1 時間ジャンプは無視 (POC では 1 時間程度の誤差を許容する旨
- * task に明記)。fail soft 設計で、戻り値が NaN なら caller が無視する。
+ * task に明記)。不正値は `null` を返し、caller 側で fail-closed reject する。
  */
 function etWallClockToUtcMs(eventDate: string, eventTime: string): number | null {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(eventDate)) return null

--- a/src/trading/risk/macroEventGate.ts
+++ b/src/trading/risk/macroEventGate.ts
@@ -41,7 +41,10 @@ export interface MacroEventGateInput {
 export interface MacroEventGateConfig {
   /** 発表前の凍結時間 (hours)。default 1。 */
   freezeHoursBefore: number
-  /** 発表後の凍結時間 (hours)。default 1。 */
+  /**
+   * 発表後の凍結時間 (hours)。default 6 (発表直後の volatility / drift を回避)。
+   * 上限は `sanitizeHours` で 6h クランプ。
+   */
   freezeHoursAfter: number
   /**
    * `event_time` が NULL の event を全日凍結するか。default true。
@@ -57,6 +60,7 @@ export interface MacroEventGateDecision {
    *   - `macro_event_gate: FOMC 2026-06-17 14:00ET` (時刻指定あり)
    *   - `macro_event_gate: ISM 2026-07-01 (full-day)` (時刻不明)
    *   - `macro_event_gate_invalid_eval_timestamp: <raw>`
+   *   - `macro_event_gate_invalid_calendar_row: <type> <date> <time>` (event_time が不正)
    *   - `macro_event_gate_fetch_failed: <error>`
    */
   reason?: string
@@ -66,7 +70,7 @@ export interface MacroEventGateDecision {
 
 export const DEFAULT_MACRO_GATE_CONFIG: MacroEventGateConfig = {
   freezeHoursBefore: 1,
-  freezeHoursAfter: 1,
+  freezeHoursAfter: 6,
   freezeFullDayWhenTimeUnknown: true,
 }
 
@@ -136,7 +140,19 @@ export async function evaluateMacroEventGate(
       // 発表時刻指定あり: ET wall-clock で `event_date + event_time` を UTC ms
       // に変換 (簡略 ET tz: `America/New_York` の現時点 offset を Intl で取得)。
       const eventMs = etWallClockToUtcMs(row.eventDate, row.eventTime)
-      if (eventMs === null) continue
+      if (eventMs === null) {
+        // 不正な event_date / event_time の row を silent skip すると
+        // その event だけ BUY 素通り = fail-open になるため fail-closed reject。
+        return {
+          approved: false,
+          reason: `macro_event_gate_invalid_calendar_row: ${row.eventType} ${row.eventDate} ${row.eventTime}`,
+          triggeringEvent: {
+            type: row.eventType,
+            date: row.eventDate,
+            time: row.eventTime,
+          },
+        }
+      }
       const delta = evalMs - eventMs // > 0 なら eval が event より後
       if (delta >= -beforeMs && delta <= afterMs) {
         return {

--- a/src/trading/risk/macroEventGate.ts
+++ b/src/trading/risk/macroEventGate.ts
@@ -1,0 +1,258 @@
+/**
+ * Macro economic event calendar gate (issue #196 2/3)。
+ *
+ * FOMC / CPI / NFP / PCE / GDP / ISM 等の重要 macro 発表 当日 (±N 時間) の
+ * BUY エントリを凍結する **avoid 用 risk gate**。
+ * - シグナル源ではない (BUY を出す根拠にしない、BUY を *止める* だけ)
+ * - 計算コストはゼロに近い (D1 read 1 本)
+ * - DB read 失敗 → fail-closed (entry block) で safe 側に倒す
+ * - `event_time` (ET) があれば 発表時刻 ± freezeHoursBefore/After で window 判定。
+ *   なければ event_date 当日全日凍結 (POC 簡略 fallback)。
+ * - tz 計算は完璧でなくて OK (POC、`Intl.DateTimeFormat('en-US', { timeZone:
+ *   'America/New_York' })` で ET の wall-clock 文字列を取って比較)。
+ *
+ * scope:
+ *   - in: BUY を ±N 時間内に macro event がある時刻について止める
+ *   - out: SELL は止めない (既存 position 保護のため macro 跨ぎ手仕舞いは許容)
+ *   - out: 銘柄非依存 (ETF だろうと個別株だろうと cron 全銘柄に適用)
+ *   - out: VIX regime filter は別 PR (#196 3/3) で
+ *
+ * 呼び出し側 (`pullbackScheduler` 経由) は gate decision の `reason` を
+ * `risk: macro_event_gate: FOMC 2026-06-17 14:00ET` 形式で
+ * `strategy_decision_log.reason` に書く。
+ */
+import type { MacroEventCalendarRepo } from '../../infrastructure/calendar/macroEventCalendarRepo'
+import type { MacroEventCalendarRow } from '../../infrastructure/db/schema'
+
+export interface MacroEventGateInput {
+  /**
+   * 評価時刻 ISO datetime (e.g. `2026-06-17T18:30:00.000Z`)。cron tick の現在
+   * 時刻を渡す。time-of-day を持つ点が earnings gate との違い (発表時刻 ±N
+   * 時間で window 判定するため)。
+   */
+  evalTimestamp: string
+  /**
+   * 評価対象の side。BUY のみ gate を効かせる。SELL は既存 position の
+   * 撤退 / cleanup を妨げないように常に approve。
+   */
+  side: 'BUY' | 'SELL'
+}
+
+export interface MacroEventGateConfig {
+  /** 発表前の凍結時間 (hours)。default 1。 */
+  freezeHoursBefore: number
+  /** 発表後の凍結時間 (hours)。default 1。 */
+  freezeHoursAfter: number
+  /**
+   * `event_time` が NULL の event を全日凍結するか。default true。
+   * false なら時刻不明 event は無視 (POC ではあまり推奨しない)。
+   */
+  freezeFullDayWhenTimeUnknown: boolean
+}
+
+export interface MacroEventGateDecision {
+  approved: boolean
+  /**
+   * Approved=false のときの reject 理由。形式:
+   *   - `macro_event_gate: FOMC 2026-06-17 14:00ET` (時刻指定あり)
+   *   - `macro_event_gate: ISM 2026-07-01 (full-day)` (時刻不明)
+   *   - `macro_event_gate_invalid_eval_timestamp: <raw>`
+   *   - `macro_event_gate_fetch_failed: <error>`
+   */
+  reason?: string
+  /** Operator UI / log 用に reject を引き起こした event を返す。 */
+  triggeringEvent?: { type: string; date: string; time: string | null }
+}
+
+export const DEFAULT_MACRO_GATE_CONFIG: MacroEventGateConfig = {
+  freezeHoursBefore: 1,
+  freezeHoursAfter: 1,
+  freezeFullDayWhenTimeUnknown: true,
+}
+
+const MS_PER_HOUR = 3_600_000
+
+/**
+ * Pure-ish gate evaluator (`repo.fetchByDateRange` のみ side-effect)。
+ *
+ * 振る舞い:
+ *  1. SELL → 常に approve (gate scope 外)
+ *  2. evalTimestamp parse 失敗 → fail-closed reject
+ *  3. ET tz の `eval` を中心に ±freezeHours で window を計算し、被りそうな
+ *     event_date 範囲を repo.fetchByDateRange で取得 (前日 / 当日 / 翌日 を
+ *     カバーすれば DST / midnight 跨ぎ含めて十分粗く拾える)
+ *  4. fetch throw → fail-closed reject (D1 read failure を silent pass させない)
+ *  5. event_time 指定行: ET wall-clock で `event_date + event_time` を組み立て
+ *     evalTimestamp と差分を取り freezeHoursBefore/After 以内なら reject
+ *  6. event_time NULL 行: `freezeFullDayWhenTimeUnknown=true` のときのみ、
+ *     ET の評価日が event_date と一致したら reject
+ *  7. 該当なければ approve
+ */
+export async function evaluateMacroEventGate(
+  input: MacroEventGateInput,
+  repo: MacroEventCalendarRepo,
+  config: MacroEventGateConfig = DEFAULT_MACRO_GATE_CONFIG,
+): Promise<MacroEventGateDecision> {
+  if (input.side === 'SELL') return { approved: true }
+
+  const evalMs = Date.parse(input.evalTimestamp)
+  if (!Number.isFinite(evalMs)) {
+    return {
+      approved: false,
+      reason: `macro_event_gate_invalid_eval_timestamp: ${input.evalTimestamp}`,
+    }
+  }
+  const evalDate = new Date(evalMs)
+
+  const freezeBefore = sanitizeHours(config.freezeHoursBefore, DEFAULT_MACRO_GATE_CONFIG.freezeHoursBefore)
+  const freezeAfter = sanitizeHours(config.freezeHoursAfter, DEFAULT_MACRO_GATE_CONFIG.freezeHoursAfter)
+  const freezeFullDayWhenTimeUnknown = config.freezeFullDayWhenTimeUnknown
+
+  // ET 観点で評価対象になりうる event_date を 3 日窓 (前日 / 当日 / 翌日) で拾う。
+  // freeze 幅が ±1〜2 時間想定であれば、ET の midnight 跨ぎが噛んでも 3 日で
+  // 包含できる (24h を超える freeze は sanitizeHours で 6h にクランプ)。
+  const evalEtYmd = formatEtYmd(evalDate)
+  const fromYmd = shiftYmd(evalEtYmd, -1)
+  const toYmd = shiftYmd(evalEtYmd, 1)
+
+  let rows: MacroEventCalendarRow[]
+  try {
+    rows = await repo.fetchByDateRange(fromYmd, toYmd)
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    return {
+      approved: false,
+      reason: `macro_event_gate_fetch_failed: ${msg}`,
+    }
+  }
+
+  if (rows.length === 0) return { approved: true }
+
+  const beforeMs = freezeBefore * MS_PER_HOUR
+  const afterMs = freezeAfter * MS_PER_HOUR
+
+  for (const row of rows) {
+    if (row.eventTime !== null && row.eventTime !== undefined && row.eventTime !== '') {
+      // 発表時刻指定あり: ET wall-clock で `event_date + event_time` を UTC ms
+      // に変換 (簡略 ET tz: `America/New_York` の現時点 offset を Intl で取得)。
+      const eventMs = etWallClockToUtcMs(row.eventDate, row.eventTime)
+      if (eventMs === null) continue
+      const delta = evalMs - eventMs // > 0 なら eval が event より後
+      if (delta >= -beforeMs && delta <= afterMs) {
+        return {
+          approved: false,
+          reason: `macro_event_gate: ${row.eventType} ${row.eventDate} ${row.eventTime}ET`,
+          triggeringEvent: {
+            type: row.eventType,
+            date: row.eventDate,
+            time: row.eventTime,
+          },
+        }
+      }
+    } else if (freezeFullDayWhenTimeUnknown) {
+      // 時刻不明 event: ET の評価日と event_date が一致したら全日凍結。
+      if (row.eventDate === evalEtYmd) {
+        return {
+          approved: false,
+          reason: `macro_event_gate: ${row.eventType} ${row.eventDate} (full-day)`,
+          triggeringEvent: {
+            type: row.eventType,
+            date: row.eventDate,
+            time: null,
+          },
+        }
+      }
+    }
+  }
+
+  return { approved: true }
+}
+
+/**
+ * 不正値を default に倒し、上限 6 時間でクランプ。POC 段階では「±1〜2 時間
+ * 凍結」が想定運用で、巨大値による全停止暴発を防ぐため軽い sane bound。
+ * 24h を超えると ±1 日窓 fetch では拾えなくなるため、6h で十分。
+ */
+function sanitizeHours(value: unknown, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback
+  if (value < 0) return fallback
+  if (value > 6) return 6
+  return value
+}
+
+/**
+ * UTC `Date` を `America/New_York` 観点の "YYYY-MM-DD" に format。
+ * `Intl.DateTimeFormat` で `en-CA` ('YYYY-MM-DD' をそのまま返す locale) を
+ * 使う方が format 後の split が要らないので採用。
+ */
+function formatEtYmd(date: Date): string {
+  const fmt = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/New_York',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  })
+  return fmt.format(date)
+}
+
+/**
+ * "YYYY-MM-DD" を `±days` 日シフトして "YYYY-MM-DD" に戻す。pure UTC 計算で
+ * tz は介さない (windowing で前日 / 翌日 を拾うため)。
+ */
+function shiftYmd(ymd: string, days: number): string {
+  const ms = Date.parse(`${ymd}T00:00:00.000Z`)
+  if (!Number.isFinite(ms)) return ymd
+  const shifted = new Date(ms + days * 86_400_000)
+  return shifted.toISOString().slice(0, 10)
+}
+
+/**
+ * `event_date` (ET YYYY-MM-DD) + `event_time` (ET HH:MM) を UTC ms に変換。
+ *
+ * 簡略 ET 変換 (POC):
+ *   1. naive UTC ms = `Date.parse(${date}T${time}:00.000Z)`
+ *   2. その瞬間に America/New_York が UTC からどれだけ offset しているかを
+ *      `Intl.DateTimeFormat` で probe (DST aware)
+ *   3. `naive UTC ms - offset` が真の UTC ms
+ *
+ * DST 境界の 1 時間ジャンプは無視 (POC では 1 時間程度の誤差を許容する旨
+ * task に明記)。fail soft 設計で、戻り値が NaN なら caller が無視する。
+ */
+function etWallClockToUtcMs(eventDate: string, eventTime: string): number | null {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(eventDate)) return null
+  if (!/^\d{2}:\d{2}$/.test(eventTime)) return null
+  const naiveUtcMs = Date.parse(`${eventDate}T${eventTime}:00.000Z`)
+  if (!Number.isFinite(naiveUtcMs)) return null
+  const offsetMin = etOffsetMinutesAt(naiveUtcMs)
+  // ET は UTC の西側 (negative offset)。例: EST = -300, EDT = -240。
+  // wall-clock が UTC `XX` のときの真 UTC = naive - offset (offset is negative)
+  // → naiveUtcMs - offsetMin*60_000 = 真の UTC ms。
+  return naiveUtcMs - offsetMin * 60_000
+}
+
+/**
+ * 与えられた瞬間 (UTC ms) で America/New_York が UTC から何分 offset している
+ * かを Intl 経由で probe。DST 切替を吸収する。
+ *
+ * 計算は `Intl.DateTimeFormat({ timeZone: 'America/New_York', timeZoneName:
+ * 'shortOffset' })` で 'GMT-4' / 'GMT-5' 文字列を取得 → 数値化。
+ */
+function etOffsetMinutesAt(utcMs: number): number {
+  try {
+    const fmt = new Intl.DateTimeFormat('en-US', {
+      timeZone: 'America/New_York',
+      timeZoneName: 'shortOffset',
+    })
+    const parts = fmt.formatToParts(new Date(utcMs))
+    const tzName = parts.find((p) => p.type === 'timeZoneName')?.value ?? ''
+    // 'GMT-4' / 'GMT-04:00' / 'GMT-5' などをサポート。
+    const match = /GMT([+-])(\d{1,2})(?::?(\d{2}))?/.exec(tzName)
+    if (!match) return -300 // 失敗時は EST 相当に倒す (POC default)
+    const sign = match[1] === '-' ? -1 : 1
+    const hours = Number(match[2])
+    const mins = match[3] !== undefined ? Number(match[3]) : 0
+    return sign * (hours * 60 + mins)
+  } catch {
+    return -300
+  }
+}

--- a/src/trading/risk/macroEventGate.ts
+++ b/src/trading/risk/macroEventGate.ts
@@ -136,6 +136,23 @@ export async function evaluateMacroEventGate(
   const afterMs = freezeAfter * MS_PER_HOUR
 
   for (const row of rows) {
+    // event_time あり / NULL の両分岐を通す前に event_date を round-trip validate。
+    // event_time NULL 分岐は単純文字列一致 (`row.eventDate === evalEtYmd`) しか
+    // しないため、不正な event_date (e.g., `2026-02-30`, `2026-13-01`) が来ても
+    // 一致する可能性が無く silent pass = fail-open する。両分岐で対称な
+    // fail-closed validation を保証するため、ループ先頭で reject する。
+    if (!isStrictYmd(row.eventDate)) {
+      return {
+        approved: false,
+        reason: `macro_event_gate_invalid_calendar_row: ${row.eventType} ${row.eventDate} ${row.eventTime ?? 'null'}`,
+        triggeringEvent: {
+          type: row.eventType,
+          date: row.eventDate,
+          time: row.eventTime ?? null,
+        },
+      }
+    }
+
     if (row.eventTime !== null && row.eventTime !== undefined && row.eventTime !== '') {
       // 発表時刻指定あり: ET wall-clock で `event_date + event_time` を UTC ms
       // に変換 (簡略 ET tz: `America/New_York` の現時点 offset を Intl で取得)。
@@ -209,6 +226,24 @@ function formatEtYmd(date: Date): string {
     day: '2-digit',
   })
   return fmt.format(date)
+}
+
+/**
+ * "YYYY-MM-DD" を厳密 validate (round-trip)。
+ *
+ * JS Date は不正な暦日 (e.g. `2026-02-30`, `2026-13-01`, `2026-04-31`) を
+ * silent normalize するため、`Date.parse` だけでは fail-open する。`toISOString`
+ * に戻して入力文字列と一致するか比較し、実在する暦日のみ true を返す。
+ *
+ * `etWallClockToUtcMs` は event_time あり経路で同等 round-trip を内部で行うが、
+ * event_time NULL 経路 (full-day freeze) ではこの helper を使って対称な
+ * fail-closed validation を行う。
+ */
+function isStrictYmd(ymd: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(ymd)) return false
+  const ms = Date.parse(`${ymd}T00:00:00.000Z`)
+  if (!Number.isFinite(ms)) return false
+  return new Date(ms).toISOString().slice(0, 10) === ymd
 }
 
 /**

--- a/src/trading/risk/macroEventGate.ts
+++ b/src/trading/risk/macroEventGate.ts
@@ -236,9 +236,20 @@ function shiftYmd(ymd: string, days: number): string {
  */
 function etWallClockToUtcMs(eventDate: string, eventTime: string): number | null {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(eventDate)) return null
-  if (!/^\d{2}:\d{2}$/.test(eventTime)) return null
+  const tm = /^(\d{2}):(\d{2})$/.exec(eventTime)
+  if (!tm) return null
+  const hh = Number(tm[1])
+  const mm = Number(tm[2])
+  if (!Number.isInteger(hh) || !Number.isInteger(mm)) return null
+  if (hh < 0 || hh > 23 || mm < 0 || mm > 59) return null
   const naiveUtcMs = Date.parse(`${eventDate}T${eventTime}:00.000Z`)
   if (!Number.isFinite(naiveUtcMs)) return null
+  // round-trip で実在しない暦日 (e.g. 2026-02-30, 2026-04-31) を reject。
+  // JS Date は不正な日付を silent normalize する (2026-02-30 → 2026-03-02) ため、
+  // ISOString に戻して入力と一致するか厳密比較しないと fail-open する。
+  const roundTrip = new Date(naiveUtcMs).toISOString()
+  if (roundTrip.slice(0, 10) !== eventDate) return null
+  if (roundTrip.slice(11, 16) !== eventTime) return null
   const offsetMin = etOffsetMinutesAt(naiveUtcMs)
   // ET は UTC の西側 (negative offset)。例: EST = -300, EDT = -240。
   // wall-clock が UTC `XX` のときの真 UTC = naive - offset (offset is negative)

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -126,8 +126,8 @@ export interface MacroEventScheduleConfig {
   repo: MacroEventCalendarRepo
   /**
    * Gate config (freeze hours / full-day fallback)。Partial で渡せて、
-   * 未指定の field は `DEFAULT_MACRO_GATE_CONFIG` (±1 時間, full-day=true) で
-   * 補う。
+   * 未指定の field は `DEFAULT_MACRO_GATE_CONFIG` (発表前 1h / 発表後 6h /
+   * full-day=true) で補う。
    */
   config?: Partial<MacroEventGateConfig>
 }

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -21,7 +21,13 @@ import {
 } from './strategies/PullbackUptrendStrategy'
 import { decideBucketGate } from '../risk/bucketExposureGate'
 import { evaluateEarningsGate } from '../risk/earningsGate'
+import {
+  DEFAULT_MACRO_GATE_CONFIG,
+  evaluateMacroEventGate,
+  type MacroEventGateConfig,
+} from '../risk/macroEventGate'
 import type { EarningsCalendarRepo } from '../../infrastructure/calendar/earningsCalendarRepo'
+import type { MacroEventCalendarRepo } from '../../infrastructure/calendar/macroEventCalendarRepo'
 import { evaluatePerSymbolRisk } from '../risk/perSymbolRiskGate'
 
 const DEFAULT_BAR_LOOKBACK = 60
@@ -101,6 +107,12 @@ export interface PullbackSchedulerOptions {
    * (`runStrategyCron`) が D1 から repo を作って渡す。
    */
   earningsGate?: EarningsScheduleConfig
+  /**
+   * Macro event gate (issue #196 2/3)。FOMC / CPI / NFP 等の発表 ±N 時間で
+   * 全銘柄 BUY を凍結。`repo` 未注入なら skip (POC 後方互換)。earnings gate
+   * より後ろで評価される (両方 reject なら earnings reason が先に確定する)。
+   */
+  macroEventGate?: MacroEventScheduleConfig
   now?: () => Date
 }
 
@@ -108,6 +120,16 @@ export interface EarningsScheduleConfig {
   repo: EarningsCalendarRepo
   /** ±N 営業日。default 1。 */
   freezeBusinessDays?: number
+}
+
+export interface MacroEventScheduleConfig {
+  repo: MacroEventCalendarRepo
+  /**
+   * Gate config (freeze hours / full-day fallback)。Partial で渡せて、
+   * 未指定の field は `DEFAULT_MACRO_GATE_CONFIG` (±1 時間, full-day=true) で
+   * 補う。
+   */
+  config?: Partial<MacroEventGateConfig>
 }
 
 export interface PerSymbolRiskScheduleConfig {
@@ -504,6 +526,35 @@ export async function runPullbackScheduler(
       }
     }
 
+    // Macro event gate (issue #196 2/3)。FOMC / CPI / NFP 等の発表 ±N 時間
+    // (default 1h) は全銘柄 BUY を凍結する。earnings gate より後で評価する
+    // ので、両方 reject なら earnings reason が先に確定する (task 指定の
+    // 優先順位)。`macroEventGate` 未注入なら skip (POC 後方互換)。
+    if (options.macroEventGate && intent.side === 'BUY') {
+      const evalTimestamp = now().toISOString()
+      const macroDecision = await evaluateMacroEventGate(
+        { evalTimestamp, side: 'BUY' },
+        options.macroEventGate.repo,
+        { ...DEFAULT_MACRO_GATE_CONFIG, ...(options.macroEventGate.config ?? {}) },
+      )
+      if (!macroDecision.approved) {
+        const reason = `risk: ${macroDecision.reason ?? 'macro_event_gate'}`
+        summary.rejected.push({ symbol: upper, reason })
+        await emitDecision({
+          symbol: upper,
+          decision: 'REJECT',
+          reason,
+          price: indicators.price,
+          indicatorsJson: JSON.stringify(indicators),
+          trace: appendTrace(
+            signal.trace,
+            traceStep('risk.macro_event', false, undefined, undefined, undefined, macroDecision.reason),
+          ),
+        })
+        continue
+      }
+    }
+
     // Per-symbol risk gate (issue #138)。manual `/trade/execute` (TradingService)
     // と同じ pure function を呼ぶことで gate parity を取る。perSymbolRisk が
     // 未注入の場合は POC 後方互換で skip。Inverse pair の SymbolState は同期
@@ -557,10 +608,10 @@ export async function runPullbackScheduler(
       }
     }
 
-    // 全 gate (bucket / earnings / perSymbolRisk) を通過したので、ここで初めて
-    // bucketExposure を新 exposure に置き換える。これより前 (= bucket gate 直後)
-    // で commit すると、reject された BUY が同 bucket の後続銘柄を誤って弾く
-    // (CodeRabbit #196 review)。
+    // 全 gate (bucket / earnings / macro / perSymbolRisk) を通過したので、
+    // ここで初めて bucketExposure を新 exposure に置き換える。これより前
+    // (= bucket gate 直後) で commit すると、reject された BUY が同 bucket の
+    // 後続銘柄を誤って弾く (CodeRabbit #196 review)。
     if (pendingBucketUpdate) {
       bucketExposure[pendingBucketUpdate.bucket] = pendingBucketUpdate.newExposure
     }
@@ -793,6 +844,7 @@ const TRACE_LABEL_JA: Record<string, string> = {
   'scheduler.pending_lock_acquired': '注文ロックを取得できた',
   'risk.bucket_cap': '同グループ建玉上限内',
   'risk.earnings_calendar': '決算日カレンダーゲート',
+  'risk.macro_event': 'マクロイベントゲート',
   'risk.per_symbol_gate': '銘柄別リスクゲート',
   'broker.submit': '証券会社への発注送信',
 }

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -23,6 +23,10 @@ import {
   createEarningsCalendarDb,
   createEarningsCalendarRepo,
 } from '../../infrastructure/calendar/earningsCalendarRepo'
+import {
+  createMacroEventCalendarDb,
+  createMacroEventCalendarRepo,
+} from '../../infrastructure/calendar/macroEventCalendarRepo'
 import { runPullbackScheduler, type PullbackDecisionTrace, type PullbackRunSummary } from './pullbackScheduler'
 
 const DEFAULT_EQUITY_USD = 10_000
@@ -399,6 +403,17 @@ export async function runStrategyCron(
       }),
     )
   }
+  // Macro event gate (issue #196 2/3): 同じ理由で 0014 未適用環境では gate を
+  // 無効化 (table 不在 → fetch 失敗 → fail-closed で全 BUY reject の連鎖を回避)。
+  const macroEventGateReady = env.DB ? await isMacroEventCalendarReady(env.DB) : false
+  if (env.DB && !macroEventGateReady) {
+    console.warn(
+      JSON.stringify({
+        event: 'macro_event_gate_disabled_table_missing',
+        requestId: options.requestId,
+      }),
+    )
+  }
 
   // Pullback デフォルト rule は D1 global_config に寄せた (#118)。
   // 実運用中の tuning は `UPDATE global_config SET ...` で即反映可能。
@@ -477,6 +492,15 @@ export async function runStrategyCron(
             earningsGate: {
               repo: createEarningsCalendarRepo(createEarningsCalendarDb(env.DB)),
               freezeBusinessDays: 1,
+            },
+          }
+        : {}),
+      // Macro event gate (issue #196 2/3)。同様に env.DB / 0014 適用の双方が
+      // あるときだけ注入。config は default (±1h, full-day=true) で POC 運用。
+      ...(env.DB && macroEventGateReady
+        ? {
+            macroEventGate: {
+              repo: createMacroEventCalendarRepo(createMacroEventCalendarDb(env.DB)),
             },
           }
         : {}),
@@ -623,6 +647,24 @@ async function isEarningsCalendarReady(db: D1Database): Promise<boolean> {
     const row = await db
       .prepare(
         "SELECT 1 AS ok FROM sqlite_master WHERE type='table' AND name='earnings_calendar' LIMIT 1",
+      )
+      .first<{ ok: number }>()
+    return row?.ok === 1
+  } catch {
+    return false
+  }
+}
+
+/**
+ * 0014 migration (`macro_event_calendar`) が当該 D1 で適用済みかを判定する
+ * (issue #196 2/3)。`isEarningsCalendarReady` と同じ理由 — 未 migrate な
+ * preview / 新環境では gate を 無効化 して fail-closed の連鎖 reject を回避。
+ */
+async function isMacroEventCalendarReady(db: D1Database): Promise<boolean> {
+  try {
+    const row = await db
+      .prepare(
+        "SELECT 1 AS ok FROM sqlite_master WHERE type='table' AND name='macro_event_calendar' LIMIT 1",
       )
       .first<{ ok: number }>()
     return row?.ok === 1

--- a/test/infrastructure/calendar/macroEventCalendarRepo.test.ts
+++ b/test/infrastructure/calendar/macroEventCalendarRepo.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createMacroEventCalendarRepo,
+  type MacroEventCalendarDb,
+  type MacroEventCalendarSeedInput,
+} from '../../../src/infrastructure/calendar/macroEventCalendarRepo'
+
+/**
+ * `bulkUpsert` の chunk insert 動作テスト (issue #196 2/3、CodeRabbit 同型)。
+ * `earningsCalendarRepo.test.ts` と同パターンで chunk 50 / multi-row VALUES /
+ * `.onConflictDoNothing()` の挙動 + inserted/skipped カウントを担保する。
+ */
+
+function makeFakeDb(opts: {
+  insertedPerChunk: Array<Array<{ id: number }>>
+}) {
+  const calls: Array<{
+    values: Array<{
+      eventType: string
+      eventDate: string
+      eventTime: string | null
+      notes: string | null
+    }>
+  }> = []
+  let chunkIdx = 0
+  const builder = {
+    values(values: Array<{
+      eventType: string
+      eventDate: string
+      eventTime: string | null
+      notes: string | null
+    }>) {
+      calls.push({ values })
+      return {
+        onConflictDoNothing(_args: unknown) {
+          return {
+            returning(_cols: unknown) {
+              const rows = opts.insertedPerChunk[chunkIdx] ?? []
+              chunkIdx += 1
+              return Promise.resolve(rows)
+            },
+          }
+        },
+      }
+    },
+  }
+  const db = {
+    insert: vi.fn(() => builder),
+  } as unknown as MacroEventCalendarDb
+  return { db, calls }
+}
+
+describe('createMacroEventCalendarRepo.bulkUpsert', () => {
+  it('returns inserted=0 / skipped=0 when records is empty', async () => {
+    const { db } = makeFakeDb({ insertedPerChunk: [] })
+    const repo = createMacroEventCalendarRepo(db)
+    const result = await repo.bulkUpsert([])
+    expect(result).toEqual({ inserted: 0, skipped: 0 })
+  })
+
+  it('chunks 50 rows per multi-row INSERT (single subrequest per chunk)', async () => {
+    const records: MacroEventCalendarSeedInput[] = Array.from({ length: 120 }, (_, i) => ({
+      eventType: 'CPI',
+      eventDate: `2026-${String((i % 12) + 1).padStart(2, '0')}-15`,
+      eventTime: '08:30',
+      notes: null,
+    }))
+    const insertedPerChunk = [
+      Array.from({ length: 50 }, (_, i) => ({ id: i + 1 })),
+      Array.from({ length: 49 }, (_, i) => ({ id: 50 + i + 1 })),
+      Array.from({ length: 20 }, (_, i) => ({ id: 100 + i + 1 })),
+    ]
+    const { db, calls } = makeFakeDb({ insertedPerChunk })
+    const repo = createMacroEventCalendarRepo(db)
+    const result = await repo.bulkUpsert(records)
+    expect(calls).toHaveLength(3)
+    expect(calls[0]!.values).toHaveLength(50)
+    expect(calls[1]!.values).toHaveLength(50)
+    expect(calls[2]!.values).toHaveLength(20)
+    expect(result).toEqual({ inserted: 50 + 49 + 20, skipped: 1 })
+  })
+
+  it('upper-cases event_type, applies notes/event_time ?? null per row', async () => {
+    const records: MacroEventCalendarSeedInput[] = [
+      { eventType: 'fomc', eventDate: '2026-06-17', eventTime: '14:00', notes: 'June FOMC' },
+      { eventType: 'gdp', eventDate: '2026-07-01', eventTime: null }, // notes omitted
+    ]
+    const { db, calls } = makeFakeDb({
+      insertedPerChunk: [[{ id: 1 }, { id: 2 }]],
+    })
+    const repo = createMacroEventCalendarRepo(db)
+    const result = await repo.bulkUpsert(records)
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.values).toEqual([
+      { eventType: 'FOMC', eventDate: '2026-06-17', eventTime: '14:00', notes: 'June FOMC' },
+      { eventType: 'GDP', eventDate: '2026-07-01', eventTime: null, notes: null },
+    ])
+    expect(result).toEqual({ inserted: 2, skipped: 0 })
+  })
+
+  it('attributes UNIQUE-violation skips correctly within a single chunk', async () => {
+    const records: MacroEventCalendarSeedInput[] = [
+      { eventType: 'FOMC', eventDate: '2026-06-17', eventTime: '14:00' },
+      { eventType: 'FOMC', eventDate: '2026-06-17', eventTime: '14:00' }, // duplicate
+      { eventType: 'CPI', eventDate: '2026-06-12', eventTime: '08:30' },
+    ]
+    const { db } = makeFakeDb({ insertedPerChunk: [[{ id: 1 }, { id: 2 }]] })
+    const repo = createMacroEventCalendarRepo(db)
+    const result = await repo.bulkUpsert(records)
+    expect(result).toEqual({ inserted: 2, skipped: 1 })
+  })
+})

--- a/test/routes/admin.test.ts
+++ b/test/routes/admin.test.ts
@@ -496,3 +496,316 @@ describe('Earnings calendar admin endpoints (#196)', () => {
     })
   })
 })
+
+describe('Macro event calendar admin endpoints (#196 2/3)', () => {
+  type MacroRow = {
+    id: number
+    eventType: string
+    eventDate: string
+    eventTime: string | null
+    notes: string | null
+    createdAt: string
+  }
+  function fakeMacroRepo() {
+    return {
+      bulkUpsert: vi.fn<(records: unknown) => Promise<{ inserted: number; skipped: number }>>(
+        async () => ({ inserted: 0, skipped: 0 }),
+      ),
+      fetchAll: vi.fn<(filter: unknown) => Promise<MacroRow[]>>(async () => []),
+      fetchByDateRange: vi.fn<
+        (from: string, to: string, type?: string) => Promise<MacroRow[]>
+      >(async () => []),
+      deleteById: vi.fn<(id: number) => Promise<boolean>>(async () => false),
+    }
+  }
+
+  async function withFakeMacroRepo<T>(
+    repo: ReturnType<typeof fakeMacroRepo>,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    const mod = await import('../../src/infrastructure/calendar/macroEventCalendarRepo')
+    const spy = vi.spyOn(mod, 'createMacroEventCalendarRepo').mockReturnValue(repo as never)
+    try {
+      return await fn()
+    } finally {
+      spy.mockRestore()
+    }
+  }
+
+  describe('POST /admin/macro-events/seed', () => {
+    it('401s without Basic Auth', async () => {
+      const app = createApp()
+      const res = await app.request(
+        '/admin/macro-events/seed',
+        {
+          method: 'POST',
+          body: JSON.stringify([{ event_type: 'FOMC', event_date: '2026-06-17' }]),
+        },
+        { ...baseEnv, DB: {} as unknown as D1Database },
+      )
+      expect(res.status).toBe(401)
+    })
+
+    it('400s when DB binding is missing', async () => {
+      const app = createApp()
+      const res = await app.request(
+        '/admin/macro-events/seed',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', ...authHeader },
+          body: JSON.stringify([{ event_type: 'FOMC', event_date: '2026-06-17' }]),
+        },
+        baseEnv,
+      )
+      expect(res.status).toBe(400)
+    })
+
+    it('400s when body is not an array', async () => {
+      const app = createApp()
+      const res = await app.request(
+        '/admin/macro-events/seed',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', ...authHeader },
+          body: JSON.stringify({ event_type: 'FOMC' }),
+        },
+        { ...baseEnv, DB: {} as unknown as D1Database },
+      )
+      expect(res.status).toBe(400)
+    })
+
+    it('400s on empty body array', async () => {
+      const app = createApp()
+      const res = await app.request(
+        '/admin/macro-events/seed',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', ...authHeader },
+          body: JSON.stringify([]),
+        },
+        { ...baseEnv, DB: {} as unknown as D1Database },
+      )
+      expect(res.status).toBe(400)
+    })
+
+    it.each([
+      'has space',
+      'lower-case-with-dash',
+      '$INVALID',
+      'a'.repeat(33), // exceeds 32 chars
+    ])('400s on invalid event_type %s', async (badType) => {
+      const app = createApp()
+      const res = await app.request(
+        '/admin/macro-events/seed',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', ...authHeader },
+          body: JSON.stringify([{ event_type: badType, event_date: '2026-06-17' }]),
+        },
+        { ...baseEnv, DB: {} as unknown as D1Database },
+      )
+      expect(res.status).toBe(400)
+    })
+
+    it.each(['2026-02-30', '2026-13-01', '06/17/2026'])(
+      '400s on invalid event_date %s',
+      async (badDate) => {
+        const app = createApp()
+        const res = await app.request(
+          '/admin/macro-events/seed',
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', ...authHeader },
+            body: JSON.stringify([{ event_type: 'FOMC', event_date: badDate }]),
+          },
+          { ...baseEnv, DB: {} as unknown as D1Database },
+        )
+        expect(res.status).toBe(400)
+      },
+    )
+
+    it.each(['8:30', '08:30:00', '24:00', '08:60', 'morning'])(
+      '400s on invalid event_time %s',
+      async (badTime) => {
+        const app = createApp()
+        const res = await app.request(
+          '/admin/macro-events/seed',
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', ...authHeader },
+            body: JSON.stringify([
+              { event_type: 'CPI', event_date: '2026-06-12', event_time: badTime },
+            ]),
+          },
+          { ...baseEnv, DB: {} as unknown as D1Database },
+        )
+        expect(res.status).toBe(400)
+      },
+    )
+
+    it('200s and forwards entries (uppercased) to bulkUpsert', async () => {
+      const repo = fakeMacroRepo()
+      repo.bulkUpsert.mockResolvedValueOnce({ inserted: 2, skipped: 0 })
+      const res = await withFakeMacroRepo(repo, async () => {
+        const app = createApp()
+        return app.request(
+          '/admin/macro-events/seed',
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', ...authHeader },
+            body: JSON.stringify([
+              { event_type: 'fomc', event_date: '2026-06-17', event_time: '14:00', notes: 'June' },
+              { event_type: 'GDP', event_date: '2026-07-01' },
+            ]),
+          },
+          { ...baseEnv, DB: {} as unknown as D1Database },
+        )
+      })
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as { inserted: number; skipped: number; total: number }
+      expect(body).toEqual({ inserted: 2, skipped: 0, total: 2 })
+      expect(repo.bulkUpsert).toHaveBeenCalledWith([
+        { eventType: 'FOMC', eventDate: '2026-06-17', eventTime: '14:00', notes: 'June' },
+        { eventType: 'GDP', eventDate: '2026-07-01', eventTime: null, notes: null },
+      ])
+    })
+
+    it('treats event_time === null and event_time === "" as null', async () => {
+      const repo = fakeMacroRepo()
+      repo.bulkUpsert.mockResolvedValueOnce({ inserted: 2, skipped: 0 })
+      const res = await withFakeMacroRepo(repo, async () => {
+        const app = createApp()
+        return app.request(
+          '/admin/macro-events/seed',
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', ...authHeader },
+            body: JSON.stringify([
+              { event_type: 'GDP', event_date: '2026-07-01', event_time: null },
+              { event_type: 'ISM', event_date: '2026-07-01', event_time: '' },
+            ]),
+          },
+          { ...baseEnv, DB: {} as unknown as D1Database },
+        )
+      })
+      expect(res.status).toBe(200)
+      expect(repo.bulkUpsert).toHaveBeenCalledWith([
+        { eventType: 'GDP', eventDate: '2026-07-01', eventTime: null, notes: null },
+        { eventType: 'ISM', eventDate: '2026-07-01', eventTime: null, notes: null },
+      ])
+    })
+  })
+
+  describe('GET /admin/macro-events', () => {
+    it('200s with rows and applies filter', async () => {
+      const repo = fakeMacroRepo()
+      repo.fetchAll.mockResolvedValueOnce([
+        {
+          id: 1,
+          eventType: 'FOMC',
+          eventDate: '2026-06-17',
+          eventTime: '14:00',
+          notes: null,
+          createdAt: '2026-04-21T00:00:00.000Z',
+        },
+      ])
+      const res = await withFakeMacroRepo(repo, async () => {
+        const app = createApp()
+        return app.request(
+          '/admin/macro-events?from=2026-06-01&to=2026-06-30&type=fomc',
+          { headers: { ...authHeader } },
+          { ...baseEnv, DB: {} as unknown as D1Database },
+        )
+      })
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as {
+        filter: { from: string | null; to: string | null; type: string | null }
+        rows: Array<{ eventType: string }>
+      }
+      expect(body.filter).toEqual({ from: '2026-06-01', to: '2026-06-30', type: 'FOMC' })
+      expect(body.rows).toHaveLength(1)
+      expect(repo.fetchAll).toHaveBeenCalledWith({
+        fromYmd: '2026-06-01',
+        toYmd: '2026-06-30',
+        eventType: 'FOMC',
+      })
+    })
+
+    it('200s with no filter (returns all)', async () => {
+      const repo = fakeMacroRepo()
+      repo.fetchAll.mockResolvedValueOnce([])
+      const res = await withFakeMacroRepo(repo, async () => {
+        const app = createApp()
+        return app.request(
+          '/admin/macro-events',
+          { headers: { ...authHeader } },
+          { ...baseEnv, DB: {} as unknown as D1Database },
+        )
+      })
+      expect(res.status).toBe(200)
+      expect(repo.fetchAll).toHaveBeenCalledWith({})
+    })
+
+    it('400s on invalid from date', async () => {
+      const app = createApp()
+      const res = await app.request(
+        '/admin/macro-events?from=2026-13-01',
+        { headers: { ...authHeader } },
+        { ...baseEnv, DB: {} as unknown as D1Database },
+      )
+      expect(res.status).toBe(400)
+    })
+
+    it('400s on invalid type', async () => {
+      const app = createApp()
+      const res = await app.request(
+        '/admin/macro-events?type=has%20space',
+        { headers: { ...authHeader } },
+        { ...baseEnv, DB: {} as unknown as D1Database },
+      )
+      expect(res.status).toBe(400)
+    })
+  })
+
+  describe('DELETE /admin/macro-events/:id', () => {
+    it('400s on non-numeric id', async () => {
+      const app = createApp()
+      const res = await app.request(
+        '/admin/macro-events/abc',
+        { method: 'DELETE', headers: { ...authHeader } },
+        { ...baseEnv, DB: {} as unknown as D1Database },
+      )
+      expect(res.status).toBe(400)
+    })
+
+    it('404 when row does not exist', async () => {
+      const repo = fakeMacroRepo()
+      repo.deleteById.mockResolvedValueOnce(false)
+      const res = await withFakeMacroRepo(repo, async () => {
+        const app = createApp()
+        return app.request(
+          '/admin/macro-events/42',
+          { method: 'DELETE', headers: { ...authHeader } },
+          { ...baseEnv, DB: {} as unknown as D1Database },
+        )
+      })
+      expect(res.status).toBe(404)
+    })
+
+    it('200 and forwards id when deletion succeeds', async () => {
+      const repo = fakeMacroRepo()
+      repo.deleteById.mockResolvedValueOnce(true)
+      const res = await withFakeMacroRepo(repo, async () => {
+        const app = createApp()
+        return app.request(
+          '/admin/macro-events/9',
+          { method: 'DELETE', headers: { ...authHeader } },
+          { ...baseEnv, DB: {} as unknown as D1Database },
+        )
+      })
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ deleted: true, id: 9 })
+      expect(repo.deleteById).toHaveBeenCalledWith(9)
+    })
+  })
+})

--- a/test/routes/admin.test.ts
+++ b/test/routes/admin.test.ts
@@ -765,6 +765,16 @@ describe('Macro event calendar admin endpoints (#196 2/3)', () => {
       )
       expect(res.status).toBe(400)
     })
+
+    it("400s when 'from' > 'to' (operator typo, distinct from empty result)", async () => {
+      const app = createApp()
+      const res = await app.request(
+        '/admin/macro-events?from=2026-07-10&to=2026-07-01',
+        { headers: { ...authHeader } },
+        { ...baseEnv, DB: {} as unknown as D1Database },
+      )
+      expect(res.status).toBe(400)
+    })
   })
 
   describe('DELETE /admin/macro-events/:id', () => {

--- a/test/trading/risk/macroEventGate.test.ts
+++ b/test/trading/risk/macroEventGate.test.ts
@@ -319,6 +319,89 @@ describe('evaluateMacroEventGate — fail-closed paths', () => {
     expect(decision.approved).toBe(false)
     expect(decision.reason).toContain('macro_event_gate_invalid_calendar_row')
   })
+
+  it('rejects nonexistent calendar date 2026-02-30 (round-trip validation)', async () => {
+    // JS Date は 2026-02-30 を 2026-03-02 に silent normalize するため、
+    // 形式チェック + Date.parse だけでは fail-open する。round-trip 比較で
+    // 実在しない暦日を弾くことを保証する。
+    const repo = fakeRepo([row('CPI', '2026-02-30', '08:30')])
+    const decision = await evaluateMacroEventGate(
+      { evalTimestamp: '2026-02-28T13:30:00.000Z', side: 'BUY' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reason).toContain('macro_event_gate_invalid_calendar_row')
+    expect(decision.reason).toContain('CPI 2026-02-30 08:30')
+  })
+
+  it('rejects nonexistent month 2026-13-01 (round-trip validation)', async () => {
+    // 月 > 12 を弾く (13 月は normalize で翌年 1 月になる)。
+    // fakeRepo の date filter を回避するため、malformed row を必ず返す repo を使う。
+    const malformedRow = row('FOMC', '2026-13-01', '14:00')
+    const repo: MacroEventCalendarRepo = {
+      async fetchByDateRange() {
+        return [malformedRow]
+      },
+      async fetchAll() {
+        return [malformedRow]
+      },
+      async bulkUpsert() {
+        return { inserted: 0, skipped: 0 }
+      },
+      async deleteById() {
+        return false
+      },
+    }
+    const decision = await evaluateMacroEventGate(
+      { evalTimestamp: '2026-12-15T19:00:00.000Z', side: 'BUY' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reason).toContain('macro_event_gate_invalid_calendar_row')
+    expect(decision.reason).toContain('FOMC 2026-13-01 14:00')
+  })
+
+  it('rejects nonexistent day 2026-04-31 (round-trip validation)', async () => {
+    // 4 月 31 日は存在しない (normalize で 5/1)。round-trip で reject されること。
+    const repo = fakeRepo([row('NFP', '2026-04-31', '08:30')])
+    const decision = await evaluateMacroEventGate(
+      { evalTimestamp: '2026-04-30T13:00:00.000Z', side: 'BUY' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reason).toContain('macro_event_gate_invalid_calendar_row')
+    expect(decision.reason).toContain('NFP 2026-04-31 08:30')
+  })
+
+  it('rejects out-of-range hour "25:00" (range validation)', async () => {
+    // 24h 超の hour は range check で reject (Date.parse は 25:00 を翌日 01:00
+    // に normalize して通してしまう)。
+    const repo = fakeRepo([row('CPI', '2026-06-12', '25:00')])
+    const decision = await evaluateMacroEventGate(
+      { evalTimestamp: '2026-06-12T12:30:00.000Z', side: 'BUY' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reason).toContain('macro_event_gate_invalid_calendar_row')
+    expect(decision.reason).toContain('CPI 2026-06-12 25:00')
+  })
+
+  it('rejects out-of-range minute "00:60" (range validation)', async () => {
+    // 60min 超は range check で reject (00:60 は normalize で 01:00 になる)。
+    const repo = fakeRepo([row('GDP', '2026-06-12', '00:60')])
+    const decision = await evaluateMacroEventGate(
+      { evalTimestamp: '2026-06-12T04:00:00.000Z', side: 'BUY' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reason).toContain('macro_event_gate_invalid_calendar_row')
+    expect(decision.reason).toContain('GDP 2026-06-12 00:60')
+  })
 })
 
 describe('evaluateMacroEventGate — config sanitisation', () => {

--- a/test/trading/risk/macroEventGate.test.ts
+++ b/test/trading/risk/macroEventGate.test.ts
@@ -402,6 +402,94 @@ describe('evaluateMacroEventGate — fail-closed paths', () => {
     expect(decision.reason).toContain('macro_event_gate_invalid_calendar_row')
     expect(decision.reason).toContain('GDP 2026-06-12 00:60')
   })
+
+  it('rejects event_time=NULL with nonexistent date 2026-02-30 (full-day branch round-trip)', async () => {
+    // event_time NULL 経路は単純文字列一致しか見ないため、`2026-02-30` のような
+    // 実在しない暦日が DB に入っていると一致せず silent pass = fail-open する。
+    // ループ先頭の `isStrictYmd` で reject されることを保証。
+    const malformedRow = row('GDP', '2026-02-30', null)
+    const repo: MacroEventCalendarRepo = {
+      async fetchByDateRange() {
+        return [malformedRow]
+      },
+      async fetchAll() {
+        return [malformedRow]
+      },
+      async bulkUpsert() {
+        return { inserted: 0, skipped: 0 }
+      },
+      async deleteById() {
+        return false
+      },
+    }
+    const decision = await evaluateMacroEventGate(
+      { evalTimestamp: '2026-02-28T13:30:00.000Z', side: 'BUY' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reason).toContain('macro_event_gate_invalid_calendar_row')
+    expect(decision.reason).toContain('GDP 2026-02-30 null')
+    expect(decision.triggeringEvent).toEqual({
+      type: 'GDP',
+      date: '2026-02-30',
+      time: null,
+    })
+  })
+
+  it('rejects event_time=NULL with nonexistent month 2026-13-01 (full-day branch round-trip)', async () => {
+    // 月 > 12 の row が full-day freeze 経路で素通りしないことを保証。
+    const malformedRow = row('FOMC', '2026-13-01', null)
+    const repo: MacroEventCalendarRepo = {
+      async fetchByDateRange() {
+        return [malformedRow]
+      },
+      async fetchAll() {
+        return [malformedRow]
+      },
+      async bulkUpsert() {
+        return { inserted: 0, skipped: 0 }
+      },
+      async deleteById() {
+        return false
+      },
+    }
+    const decision = await evaluateMacroEventGate(
+      { evalTimestamp: '2026-12-15T19:00:00.000Z', side: 'BUY' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reason).toContain('macro_event_gate_invalid_calendar_row')
+    expect(decision.reason).toContain('FOMC 2026-13-01 null')
+  })
+
+  it('rejects event_time=NULL with nonexistent day 2026-04-31 (full-day branch round-trip)', async () => {
+    // 4 月 31 日は存在しない (normalize で 5/1)。round-trip で reject されること。
+    const malformedRow = row('NFP', '2026-04-31', null)
+    const repo: MacroEventCalendarRepo = {
+      async fetchByDateRange() {
+        return [malformedRow]
+      },
+      async fetchAll() {
+        return [malformedRow]
+      },
+      async bulkUpsert() {
+        return { inserted: 0, skipped: 0 }
+      },
+      async deleteById() {
+        return false
+      },
+    }
+    const decision = await evaluateMacroEventGate(
+      { evalTimestamp: '2026-04-30T13:00:00.000Z', side: 'BUY' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reason).toContain('macro_event_gate_invalid_calendar_row')
+    expect(decision.reason).toContain('NFP 2026-04-31 null')
+  })
 })
 
 describe('evaluateMacroEventGate — config sanitisation', () => {

--- a/test/trading/risk/macroEventGate.test.ts
+++ b/test/trading/risk/macroEventGate.test.ts
@@ -14,12 +14,13 @@ import type { MacroEventCalendarRow } from '../../../src/infrastructure/db/schem
  * Tests for the macro event gate (#196 2/3)。
  *
  * 観点:
- *   - event_time 指定: 発表 ±1h 内 reject、外 approve
+ *   - event_time 指定: 発表前 1h / 発表後 6h 内 reject、外 approve (default)
  *   - event_time NULL: 当日全日 reject (default)
  *   - 範囲外 → approve
  *   - DB 失敗 → fail-closed reject
  *   - SELL は常に approve (撤退路を妨げない)
  *   - 不正 timestamp → fail-closed reject
+ *   - 不正 event_time row → fail-closed reject (silent fail-open 防止)
  */
 
 const baseConfig: MacroEventGateConfig = { ...DEFAULT_MACRO_GATE_CONFIG }
@@ -120,7 +121,7 @@ describe('evaluateMacroEventGate — event_time specified', () => {
     expect(decision.reason).toContain('CPI 2026-06-12 08:30ET')
   })
 
-  it('rejects 30min after event (within freezeHoursAfter=1)', async () => {
+  it('rejects 30min after event (within freezeHoursAfter=6 default)', async () => {
     const repo = fakeRepo([row('NFP', '2026-06-05', '08:30')])
     // 09:00 ET (EDT) = 13:00 UTC
     const decision = await evaluateMacroEventGate(
@@ -130,6 +131,30 @@ describe('evaluateMacroEventGate — event_time specified', () => {
     )
     expect(decision.approved).toBe(false)
     expect(decision.reason).toContain('NFP 2026-06-05 08:30ET')
+  })
+
+  it('rejects 5h after event with default freezeHoursAfter=6', async () => {
+    // CPI 08:30 ET (EDT) = 12:30 UTC、5h 後 = 17:30 UTC は default 6h 内で reject。
+    const repo = fakeRepo([row('CPI', '2026-06-12', '08:30')])
+    const decision = await evaluateMacroEventGate(
+      { evalTimestamp: '2026-06-12T17:30:00.000Z', side: 'BUY' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reason).toContain('CPI 2026-06-12 08:30ET')
+  })
+
+  it('approves >6h after event (outside default freezeHoursAfter=6)', async () => {
+    // NFP 08:30 ET (EDT) = 12:30 UTC、6h+1min 後 = 18:31 UTC は default 6h を
+    // 超えるので approve。
+    const repo = fakeRepo([row('NFP', '2026-06-05', '08:30')])
+    const decision = await evaluateMacroEventGate(
+      { evalTimestamp: '2026-06-05T18:31:00.000Z', side: 'BUY' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(true)
   })
 
   it('approves 90min before event (outside ±1h window)', async () => {
@@ -143,13 +168,14 @@ describe('evaluateMacroEventGate — event_time specified', () => {
     expect(decision.approved).toBe(true)
   })
 
-  it('approves 90min after event (outside ±1h window)', async () => {
+  it('approves 90min after event when freezeHoursAfter=1 override', async () => {
+    // default は 6h だが、explicit 1h override で 90 分後は window 外。
     const repo = fakeRepo([row('NFP', '2026-06-05', '08:30')])
     // 10:00 ET (EDT) = 14:00 UTC
     const decision = await evaluateMacroEventGate(
       { evalTimestamp: '2026-06-05T14:00:00.000Z', side: 'BUY' },
       repo,
-      baseConfig,
+      { freezeHoursBefore: 1, freezeHoursAfter: 1, freezeFullDayWhenTimeUnknown: true },
     )
     expect(decision.approved).toBe(true)
   })
@@ -260,6 +286,38 @@ describe('evaluateMacroEventGate — fail-closed paths', () => {
     )
     expect(decision.approved).toBe(false)
     expect(decision.reason).toContain('macro_event_gate_invalid_eval_timestamp')
+  })
+
+  it('rejects when calendar row has invalid event_time (silent fail-open prevention)', async () => {
+    // event_time が `HH:MM` 規格を満たさない row は parse できない。
+    // continue (silent skip) すると当該 event だけ BUY 素通り = fail-open に
+    // なるため、fail-closed で reject させる。
+    const repo = fakeRepo([row('CPI', '2026-06-12', 'invalid-time')])
+    const decision = await evaluateMacroEventGate(
+      { evalTimestamp: '2026-06-12T12:30:00.000Z', side: 'BUY' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reason).toContain('macro_event_gate_invalid_calendar_row')
+    expect(decision.reason).toContain('CPI 2026-06-12 invalid-time')
+    expect(decision.triggeringEvent).toEqual({
+      type: 'CPI',
+      date: '2026-06-12',
+      time: 'invalid-time',
+    })
+  })
+
+  it('rejects when calendar row has malformed event_time like "8:30" (silent fail-open prevention)', async () => {
+    // 規格は `HH:MM` (2 桁:2 桁)。`8:30` のような 1 桁時間は弾く。
+    const repo = fakeRepo([row('NFP', '2026-06-05', '8:30')])
+    const decision = await evaluateMacroEventGate(
+      { evalTimestamp: '2026-06-05T12:30:00.000Z', side: 'BUY' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reason).toContain('macro_event_gate_invalid_calendar_row')
   })
 })
 

--- a/test/trading/risk/macroEventGate.test.ts
+++ b/test/trading/risk/macroEventGate.test.ts
@@ -405,9 +405,9 @@ describe('evaluateMacroEventGate — fail-closed paths', () => {
 })
 
 describe('evaluateMacroEventGate — config sanitisation', () => {
-  it('clamps negative freezeHoursBefore/After to default (1h each)', async () => {
-    // negative → default 1h。FOMC 14:00 ET ±1h で 13:30 ET (= 17:30 UTC) は
-    // window 内で reject されるはず。
+  it('clamps negative freezeHoursBefore/After to defaults (1h/6h)', async () => {
+    // negative → defaults (before=1h, after=6h)。FOMC 14:00 ET、before=1h で
+    // 13:30 ET (= 17:30 UTC) は window 内 (-1h ≤ delta ≤ +6h) なので reject されるはず。
     const repo = fakeRepo([row('FOMC', '2026-06-17', '14:00')])
     const decision = await evaluateMacroEventGate(
       { evalTimestamp: '2026-06-17T17:30:00.000Z', side: 'BUY' },

--- a/test/trading/risk/macroEventGate.test.ts
+++ b/test/trading/risk/macroEventGate.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_MACRO_GATE_CONFIG,
+  evaluateMacroEventGate,
+  type MacroEventGateConfig,
+} from '../../../src/trading/risk/macroEventGate'
+import type {
+  MacroEventCalendarRepo,
+  MacroEventCalendarSeedInput,
+} from '../../../src/infrastructure/calendar/macroEventCalendarRepo'
+import type { MacroEventCalendarRow } from '../../../src/infrastructure/db/schema'
+
+/**
+ * Tests for the macro event gate (#196 2/3)。
+ *
+ * 観点:
+ *   - event_time 指定: 発表 ±1h 内 reject、外 approve
+ *   - event_time NULL: 当日全日 reject (default)
+ *   - 範囲外 → approve
+ *   - DB 失敗 → fail-closed reject
+ *   - SELL は常に approve (撤退路を妨げない)
+ *   - 不正 timestamp → fail-closed reject
+ */
+
+const baseConfig: MacroEventGateConfig = { ...DEFAULT_MACRO_GATE_CONFIG }
+
+function row(
+  type: string,
+  date: string,
+  time: string | null,
+  id = 1,
+): MacroEventCalendarRow {
+  return {
+    id,
+    eventType: type.toUpperCase(),
+    eventDate: date,
+    eventTime: time,
+    notes: null,
+    createdAt: '2026-04-21T00:00:00.000Z',
+  }
+}
+
+function fakeRepo(rows: MacroEventCalendarRow[]): MacroEventCalendarRepo & {
+  calls: Array<{ from: string; to: string; type?: string }>
+} {
+  const calls: Array<{ from: string; to: string; type?: string }> = []
+  return {
+    calls,
+    async fetchByDateRange(from, to, type) {
+      calls.push(type !== undefined ? { from, to, type } : { from, to })
+      return rows.filter((r) => {
+        if (type !== undefined && r.eventType !== type.toUpperCase()) return false
+        return r.eventDate >= from && r.eventDate <= to
+      })
+    },
+    async fetchAll() {
+      return rows
+    },
+    async bulkUpsert(_records: MacroEventCalendarSeedInput[]) {
+      return { inserted: 0, skipped: 0 }
+    },
+    async deleteById(_id: number) {
+      return false
+    },
+  }
+}
+
+describe('evaluateMacroEventGate — base behaviour', () => {
+  it('approves when no rows are returned', async () => {
+    const repo = fakeRepo([])
+    const decision = await evaluateMacroEventGate(
+      { evalTimestamp: '2026-06-17T18:00:00.000Z', side: 'BUY' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(true)
+    expect(repo.calls).toHaveLength(1)
+  })
+
+  it('always approves SELL regardless of nearby events', async () => {
+    // FOMC at 2026-06-17 14:00 ET = 18:00 UTC (EDT)。同瞬間に SELL を評価。
+    const repo = fakeRepo([row('FOMC', '2026-06-17', '14:00')])
+    const decision = await evaluateMacroEventGate(
+      { evalTimestamp: '2026-06-17T18:00:00.000Z', side: 'SELL' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(true)
+    expect(repo.calls).toHaveLength(0)
+  })
+})
+
+describe('evaluateMacroEventGate — event_time specified', () => {
+  it('rejects when eval is exactly at the event time (FOMC 14:00 ET)', async () => {
+    // 2026-06-17 14:00 ET (EDT, UTC-4) = 18:00 UTC
+    const repo = fakeRepo([row('FOMC', '2026-06-17', '14:00')])
+    const decision = await evaluateMacroEventGate(
+      { evalTimestamp: '2026-06-17T18:00:00.000Z', side: 'BUY' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reason).toBe('macro_event_gate: FOMC 2026-06-17 14:00ET')
+    expect(decision.triggeringEvent).toEqual({
+      type: 'FOMC',
+      date: '2026-06-17',
+      time: '14:00',
+    })
+  })
+
+  it('rejects 30min before event (within freezeHoursBefore=1)', async () => {
+    // CPI 08:30 ET (EDT) = 12:30 UTC、30 分前 = 12:00 UTC。
+    const repo = fakeRepo([row('CPI', '2026-06-12', '08:30')])
+    const decision = await evaluateMacroEventGate(
+      { evalTimestamp: '2026-06-12T12:00:00.000Z', side: 'BUY' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reason).toContain('CPI 2026-06-12 08:30ET')
+  })
+
+  it('rejects 30min after event (within freezeHoursAfter=1)', async () => {
+    const repo = fakeRepo([row('NFP', '2026-06-05', '08:30')])
+    // 09:00 ET (EDT) = 13:00 UTC
+    const decision = await evaluateMacroEventGate(
+      { evalTimestamp: '2026-06-05T13:00:00.000Z', side: 'BUY' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reason).toContain('NFP 2026-06-05 08:30ET')
+  })
+
+  it('approves 90min before event (outside ±1h window)', async () => {
+    // CPI 08:30 ET、90 分前 = 07:00 ET = 11:00 UTC (EDT)
+    const repo = fakeRepo([row('CPI', '2026-06-12', '08:30')])
+    const decision = await evaluateMacroEventGate(
+      { evalTimestamp: '2026-06-12T11:00:00.000Z', side: 'BUY' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(true)
+  })
+
+  it('approves 90min after event (outside ±1h window)', async () => {
+    const repo = fakeRepo([row('NFP', '2026-06-05', '08:30')])
+    // 10:00 ET (EDT) = 14:00 UTC
+    const decision = await evaluateMacroEventGate(
+      { evalTimestamp: '2026-06-05T14:00:00.000Z', side: 'BUY' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(true)
+  })
+
+  it('respects freezeHoursBefore/After overrides', async () => {
+    // 2h 幅 → 90 分前なら reject されるはず
+    const repo = fakeRepo([row('CPI', '2026-06-12', '08:30')])
+    const decision = await evaluateMacroEventGate(
+      { evalTimestamp: '2026-06-12T11:00:00.000Z', side: 'BUY' },
+      repo,
+      { freezeHoursBefore: 2, freezeHoursAfter: 2, freezeFullDayWhenTimeUnknown: true },
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reason).toContain('CPI')
+  })
+
+  it('handles winter ET (EST = UTC-5) correctly', async () => {
+    // FOMC 2026-12-16 14:00 EST = 19:00 UTC
+    const repo = fakeRepo([row('FOMC', '2026-12-16', '14:00')])
+    const decision = await evaluateMacroEventGate(
+      { evalTimestamp: '2026-12-16T19:00:00.000Z', side: 'BUY' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reason).toContain('FOMC 2026-12-16 14:00ET')
+  })
+})
+
+describe('evaluateMacroEventGate — event_time NULL (full-day fallback)', () => {
+  it('rejects on the event day when event_time is NULL and freezeFullDay=true', async () => {
+    // ET の評価日が event_date と一致 → 全日凍結
+    // 2026-07-01 12:00 UTC = 2026-07-01 08:00 EDT
+    const repo = fakeRepo([row('GDP', '2026-07-01', null)])
+    const decision = await evaluateMacroEventGate(
+      { evalTimestamp: '2026-07-01T12:00:00.000Z', side: 'BUY' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reason).toBe('macro_event_gate: GDP 2026-07-01 (full-day)')
+    expect(decision.triggeringEvent).toEqual({
+      type: 'GDP',
+      date: '2026-07-01',
+      time: null,
+    })
+  })
+
+  it('approves NULL-time event one ET day before', async () => {
+    // 2026-06-30 23:00 ET ≠ 2026-07-01。ET YMD で別日扱い。
+    // 2026-07-01 02:59:59 UTC = 2026-06-30 22:59:59 EDT
+    const repo = fakeRepo([row('GDP', '2026-07-01', null)])
+    const decision = await evaluateMacroEventGate(
+      { evalTimestamp: '2026-07-01T02:59:59.000Z', side: 'BUY' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(true)
+  })
+
+  it('skips NULL-time events when freezeFullDayWhenTimeUnknown=false', async () => {
+    const repo = fakeRepo([row('GDP', '2026-07-01', null)])
+    const decision = await evaluateMacroEventGate(
+      { evalTimestamp: '2026-07-01T12:00:00.000Z', side: 'BUY' },
+      repo,
+      {
+        freezeHoursBefore: 1,
+        freezeHoursAfter: 1,
+        freezeFullDayWhenTimeUnknown: false,
+      },
+    )
+    expect(decision.approved).toBe(true)
+  })
+})
+
+describe('evaluateMacroEventGate — fail-closed paths', () => {
+  it('rejects when D1 read throws (fail-closed)', async () => {
+    const repo: MacroEventCalendarRepo = {
+      async fetchByDateRange() {
+        throw new Error('d1 connection lost')
+      },
+      async fetchAll() {
+        return []
+      },
+      async bulkUpsert() {
+        return { inserted: 0, skipped: 0 }
+      },
+      async deleteById() {
+        return false
+      },
+    }
+    const decision = await evaluateMacroEventGate(
+      { evalTimestamp: '2026-06-17T18:00:00.000Z', side: 'BUY' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reason).toContain('macro_event_gate_fetch_failed')
+    expect(decision.reason).toContain('d1 connection lost')
+  })
+
+  it('rejects on invalid evalTimestamp', async () => {
+    const repo = fakeRepo([])
+    const decision = await evaluateMacroEventGate(
+      { evalTimestamp: 'not-a-timestamp', side: 'BUY' },
+      repo,
+      baseConfig,
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reason).toContain('macro_event_gate_invalid_eval_timestamp')
+  })
+})
+
+describe('evaluateMacroEventGate — config sanitisation', () => {
+  it('clamps negative freezeHoursBefore/After to default (1h each)', async () => {
+    // negative → default 1h。FOMC 14:00 ET ±1h で 13:30 ET (= 17:30 UTC) は
+    // window 内で reject されるはず。
+    const repo = fakeRepo([row('FOMC', '2026-06-17', '14:00')])
+    const decision = await evaluateMacroEventGate(
+      { evalTimestamp: '2026-06-17T17:30:00.000Z', side: 'BUY' },
+      repo,
+      { freezeHoursBefore: -3, freezeHoursAfter: -3, freezeFullDayWhenTimeUnknown: true },
+    )
+    expect(decision.approved).toBe(false)
+  })
+
+  it('clamps absurdly large freezeHours to 6h', async () => {
+    // FOMC 14:00 ET、5h 後 = 19:00 ET = 23:00 UTC は cap=6 なら reject。
+    const repo = fakeRepo([row('FOMC', '2026-06-17', '14:00')])
+    const decision = await evaluateMacroEventGate(
+      { evalTimestamp: '2026-06-17T23:00:00.000Z', side: 'BUY' },
+      repo,
+      { freezeHoursBefore: 9999, freezeHoursAfter: 9999, freezeFullDayWhenTimeUnknown: true },
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reason).toContain('FOMC')
+  })
+})

--- a/test/trading/strategy/pullbackScheduler.test.ts
+++ b/test/trading/strategy/pullbackScheduler.test.ts
@@ -627,7 +627,7 @@ describe('runPullbackScheduler earnings calendar gate (#196)', () => {
 })
 
 describe('runPullbackScheduler macro event gate (#196 2/3)', () => {
-  it('rejects BUY when a macro event is within ±1h of eval timestamp', async () => {
+  it('rejects BUY when a macro event is within the freeze window of eval timestamp', async () => {
     // FOMC 14:00 ET (= 18:30 UTC EDT) を `now` (= 14:30 UTC EDT に近い) と
     // 同瞬間に置く simple repo。`now` 経由で 14:30 UTC が渡るので CPI 08:30 ET
     // (= 12:30 UTC) を window 内に置く。

--- a/test/trading/strategy/pullbackScheduler.test.ts
+++ b/test/trading/strategy/pullbackScheduler.test.ts
@@ -625,3 +625,162 @@ describe('runPullbackScheduler earnings calendar gate (#196)', () => {
     expect(msftDecision?.decision).toBe('BUY')
   })
 })
+
+describe('runPullbackScheduler macro event gate (#196 2/3)', () => {
+  it('rejects BUY when a macro event is within ±1h of eval timestamp', async () => {
+    // FOMC 14:00 ET (= 18:30 UTC EDT) を `now` (= 14:30 UTC EDT に近い) と
+    // 同瞬間に置く simple repo。`now` 経由で 14:30 UTC が渡るので CPI 08:30 ET
+    // (= 12:30 UTC) を window 内に置く。
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution,
+      macroEventGate: {
+        repo: {
+          async fetchByDateRange() {
+            // 2026-04-20 12:30 UTC = 08:30 EDT — `now` 14:30 UTC = 10:30 EDT。
+            // 2h 差で window 外。代わりに 14:30 UTC = 10:30 EDT を CPI 時刻に
+            // することで window 内に入れる。
+            return [
+              {
+                id: 1,
+                eventType: 'CPI',
+                eventDate: '2026-04-20',
+                eventTime: '10:30',
+                notes: null,
+                createdAt: now.toISOString(),
+              },
+            ]
+          },
+          async fetchAll() {
+            return []
+          },
+          async bulkUpsert() {
+            return { inserted: 0, skipped: 0 }
+          },
+          async deleteById() {
+            return false
+          },
+        },
+      },
+      now: () => now,
+    })
+    expect(summary.buys).toBe(0)
+    expect(execution.calls).toHaveLength(0)
+    const reject = summary.decisions.find((d) => d.decision === 'REJECT')
+    expect(reject?.reason).toContain('risk: macro_event_gate: CPI')
+  })
+
+  it('approves BUY when macro repo returns no rows', async () => {
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution,
+      macroEventGate: {
+        repo: {
+          async fetchByDateRange() {
+            return []
+          },
+          async fetchAll() {
+            return []
+          },
+          async bulkUpsert() {
+            return { inserted: 0, skipped: 0 }
+          },
+          async deleteById() {
+            return false
+          },
+        },
+      },
+      now: () => now,
+    })
+    expect(summary.buys).toBe(1)
+    expect(execution.calls).toHaveLength(1)
+  })
+
+  it('skips the macro gate when option is omitted (back-compat)', async () => {
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution,
+      now: () => now,
+    })
+    expect(summary.buys).toBe(1)
+  })
+
+  it('earnings reason wins when both gates would reject (priority order)', async () => {
+    // 両 gate 入れたら earnings の reject が先 (task 指定の優先順位 earnings → macro)。
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution,
+      earningsGate: {
+        repo: {
+          async fetchByRange() {
+            return [
+              {
+                id: 1,
+                symbol: 'AAPL',
+                earningsDate: now.toISOString().slice(0, 10),
+                notes: null,
+                createdAt: now.toISOString(),
+              },
+            ]
+          },
+          async fetchBySymbol() {
+            return []
+          },
+          async bulkUpsert() {
+            return { inserted: 0, skipped: 0 }
+          },
+          async deleteById() {
+            return false
+          },
+        },
+        freezeBusinessDays: 1,
+      },
+      macroEventGate: {
+        repo: {
+          async fetchByDateRange() {
+            return [
+              {
+                id: 1,
+                eventType: 'CPI',
+                eventDate: now.toISOString().slice(0, 10),
+                eventTime: '10:30',
+                notes: null,
+                createdAt: now.toISOString(),
+              },
+            ]
+          },
+          async fetchAll() {
+            return []
+          },
+          async bulkUpsert() {
+            return { inserted: 0, skipped: 0 }
+          },
+          async deleteById() {
+            return false
+          },
+        },
+      },
+      now: () => now,
+    })
+    expect(summary.buys).toBe(0)
+    const reject = summary.decisions.find((d) => d.decision === 'REJECT')
+    expect(reject?.reason).toContain('earnings_within_1bd')
+    expect(reject?.reason).not.toContain('macro_event_gate')
+  })
+})

--- a/test/trading/strategy/runStrategyCron.test.ts
+++ b/test/trading/strategy/runStrategyCron.test.ts
@@ -202,6 +202,52 @@ describe('runStrategyCron', () => {
     }
   })
 
+  // issue #196 2/3: macro_event_calendar (0014) も同パターンで table 未存在
+  // 環境では gate 無効化される。probe SELECT が走り、warn ログ
+  // `macro_event_gate_disabled_table_missing` が出ることを確認する。
+  it('disables macro event gate when macro_event_calendar table is missing (#196 2/3)', async () => {
+    const firstSpy = vi.fn(async () => null)
+    const fakeDb = {
+      prepare: vi.fn(() => ({
+        first: firstSpy,
+      })),
+    } as unknown as D1Database
+    const warnSpy2 = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    try {
+      const envWithMissingTable = {
+        DB: fakeDb,
+        SYMBOL_STATE: {} as DurableObjectNamespace<never>,
+        PORTFOLIO_STATE: {
+          idFromName: () => ({}),
+          get: () => ({
+            getPortfolio: vi.fn().mockResolvedValue({
+              dailyStartEquity: 10_000,
+              dailyRealizedPnl: 0,
+              tradingDisabledUntil: null,
+              updatedAt: new Date().toISOString(),
+            }),
+          }),
+        },
+      } as unknown as Parameters<typeof runStrategyCron>[0]
+
+      await runStrategyCron(envWithMissingTable, { requestId: 'req-no-macro-table' }).catch(
+        () => undefined,
+      )
+
+      const calls = (fakeDb.prepare as ReturnType<typeof vi.fn>).mock.calls as Array<[string]>
+      const probedSqliteMaster = calls.some(
+        (c) => c[0].includes('sqlite_master') && c[0].includes('macro_event_calendar'),
+      )
+      expect(probedSqliteMaster).toBe(true)
+      const warnLines = warnSpy2.mock.calls.map((c) => String(c[0]))
+      expect(
+        warnLines.some((l) => l.includes('macro_event_gate_disabled_table_missing')),
+      ).toBe(true)
+    } finally {
+      warnSpy2.mockRestore()
+    }
+  })
+
   // #141: critical な skip reason は Notifier 経由で push 通知される。
   // env.SLACK_WEBHOOK_URL を設定して fetch を spy し、webhook 行きの POST が
   // 1 回入ることだけ確認する (formatter は WebhookNotifier.test に分離済み)。


### PR DESCRIPTION
## 動機

Issue #196 の 3 sub-feature のうちの **2 つ目: macro event gate**。

FOMC / CPI / NFP / PCE / GDP / ISM 等の重要 macro 発表当日 (±N 時間) に被る BUY エントリを機械的に凍結する avoid 用 risk gate を導入。シグナル源ではなく、発表ボラ + 流動性枯渇を跨ぐ建玉を避けるための guard。

PR #211 (earnings gate, 1/3) と同じ pattern を踏襲。残り 1 つ (VIX regime filter) は **別 PR で続ける** (本 PR の scope 外)。

## 実装概要

- D1 schema 追加 (`drizzle/0014_macro_event_calendar.sql`):
  - `macro_event_calendar(id, event_type, event_date, event_time, notes, created_at)`
  - UNIQUE INDEX `(event_type, event_date)` で重複 seed を物理的に弾く
  - 別 INDEX `(event_date)` で gate の range read を加速
  - `src/infrastructure/db/schema.ts` に Drizzle entry 追加
- repo (`src/infrastructure/calendar/macroEventCalendarRepo.ts`):
  - `fetchByDateRange` (gate read; date 範囲 + optional type) / `fetchAll` (admin inspect; from/to/type filter) / `bulkUpsert` (chunk multi-row INSERT + `onConflictDoNothing`) / `deleteById`
- gate 本体 (`src/trading/risk/macroEventGate.ts`):
  - `evaluateMacroEventGate(input, repo, config)`: 評価時刻 (UTC) を中心に ±freezeHours の window を計算し、event_date ±1 日の row を repo から取得 → ET 時刻に換算して window 比較
  - `event_time` 指定行: `Intl.DateTimeFormat({ timeZone: 'America/New_York', timeZoneName: 'shortOffset' })` で DST aware の ET offset を probe して naive UTC ms から逆算 (POC 簡略実装、DST 切替の 1h ジャンプは無視)
  - `event_time` NULL 行: ET 評価日と event_date が一致したら全日凍結 (`freezeFullDayWhenTimeUnknown=true` のとき)
  - SELL は常に approve (撤退路は妨げない)
  - **fail-closed**: D1 read 失敗 / 不正 evalTimestamp → reject (entry block)
  - `freezeHoursBefore`/`After` は default 1h、6h で sane bound (24h を超える window は ±1 日 fetch で拾えなくなるため)
- cron への配線 (`pullbackScheduler` / `runStrategyCron`):
  - `runPullbackScheduler` に `macroEventGate?` option 追加。BUY 経路で **earnings gate の後** に評価 (両方 reject なら earnings reason が先に確定する優先順位)
  - reject reason は `risk: macro_event_gate: FOMC 2026-06-17 14:00ET` 形式で `strategy_decision_log.reason` に書く
  - decision trace に `risk.macro_event` step を追加 (label_ja: `マクロイベントゲート`)
  - `runStrategyCron` は `env.DB` + `isMacroEventCalendarReady` 判定で 0014 適用済みのときだけ gate 注入。未適用環境では warn ログ (`macro_event_gate_disabled_table_missing`) を出して gate skip (POC 後方互換 / 新環境 protection)
- admin endpoints (`src/routes/admin.ts`):
  - `POST /admin/macro-events/seed` — bulk seed (`[{event_type, event_date, event_time?, notes?}]`)
  - `GET /admin/macro-events?from=&to=&type=` — operator inspect (全 filter optional)
  - `DELETE /admin/macro-events/:id` — 誤 seed の取り消し
  - `event_type`: `[A-Za-z0-9_]{1,32}`、`event_date`: round-trip ISO 'YYYY-MM-DD'、`event_time`: optional 'HH:MM' (24h)、`notes`: <=256 chars validation

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test --run` 全 pass (63 files / 735 tests)
- [x] 新規 unit test `test/trading/risk/macroEventGate.test.ts` (16 cases):
  - 当日 14:00 ET (= 18:00 UTC EDT) の発表時刻ぴったりで reject
  - 30min 前後 (within ±1h) で reject、90min 前後で approve
  - `freezeHoursBefore`/`After` overrides で 2h 幅にしたケース
  - 冬時刻 (EST = UTC-5) の FOMC で UTC 19:00 = ET 14:00 が reject
  - `event_time = null` + `freezeFullDayWhenTimeUnknown=true` で当日全日 reject、別日 approve、`false` なら approve
  - DB read throw → fail-closed reject
  - 不正 evalTimestamp → fail-closed reject
  - SELL は常に approve、不正 negative/巨大 freeze hours は default/6h クランプ
- [x] 新規 `test/infrastructure/calendar/macroEventCalendarRepo.test.ts` (4 cases):
  - empty 入力 / 50 chunk / multi-row INSERT / `event_type` upper-case / `event_time`/`notes` ?? null / UNIQUE skip
- [x] `test/trading/strategy/pullbackScheduler.test.ts` に macro gate 経路 4 ケース追加:
  - macro reject 経路 / 該当 0 件 approve / option 未注入で back-compat / earnings + macro 同時 reject で earnings reason 優先
- [x] `test/routes/admin.test.ts` に macro 系 admin 経路を追加:
  - 401/400 (no auth / no DB / not array / empty / invalid event_type / invalid date / invalid time)
  - 200 (uppercased forward to bulkUpsert) / null & "" を null として扱う
  - GET `from`/`to`/`type` filter forward / 不正 from / 不正 type で 400
  - DELETE: 400 / 404 / 200
- [x] `test/trading/strategy/runStrategyCron.test.ts` に 0014 未適用環境の gate skip 確認を追加 (`macro_event_gate_disabled_table_missing` warn が出る + sqlite_master probe が走る)

## Out of scope (別 PR で対応)

- VIX regime filter (#196 3/3)
- 外部 API からの economic calendar 自動 seed (今回は admin 経由の手動 seed)
- dashboard `localizeReason` での `macro_event_gate: ...` 日本語化 (PR #211 と同じ pattern で follow-up に切り出し)
- DST 境界の 1 時間ジャンプ厳密対応 (POC では Intl 経由の shortOffset probe で十分粗く扱う)
- per-event 個別 freeze 設定 (`global_config` 寄せは #196 follow-up)

## 運用上の seed 手順

```sh
curl -u admin:$ADMIN_PASS https://<host>/admin/macro-events/seed \
  -H 'content-type: application/json' \
  -d '[
    {"event_type":"FOMC","event_date":"2026-06-17","event_time":"14:00","notes":"June FOMC"},
    {"event_type":"CPI","event_date":"2026-06-12","event_time":"08:30"},
    {"event_type":"NFP","event_date":"2026-06-05","event_time":"08:30"},
    {"event_type":"GDP","event_date":"2026-07-01"}
  ]'
```

inspect:
```sh
curl -u admin:$ADMIN_PASS 'https://<host>/admin/macro-events?from=2026-06-01&to=2026-12-31&type=FOMC'
```

## Notes

- `freezeHoursBefore`/`After` は POC 段階では default 1h 固定 (config 化は #196 follow-up)
- `INSERT OR IGNORE` 相当 (drizzle `.onConflictDoNothing()`) なので運用上 idempotent
- earnings → macro の優先順位は `pullbackScheduler` の評価順で実現 (両方該当時の reason は earnings が先)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * マクロ経済イベントカレンダー追加：DBスキーマ、マイグレーション、管理API（一括シード／一覧／削除）を導入
  * BUY注文向けマクロイベント評価ゲート追加：ET対応、前後凍結時間、未指定時間の終日処理

* **変更（運用）**
  * 起動時にテーブル存在チェックを追加。未存在時はゲートを無効化し警告を出力

* **テスト**
  * 管理API、リポジトリ、評価ゲート、スケジューラ、起動チェックの網羅的なテストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->