### PR TITLE
fix: reconcile repair uses pre_submit side

### DIFF
--- a/src/trading/reconciliation/reconcileFills.ts
+++ b/src/trading/reconciliation/reconcileFills.ts
@@ -1,4 +1,5 @@
 import { and, desc, eq, gte, isNull, or, sql } from 'drizzle-orm'
+import { alias } from 'drizzle-orm/sqlite-core'
 import type { Env } from '../../config/env'
 import { createDb } from '../../infrastructure/db/tradeJournalRepo'
 import { tradeJournal } from '../../infrastructure/db/schema'
@@ -146,12 +147,14 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
     eq(tradeJournal.brokerStatus, 'FILLED'),
     isNull(tradeJournal.stateAppliedAt),
   )
+  const preSubmit = alias(tradeJournal, 'pre_submit')
   const candidates = await db
     .select({
       id: tradeJournal.id,
       clientOrderId: tradeJournal.clientOrderId,
       symbol: tradeJournal.symbol,
       side: tradeJournal.side,
+      preSubmitSide: preSubmit.side,
       brokerStatus: tradeJournal.brokerStatus,
       filledQty: tradeJournal.filledQty,
       filledPrice: tradeJournal.filledPrice,
@@ -160,6 +163,13 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
       stateApplyAttempts: tradeJournal.stateApplyAttempts,
     })
     .from(tradeJournal)
+    .leftJoin(
+      preSubmit,
+      and(
+        eq(preSubmit.clientOrderId, tradeJournal.clientOrderId),
+        eq(preSubmit.tradeEventType, 'pre_submit'),
+      ),
+    )
     .where(
       and(
         eq(tradeJournal.tradeEventType, 'post_submit'),
@@ -212,7 +222,7 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
       // re-poll Webull — orders/history can rotate the row off the first
       // page after a few days, and re-polling would also waste a quota.
       const symbol = row.symbol
-      const side = row.side as 'BUY' | 'SELL' | null
+      const side = resolveJournalSide(row.side, row.preSubmitSide)
       const filledQty = row.filledQty ?? null
       const filledPrice = row.filledPrice ?? null
       if (
@@ -288,12 +298,13 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
     // the symbol's current avg cost from SymbolStateDO, which is only
     // meaningful after we've been recording BUY fills. Early trades with no
     // prior position yield realized=null (can't compute).
-    const side = (detail.side ?? row.side ?? null) as 'BUY' | 'SELL' | null
+    const journalSide = resolveJournalSide(row.side, row.preSubmitSide)
+    const resolvedSide = resolveJournalSide(detail.side, journalSide)
     const symbol = row.symbol ?? detail.symbol ?? null
     let realizedPnl: number | null = null
     if (
       status === 'FILLED' &&
-      side === 'SELL' &&
+      resolvedSide === 'SELL' &&
       symbol !== null &&
       filledQty !== null && filledQty > 0 &&
       filledPrice !== null && filledPrice > 0 &&
@@ -336,7 +347,7 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
       // `state_applied_at = NULL` so the next reconcile tick will retry.
       if (
         status === 'FILLED' &&
-        side !== null &&
+        resolvedSide !== null &&
         symbol !== null &&
         filledQty !== null && filledQty > 0 &&
         filledPrice !== null && filledPrice > 0
@@ -348,7 +359,7 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
           rowId: row.id,
           clientOrderId: coid,
           symbol,
-          side,
+          side: resolvedSide,
           filledQty,
           filledPrice,
           realizedPnl,
@@ -533,6 +544,15 @@ async function tryApplyAndStamp(args: {
     return false
   }
   return true
+}
+
+function resolveJournalSide(
+  primary: string | null | undefined,
+  fallback: string | null | undefined,
+): 'BUY' | 'SELL' | null {
+  if (primary === 'BUY' || primary === 'SELL') return primary
+  if (fallback === 'BUY' || fallback === 'SELL') return fallback
+  return null
 }
 
 async function recordApplyFailure(

--- a/src/trading/reconciliation/reconcileFills.ts
+++ b/src/trading/reconciliation/reconcileFills.ts
@@ -185,15 +185,17 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
         ),
       ),
     )
+    .groupBy(tradeJournal.id)
     .orderBy(desc(tradeJournal.id))
     .limit(limit)
 
-  if (candidates.length === 0) return summary
+  const uniqueCandidates = dedupeCandidatesByRowId(candidates)
+  if (uniqueCandidates.length === 0) return summary
 
-  summary.inspected = candidates.length
+  summary.inspected = uniqueCandidates.length
   const client = createWebullHttpClient(options.env)
 
-  for (const row of candidates) {
+  for (const row of uniqueCandidates) {
     const coid = row.clientOrderId
     if (!coid) {
       // In practice a post_submit row with submitted=1 always has a coid
@@ -553,6 +555,27 @@ function resolveJournalSide(
   if (primary === 'BUY' || primary === 'SELL') return primary
   if (fallback === 'BUY' || fallback === 'SELL') return fallback
   return null
+}
+
+function dedupeCandidatesByRowId<T extends { id: number; side: string | null; preSubmitSide?: string | null }>(
+  rows: T[],
+): T[] {
+  const byId = new Map<number, T>()
+  for (const row of rows) {
+    const existing = byId.get(row.id)
+    if (!existing) {
+      byId.set(row.id, row)
+      continue
+    }
+    // Defensive fallback for malformed append-only journals. If a duplicate
+    // join row has the only usable pre_submit side, keep that one while still
+    // processing the post_submit row at most once.
+    if (resolveJournalSide(existing.side, existing.preSubmitSide) === null &&
+      resolveJournalSide(row.side, row.preSubmitSide) !== null) {
+      byId.set(row.id, row)
+    }
+  }
+  return [...byId.values()]
 }
 
 async function recordApplyFailure(

--- a/test/trading/reconciliation/reconcileFills.test.ts
+++ b/test/trading/reconciliation/reconcileFills.test.ts
@@ -115,6 +115,7 @@ function makeFakeDb(rows: CandidateRow[]): {
     from: () => selectChain,
     leftJoin: () => selectChain,
     where: () => selectChain,
+    groupBy: () => selectChain,
     orderBy: () => selectChain,
     limit: async () => rows,
     // Drizzle's chain is also thenable; not exercised here but kept for
@@ -427,6 +428,63 @@ describe('reconcileFills state-apply marker (issue #142)', () => {
     expect(updates).toHaveLength(1)
     expect(updates[0]!.set.stateAppliedAt).toBe('2026-04-25T12:00:00.000Z')
     expect(updates[0]!.set.stateApplyError).toBeNull()
+  })
+
+  it('repair cohort: processes duplicate joined pre_submit rows at most once', async () => {
+    const duplicateRows: CandidateRow[] = [
+      {
+        id: 12,
+        clientOrderId: 'coid-repair-duplicate-pre-side',
+        symbol: 'SOXL',
+        side: null,
+        preSubmitSide: null,
+        brokerStatus: 'FILLED',
+        filledQty: 4,
+        filledPrice: 124.95,
+        realizedPnl: null,
+        stateAppliedAt: null,
+        stateApplyAttempts: 33,
+      },
+      {
+        id: 12,
+        clientOrderId: 'coid-repair-duplicate-pre-side',
+        symbol: 'SOXL',
+        side: null,
+        preSubmitSide: 'BUY',
+        brokerStatus: 'FILLED',
+        filledQty: 4,
+        filledPrice: 124.95,
+        realizedPnl: null,
+        stateAppliedAt: null,
+        stateApplyAttempts: 33,
+      },
+    ]
+    const { db, updates } = makeFakeDb(duplicateRows)
+    vi.mocked(createDb).mockReturnValue(db)
+    vi.mocked(createWebullHttpClient).mockReturnValue(
+      makeWebullStub({}) as unknown as ReturnType<typeof createWebullHttpClient>,
+    )
+    const symbolStub = emptySymbolStateStub()
+
+    const summary = await reconcileFills({
+      env: {
+        DB: FAKE_DB_BINDING,
+        SYMBOL_STATE: makeSymbolStateNamespace(symbolStub) as never,
+      } as never,
+      now: () => new Date('2026-04-25T12:00:00.000Z'),
+      retryStateApply: true,
+    })
+
+    expect(summary.inspected).toBe(1)
+    expect(summary.errors).toEqual([])
+    expect(summary.stateApplied).toBe(1)
+    expect(symbolStub.recordFill).toHaveBeenCalledTimes(1)
+    expect(symbolStub.recordFill).toHaveBeenCalledWith('SOXL', {
+      side: 'BUY',
+      qty: 4,
+      price: 124.95,
+    })
+    expect(updates).toHaveLength(1)
   })
 
   it('repair cohort with no apply prerequisites: records error and skips DO call', async () => {

--- a/test/trading/reconciliation/reconcileFills.test.ts
+++ b/test/trading/reconciliation/reconcileFills.test.ts
@@ -79,6 +79,7 @@ interface CandidateRow {
   clientOrderId: string | null
   symbol: string | null
   side: string | null
+  preSubmitSide?: string | null
   brokerStatus: string | null
   filledQty: number | null
   filledPrice: number | null
@@ -112,6 +113,7 @@ function makeFakeDb(rows: CandidateRow[]): {
 
   const selectChain = {
     from: () => selectChain,
+    leftJoin: () => selectChain,
     where: () => selectChain,
     orderBy: () => selectChain,
     limit: async () => rows,
@@ -376,6 +378,52 @@ describe('reconcileFills state-apply marker (issue #142)', () => {
     expect(summary.stateApplied).toBe(1)
     expect(summary.repaired).toBe(1)
     // Only one UPDATE on the repair path: the marker stamp.
+    expect(updates).toHaveLength(1)
+    expect(updates[0]!.set.stateAppliedAt).toBe('2026-04-25T12:00:00.000Z')
+    expect(updates[0]!.set.stateApplyError).toBeNull()
+  })
+
+  it('repair cohort: resolves side from matching pre_submit when post_submit side is NULL', async () => {
+    const row: CandidateRow = {
+      id: 12,
+      clientOrderId: 'coid-repair-pre-side',
+      symbol: 'SOXL',
+      side: null,
+      preSubmitSide: 'BUY',
+      brokerStatus: 'FILLED',
+      filledQty: 4,
+      filledPrice: 124.95,
+      realizedPnl: null,
+      stateAppliedAt: null,
+      stateApplyAttempts: 33,
+    }
+    const { db, updates } = makeFakeDb([row])
+    vi.mocked(createDb).mockReturnValue(db)
+    const webullStub = makeWebullStub({})
+    vi.mocked(createWebullHttpClient).mockReturnValue(
+      webullStub as unknown as ReturnType<typeof createWebullHttpClient>,
+    )
+    const symbolStub = emptySymbolStateStub()
+
+    const summary = await reconcileFills({
+      env: {
+        DB: FAKE_DB_BINDING,
+        SYMBOL_STATE: makeSymbolStateNamespace(symbolStub) as never,
+      } as never,
+      now: () => new Date('2026-04-25T12:00:00.000Z'),
+      retryStateApply: true,
+    })
+
+    expect(webullStub.findOrderByClientId).not.toHaveBeenCalled()
+    expect(symbolStub.recordFill).toHaveBeenCalledWith('SOXL', {
+      side: 'BUY',
+      qty: 4,
+      price: 124.95,
+    })
+    expect(summary.errors).toEqual([])
+    expect(summary.stateApplied).toBe(1)
+    expect(summary.stateApplyFailed).toBe(0)
+    expect(summary.repaired).toBe(1)
     expect(updates).toHaveLength(1)
     expect(updates[0]!.set.stateAppliedAt).toBe('2026-04-25T12:00:00.000Z')
     expect(updates[0]!.set.stateApplyError).toBeNull()


### PR DESCRIPTION
## Summary

Fixes #213.

`reconcileFills()` now resolves the order side from the matching `pre_submit` row when the `post_submit` row has `side = NULL`. This matches the existing dashboard model and allows FILLED repair rows to apply/stamp state instead of looping with `repair_skipped_invalid_row`.

## Root cause

`logPostSubmit()` does not write `side` onto `post_submit` rows. The repair path in `reconcileFills()` previously read only `post_submit.side`, so otherwise valid FILLED rows could not be applied to DO state even though the corresponding `pre_submit.side` existed.

## Changes

- LEFT JOIN `post_submit` candidates to matching `pre_submit` by `client_order_id`.
- Resolve side as `post_submit.side ?? pre_submit.side`, guarded to `BUY` / `SELL` only.
- Add a regression test for the observed shape: `post_submit.side = NULL`, `pre_submit.side = BUY`, `broker_status = FILLED`, `state_applied_at = NULL`.

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run test/trading/reconciliation/reconcileFills.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 決済処理のサイド判定を強化し、事前送信側情報を優先して欠損時に補完するよう改良
  * 同一ジャーナルの重複結合を排除して重複記録や重複マーカー更新を防止
  * 実現損益や適用前提の判定を解決済みサイドで一貫して処理
  * 修復モードで不要な外部再取得を回避

* **テスト**
  * 修復モードのサイド解決と重複排除を検証するテストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->