### PR TITLE
feat(risk): VIX regime filter 実装 (#196 3/3 完了)

### DIFF
--- a/drizzle/0015_vix_regime_thresholds.sql
+++ b/drizzle/0015_vix_regime_thresholds.sql
@@ -1,0 +1,17 @@
+-- VIX regime filter (issue #196 3/3) — global_config に VIX 閾値 / size 縮小率を追加。
+-- earnings (0013) / macro (0014) gate と異なり VIX は **size scaling 系** なので、
+-- 専用 table は持たず global_config に閾値だけ生やす。
+-- - vix_warning_threshold:  VIX > これで size を `vix_warning_size_scale` 倍に
+-- - vix_critical_threshold: VIX > これで BUY 全停止 (sizeScale=0)
+-- - vix_warning_size_scale: warning 領域の size 倍率 (default 0.5)
+--
+-- SQLite は ALTER TABLE ADD COLUMN で CHECK 制約を直接付けられないため、
+-- range / order 制約は schema.ts 側で宣言し、DB 制約は global_config の
+-- 次回 table-rebuild migration (将来) でまとめて流す方針。本 migration では
+-- column 追加と default のみ。0007_add_risk_scale_params.sql のような
+-- table-rebuild は schema 全体の再生成が必要で副作用が大きいので避ける。
+ALTER TABLE `global_config` ADD COLUMN `vix_warning_threshold` REAL NOT NULL DEFAULT 25.0;
+--> statement-breakpoint
+ALTER TABLE `global_config` ADD COLUMN `vix_critical_threshold` REAL NOT NULL DEFAULT 30.0;
+--> statement-breakpoint
+ALTER TABLE `global_config` ADD COLUMN `vix_warning_size_scale` REAL NOT NULL DEFAULT 0.5;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1777901600000,
       "tag": "0014_macro_event_calendar",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "6",
+      "when": 1778204800000,
+      "tag": "0015_vix_regime_thresholds",
+      "breakpoints": true
     }
   ]
 }

--- a/src/infrastructure/db/globalConfigLoader.ts
+++ b/src/infrastructure/db/globalConfigLoader.ts
@@ -14,12 +14,18 @@ interface GlobalConfigEnv {
  *
  * D1 binding is **required** (Phase E で env fallback を削除)。未 bind は
  * setup ミスなので明示的に throw して fail-closed にする。
+ *
+ * `requestId` を任意で受け取り、pre-0015 fallback 警告ログに含める
+ * (CodeRabbit 2nd round Major)。caller (cron / route) で手元にあれば必ず渡す。
  */
-export async function loadGlobalConfigFrom(env: GlobalConfigEnv): Promise<LoadedGlobalConfig> {
+export async function loadGlobalConfigFrom(
+  env: GlobalConfigEnv,
+  requestId?: string,
+): Promise<LoadedGlobalConfig> {
   if (!env.DB) {
     throw new Error('loadGlobalConfigFrom: env.DB is not bound (D1 setup required)')
   }
   const db = createDb(env.DB)
-  const snapshot = await loadGlobalConfig(db)
+  const snapshot = await loadGlobalConfig(db, requestId)
   return { ...snapshot, source: 'd1' }
 }

--- a/src/infrastructure/db/globalConfigRepo.ts
+++ b/src/infrastructure/db/globalConfigRepo.ts
@@ -1,6 +1,6 @@
 import { eq } from 'drizzle-orm'
 import type { DrizzleD1Database } from 'drizzle-orm/d1'
-import { globalConfig } from './schema'
+import { globalConfig, type GlobalConfigRow } from './schema'
 
 export interface GlobalConfigSnapshot {
   dryRun: boolean
@@ -91,7 +91,28 @@ export const GLOBAL_CONFIG_DEFAULTS: GlobalConfigSnapshot = Object.freeze({
 export async function loadGlobalConfig(
   db: DrizzleD1Database,
 ): Promise<GlobalConfigSnapshot> {
-  const rows = await db.select().from(globalConfig).where(eq(globalConfig.id, 'default')).limit(1)
+  // VIX 列 (vix_warning_threshold / vix_critical_threshold / vix_warning_size_scale)
+  // は migration 0015 で追加。pre-0015 deploy / ALTER 適用前の D1 では `select` 自体が
+  // SQL レベルで失敗するため、`row.vixXxx ?? defaults` の null fallback では救えない。
+  // ここでは query 境界を try/catch で囲み、「missing column」を文字列マッチで検知して
+  // defaults を返す段階デプロイ救済を行う (POC 用フォールバック)。それ以外のエラーは
+  // 上に再 throw して fail-closed を維持する。
+  let rows: GlobalConfigRow[]
+  try {
+    rows = await db.select().from(globalConfig).where(eq(globalConfig.id, 'default')).limit(1)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    if (/no such column|vix_/i.test(message)) {
+      console.warn(
+        JSON.stringify({
+          event: 'global_config_pre_0015_fallback',
+          message,
+        }),
+      )
+      return { ...GLOBAL_CONFIG_DEFAULTS }
+    }
+    throw error
+  }
   const row = rows[0]
   if (!row) return { ...GLOBAL_CONFIG_DEFAULTS }
   return {
@@ -123,6 +144,7 @@ export async function loadGlobalConfig(
     bucketExposurePct: row.bucketExposurePct,
     // VIX 列は 0015 で追加。古い D1 (snapshot 取得失敗 / ALTER 直前 race) では
     // undefined になり得るため、defaults へ畳む (snapshot 経由 read だが safety)。
+    // schema 自体の欠落は上の try/catch で defaults fallback する。
     vixWarningThreshold:
       row.vixWarningThreshold ?? GLOBAL_CONFIG_DEFAULTS.vixWarningThreshold,
     vixCriticalThreshold:

--- a/src/infrastructure/db/globalConfigRepo.ts
+++ b/src/infrastructure/db/globalConfigRepo.ts
@@ -40,6 +40,15 @@ export interface GlobalConfigSnapshot {
   riskDdHaltThreshold: number
   /** 同一 bucket の open 合計 notional 上限 = equity × この比率。#23 Lane 3。 */
   bucketExposurePct: number
+  /**
+   * VIX regime filter (issue #196 3/3)。`^VIX` 最新値がこの閾値超で BUY size を
+   * `vixWarningSizeScale` 倍に縮小 (default 25 → x0.5)。
+   */
+  vixWarningThreshold: number
+  /** VIX がこの閾値超で BUY 全停止 (sizeScale=0)。default 30。 */
+  vixCriticalThreshold: number
+  /** warning 領域の size 倍率。default 0.5。 */
+  vixWarningSizeScale: number
 }
 
 /**
@@ -74,6 +83,9 @@ export const GLOBAL_CONFIG_DEFAULTS: GlobalConfigSnapshot = Object.freeze({
   riskDdHalfThreshold: -0.05,
   riskDdHaltThreshold: -0.10,
   bucketExposurePct: 0.30,
+  vixWarningThreshold: 25.0,
+  vixCriticalThreshold: 30.0,
+  vixWarningSizeScale: 0.5,
 })
 
 export async function loadGlobalConfig(
@@ -109,5 +121,13 @@ export async function loadGlobalConfig(
     riskDdHalfThreshold: row.riskDdHalfThreshold,
     riskDdHaltThreshold: row.riskDdHaltThreshold,
     bucketExposurePct: row.bucketExposurePct,
+    // VIX 列は 0015 で追加。古い D1 (snapshot 取得失敗 / ALTER 直前 race) では
+    // undefined になり得るため、defaults へ畳む (snapshot 経由 read だが safety)。
+    vixWarningThreshold:
+      row.vixWarningThreshold ?? GLOBAL_CONFIG_DEFAULTS.vixWarningThreshold,
+    vixCriticalThreshold:
+      row.vixCriticalThreshold ?? GLOBAL_CONFIG_DEFAULTS.vixCriticalThreshold,
+    vixWarningSizeScale:
+      row.vixWarningSizeScale ?? GLOBAL_CONFIG_DEFAULTS.vixWarningSizeScale,
   }
 }

--- a/src/infrastructure/db/globalConfigRepo.ts
+++ b/src/infrastructure/db/globalConfigRepo.ts
@@ -90,6 +90,7 @@ export const GLOBAL_CONFIG_DEFAULTS: GlobalConfigSnapshot = Object.freeze({
 
 export async function loadGlobalConfig(
   db: DrizzleD1Database,
+  requestId?: string,
 ): Promise<GlobalConfigSnapshot> {
   // VIX 列 (vix_warning_threshold / vix_critical_threshold / vix_warning_size_scale)
   // は migration 0015 で追加。pre-0015 deploy / ALTER 適用前の D1 では `select` 自体が
@@ -97,15 +98,24 @@ export async function loadGlobalConfig(
   // ここでは query 境界を try/catch で囲み、「missing column」を文字列マッチで検知して
   // defaults を返す段階デプロイ救済を行う (POC 用フォールバック)。それ以外のエラーは
   // 上に再 throw して fail-closed を維持する。
+  //
+  // Regex は **schema-missing 限定**で組む: `vix_` 単独マッチを許すと非スキーマ
+  // 障害メッセージに `vix_` が偶然含まれただけで fail-open 化するリスクがあるため、
+  // SQLite 系の `no such column: vix_*` か、`vix_<col> not found / does not exist /
+  // unknown column` 形式に絞る (CodeRabbit 2nd round 指摘)。
   let rows: GlobalConfigRow[]
   try {
     rows = await db.select().from(globalConfig).where(eq(globalConfig.id, 'default')).limit(1)
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
-    if (/no such column|vix_/i.test(message)) {
+    const isMissingVixColumn =
+      /no such column:\s*vix_/i.test(message) ||
+      /vix_[a-z_]*\s+(not found|does not exist|unknown column)/i.test(message)
+    if (isMissingVixColumn) {
       console.warn(
         JSON.stringify({
           event: 'global_config_pre_0015_fallback',
+          requestId: requestId ?? null,
           message,
         }),
       )

--- a/src/infrastructure/db/globalConfigRepo.ts
+++ b/src/infrastructure/db/globalConfigRepo.ts
@@ -119,6 +119,92 @@ export async function loadGlobalConfig(
           message,
         }),
       )
+      // 段階デプロイ救済: VIX 3 列だけ defaults で埋め、他の列は legacy row から
+      // 読み出す。`{ ...GLOBAL_CONFIG_DEFAULTS }` で全部上書きすると
+      // `tradingEnabled: false` のような既存運用値が `tradingEnabled: true` (default)
+      // で踏み潰されるリスクがある。明示的に vix_ 以外の列だけを select し、
+      // defaults と shallow-merge する。
+      try {
+        const legacyRows = await db
+          .select({
+            id: globalConfig.id,
+            dryRun: globalConfig.dryRun,
+            tradingEnabled: globalConfig.tradingEnabled,
+            marketHoursCheck: globalConfig.marketHoursCheck,
+            maxOrderNotional: globalConfig.maxOrderNotional,
+            maxOrderNotionalUsd: globalConfig.maxOrderNotionalUsd,
+            maxOrderNotionalJpy: globalConfig.maxOrderNotionalJpy,
+            totalCapitalUsd: globalConfig.totalCapitalUsd,
+            totalCapitalJpy: globalConfig.totalCapitalJpy,
+            maxPortfolioExposurePct: globalConfig.maxPortfolioExposurePct,
+            drawdownKillThreshold: globalConfig.drawdownKillThreshold,
+            staleQuoteMs: globalConfig.staleQuoteMs,
+            gapRejectPct: globalConfig.gapRejectPct,
+            spreadLimitPctUs: globalConfig.spreadLimitPctUs,
+            spreadLimitPctJp: globalConfig.spreadLimitPctJp,
+            pullbackDefaultStopPct: globalConfig.pullbackDefaultStopPct,
+            pullbackDefaultTakeProfitPct: globalConfig.pullbackDefaultTakeProfitPct,
+            pullbackDefaultTimeStopDays: globalConfig.pullbackDefaultTimeStopDays,
+            pullbackDefaultPullbackMax: globalConfig.pullbackDefaultPullbackMax,
+            pullbackDefaultPullbackMin: globalConfig.pullbackDefaultPullbackMin,
+            pullbackDefaultMinReturn50d: globalConfig.pullbackDefaultMinReturn50d,
+            pullbackDefaultRequireAboveSma50: globalConfig.pullbackDefaultRequireAboveSma50,
+            pullbackDefaultKAtr: globalConfig.pullbackDefaultKAtr,
+            riskBasePerTradePct: globalConfig.riskBasePerTradePct,
+            riskDdHalfThreshold: globalConfig.riskDdHalfThreshold,
+            riskDdHaltThreshold: globalConfig.riskDdHaltThreshold,
+            bucketExposurePct: globalConfig.bucketExposurePct,
+          })
+          .from(globalConfig)
+          .where(eq(globalConfig.id, 'default'))
+          .limit(1)
+        const legacyRow = legacyRows[0]
+        if (legacyRow) {
+          return {
+            dryRun: legacyRow.dryRun,
+            tradingEnabled: legacyRow.tradingEnabled,
+            marketHoursCheck: legacyRow.marketHoursCheck,
+            maxOrderNotional: legacyRow.maxOrderNotional,
+            maxOrderNotionalUsd: legacyRow.maxOrderNotionalUsd,
+            maxOrderNotionalJpy: legacyRow.maxOrderNotionalJpy,
+            totalCapitalUsd: legacyRow.totalCapitalUsd,
+            totalCapitalJpy: legacyRow.totalCapitalJpy,
+            maxPortfolioExposurePct: legacyRow.maxPortfolioExposurePct,
+            drawdownKillThreshold: legacyRow.drawdownKillThreshold,
+            staleQuoteMs: legacyRow.staleQuoteMs,
+            gapRejectPct: legacyRow.gapRejectPct,
+            spreadLimitPctUs: legacyRow.spreadLimitPctUs,
+            spreadLimitPctJp: legacyRow.spreadLimitPctJp,
+            pullbackDefaultStopPct: legacyRow.pullbackDefaultStopPct,
+            pullbackDefaultTakeProfitPct: legacyRow.pullbackDefaultTakeProfitPct,
+            pullbackDefaultTimeStopDays: legacyRow.pullbackDefaultTimeStopDays,
+            pullbackDefaultPullbackMax: legacyRow.pullbackDefaultPullbackMax,
+            pullbackDefaultPullbackMin: legacyRow.pullbackDefaultPullbackMin,
+            pullbackDefaultMinReturn50d: legacyRow.pullbackDefaultMinReturn50d,
+            pullbackDefaultRequireAboveSma50: legacyRow.pullbackDefaultRequireAboveSma50,
+            pullbackDefaultKAtr: legacyRow.pullbackDefaultKAtr,
+            riskBasePerTradePct: legacyRow.riskBasePerTradePct,
+            riskDdHalfThreshold: legacyRow.riskDdHalfThreshold,
+            riskDdHaltThreshold: legacyRow.riskDdHaltThreshold,
+            bucketExposurePct: legacyRow.bucketExposurePct,
+            // VIX 3 項目だけ defaults (列が存在しないので legacy row には無い)
+            vixWarningThreshold: GLOBAL_CONFIG_DEFAULTS.vixWarningThreshold,
+            vixCriticalThreshold: GLOBAL_CONFIG_DEFAULTS.vixCriticalThreshold,
+            vixWarningSizeScale: GLOBAL_CONFIG_DEFAULTS.vixWarningSizeScale,
+          }
+        }
+      } catch (legacyError) {
+        // legacy fetch も失敗 → 想定外の double failure。ここまで来たら全 defaults
+        // で fail-open を選ぶ (cron 全停止より既知 default で動かす)。
+        console.warn(
+          JSON.stringify({
+            event: 'global_config_legacy_load_failed',
+            requestId: requestId ?? null,
+            message: legacyError instanceof Error ? legacyError.message : String(legacyError),
+          }),
+        )
+      }
+      // legacy row なし or legacy fetch 失敗 → 全 defaults
       return { ...GLOBAL_CONFIG_DEFAULTS }
     }
     throw error

--- a/src/infrastructure/db/globalConfigRepo.ts
+++ b/src/infrastructure/db/globalConfigRepo.ts
@@ -88,6 +88,74 @@ export const GLOBAL_CONFIG_DEFAULTS: GlobalConfigSnapshot = Object.freeze({
   vixWarningSizeScale: 0.5,
 })
 
+/**
+ * VIX 値の application-level validation。
+ *
+ * 0015 migration は ALTER TABLE ADD COLUMN しか実行しておらず CHECK 制約は
+ * 将来の table-rebuild migration で一括投入予定 (schema.ts 参照)。それまでの
+ * 補完として、`loadGlobalConfig` が返す前にここで範囲・順序を検証する。
+ *
+ * 違反時は **fail-closed = defaults fallback**:
+ * - cron 全停止より既知 default で動かす方が POC では安全
+ * - warn ログに違反 field / 値 / 期待範囲を出して運用で検知できるようにする
+ *
+ * CodeRabbit #216 6th round 対応。
+ */
+function validateVixConfig(
+  config: GlobalConfigSnapshot,
+  requestId: string | undefined,
+): GlobalConfigSnapshot {
+  const violations: Array<{ field: string; value: unknown; expected: string }> = []
+  const { vixWarningThreshold, vixCriticalThreshold, vixWarningSizeScale } = config
+
+  if (!(vixWarningThreshold > 0 && vixWarningThreshold <= 200)) {
+    violations.push({
+      field: 'vixWarningThreshold',
+      value: vixWarningThreshold,
+      expected: '>0 and <=200',
+    })
+  }
+  if (!(vixCriticalThreshold > 0 && vixCriticalThreshold <= 200)) {
+    violations.push({
+      field: 'vixCriticalThreshold',
+      value: vixCriticalThreshold,
+      expected: '>0 and <=200',
+    })
+  }
+  if (vixWarningThreshold > vixCriticalThreshold) {
+    violations.push({
+      field: 'vixWarningThreshold/vixCriticalThreshold',
+      value: { warning: vixWarningThreshold, critical: vixCriticalThreshold },
+      expected: 'warning <= critical',
+    })
+  }
+  if (!(vixWarningSizeScale >= 0 && vixWarningSizeScale <= 1)) {
+    violations.push({
+      field: 'vixWarningSizeScale',
+      value: vixWarningSizeScale,
+      expected: '>=0 and <=1',
+    })
+  }
+
+  if (violations.length > 0) {
+    console.warn(
+      JSON.stringify({
+        event: 'global_config_vix_validation_failed',
+        requestId: requestId ?? null,
+        violations,
+      }),
+    )
+    return {
+      ...config,
+      vixWarningThreshold: GLOBAL_CONFIG_DEFAULTS.vixWarningThreshold,
+      vixCriticalThreshold: GLOBAL_CONFIG_DEFAULTS.vixCriticalThreshold,
+      vixWarningSizeScale: GLOBAL_CONFIG_DEFAULTS.vixWarningSizeScale,
+    }
+  }
+
+  return config
+}
+
 export async function loadGlobalConfig(
   db: DrizzleD1Database,
   requestId?: string,
@@ -160,7 +228,7 @@ export async function loadGlobalConfig(
           .limit(1)
         const legacyRow = legacyRows[0]
         if (legacyRow) {
-          return {
+          return validateVixConfig({
             dryRun: legacyRow.dryRun,
             tradingEnabled: legacyRow.tradingEnabled,
             marketHoursCheck: legacyRow.marketHoursCheck,
@@ -191,7 +259,7 @@ export async function loadGlobalConfig(
             vixWarningThreshold: GLOBAL_CONFIG_DEFAULTS.vixWarningThreshold,
             vixCriticalThreshold: GLOBAL_CONFIG_DEFAULTS.vixCriticalThreshold,
             vixWarningSizeScale: GLOBAL_CONFIG_DEFAULTS.vixWarningSizeScale,
-          }
+          }, requestId)
         }
       } catch (legacyError) {
         // legacy fetch も失敗 → 想定外の double failure。ここまで来たら全 defaults
@@ -205,13 +273,13 @@ export async function loadGlobalConfig(
         )
       }
       // legacy row なし or legacy fetch 失敗 → 全 defaults
-      return { ...GLOBAL_CONFIG_DEFAULTS }
+      return validateVixConfig({ ...GLOBAL_CONFIG_DEFAULTS }, requestId)
     }
     throw error
   }
   const row = rows[0]
-  if (!row) return { ...GLOBAL_CONFIG_DEFAULTS }
-  return {
+  if (!row) return validateVixConfig({ ...GLOBAL_CONFIG_DEFAULTS }, requestId)
+  return validateVixConfig({
     dryRun: row.dryRun,
     tradingEnabled: row.tradingEnabled,
     marketHoursCheck: row.marketHoursCheck,
@@ -247,5 +315,5 @@ export async function loadGlobalConfig(
       row.vixCriticalThreshold ?? GLOBAL_CONFIG_DEFAULTS.vixCriticalThreshold,
     vixWarningSizeScale:
       row.vixWarningSizeScale ?? GLOBAL_CONFIG_DEFAULTS.vixWarningSizeScale,
-  }
+  }, requestId)
 }

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -206,6 +206,23 @@ export const globalConfig = sqliteTable(
      * `equity * bucket_exposure_pct` で算出 (#23 Lane 3)。POC default 0.30。
      */
     bucketExposurePct: real('bucket_exposure_pct').notNull().default(0.30),
+    /**
+     * VIX regime filter (issue #196 3/3)。`^VIX` 最新値がこの閾値を超えたら
+     * BUY size を `vix_warning_size_scale` 倍に縮小 (default 25 → x0.5)。
+     * 25 以下は normal (size scale 1.0)、SELL は閾値関係なく通す。
+     */
+    vixWarningThreshold: real('vix_warning_threshold').notNull().default(25.0),
+    /**
+     * VIX が `vix_critical_threshold` を超えたら BUY を全停止 (sizeScale=0)。
+     * SELL は VIX 関係なく通す (= existing position の exit を妨げない)。
+     * default 30。
+     */
+    vixCriticalThreshold: real('vix_critical_threshold').notNull().default(30.0),
+    /**
+     * VIX warning 領域 (warning < VIX <= critical) で適用する size 倍率。
+     * default 0.5 (= 半分に縮小)。0..1 で運用想定。
+     */
+    vixWarningSizeScale: real('vix_warning_size_scale').notNull().default(0.5),
     updatedAt: text('updated_at').notNull(),
   },
   (t) => ({
@@ -310,6 +327,26 @@ export const globalConfig = sqliteTable(
     bucketExposurePctRange: check(
       'global_config_bucket_exposure_pct_range',
       sql`${t.bucketExposurePct} > 0 AND ${t.bucketExposurePct} <= 1`,
+    ),
+    // VIX 閾値は実数値 (10..100 程度の運用想定だが余裕を持って 0..200)。
+    // 0 以下 / 上限超 / 順序逆 (warning > critical) を弾く。
+    vixWarningThresholdRange: check(
+      'global_config_vix_warning_threshold_range',
+      sql`${t.vixWarningThreshold} > 0 AND ${t.vixWarningThreshold} <= 200`,
+    ),
+    vixCriticalThresholdRange: check(
+      'global_config_vix_critical_threshold_range',
+      sql`${t.vixCriticalThreshold} > 0 AND ${t.vixCriticalThreshold} <= 200`,
+    ),
+    // warning ≤ critical の順序を強制。逆転すると warning 領域が空集合になり
+    // 「critical を超えていないのに sizeScale が 0」みたいな矛盾が出る。
+    vixThresholdOrder: check(
+      'global_config_vix_threshold_order',
+      sql`${t.vixWarningThreshold} <= ${t.vixCriticalThreshold}`,
+    ),
+    vixWarningSizeScaleRange: check(
+      'global_config_vix_warning_size_scale_range',
+      sql`${t.vixWarningSizeScale} >= 0 AND ${t.vixWarningSizeScale} <= 1`,
     ),
   }),
 )

--- a/src/infrastructure/notification/vixRegimeChange.ts
+++ b/src/infrastructure/notification/vixRegimeChange.ts
@@ -1,0 +1,179 @@
+/**
+ * VIX regime 遷移検知 + STATE_CHANGE 通知 (issue #196 3/3)。
+ *
+ * cron tick で算出した `VixRegimeFilterDecision.regime` を `config_state_snapshot`
+ * に保存し、前回 tick との diff (e.g. `normal → warning`, `warning → critical`)
+ * のみ Notifier に push する。同 regime が連続する tick では emit しない (dedup)。
+ *
+ * `configStateChange.ts` と同じ pattern (snapshot table 共有) で実装する:
+ *   - key: `vix_regime` 固定 (1 行)
+ *   - value: JSON.stringify(regime) (e.g. `"normal"`)
+ *   - 初回 (snapshot 行なし) は通知を出さず単に snapshot を作る (false alert 防止)
+ *
+ * severity 規則:
+ *   - normal → warning   : warning  (size 縮小開始)
+ *   - normal → critical  : critical (BUY 全停止)
+ *   - warning → critical : critical (escalation)
+ *   - critical → warning : info     (緩和)
+ *   - critical → normal  : info     (解除)
+ *   - warning → normal   : info     (解除)
+ *
+ * fail-silent: D1 read / write が落ちても cron 本体には影響させない。
+ */
+import { eq } from 'drizzle-orm'
+import { configStateSnapshot } from '../db/schema'
+import { createDb } from '../db/tradeJournalRepo'
+import type { Notifier, NotificationSeverity } from './Notifier'
+import type { VixRegime, VixRegimeFilterDecision } from '../../trading/risk/vixRegimeFilter'
+
+/** snapshot table の key 値。`config_state_snapshot.key` の他 watched-config 群と衝突しない短名。 */
+export const VIX_REGIME_SNAPSHOT_KEY = 'vix_regime'
+
+/**
+ * regime のランク (低 → 高)。「critical 方向への遷移は警告強め、緩和方向は info」
+ * の severity 判定に使う。
+ */
+const REGIME_RANK: Record<VixRegime, number> = {
+  normal: 0,
+  warning: 1,
+  critical: 2,
+}
+
+/**
+ * 遷移の severity を返す。同 regime 連続は呼び出し側でフィルタする想定なので
+ * ここでは `from === to` を考慮しない (caller の責務)。
+ */
+export function classifyVixRegimeSeverity(
+  from: VixRegime | null,
+  to: VixRegime,
+): NotificationSeverity {
+  if (from === null) return 'info'
+  const fromRank = REGIME_RANK[from]
+  const toRank = REGIME_RANK[to]
+  if (toRank > fromRank) {
+    // 悪化方向。critical へ到達する遷移は critical、それ以外 (normal→warning) は warning。
+    return to === 'critical' ? 'critical' : 'warning'
+  }
+  // 緩和方向は info。
+  return 'info'
+}
+
+/**
+ * 前回 snapshot を読む。table 未 migration / 接続失敗等は null フォールバック
+ * (= 「初回扱い」、通知は出さない)。
+ */
+export async function loadVixRegimeSnapshot(
+  db: D1Database,
+): Promise<VixRegime | null> {
+  try {
+    const drizzle = createDb(db)
+    const rows = await drizzle
+      .select({ value: configStateSnapshot.value })
+      .from(configStateSnapshot)
+      .where(eq(configStateSnapshot.key, VIX_REGIME_SNAPSHOT_KEY))
+      .limit(1)
+    const raw = rows[0]?.value
+    if (!raw) return null
+    const parsed = parseSafe(raw)
+    if (parsed === 'normal' || parsed === 'warning' || parsed === 'critical') {
+      return parsed
+    }
+    return null
+  } catch (error) {
+    console.warn(
+      JSON.stringify({
+        event: 'vix_regime_snapshot_load_failed',
+        message: error instanceof Error ? error.message : String(error),
+      }),
+    )
+    return null
+  }
+}
+
+/**
+ * 現在 regime で snapshot を upsert する。失敗は throw しない (caller が握りつぶす)。
+ * 書き込み失敗は次 tick で「変わらなかった」誤検知が増えるだけで実害は小さい。
+ */
+export async function persistVixRegimeSnapshot(
+  db: D1Database,
+  regime: VixRegime,
+  requestId: string | undefined,
+  now: Date,
+): Promise<void> {
+  const drizzle = createDb(db)
+  const snapshotAt = now.toISOString()
+  const value = JSON.stringify(regime)
+  try {
+    // configStateChange と同様、portable upsert は delete + insert で emulate。
+    await drizzle.delete(configStateSnapshot).where(eq(configStateSnapshot.key, VIX_REGIME_SNAPSHOT_KEY))
+    await drizzle.insert(configStateSnapshot).values({
+      key: VIX_REGIME_SNAPSHOT_KEY,
+      value,
+      snapshotAt,
+      requestId: requestId ?? null,
+    })
+  } catch (error) {
+    console.warn(
+      JSON.stringify({
+        event: 'vix_regime_snapshot_persist_failed',
+        message: error instanceof Error ? error.message : String(error),
+      }),
+    )
+  }
+}
+
+/**
+ * cron tick から呼ばれる top-level helper (configStateChange の pattern を踏襲)。
+ *
+ *   1. snapshot を読む (失敗 → null)
+ *   2. regime に変化があれば notifier に流す (fire-and-forget)
+ *   3. snapshot を upsert (await する: 次 tick の比較に必要)
+ *
+ * `env.DB` が無い場合は noop (configStateChange と同じ — caller の if 分岐削減)。
+ */
+export async function detectAndNotifyVixRegimeChange(args: {
+  db: D1Database | undefined
+  notifier: Notifier
+  current: VixRegimeFilterDecision
+  requestId?: string
+  now?: () => Date
+}): Promise<{ from: VixRegime | null; to: VixRegime; emitted: boolean }> {
+  if (!args.db) {
+    return { from: null, to: args.current.regime, emitted: false }
+  }
+  const previous = await loadVixRegimeSnapshot(args.db)
+  let emitted = false
+  if (previous !== null && previous !== args.current.regime) {
+    const severity = classifyVixRegimeSeverity(previous, args.current.regime)
+    const note = args.requestId ? `requestId=${args.requestId}` : undefined
+    args.notifier
+      .notify({
+        type: 'STATE_CHANGE',
+        field: VIX_REGIME_SNAPSHOT_KEY,
+        from: previous,
+        to: args.current.regime,
+        severity,
+        ...(note !== undefined ? { note: `${note} ${args.current.reason}`.trim() } : { note: args.current.reason }),
+      })
+      .catch((err) => {
+        console.warn(
+          JSON.stringify({
+            event: 'vix_regime_change_notify_failed',
+            message: err instanceof Error ? err.message : String(err),
+          }),
+        )
+      })
+    emitted = true
+  }
+  const now = (args.now ?? (() => new Date()))()
+  await persistVixRegimeSnapshot(args.db, args.current.regime, args.requestId, now)
+  return { from: previous, to: args.current.regime, emitted }
+}
+
+function parseSafe(json: string): unknown {
+  try {
+    return JSON.parse(json)
+  } catch {
+    return json
+  }
+}

--- a/src/infrastructure/notification/vixRegimeChange.ts
+++ b/src/infrastructure/notification/vixRegimeChange.ts
@@ -128,6 +128,106 @@ export async function persistVixRegimeSnapshot(
 }
 
 /**
+ * Atomic compare-and-update for the VIX regime snapshot (CodeRabbit #216 4th).
+ *
+ * 同 cron tick が並行して走った場合 (e.g. cron 重複 / 手動 trigger 並行) に
+ * `loadVixRegimeSnapshot → notify → persistVixRegimeSnapshot` の 3 step が
+ * race して、両 caller が同じ previous を読み → 両方が notify → 後勝ち update、
+ * という重複通知が起きうる。これを D1 の `UPDATE ... WHERE value = old` (CAS)
+ * で原子化する。
+ *
+ * 戻り値:
+ *   - `previous`: 直前の snapshot 値 (初回は null)
+ *   - `updated`: この caller が実際に snapshot を書き換えたか
+ *
+ * caller は `updated === true && previous !== null && previous !== next` の
+ * ときだけ notify することで、race 下でも重複通知を防げる。初回 (previous=null)
+ * は updated=true でも emit しない (false alert 防止 — 既存挙動と同じ)。
+ *
+ * fail-silent: D1 が落ちたら `{ previous: null, updated: false }` を返す。
+ * 既存 `loadVixRegimeSnapshot` / `persistVixRegimeSnapshot` の signature は
+ * 温存し、新 caller (`detectAndNotifyVixRegimeChange`) のみがこの helper を
+ * 使う。
+ */
+export async function atomicallyUpdateVixRegimeSnapshot(
+  db: D1Database,
+  next: VixRegime,
+  now: Date,
+  requestId?: string,
+): Promise<{ previous: VixRegime | null; updated: boolean }> {
+  const snapshotAt = now.toISOString()
+  const nextJson = JSON.stringify(next)
+  try {
+    // 1) 初回 race を防ぐため INSERT OR IGNORE で行を確保する。
+    //    ただ、この時点では「INSERT した = この caller が初回」と確定はしない
+    //    (drizzle 既存 path で別 helper が delete+insert してる可能性)。
+    //    meta.changes >= 1 なら自分が初回 row を作った。
+    const insertRes = await db
+      .prepare(
+        'INSERT OR IGNORE INTO config_state_snapshot (key, value, snapshot_at, request_id) VALUES (?, ?, ?, ?)',
+      )
+      .bind(VIX_REGIME_SNAPSHOT_KEY, nextJson, snapshotAt, requestId ?? null)
+      .run()
+    const insertedRows = insertRes?.meta?.changes ?? 0
+    if (insertedRows >= 1) {
+      // この caller が初めて snapshot を作った。previous は null。
+      // updated=true だが、caller 側で previous=null は emit しない約束。
+      return { previous: null, updated: true }
+    }
+
+    // 2) 既存 row があるので current を読む。
+    const current = await readCurrentRegime(db)
+    if (current === null) {
+      // 行は存在するが値が壊れている等。CAS の起点が無いので fail-silent で抜ける。
+      return { previous: null, updated: false }
+    }
+    if (current === next) {
+      // 値が同じ → no-op (snapshot_at だけ更新する意味は薄い、emit もしない)。
+      return { previous: current, updated: false }
+    }
+
+    // 3) UPDATE WHERE value = current で CAS。他 caller が先に書き換えていたら
+    //    meta.changes === 0 になる。
+    const updateRes = await db
+      .prepare(
+        'UPDATE config_state_snapshot SET value = ?, snapshot_at = ?, request_id = ? WHERE key = ? AND value = ?',
+      )
+      .bind(nextJson, snapshotAt, requestId ?? null, VIX_REGIME_SNAPSHOT_KEY, JSON.stringify(current))
+      .run()
+    const changed = updateRes?.meta?.changes ?? 0
+    if (changed >= 1) {
+      // CAS 成功。この caller の責任で notify してよい。
+      return { previous: current, updated: true }
+    }
+    // 4) 他 caller が先に書き換えた。最新値を再取得して updated=false で返す。
+    const latest = await readCurrentRegime(db)
+    return { previous: latest, updated: false }
+  } catch (error) {
+    console.warn(
+      JSON.stringify({
+        event: 'vix_regime_snapshot_cas_failed',
+        requestId: requestId ?? null,
+        message: error instanceof Error ? error.message : String(error),
+      }),
+    )
+    return { previous: null, updated: false }
+  }
+}
+
+async function readCurrentRegime(db: D1Database): Promise<VixRegime | null> {
+  const row = await db
+    .prepare('SELECT value FROM config_state_snapshot WHERE key = ? LIMIT 1')
+    .bind(VIX_REGIME_SNAPSHOT_KEY)
+    .first<{ value: string }>()
+  if (!row || typeof row.value !== 'string') return null
+  const parsed = parseSafe(row.value)
+  if (parsed === 'normal' || parsed === 'warning' || parsed === 'critical') {
+    return parsed
+  }
+  return null
+}
+
+/**
  * cron tick から呼ばれる top-level helper (configStateChange の pattern を踏襲)。
  *
  *   1. snapshot を読む (失敗 → null)
@@ -146,9 +246,17 @@ export async function detectAndNotifyVixRegimeChange(args: {
   if (!args.db) {
     return { from: null, to: args.current.regime, emitted: false }
   }
-  const previous = await loadVixRegimeSnapshot(args.db, args.requestId)
+  const now = (args.now ?? (() => new Date()))()
+  // CAS で snapshot を更新。並行 cron で重複通知が出ないように、ここで「自分が
+  // 更新した」と判定された caller だけが notify する (CodeRabbit #216 4th)。
+  const { previous, updated } = await atomicallyUpdateVixRegimeSnapshot(
+    args.db,
+    args.current.regime,
+    now,
+    args.requestId,
+  )
   let emitted = false
-  if (previous !== null && previous !== args.current.regime) {
+  if (updated && previous !== null && previous !== args.current.regime) {
     const severity = classifyVixRegimeSeverity(previous, args.current.regime)
     const note = args.requestId ? `requestId=${args.requestId}` : undefined
     // notify は fire-and-forget。`.catch(...)` は async rejection しか拾えない
@@ -186,8 +294,6 @@ export async function detectAndNotifyVixRegimeChange(args: {
     }
     emitted = true
   }
-  const now = (args.now ?? (() => new Date()))()
-  await persistVixRegimeSnapshot(args.db, args.current.regime, args.requestId, now)
   return { from: previous, to: args.current.regime, emitted }
 }
 

--- a/src/infrastructure/notification/vixRegimeChange.ts
+++ b/src/infrastructure/notification/vixRegimeChange.ts
@@ -61,9 +61,12 @@ export function classifyVixRegimeSeverity(
 /**
  * 前回 snapshot を読む。table 未 migration / 接続失敗等は null フォールバック
  * (= 「初回扱い」、通知は出さない)。
+ *
+ * `requestId` は失敗 warn ログにのみ使用する (cron run と相関させるため)。
  */
 export async function loadVixRegimeSnapshot(
   db: D1Database,
+  requestId?: string,
 ): Promise<VixRegime | null> {
   try {
     const drizzle = createDb(db)
@@ -83,6 +86,7 @@ export async function loadVixRegimeSnapshot(
     console.warn(
       JSON.stringify({
         event: 'vix_regime_snapshot_load_failed',
+        requestId: requestId ?? null,
         message: error instanceof Error ? error.message : String(error),
       }),
     )
@@ -116,6 +120,7 @@ export async function persistVixRegimeSnapshot(
     console.warn(
       JSON.stringify({
         event: 'vix_regime_snapshot_persist_failed',
+        requestId: requestId ?? null,
         message: error instanceof Error ? error.message : String(error),
       }),
     )
@@ -141,13 +146,17 @@ export async function detectAndNotifyVixRegimeChange(args: {
   if (!args.db) {
     return { from: null, to: args.current.regime, emitted: false }
   }
-  const previous = await loadVixRegimeSnapshot(args.db)
+  const previous = await loadVixRegimeSnapshot(args.db, args.requestId)
   let emitted = false
   if (previous !== null && previous !== args.current.regime) {
     const severity = classifyVixRegimeSeverity(previous, args.current.regime)
     const note = args.requestId ? `requestId=${args.requestId}` : undefined
-    args.notifier
-      .notify({
+    // notify は fire-and-forget。`.catch(...)` は async rejection しか拾えない
+    // ため、type error 等の同期 throw が起きると下の snapshot 永続化に到達せず
+    // 「次 tick も同じ regime → 再通知 + snapshot 不整合」のリスクがあった。
+    // try/catch で sync throw も握りつぶし、両系統を同じ event 名で warn する。
+    try {
+      const result = args.notifier.notify({
         type: 'STATE_CHANGE',
         field: VIX_REGIME_SNAPSHOT_KEY,
         from: previous,
@@ -155,14 +164,26 @@ export async function detectAndNotifyVixRegimeChange(args: {
         severity,
         ...(note !== undefined ? { note: `${note} ${args.current.reason}`.trim() } : { note: args.current.reason }),
       })
-      .catch((err) => {
-        console.warn(
-          JSON.stringify({
-            event: 'vix_regime_change_notify_failed',
-            message: err instanceof Error ? err.message : String(err),
-          }),
-        )
-      })
+      if (result && typeof (result as Promise<unknown>).catch === 'function') {
+        ;(result as Promise<unknown>).catch((err) => {
+          console.warn(
+            JSON.stringify({
+              event: 'vix_regime_change_notify_failed',
+              requestId: args.requestId ?? null,
+              message: err instanceof Error ? err.message : String(err),
+            }),
+          )
+        })
+      }
+    } catch (err) {
+      console.warn(
+        JSON.stringify({
+          event: 'vix_regime_change_notify_failed',
+          requestId: args.requestId ?? null,
+          message: err instanceof Error ? err.message : String(err),
+        }),
+      )
+    }
     emitted = true
   }
   const now = (args.now ?? (() => new Date()))()

--- a/src/infrastructure/notification/vixRegimeChange.ts
+++ b/src/infrastructure/notification/vixRegimeChange.ts
@@ -178,8 +178,18 @@ export async function atomicallyUpdateVixRegimeSnapshot(
     // 2) 既存 row があるので current を読む。
     const current = await readCurrentRegime(db)
     if (current === null) {
-      // 行は存在するが値が壊れている等。CAS の起点が無いので fail-silent で抜ける。
-      return { previous: null, updated: false }
+      // 行は存在するが値が壊れている (parse 失敗等)。CAS の起点が無いままだと
+      // 毎 tick 同じ分岐で stuck し snapshot が永久に self-heal せず通知も再開
+      // しないので、初回観測と同じ扱いで next を書き込み snapshot を直す
+      // (CodeRabbit #216 5th)。previous=null のため caller 側で notify は
+      // skip される (false alert 防止)。
+      await db
+        .prepare(
+          'UPDATE config_state_snapshot SET value = ?, snapshot_at = ?, request_id = ? WHERE key = ?',
+        )
+        .bind(nextJson, snapshotAt, requestId ?? null, VIX_REGIME_SNAPSHOT_KEY)
+        .run()
+      return { previous: null, updated: true }
     }
     if (current === next) {
       // 値が同じ → no-op (snapshot_at だけ更新する意味は薄い、emit もしない)。

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -113,7 +113,7 @@ export const admin = new Hono<AppBindings>()
       mustBePositive: true,
     })
 
-    const global = await loadGlobalConfigFrom(c.env)
+    const global = await loadGlobalConfigFrom(c.env, c.get('requestId'))
     const rule: SymbolRule = {
       stopPct: readOptionalNumber(
         c.req.query('stopPct'),

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -56,7 +56,9 @@ export const dashboard = new Hono<AppBindings>()
       const portfolio = await new PortfolioStateClient(c.env.PORTFOLIO_STATE).getPortfolio()
       // VIX regime (issue #196 3/3) を D1 snapshot から読む。table 未 migration /
       // bind 不在は null fallback (= 未知扱い、ページ自体は表示)。
-      const vixRegime = c.env.DB ? await loadVixRegimeSnapshot(c.env.DB) : null
+      const vixRegime = c.env.DB
+        ? await loadVixRegimeSnapshot(c.env.DB, c.get('requestId'))
+        : null
       return c.html(layout('ポートフォリオ', portfolioBody(portfolio, vixRegime)))
     } catch (err) {
       return c.html(layout('ポートフォリオ', unavailable(messageOf(err))))

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -76,7 +76,7 @@ export const dashboard = new Hono<AppBindings>()
       return c.html(layout('設定', unavailable('DB not bound')))
     }
     const [global, universe] = await Promise.all([
-      loadGlobalConfigFrom(c.env),
+      loadGlobalConfigFrom(c.env, c.get('requestId')),
       loadSymbolUniverse(c.env),
     ])
     return c.html(layout('設定', configBody(global, universe)))
@@ -120,7 +120,7 @@ export const dashboard = new Hono<AppBindings>()
       if (tab === 'grid') {
         const [universe, global] = await Promise.all([
           loadSymbolUniverse(c.env),
-          loadGlobalConfigFrom(c.env),
+          loadGlobalConfigFrom(c.env, c.get('requestId')),
         ])
         const rules: SymbolChartRules = {
           pullbackMax: global.pullbackDefaultPullbackMax,
@@ -150,7 +150,7 @@ export const dashboard = new Hono<AppBindings>()
       const symbolParam = c.req.query('symbol')?.toUpperCase().trim() || undefined
       const [universe, global] = await Promise.all([
         loadSymbolUniverse(c.env),
-        loadGlobalConfigFrom(c.env),
+        loadGlobalConfigFrom(c.env, c.get('requestId')),
       ])
       const allowed = new Set(universe.allowedSymbols)
       const defaultSymbol = await pickDefaultSymbol(c.env.DB)

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -11,6 +11,8 @@ import {
   type LoadAlertOptions,
 } from '../infrastructure/notification/notificationEmitLog'
 import type { NotificationSeverity, NotificationEvent } from '../infrastructure/notification/Notifier'
+import { loadVixRegimeSnapshot } from '../infrastructure/notification/vixRegimeChange'
+import type { VixRegime } from '../trading/risk/vixRegimeFilter'
 import { and, asc, desc, eq } from 'drizzle-orm'
 import { PortfolioStateClient } from '../trading/state/PortfolioStateClient'
 import { SymbolStateClient } from '../trading/state/SymbolStateClient'
@@ -52,7 +54,10 @@ export const dashboard = new Hono<AppBindings>()
     }
     try {
       const portfolio = await new PortfolioStateClient(c.env.PORTFOLIO_STATE).getPortfolio()
-      return c.html(layout('ポートフォリオ', portfolioBody(portfolio)))
+      // VIX regime (issue #196 3/3) を D1 snapshot から読む。table 未 migration /
+      // bind 不在は null fallback (= 未知扱い、ページ自体は表示)。
+      const vixRegime = c.env.DB ? await loadVixRegimeSnapshot(c.env.DB) : null
+      return c.html(layout('ポートフォリオ', portfolioBody(portfolio, vixRegime)))
     } catch (err) {
       return c.html(layout('ポートフォリオ', unavailable(messageOf(err))))
     }
@@ -637,22 +642,48 @@ function portfolioBody(p: {
   tradingDisabledUntil: string | null
   lastRolledAt?: string | null
   updatedAt: string
-}): string {
+}, vixRegime: VixRegime | null): string {
   const drawdownPct =
     p.dailyStartEquity > 0 ? (p.dailyRealizedPnl / p.dailyStartEquity) * 100 : null
   const ddClass = drawdownPct === null ? 'muted' : drawdownPct >= 0 ? 'ok' : 'err'
   const kill = p.tradingDisabledUntil
   const lastRolledCell = renderLastRolledCell(p.lastRolledAt ?? null)
+  const vixCell = renderVixRegimeCell(vixRegime)
   return `<table>
     <tbody>
       <tr><th>当日始値資産 (dailyStartEquity)</th><td>${fmtNumber(p.dailyStartEquity, 2)}</td></tr>
       <tr><th>当日実現損益 (dailyRealizedPnl)</th><td class="${ddClass}">${fmtNumber(p.dailyRealizedPnl, 2)}</td></tr>
       <tr><th>ドローダウン (drawdown)</th><td class="${ddClass}">${drawdownPct === null ? '—' : fmtNumber(drawdownPct, 2) + '%'}</td></tr>
       <tr><th>取引停止解除時刻 (tradingDisabledUntil)</th><td>${kill ? `<span class="warn">${esc(fmtJst(kill))}</span>` : '<span class="ok">稼働中</span>'}</td></tr>
+      <tr><th>VIX レジーム (vixRegime)</th><td>${vixCell}</td></tr>
       <tr><th>EOD ロールオーバー実行時刻 (lastRolledAt)</th><td>${lastRolledCell}</td></tr>
       <tr><th>更新時刻 (updatedAt)</th><td class="muted">${esc(fmtJst(p.updatedAt))}</td></tr>
     </tbody>
   </table>`
+}
+
+/**
+ * VIX regime snapshot を bage 風に表示 (issue #196 3/3)。
+ *
+ *   - normal:   緑 (size 1.0、通常運用)
+ *   - warning:  黄 (size 0.5、新規 BUY 縮小)
+ *   - critical: 赤 (新規 BUY 全停止 / SELL は通常)
+ *   - null:     灰 (snapshot 未生成、初回 cron tick 前 or DB 未配線)
+ *
+ * VIX 値そのものは snapshot table に持たないので regime ラベルのみ表示。
+ * 値が必要なら strategy_decision_log の VIX reject reason を見る運用 (POC)。
+ */
+export function renderVixRegimeCell(regime: VixRegime | null): string {
+  if (regime === null) {
+    return `<span class="muted">— (cron 未到達 or DB 未配線、fail-open で通常運用)</span>`
+  }
+  if (regime === 'critical') {
+    return `<span class="err">critical — 新規買い停止 (売却は通常)</span>`
+  }
+  if (regime === 'warning') {
+    return `<span class="warn">warning — 新規買いを縮小 (size scale 適用)</span>`
+  }
+  return `<span class="ok">normal — 通常運用</span>`
 }
 
 /**
@@ -920,6 +951,18 @@ const CONFIG_KEY_META: Record<string, ConfigKeyMeta> = {
   bucket_exposure_pct: {
     label: '同グループ建玉上限率 (比率)',
     detail: '同じグループ (例: 半導体 ETF) の合計をこの率まで保有可。0.30 = 総資本の 30%。大きくすると集中投資↑、小さいと分散↑。',
+  },
+  vix_warning_threshold: {
+    label: 'VIX 警戒閾値',
+    detail: '恐怖指数 (VIX) がこの値を超えたら新規買いの数量を縮小。25 が標準。下げると早めに用心、上げると VIX 高でも普段通り。',
+  },
+  vix_critical_threshold: {
+    label: 'VIX 緊急閾値',
+    detail: '恐怖指数 (VIX) がこの値を超えたら新規買いを全停止 (売却は通常通り)。30 が標準。下げると守り重視、上げると荒れ相場でも買いに行く。',
+  },
+  vix_warning_size_scale: {
+    label: 'VIX 警戒時の建玉縮小率 (比率)',
+    detail: 'VIX 警戒時 (warning ≤ VIX < critical) の発注数量倍率。0.5 = 半分に縮小。1.0 で縮小なし、0 で停止と同義。',
   },
 }
 

--- a/src/routes/trade.ts
+++ b/src/routes/trade.ts
@@ -25,27 +25,29 @@ interface TradeRequest {
 export const trade = new Hono<AppBindings>()
   .post('/decide', async (c) => {
     const request = await parseTradeRequest(c.req.json())
+    const requestId = c.get('requestId')
     const [universe, global] = await Promise.all([
       loadSymbolUniverse(c.env),
-      loadGlobalConfigFrom(c.env),
+      loadGlobalConfigFrom(c.env, requestId),
     ])
     const service = createTradingService(request, c.env, universe, global)
     return c.json(
       service.decide(request, toTradingConfig(request, universe, global), {
-        requestId: c.get('requestId'),
+        requestId,
       }),
     )
   })
   .post('/execute', async (c) => {
     const request = await parseTradeRequest(c.req.json())
+    const requestId = c.get('requestId')
     const [universe, global] = await Promise.all([
       loadSymbolUniverse(c.env),
-      loadGlobalConfigFrom(c.env),
+      loadGlobalConfigFrom(c.env, requestId),
     ])
     const service = createTradingService(request, c.env, universe, global)
     return c.json(
       await service.executeTrade(request, toTradingConfig(request, universe, global), {
-        requestId: c.get('requestId'),
+        requestId,
       }),
     )
   })

--- a/src/routes/webull.ts
+++ b/src/routes/webull.ts
@@ -21,7 +21,7 @@ export const webull = new Hono<AppBindings>().post('/order/place', async (c) => 
 
   logPreSubmit({ requestId, clientOrderId: intent.clientOrderId, intent })
 
-  const global = await loadGlobalConfigFrom(c.env)
+  const global = await loadGlobalConfigFrom(c.env, requestId)
   if (!global.dryRun) {
     logPostSubmit({
       requestId,

--- a/src/trading/risk/vixRegimeFilter.ts
+++ b/src/trading/risk/vixRegimeFilter.ts
@@ -1,0 +1,153 @@
+/**
+ * VIX regime filter (issue #196 3/3)。
+ *
+ * `^VIX` (CBOE Volatility Index) の最新値で BUY size を縮小 / 停止する
+ * **size scaling 系** filter。earnings (1/3) / macro (2/3) gate と異なり
+ * 「BUY を 0/1 で止める」のではなく「size を 0..1 倍にスケール」する。
+ *
+ * scope:
+ *   - in: BUY の `intent.quantity` を倍率調整 (1.0 / 0.5 / 0.0)
+ *   - out: SELL は常に通す (existing position の exit を妨げない)
+ *   - out: VIX 取得失敗は **fail-open warning** で normal fallback (POC 適切 —
+ *     VIX は part-of-the-system で必須ではない、fail-closed BUY 全停止は厳しすぎる)
+ *
+ * 規則:
+ *   - VIX <= warningThreshold: regime='normal', sizeScale=1.0
+ *   - warningThreshold < VIX <= criticalThreshold: regime='warning', sizeScale=warningSizeScale
+ *   - VIX > criticalThreshold: regime='critical', sizeScale=0 (= BUY block)
+ *   - vix === null (取得失敗): regime='normal', sizeScale=1.0 (fail-open)
+ *
+ * 呼び出し側 (`pullbackScheduler` 経由) は decision の `reason` を
+ * `risk: vix_critical: 35.10 (block)` 形式で `strategy_decision_log.reason` に書く。
+ */
+
+export type VixRegime = 'normal' | 'warning' | 'critical'
+
+export interface VixRegimeFilterConfig {
+  /** VIX > これで warning 領域 (size を warningSizeScale 倍に縮小)。default 25。 */
+  warningThreshold: number
+  /** VIX > これで critical 領域 (BUY 全停止 / sizeScale=0)。default 30。 */
+  criticalThreshold: number
+  /** warning 領域の size 倍率。default 0.5 (= 半分)。0..1 で運用想定。 */
+  warningSizeScale: number
+}
+
+export interface VixRegimeFilterDecision {
+  regime: VixRegime
+  /**
+   * size を倍率調整。1.0 (normal) / warningSizeScale (warning, default 0.5) /
+   * 0.0 (critical = block)。`pullbackScheduler` BUY 段で
+   * `intent.quantity = floor(intent.quantity * sizeScale)` する。
+   * critical (sizeScale === 0) は BUY 全 reject、reason に critical を載せる。
+   */
+  sizeScale: number
+  /**
+   * 通知 / log 用の説明 (英文 canonical、表示層で日本語化)。形式:
+   *   - `vix_normal: 18.50`
+   *   - `vix_warning: 27.30 (size x0.5)`
+   *   - `vix_critical: 35.10 (block)`
+   *   - `vix_unavailable_fallback_normal` (取得失敗時)
+   */
+  reason: string
+  /**
+   * 評価対象の VIX 値 (取得失敗時は null)。dashboard / 通知向けの素材。
+   * decision.reason に載せる以外でも UI 側で生値を使うために露出する。
+   */
+  vix: number | null
+}
+
+export const DEFAULT_VIX_REGIME_CONFIG: VixRegimeFilterConfig = {
+  warningThreshold: 25.0,
+  criticalThreshold: 30.0,
+  warningSizeScale: 0.5,
+}
+
+/**
+ * Pure function — VIX 値 + config から regime decision を返す。
+ *
+ * 呼び出し側で fetch を済ませて `vix: number | null` を渡す。`null` は
+ * 「fetch 失敗 / 値が無効」を意味し、fail-open で normal 扱いになる。
+ *
+ * config が壊れている (NaN / 順序逆転 / sizeScale が 0..1 範囲外) 場合は
+ * `DEFAULT_VIX_REGIME_CONFIG` の対応 field に倒す。「DB UPDATE typo で
+ * VIX gate 経路が暴発」を避けるための defensive normalization。
+ */
+export function evaluateVixRegime(
+  vix: number | null,
+  config: VixRegimeFilterConfig = DEFAULT_VIX_REGIME_CONFIG,
+): VixRegimeFilterDecision {
+  const sane = sanitizeConfig(config)
+
+  // 取得失敗 → normal fallback (fail-open warning)。VIX は part-of-the-system
+  // で必須ではないので、fail-closed で全 BUY 停止は POC では厳しすぎる。
+  if (vix === null || !Number.isFinite(vix) || vix <= 0) {
+    return {
+      regime: 'normal',
+      sizeScale: 1.0,
+      reason: 'vix_unavailable_fallback_normal',
+      vix: null,
+    }
+  }
+
+  if (vix > sane.criticalThreshold) {
+    return {
+      regime: 'critical',
+      sizeScale: 0,
+      reason: `vix_critical: ${vix.toFixed(2)} (block)`,
+      vix,
+    }
+  }
+  if (vix > sane.warningThreshold) {
+    return {
+      regime: 'warning',
+      sizeScale: sane.warningSizeScale,
+      reason: `vix_warning: ${vix.toFixed(2)} (size x${sane.warningSizeScale})`,
+      vix,
+    }
+  }
+  return {
+    regime: 'normal',
+    sizeScale: 1.0,
+    reason: `vix_normal: ${vix.toFixed(2)}`,
+    vix,
+  }
+}
+
+/**
+ * config を default に倒して安全圏に正規化する。狙い: DB の UPDATE で
+ * 入った typo (e.g. warningThreshold=NaN, sizeScale=2.5) で VIX 経路が
+ * 暴発しないようにする。schema CHECK 制約で大半は弾けるが、layered
+ * defense として scheduler 寄りでも一段噛ませる。
+ */
+function sanitizeConfig(config: VixRegimeFilterConfig): VixRegimeFilterConfig {
+  const warning = isPositiveFinite(config.warningThreshold)
+    ? config.warningThreshold
+    : DEFAULT_VIX_REGIME_CONFIG.warningThreshold
+  const critical = isPositiveFinite(config.criticalThreshold)
+    ? config.criticalThreshold
+    : DEFAULT_VIX_REGIME_CONFIG.criticalThreshold
+  // warning > critical (順序逆転) は schema CHECK で弾くが、defensive に
+  // default に戻す。runtime で「warning は反応するのに critical は無反応」
+  // のような中途半端な挙動になるよりも、明確に default に倒す方が運用的に
+  // 分かりやすい。
+  const orderedWarning =
+    warning <= critical ? warning : DEFAULT_VIX_REGIME_CONFIG.warningThreshold
+  const orderedCritical =
+    warning <= critical ? critical : DEFAULT_VIX_REGIME_CONFIG.criticalThreshold
+  const scale =
+    typeof config.warningSizeScale === 'number' &&
+    Number.isFinite(config.warningSizeScale) &&
+    config.warningSizeScale >= 0 &&
+    config.warningSizeScale <= 1
+      ? config.warningSizeScale
+      : DEFAULT_VIX_REGIME_CONFIG.warningSizeScale
+  return {
+    warningThreshold: orderedWarning,
+    criticalThreshold: orderedCritical,
+    warningSizeScale: scale,
+  }
+}
+
+function isPositiveFinite(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+}

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -26,6 +26,7 @@ import {
   evaluateMacroEventGate,
   type MacroEventGateConfig,
 } from '../risk/macroEventGate'
+import type { VixRegimeFilterDecision } from '../risk/vixRegimeFilter'
 import type { EarningsCalendarRepo } from '../../infrastructure/calendar/earningsCalendarRepo'
 import type { MacroEventCalendarRepo } from '../../infrastructure/calendar/macroEventCalendarRepo'
 import { evaluatePerSymbolRisk } from '../risk/perSymbolRiskGate'
@@ -113,6 +114,16 @@ export interface PullbackSchedulerOptions {
    * より後ろで評価される (両方 reject なら earnings reason が先に確定する)。
    */
   macroEventGate?: MacroEventScheduleConfig
+  /**
+   * VIX regime filter decision (issue #196 3/3)。caller (`runStrategyCron`) が
+   * cron tick 起動時に `^VIX` を fetch し `evaluateVixRegime` を呼んで作る。
+   * scheduler は decision を受け取って:
+   *   - sizeScale === 0 (critical): BUY 全 reject (reason: `risk: vix_critical: ...`)
+   *   - 0 < sizeScale < 1 (warning): `intent.quantity = floor(qty * sizeScale)`
+   *   - sizeScale === 1 (normal / unavailable): no-op
+   * 未注入なら skip (POC 後方互換)。SELL は VIX 関係なく通す。
+   */
+  vixDecision?: VixRegimeFilterDecision
   now?: () => Date
 }
 
@@ -156,6 +167,13 @@ export interface PullbackRunSummary {
    * reconstructing context from scattered log lines.
    */
   decisions: PullbackDecisionTrace[]
+  /**
+   * VIX regime filter decision applied to this run (issue #196 3/3)。
+   * `vixDecision` option を渡された時のみ set される (POC 後方互換)。
+   * cron summary log / dashboard で「この run でどの regime で動いていたか」
+   * を可視化するために残す。
+   */
+  vix?: VixRegimeFilterDecision
 }
 
 export interface PullbackDecisionTrace {
@@ -201,6 +219,7 @@ export async function runPullbackScheduler(
     rejected: [],
     errors: [],
     decisions: [],
+    ...(options.vixDecision !== undefined ? { vix: options.vixDecision } : {}),
   }
 
   // Notifier helper: fire-and-forget。Notifier 実装側で silent fallback する
@@ -390,6 +409,68 @@ export async function runPullbackScheduler(
         })
         continue
       }
+      // VIX regime filter (issue #196 3/3) — sizing 直後 / bucket gate 直前で適用。
+      //   - critical (sizeScale === 0): BUY 全 reject
+      //   - warning (0 < sizeScale < 1): qty = floor(qty * sizeScale / lot) * lot
+      //   - normal (sizeScale === 1): no-op
+      // SELL は VIX 関係なく通すため、ここで scaling しても OK (BUY 経路だけ)。
+      // sizing 後 / bucket 前に置く理由:
+      //   - 縮小後の notional で bucket cap を判定したい (= over-block を避ける)
+      //   - 同時に VIX critical の reject は bucket 計算前に確定させたい (前段判定)
+      let scaledQuantity = sizing.quantity
+      if (options.vixDecision) {
+        if (options.vixDecision.sizeScale === 0) {
+          // critical: BUY 全 reject。decision.reason をそのまま乗せて操作者に
+          // 「VIX で止めた」を明示する (localizeReason が日本語化)。
+          const reason = `risk: ${options.vixDecision.reason}`
+          summary.rejected.push({ symbol: upper, reason })
+          await emitDecision({
+            symbol: upper,
+            decision: 'REJECT',
+            reason,
+            price: indicators.price,
+            indicatorsJson: JSON.stringify(indicators),
+            trace: appendTrace(
+              signal.trace,
+              traceStep('risk.vix_regime', false, options.vixDecision.vix ?? null, '<=', null, options.vixDecision.reason),
+            ),
+          })
+          continue
+        }
+        if (options.vixDecision.sizeScale < 1) {
+          // warning: qty を `floor(qty * scale / lot) * lot` で lot に揃える。
+          // lot=1 の US 株は単純な floor、lot=100 の JP 株は単元未満で 0 になり得る。
+          // 結果が 0 になった場合は次の `scaledQuantity <= 0` reject で拾う。
+          const lot = options.lotSize ?? 1
+          const rawScaled = sizing.quantity * options.vixDecision.sizeScale
+          scaledQuantity = lot > 1
+            ? Math.floor(rawScaled / lot) * lot
+            : Math.floor(rawScaled)
+          if (scaledQuantity <= 0) {
+            const reason = `risk: ${options.vixDecision.reason} (qty rounded to 0, lot=${lot})`
+            summary.rejected.push({ symbol: upper, reason })
+            await emitDecision({
+              symbol: upper,
+              decision: 'REJECT',
+              reason,
+              price: indicators.price,
+              indicatorsJson: JSON.stringify(indicators),
+              trace: appendTrace(
+                signal.trace,
+                traceStep(
+                  'risk.vix_regime',
+                  false,
+                  scaledQuantity,
+                  '>',
+                  0,
+                  `${options.vixDecision.reason}; qty 0 after lot round`,
+                ),
+              ),
+            })
+            continue
+          }
+        }
+      }
       if (!Number.isFinite(indicators.price) || indicators.price <= 0) {
         const reason = `invalid price: ${indicators.price}`
         summary.rejected.push({ symbol: upper, reason })
@@ -402,9 +483,9 @@ export async function runPullbackScheduler(
         })
         continue
       }
-      const notional = sizing.quantity * indicators.price
+      const notional = scaledQuantity * indicators.price
       if (!Number.isFinite(notional) || notional <= 0) {
-        const reason = `invalid notional: ${notional} (qty=${sizing.quantity}, price=${indicators.price})`
+        const reason = `invalid notional: ${notional} (qty=${scaledQuantity}, price=${indicators.price})`
         summary.rejected.push({ symbol: upper, reason })
         await emitDecision({
           symbol: upper,
@@ -441,7 +522,7 @@ export async function runPullbackScheduler(
       if (bucket && bucketDecision.newExposure !== undefined) {
         pendingBucketUpdate = { bucket, newExposure: bucketDecision.newExposure }
       }
-      intent = buildIntent(upper, 'BUY', sizing.quantity, indicators.price)
+      intent = buildIntent(upper, 'BUY', scaledQuantity, indicators.price)
     } else {
       // SELL: close the full open position.
       if (state.position === null) {
@@ -846,6 +927,7 @@ const TRACE_LABEL_JA: Record<string, string> = {
   'risk.earnings_calendar': '決算日カレンダーゲート',
   'risk.macro_event': 'マクロイベントゲート',
   'risk.per_symbol_gate': '銘柄別リスクゲート',
+  'risk.vix_regime': 'VIX レジーム判定',
   'broker.submit': '証券会社への発注送信',
 }
 

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -450,7 +450,10 @@ export async function runStrategyCron(
 
   // Pullback デフォルト rule は D1 global_config に寄せた (#118)。
   // 実運用中の tuning は `UPDATE global_config SET ...` で即反映可能。
-  const summary = emptySummary()
+  // VIX regime decision を summary にも載せる (CodeRabbit #216 4th):
+  // sub-run ごとに独立した summary が `vix` を持つので、aggregate もそれと
+  // 揃えておく。`emptySummary()` は `vix` を埋めないので明示的に上書きする。
+  const summary: PullbackRunSummary = { ...emptySummary(), vix: vixDecision }
   const runs: Array<{ currency: SymbolCurrency; equity: number; lotSize: number; symbols: string[] }> = []
   if (byCurrency.USD.length > 0) {
     runs.push({

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -149,7 +149,7 @@ export async function runStrategyCron(
   })
 
   const [global, universe] = await Promise.all([
-    loadGlobalConfigFrom(env),
+    loadGlobalConfigFrom(env, options.requestId),
     loadSymbolUniverse(env),
   ])
 

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -27,6 +27,11 @@ import {
   createMacroEventCalendarDb,
   createMacroEventCalendarRepo,
 } from '../../infrastructure/calendar/macroEventCalendarRepo'
+import {
+  evaluateVixRegime,
+  type VixRegimeFilterDecision,
+} from '../risk/vixRegimeFilter'
+import { detectAndNotifyVixRegimeChange } from '../../infrastructure/notification/vixRegimeChange'
 import { runPullbackScheduler, type PullbackDecisionTrace, type PullbackRunSummary } from './pullbackScheduler'
 
 const DEFAULT_EQUITY_USD = 10_000
@@ -93,6 +98,11 @@ export interface StrategyCronAnalysis {
     scale: number
     drawdown: number
   }
+  /**
+   * VIX regime decision (issue #196 3/3)。`^VIX` の最新値から導出。
+   * cron tick で一度だけ算出し、両 currency run に同じ decision を渡す。
+   */
+  vix?: VixRegimeFilterDecision
   runs: Array<{
     currency: SymbolCurrency
     equity: number
@@ -415,6 +425,29 @@ export async function runStrategyCron(
     )
   }
 
+  // VIX regime filter (issue #196 3/3)。`^VIX` daily の最新 close を 1 本だけ
+  // 取得し、`evaluateVixRegime` で regime / sizeScale を決める。fetch 失敗は
+  // fail-open (= normal fallback)。POC 段階で fail-closed BUY 全停止は厳しい。
+  // `^VIX` は free / no-auth で Yahoo `chart` endpoint がそのまま使える。
+  const vixDecision = await loadVixDecision(barClient, global, options.requestId)
+  analysis = { ...analysis, vix: vixDecision }
+  // Regime 遷移 (normal → warning, warning → critical 等) を STATE_CHANGE 通知。
+  // 同 regime の連続 tick では emit しない (snapshot table で dedup)。
+  await detectAndNotifyVixRegimeChange({
+    db: env.DB,
+    notifier,
+    current: vixDecision,
+    requestId: options.requestId,
+  }).catch((err) => {
+    console.warn(
+      JSON.stringify({
+        event: 'vix_regime_change_detect_failed',
+        requestId: options.requestId,
+        message: err instanceof Error ? err.message : String(err),
+      }),
+    )
+  })
+
   // Pullback デフォルト rule は D1 global_config に寄せた (#118)。
   // 実運用中の tuning は `UPDATE global_config SET ...` で即反映可能。
   const summary = emptySummary()
@@ -504,6 +537,10 @@ export async function runStrategyCron(
             },
           }
         : {}),
+      // VIX regime filter (issue #196 3/3)。critical で BUY 全停止、warning で
+      // size を縮小、normal は no-op。両 currency run に同じ decision を渡す
+      // (`^VIX` は global indicator なので per-currency に変える意味はない)。
+      vixDecision,
       onDecision: (record) =>
         logStrategyDecision(decisionDb, {
           timestamp: new Date().toISOString(),
@@ -653,6 +690,54 @@ async function isEarningsCalendarReady(db: D1Database): Promise<boolean> {
   } catch {
     return false
   }
+}
+
+/**
+ * `^VIX` の最新 close を取って `evaluateVixRegime` に流し、size scaling 用
+ * decision を返す (issue #196 3/3)。
+ *
+ * fail-open: VIX fetch / parse 失敗時は `null` を渡して `regime: 'normal'` /
+ * `sizeScale: 1.0` (= 通常運用) に倒す。POC 段階では VIX は part-of-the-system
+ * で必須ではなく、fetch 失敗 = BUY 全停止は副作用が大きすぎる。warning ログ
+ * だけ吐いて続行。
+ */
+async function loadVixDecision(
+  barClient: YahooBarClient,
+  global: { vixWarningThreshold: number; vixCriticalThreshold: number; vixWarningSizeScale: number },
+  requestId: string | undefined,
+): Promise<VixRegimeFilterDecision> {
+  let vix: number | null = null
+  try {
+    // `^VIX` (CBOE Volatility Index)。Yahoo は記号付き symbol を URL encode で
+    // 受けてくれる。lookback=1 で最新 close 1 本だけ。
+    const bars = await barClient.getDailyBars('^VIX', 1)
+    const last = bars[bars.length - 1]
+    if (last && Number.isFinite(last.close) && last.close > 0) {
+      vix = last.close
+    } else {
+      console.warn(
+        JSON.stringify({
+          event: 'vix_fetch_no_bars',
+          requestId,
+          barsLength: bars.length,
+        }),
+      )
+    }
+  } catch (err) {
+    // fail-open: warning ログだけ。decision は null = normal fallback。
+    console.warn(
+      JSON.stringify({
+        event: 'vix_fetch_failed',
+        requestId,
+        message: err instanceof Error ? err.message : String(err),
+      }),
+    )
+  }
+  return evaluateVixRegime(vix, {
+    warningThreshold: global.vixWarningThreshold,
+    criticalThreshold: global.vixCriticalThreshold,
+    warningSizeScale: global.vixWarningSizeScale,
+  })
 }
 
 /**

--- a/test/helpers/configFixtures.ts
+++ b/test/helpers/configFixtures.ts
@@ -36,6 +36,9 @@ export function makeGlobalConfigSnapshot(
     riskDdHalfThreshold: -0.05,
     riskDdHaltThreshold: -0.10,
     bucketExposurePct: 0.30,
+    vixWarningThreshold: 25.0,
+    vixCriticalThreshold: 30.0,
+    vixWarningSizeScale: 0.5,
     source: 'd1',
     ...overrides,
   }

--- a/test/infrastructure/db/globalConfigRepo.test.ts
+++ b/test/infrastructure/db/globalConfigRepo.test.ts
@@ -7,10 +7,18 @@ import {
 /**
  * pre-0015 (= migration 適用前 / 適用 race) D1 では VIX 列が schema に無く、
  * `select` 自体が `Error('no such column: vix_warning_threshold')` で失敗する。
- * その場合に defaults へ fallback して cron 全停止を避けることを確認する。
+ * その場合に
+ *   1. legacy 列だけを明示 select する path で既存 row 値を保持し
+ *      VIX 3 項目だけ defaults で埋める (#216 3rd round)、
+ *   2. legacy fetch も失敗するケースで初めて全 defaults に倒す
+ * の 2 段階 fallback を検証する。
  */
 describe('loadGlobalConfig — pre-0015 fallback', () => {
-  function fakeDbThrowing(message: string) {
+  /**
+   * full select (1st call) は throw、explicit-column legacy select (2nd call) も throw。
+   * 「row が無い / DB ごと壊れている」の double failure ケース。
+   */
+  function fakeDbAllThrowing(message: string) {
     return {
       select() {
         return {
@@ -30,41 +38,144 @@ describe('loadGlobalConfig — pre-0015 fallback', () => {
     } as unknown as Parameters<typeof loadGlobalConfig>[0]
   }
 
-  it('returns defaults when select fails with "no such column" error', async () => {
+  /**
+   * full select (引数なし) は throw、explicit-column select (引数あり = legacy path) は
+   * `legacyRow` を返す。pre-0015 で legacy row が存在する正常 fallback ケース。
+   */
+  function fakeDbThrowingThenLegacy(
+    message: string,
+    legacyRow: Record<string, unknown>,
+  ) {
+    return {
+      select(columns?: unknown) {
+        // legacy path = `select({ id, dryRun, ... })` で columns 指定あり。
+        // full path = `select()` で columns 指定なし。
+        const isLegacy = columns !== undefined
+        return {
+          from() {
+            return {
+              where() {
+                return {
+                  async limit() {
+                    if (isLegacy) return [legacyRow]
+                    throw new Error(message)
+                  },
+                }
+              },
+            }
+          },
+        }
+      },
+    } as unknown as Parameters<typeof loadGlobalConfig>[0]
+  }
+
+  it('preserves legacy row values and only fills VIX 3 fields from defaults (legacy fetch ok)', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    const db = fakeDbThrowing('no such column: vix_warning_threshold')
+    // legacy row: tradingEnabled は false (= 既存運用値) のまま保持されるべき。
+    // defaults では tradingEnabled: false なので `tradingEnabled` の検証は別 field でも行う。
+    const legacyRow = {
+      id: 'default',
+      dryRun: false, // defaults: true → legacy 値 false が保持されるか
+      tradingEnabled: true, // defaults: false → legacy 値 true が保持されるか
+      marketHoursCheck: true,
+      maxOrderNotional: 500,
+      maxOrderNotionalUsd: 5000,
+      maxOrderNotionalJpy: 250000,
+      totalCapitalUsd: 10000,
+      totalCapitalJpy: 1500000,
+      maxPortfolioExposurePct: 0.8,
+      drawdownKillThreshold: -0.05,
+      staleQuoteMs: 60000,
+      gapRejectPct: 0.05,
+      spreadLimitPctUs: 0.005,
+      spreadLimitPctJp: 0.01,
+      pullbackDefaultStopPct: -0.06,
+      pullbackDefaultTakeProfitPct: 0.1,
+      pullbackDefaultTimeStopDays: 15,
+      pullbackDefaultPullbackMax: -0.04,
+      pullbackDefaultPullbackMin: -0.08,
+      pullbackDefaultMinReturn50d: 0.12,
+      pullbackDefaultRequireAboveSma50: false,
+      pullbackDefaultKAtr: 2.5,
+      riskBasePerTradePct: 0.006,
+      riskDdHalfThreshold: -0.07,
+      riskDdHaltThreshold: -0.15,
+      bucketExposurePct: 0.4,
+    }
+    const db = fakeDbThrowingThenLegacy(
+      'no such column: vix_warning_threshold',
+      legacyRow,
+    )
     const result = await loadGlobalConfig(db, 'req-abc-123')
-    expect(result).toEqual({ ...GLOBAL_CONFIG_DEFAULTS })
+
+    // legacy row の値が保持されていること
+    expect(result.dryRun).toBe(false)
+    expect(result.tradingEnabled).toBe(true)
+    expect(result.marketHoursCheck).toBe(true)
+    expect(result.maxOrderNotional).toBe(500)
+    expect(result.maxOrderNotionalUsd).toBe(5000)
+    expect(result.maxOrderNotionalJpy).toBe(250000)
+    expect(result.totalCapitalUsd).toBe(10000)
+    expect(result.totalCapitalJpy).toBe(1500000)
+    expect(result.maxPortfolioExposurePct).toBe(0.8)
+    expect(result.drawdownKillThreshold).toBe(-0.05)
+    expect(result.pullbackDefaultStopPct).toBe(-0.06)
+    expect(result.pullbackDefaultRequireAboveSma50).toBe(false)
+    expect(result.bucketExposurePct).toBe(0.4)
+
+    // VIX 3 項目だけは defaults で埋められること
+    expect(result.vixWarningThreshold).toBe(GLOBAL_CONFIG_DEFAULTS.vixWarningThreshold)
+    expect(result.vixCriticalThreshold).toBe(GLOBAL_CONFIG_DEFAULTS.vixCriticalThreshold)
+    expect(result.vixWarningSizeScale).toBe(GLOBAL_CONFIG_DEFAULTS.vixWarningSizeScale)
+
+    // pre_0015_fallback の 1 件だけ warn (legacy_load_failed は出ない)
     expect(warnSpy).toHaveBeenCalledTimes(1)
     const logged = JSON.parse(warnSpy.mock.calls[0]![0] as string)
     expect(logged.event).toBe('global_config_pre_0015_fallback')
-    expect(logged.message).toMatch(/no such column/)
     expect(logged.requestId).toBe('req-abc-123')
     warnSpy.mockRestore()
   })
 
-  it('returns defaults when select fails with vix_-prefixed column error', async () => {
+  it('returns full defaults and emits 2 warnings when legacy fetch also fails', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    const db = fakeDbThrowing('SQLITE_ERROR: vix_critical_threshold not found')
-    const result = await loadGlobalConfig(db)
+    const db = fakeDbAllThrowing('no such column: vix_warning_threshold')
+    const result = await loadGlobalConfig(db, 'req-abc-123')
     expect(result).toEqual({ ...GLOBAL_CONFIG_DEFAULTS })
-    expect(warnSpy).toHaveBeenCalledTimes(1)
-    const logged = JSON.parse(warnSpy.mock.calls[0]![0] as string)
-    expect(logged.requestId).toBeNull()
+    // pre_0015_fallback + legacy_load_failed の 2 件 warn
+    expect(warnSpy).toHaveBeenCalledTimes(2)
+    const first = JSON.parse(warnSpy.mock.calls[0]![0] as string)
+    const second = JSON.parse(warnSpy.mock.calls[1]![0] as string)
+    expect(first.event).toBe('global_config_pre_0015_fallback')
+    expect(first.requestId).toBe('req-abc-123')
+    expect(second.event).toBe('global_config_legacy_load_failed')
+    expect(second.requestId).toBe('req-abc-123')
     warnSpy.mockRestore()
   })
 
-  it('returns defaults when select fails with "does not exist" form', async () => {
+  it('triggers fallback for vix_-prefixed "not found" error and reaches legacy_load_failed when legacy also throws', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    const db = fakeDbThrowing('column vix_warning_size_scale does not exist')
+    const db = fakeDbAllThrowing('SQLITE_ERROR: vix_critical_threshold not found')
     const result = await loadGlobalConfig(db)
     expect(result).toEqual({ ...GLOBAL_CONFIG_DEFAULTS })
+    expect(warnSpy).toHaveBeenCalledTimes(2)
+    const first = JSON.parse(warnSpy.mock.calls[0]![0] as string)
+    expect(first.event).toBe('global_config_pre_0015_fallback')
+    expect(first.requestId).toBeNull()
+    warnSpy.mockRestore()
+  })
+
+  it('triggers fallback for "does not exist" form', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const db = fakeDbAllThrowing('column vix_warning_size_scale does not exist')
+    const result = await loadGlobalConfig(db)
+    expect(result).toEqual({ ...GLOBAL_CONFIG_DEFAULTS })
+    expect(warnSpy).toHaveBeenCalledTimes(2)
     warnSpy.mockRestore()
   })
 
   it('rethrows unrelated errors (fail-closed for non-schema issues)', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    const db = fakeDbThrowing('connection refused')
+    const db = fakeDbAllThrowing('connection refused')
     await expect(loadGlobalConfig(db)).rejects.toThrow(/connection refused/)
     expect(warnSpy).not.toHaveBeenCalled()
     warnSpy.mockRestore()
@@ -78,9 +189,40 @@ describe('loadGlobalConfig — pre-0015 fallback', () => {
    */
   it('rethrows non-schema errors that incidentally contain "vix_"', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    const db = fakeDbThrowing('connection refused while serving vix_pipeline_42')
+    const db = fakeDbAllThrowing('connection refused while serving vix_pipeline_42')
     await expect(loadGlobalConfig(db)).rejects.toThrow(/connection refused/)
     expect(warnSpy).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
+  it('returns full defaults when legacy fetch succeeds but row is absent', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    // legacy 配列が空 = row 未 seed のレア case
+    const db = {
+      select(columns?: unknown) {
+        const isLegacy = columns !== undefined
+        return {
+          from() {
+            return {
+              where() {
+                return {
+                  async limit() {
+                    if (isLegacy) return [] // empty
+                    throw new Error('no such column: vix_warning_threshold')
+                  },
+                }
+              },
+            }
+          },
+        }
+      },
+    } as unknown as Parameters<typeof loadGlobalConfig>[0]
+    const result = await loadGlobalConfig(db)
+    expect(result).toEqual({ ...GLOBAL_CONFIG_DEFAULTS })
+    // pre_0015_fallback の 1 件のみ (legacy fetch は成功し row なしなので legacy_load_failed は出ない)
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    const first = JSON.parse(warnSpy.mock.calls[0]![0] as string)
+    expect(first.event).toBe('global_config_pre_0015_fallback')
     warnSpy.mockRestore()
   })
 })

--- a/test/infrastructure/db/globalConfigRepo.test.ts
+++ b/test/infrastructure/db/globalConfigRepo.test.ts
@@ -226,3 +226,173 @@ describe('loadGlobalConfig — pre-0015 fallback', () => {
     warnSpy.mockRestore()
   })
 })
+
+/**
+ * 0015 migration は ALTER TABLE ADD COLUMN しか流していないため CHECK 制約は
+ * 未投入。table-rebuild migration で一括投入するまでの compensating control
+ * として `loadGlobalConfig` 内で application-level validation を行う:
+ *   - vixWarningThreshold / vixCriticalThreshold ∈ (0, 200]
+ *   - vixWarningThreshold <= vixCriticalThreshold
+ *   - vixWarningSizeScale ∈ [0, 1]
+ * 違反時は **fail-closed = defaults fallback** + warn ログ。
+ * CodeRabbit #216 6th round 対応。
+ */
+describe('loadGlobalConfig — VIX validation (CHECK 制約 補完)', () => {
+  /**
+   * full select (1st call) が `[row]` を返す (= post-0015 path)。VIX 列を含む
+   * 完全な row。validation の対象は最終 return 直前なので、ここから不正値を
+   * 挿入することで validateVixConfig の挙動を検証できる。
+   */
+  function fakeDbWithRow(row: Record<string, unknown>) {
+    return {
+      select(_columns?: unknown) {
+        return {
+          from() {
+            return {
+              where() {
+                return {
+                  async limit() {
+                    return [row]
+                  },
+                }
+              },
+            }
+          },
+        }
+      },
+    } as unknown as Parameters<typeof loadGlobalConfig>[0]
+  }
+
+  // post-0015 row 用の baseline。検証ケースごとに VIX 3 列を上書きする。
+  const baseRow = {
+    id: 'default',
+    dryRun: true,
+    tradingEnabled: false,
+    marketHoursCheck: false,
+    maxOrderNotional: 100,
+    maxOrderNotionalUsd: 2000,
+    maxOrderNotionalJpy: 100000,
+    totalCapitalUsd: null,
+    totalCapitalJpy: null,
+    maxPortfolioExposurePct: 0.6,
+    drawdownKillThreshold: -0.02,
+    staleQuoteMs: 900000,
+    gapRejectPct: 0.03,
+    spreadLimitPctUs: 0.0025,
+    spreadLimitPctJp: 0.006,
+    pullbackDefaultStopPct: -0.04,
+    pullbackDefaultTakeProfitPct: 0.07,
+    pullbackDefaultTimeStopDays: 10,
+    pullbackDefaultPullbackMax: -0.03,
+    pullbackDefaultPullbackMin: -0.06,
+    pullbackDefaultMinReturn50d: 0.08,
+    pullbackDefaultRequireAboveSma50: true,
+    pullbackDefaultKAtr: 2.0,
+    riskBasePerTradePct: 0.004,
+    riskDdHalfThreshold: -0.05,
+    riskDdHaltThreshold: -0.1,
+    bucketExposurePct: 0.3,
+  }
+
+  it('passes through valid VIX values without warning', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const db = fakeDbWithRow({
+      ...baseRow,
+      vixWarningThreshold: 22.5,
+      vixCriticalThreshold: 28.0,
+      vixWarningSizeScale: 0.4,
+    })
+    const result = await loadGlobalConfig(db, 'req-vix-ok')
+    expect(result.vixWarningThreshold).toBe(22.5)
+    expect(result.vixCriticalThreshold).toBe(28.0)
+    expect(result.vixWarningSizeScale).toBe(0.4)
+    expect(warnSpy).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
+  it('falls back to defaults when vixWarningThreshold = 0 (range violation)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const db = fakeDbWithRow({
+      ...baseRow,
+      vixWarningThreshold: 0,
+      vixCriticalThreshold: 30,
+      vixWarningSizeScale: 0.5,
+    })
+    const result = await loadGlobalConfig(db, 'req-vix-zero')
+    expect(result.vixWarningThreshold).toBe(GLOBAL_CONFIG_DEFAULTS.vixWarningThreshold)
+    expect(result.vixCriticalThreshold).toBe(GLOBAL_CONFIG_DEFAULTS.vixCriticalThreshold)
+    expect(result.vixWarningSizeScale).toBe(GLOBAL_CONFIG_DEFAULTS.vixWarningSizeScale)
+    // 他の non-VIX 列は row 値が保持されること
+    expect(result.tradingEnabled).toBe(false)
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    const logged = JSON.parse(warnSpy.mock.calls[0]![0] as string)
+    expect(logged.event).toBe('global_config_vix_validation_failed')
+    expect(logged.requestId).toBe('req-vix-zero')
+    expect(Array.isArray(logged.violations)).toBe(true)
+    expect(logged.violations.some((v: { field: string }) => v.field === 'vixWarningThreshold')).toBe(true)
+    warnSpy.mockRestore()
+  })
+
+  it('falls back when warning > critical (order violation)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const db = fakeDbWithRow({
+      ...baseRow,
+      vixWarningThreshold: 30,
+      vixCriticalThreshold: 25,
+      vixWarningSizeScale: 0.5,
+    })
+    const result = await loadGlobalConfig(db, 'req-vix-order')
+    expect(result.vixWarningThreshold).toBe(GLOBAL_CONFIG_DEFAULTS.vixWarningThreshold)
+    expect(result.vixCriticalThreshold).toBe(GLOBAL_CONFIG_DEFAULTS.vixCriticalThreshold)
+    expect(result.vixWarningSizeScale).toBe(GLOBAL_CONFIG_DEFAULTS.vixWarningSizeScale)
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    const logged = JSON.parse(warnSpy.mock.calls[0]![0] as string)
+    expect(logged.event).toBe('global_config_vix_validation_failed')
+    expect(
+      logged.violations.some((v: { field: string }) =>
+        v.field === 'vixWarningThreshold/vixCriticalThreshold',
+      ),
+    ).toBe(true)
+    warnSpy.mockRestore()
+  })
+
+  it('falls back when vixWarningSizeScale = 1.5 (range violation)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const db = fakeDbWithRow({
+      ...baseRow,
+      vixWarningThreshold: 25,
+      vixCriticalThreshold: 30,
+      vixWarningSizeScale: 1.5,
+    })
+    const result = await loadGlobalConfig(db, 'req-vix-scale')
+    expect(result.vixWarningSizeScale).toBe(GLOBAL_CONFIG_DEFAULTS.vixWarningSizeScale)
+    // 単独違反でも他 2 項目も defaults に倒される (compensating control の安全側)
+    expect(result.vixWarningThreshold).toBe(GLOBAL_CONFIG_DEFAULTS.vixWarningThreshold)
+    expect(result.vixCriticalThreshold).toBe(GLOBAL_CONFIG_DEFAULTS.vixCriticalThreshold)
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    const logged = JSON.parse(warnSpy.mock.calls[0]![0] as string)
+    expect(logged.event).toBe('global_config_vix_validation_failed')
+    expect(
+      logged.violations.some((v: { field: string }) => v.field === 'vixWarningSizeScale'),
+    ).toBe(true)
+    warnSpy.mockRestore()
+  })
+
+  it('falls back when vixCriticalThreshold > 200 (range violation, upper bound)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const db = fakeDbWithRow({
+      ...baseRow,
+      vixWarningThreshold: 25,
+      vixCriticalThreshold: 250,
+      vixWarningSizeScale: 0.5,
+    })
+    const result = await loadGlobalConfig(db, 'req-vix-upper')
+    expect(result.vixCriticalThreshold).toBe(GLOBAL_CONFIG_DEFAULTS.vixCriticalThreshold)
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    const logged = JSON.parse(warnSpy.mock.calls[0]![0] as string)
+    expect(
+      logged.violations.some((v: { field: string }) => v.field === 'vixCriticalThreshold'),
+    ).toBe(true)
+    warnSpy.mockRestore()
+  })
+})

--- a/test/infrastructure/db/globalConfigRepo.test.ts
+++ b/test/infrastructure/db/globalConfigRepo.test.ts
@@ -33,18 +33,30 @@ describe('loadGlobalConfig — pre-0015 fallback', () => {
   it('returns defaults when select fails with "no such column" error', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const db = fakeDbThrowing('no such column: vix_warning_threshold')
-    const result = await loadGlobalConfig(db)
+    const result = await loadGlobalConfig(db, 'req-abc-123')
     expect(result).toEqual({ ...GLOBAL_CONFIG_DEFAULTS })
     expect(warnSpy).toHaveBeenCalledTimes(1)
     const logged = JSON.parse(warnSpy.mock.calls[0]![0] as string)
     expect(logged.event).toBe('global_config_pre_0015_fallback')
     expect(logged.message).toMatch(/no such column/)
+    expect(logged.requestId).toBe('req-abc-123')
     warnSpy.mockRestore()
   })
 
   it('returns defaults when select fails with vix_-prefixed column error', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const db = fakeDbThrowing('SQLITE_ERROR: vix_critical_threshold not found')
+    const result = await loadGlobalConfig(db)
+    expect(result).toEqual({ ...GLOBAL_CONFIG_DEFAULTS })
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    const logged = JSON.parse(warnSpy.mock.calls[0]![0] as string)
+    expect(logged.requestId).toBeNull()
+    warnSpy.mockRestore()
+  })
+
+  it('returns defaults when select fails with "does not exist" form', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const db = fakeDbThrowing('column vix_warning_size_scale does not exist')
     const result = await loadGlobalConfig(db)
     expect(result).toEqual({ ...GLOBAL_CONFIG_DEFAULTS })
     warnSpy.mockRestore()
@@ -54,6 +66,21 @@ describe('loadGlobalConfig — pre-0015 fallback', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const db = fakeDbThrowing('connection refused')
     await expect(loadGlobalConfig(db)).rejects.toThrow(/connection refused/)
+    expect(warnSpy).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
+  /**
+   * Regression guard: the previous regex `/no such column|vix_/i` happily
+   * matched any error string that contained the substring `vix_` (e.g. a
+   * connection error mentioning a request id like `vix_pipeline_xxx`),
+   * fail-opening to defaults. The tightened regex must NOT match here.
+   */
+  it('rethrows non-schema errors that incidentally contain "vix_"', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const db = fakeDbThrowing('connection refused while serving vix_pipeline_42')
+    await expect(loadGlobalConfig(db)).rejects.toThrow(/connection refused/)
+    expect(warnSpy).not.toHaveBeenCalled()
     warnSpy.mockRestore()
   })
 })

--- a/test/infrastructure/db/globalConfigRepo.test.ts
+++ b/test/infrastructure/db/globalConfigRepo.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  GLOBAL_CONFIG_DEFAULTS,
+  loadGlobalConfig,
+} from '../../../src/infrastructure/db/globalConfigRepo'
+
+/**
+ * pre-0015 (= migration 適用前 / 適用 race) D1 では VIX 列が schema に無く、
+ * `select` 自体が `Error('no such column: vix_warning_threshold')` で失敗する。
+ * その場合に defaults へ fallback して cron 全停止を避けることを確認する。
+ */
+describe('loadGlobalConfig — pre-0015 fallback', () => {
+  function fakeDbThrowing(message: string) {
+    return {
+      select() {
+        return {
+          from() {
+            return {
+              where() {
+                return {
+                  async limit() {
+                    throw new Error(message)
+                  },
+                }
+              },
+            }
+          },
+        }
+      },
+    } as unknown as Parameters<typeof loadGlobalConfig>[0]
+  }
+
+  it('returns defaults when select fails with "no such column" error', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const db = fakeDbThrowing('no such column: vix_warning_threshold')
+    const result = await loadGlobalConfig(db)
+    expect(result).toEqual({ ...GLOBAL_CONFIG_DEFAULTS })
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    const logged = JSON.parse(warnSpy.mock.calls[0]![0] as string)
+    expect(logged.event).toBe('global_config_pre_0015_fallback')
+    expect(logged.message).toMatch(/no such column/)
+    warnSpy.mockRestore()
+  })
+
+  it('returns defaults when select fails with vix_-prefixed column error', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const db = fakeDbThrowing('SQLITE_ERROR: vix_critical_threshold not found')
+    const result = await loadGlobalConfig(db)
+    expect(result).toEqual({ ...GLOBAL_CONFIG_DEFAULTS })
+    warnSpy.mockRestore()
+  })
+
+  it('rethrows unrelated errors (fail-closed for non-schema issues)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const db = fakeDbThrowing('connection refused')
+    await expect(loadGlobalConfig(db)).rejects.toThrow(/connection refused/)
+    warnSpy.mockRestore()
+  })
+})

--- a/test/infrastructure/notification/vixRegimeChange.test.ts
+++ b/test/infrastructure/notification/vixRegimeChange.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
   classifyVixRegimeSeverity,
   detectAndNotifyVixRegimeChange,
+  loadVixRegimeSnapshot,
+  persistVixRegimeSnapshot,
 } from '../../../src/infrastructure/notification/vixRegimeChange'
 import type {
   Notifier,
@@ -60,20 +62,28 @@ function fakeDb(initialRegime: string | null): {
       : null
   const inserts: Array<{ key: string; value: string }> = []
 
-  // drizzle は env.DB.prepare(sql).bind(args).all() / .run() / .first() の流れで叩く。
-  // ここは最低限「key='vix_regime' を select / delete / insert する」だけ動かす
-  // テスト用 fake。詳細は configStateChange と同様の構造。
+  // drizzle は env.DB.prepare(sql).bind(args).all() / .run() / .first() / .raw()
+  // の流れで叩く。`select({ value: ... })` の field 指定形式は drizzle 内部で
+  // `.raw()` 経由 (= 配列で返す) になるため raw() も実装する。`select / delete /
+  // insert` だけ動かす最低限の fake。詳細は configStateChange と同様の構造。
   const prepare = (sql: string): unknown => {
     return {
       bind(...args: unknown[]) {
         return {
           async all() {
-            // SELECT path
             if (sql.includes('select')) {
               if (stored) return { results: [stored] }
               return { results: [] }
             }
             return { results: [] }
+          },
+          async raw() {
+            // drizzle `select({ value: x })` は raw 配列を期待する。
+            if (sql.includes('select')) {
+              if (stored) return [[stored.value]]
+              return []
+            }
+            return []
           },
           async run() {
             if (sql.includes('delete')) {
@@ -159,3 +169,116 @@ describe('detectAndNotifyVixRegimeChange — dedup / first-run', () => {
 // `db: undefined` 経路のみを unit test でカバー。
 // 「同 regime 連続では emit しない」「DB に書く / 読む」結合は
 // configStateChange と同じ pattern で動くことを既存実装で担保している。
+
+/**
+ * `prepare` を呼ぶと throw する D1 fake。drizzle `select` / `delete` /
+ * `insert` のいずれも prepare phase で死ぬ。load/persist 失敗時の warn ログに
+ * requestId が含まれることだけを確認する。
+ */
+function brokenDb(): D1Database {
+  return {
+    prepare(_sql: string) {
+      throw new Error('boom: db unavailable')
+    },
+    async batch() {
+      return []
+    },
+  } as unknown as D1Database
+}
+
+describe('loadVixRegimeSnapshot — failure logging', () => {
+  it('logs warn with requestId when snapshot load throws', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const result = await loadVixRegimeSnapshot(brokenDb(), 'req-abc-123')
+    expect(result).toBeNull()
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    const logged = JSON.parse(warnSpy.mock.calls[0]![0] as string)
+    expect(logged.event).toBe('vix_regime_snapshot_load_failed')
+    expect(logged.requestId).toBe('req-abc-123')
+    expect(logged.message).toMatch(/boom/)
+    warnSpy.mockRestore()
+  })
+
+  it('logs requestId=null when not provided', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const result = await loadVixRegimeSnapshot(brokenDb())
+    expect(result).toBeNull()
+    const logged = JSON.parse(warnSpy.mock.calls[0]![0] as string)
+    expect(logged.requestId).toBeNull()
+    warnSpy.mockRestore()
+  })
+})
+
+describe('persistVixRegimeSnapshot — failure logging', () => {
+  it('logs warn with requestId when persist throws (fail-silent)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    await persistVixRegimeSnapshot(brokenDb(), 'warning', 'req-xyz-456', new Date())
+    expect(warnSpy).toHaveBeenCalled()
+    const logged = JSON.parse(warnSpy.mock.calls[0]![0] as string)
+    expect(logged.event).toBe('vix_regime_snapshot_persist_failed')
+    expect(logged.requestId).toBe('req-xyz-456')
+    warnSpy.mockRestore()
+  })
+})
+
+describe('detectAndNotifyVixRegimeChange — sync throw from notify', () => {
+  it('still persists snapshot when notify() throws synchronously', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { db, inserts } = fakeDb('normal')
+    // 同期 throw する notifier。`.catch(...)` では拾えない経路を再現する。
+    const throwingNotifier: Notifier = {
+      notify(_event) {
+        throw new Error('boom: sync notify failure')
+      },
+    }
+    const result = await detectAndNotifyVixRegimeChange({
+      db,
+      notifier: throwingNotifier,
+      current: decision('warning', 27.3),
+      requestId: 'req-sync-throw',
+    })
+    expect(result.from).toBe('normal')
+    expect(result.to).toBe('warning')
+    expect(result.emitted).toBe(true)
+    // notify が同期 throw しても snapshot は upsert されているはず。
+    expect(inserts).toHaveLength(1)
+    expect(inserts[0]!.key).toBe('vix_regime')
+    expect(inserts[0]!.value).toBe(JSON.stringify('warning'))
+    // warn ログに requestId が乗っていること。
+    const failedLogs = warnSpy.mock.calls
+      .map((call) => {
+        try {
+          return JSON.parse(call[0] as string) as Record<string, unknown>
+        } catch {
+          return null
+        }
+      })
+      .filter((entry): entry is Record<string, unknown> =>
+        entry !== null && entry.event === 'vix_regime_change_notify_failed',
+      )
+    expect(failedLogs.length).toBeGreaterThanOrEqual(1)
+    expect(failedLogs[0]!.requestId).toBe('req-sync-throw')
+    warnSpy.mockRestore()
+  })
+
+  it('still persists snapshot when notify() rejects asynchronously', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { db, inserts } = fakeDb('normal')
+    const rejectingNotifier: Notifier = {
+      async notify(_event) {
+        throw new Error('boom: async notify rejection')
+      },
+    }
+    const result = await detectAndNotifyVixRegimeChange({
+      db,
+      notifier: rejectingNotifier,
+      current: decision('critical', 32.1),
+      requestId: 'req-async-reject',
+    })
+    expect(result.emitted).toBe(true)
+    // async rejection でも snapshot は到達する (これは既存挙動の確認)。
+    expect(inserts).toHaveLength(1)
+    expect(inserts[0]!.value).toBe(JSON.stringify('critical'))
+    warnSpy.mockRestore()
+  })
+})

--- a/test/infrastructure/notification/vixRegimeChange.test.ts
+++ b/test/infrastructure/notification/vixRegimeChange.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest'
+import {
+  classifyVixRegimeSeverity,
+  detectAndNotifyVixRegimeChange,
+} from '../../../src/infrastructure/notification/vixRegimeChange'
+import type {
+  Notifier,
+  NotificationEvent,
+} from '../../../src/infrastructure/notification/Notifier'
+import type { VixRegimeFilterDecision } from '../../../src/trading/risk/vixRegimeFilter'
+
+/**
+ * Tests for VIX regime change detection (#196 3/3)。
+ *
+ * 観点:
+ *   - 同 regime 連続では通知しない (dedup)
+ *   - 初回 (snapshot null) では通知しない (false alert 防止)
+ *   - normal → warning は warning severity、normal → critical は critical
+ *   - critical → normal / critical → warning は info (緩和方向)
+ *   - DB 未注入時は noop
+ */
+
+describe('classifyVixRegimeSeverity', () => {
+  it('first observation (from=null) is info', () => {
+    expect(classifyVixRegimeSeverity(null, 'warning')).toBe('info')
+    expect(classifyVixRegimeSeverity(null, 'critical')).toBe('info')
+    expect(classifyVixRegimeSeverity(null, 'normal')).toBe('info')
+  })
+  it('normal → warning is warning', () => {
+    expect(classifyVixRegimeSeverity('normal', 'warning')).toBe('warning')
+  })
+  it('normal → critical is critical', () => {
+    expect(classifyVixRegimeSeverity('normal', 'critical')).toBe('critical')
+  })
+  it('warning → critical is critical (escalation)', () => {
+    expect(classifyVixRegimeSeverity('warning', 'critical')).toBe('critical')
+  })
+  it('warning → normal is info (relief)', () => {
+    expect(classifyVixRegimeSeverity('warning', 'normal')).toBe('info')
+  })
+  it('critical → warning is info', () => {
+    expect(classifyVixRegimeSeverity('critical', 'warning')).toBe('info')
+  })
+  it('critical → normal is info', () => {
+    expect(classifyVixRegimeSeverity('critical', 'normal')).toBe('info')
+  })
+})
+
+/**
+ * Fake D1 — drizzle が呼ぶ select / delete / insert を素朴に動かす最小限の
+ * spy。`config_state_snapshot` 1 行のみ扱う。
+ */
+function fakeDb(initialRegime: string | null): {
+  db: D1Database
+  inserts: Array<{ key: string; value: string }>
+} {
+  let stored: { key: string; value: string } | null =
+    initialRegime !== null
+      ? { key: 'vix_regime', value: JSON.stringify(initialRegime) }
+      : null
+  const inserts: Array<{ key: string; value: string }> = []
+
+  // drizzle は env.DB.prepare(sql).bind(args).all() / .run() / .first() の流れで叩く。
+  // ここは最低限「key='vix_regime' を select / delete / insert する」だけ動かす
+  // テスト用 fake。詳細は configStateChange と同様の構造。
+  const prepare = (sql: string): unknown => {
+    return {
+      bind(...args: unknown[]) {
+        return {
+          async all() {
+            // SELECT path
+            if (sql.includes('select')) {
+              if (stored) return { results: [stored] }
+              return { results: [] }
+            }
+            return { results: [] }
+          },
+          async run() {
+            if (sql.includes('delete')) {
+              stored = null
+              return { meta: { changes: 1 } }
+            }
+            if (sql.includes('insert')) {
+              const key = String(args[0])
+              const value = String(args[1])
+              stored = { key, value }
+              inserts.push({ key, value })
+              return { meta: { changes: 1 } }
+            }
+            return { meta: { changes: 0 } }
+          },
+          async first() {
+            return stored
+          },
+        }
+      },
+    }
+  }
+
+  const db = {
+    prepare,
+    async batch(_stmts: unknown[]) {
+      return []
+    },
+  } as unknown as D1Database
+  return { db, inserts }
+}
+
+function makeNotifier(): { notifier: Notifier; calls: NotificationEvent[] } {
+  const calls: NotificationEvent[] = []
+  return {
+    notifier: {
+      async notify(event) {
+        calls.push(event)
+      },
+    },
+    calls,
+  }
+}
+
+function decision(
+  regime: 'normal' | 'warning' | 'critical',
+  vix: number | null = null,
+): VixRegimeFilterDecision {
+  return {
+    regime,
+    sizeScale: regime === 'critical' ? 0 : regime === 'warning' ? 0.5 : 1.0,
+    reason:
+      regime === 'critical'
+        ? `vix_critical: ${vix ?? '?'} (block)`
+        : regime === 'warning'
+          ? `vix_warning: ${vix ?? '?'} (size x0.5)`
+          : `vix_normal: ${vix ?? '?'}`,
+    vix,
+  }
+}
+
+describe('detectAndNotifyVixRegimeChange — dedup / first-run', () => {
+  it('does not emit on first observation (no previous snapshot)', async () => {
+    // detectAndNotifyVixRegimeChange は drizzle 経由で D1 を叩く。drizzle の
+    // 内部 SQL 文字列に依存した fake は脆いので、ここでは「DB 未注入時の noop」
+    // 経路だけテストする。完全な D1 経由 path は wrangler dev 越しの結合 test に
+    // 委ねる (POC scope の trade-off)。
+    const { notifier, calls } = makeNotifier()
+    const result = await detectAndNotifyVixRegimeChange({
+      db: undefined,
+      notifier,
+      current: decision('warning', 27.3),
+    })
+    expect(calls).toHaveLength(0)
+    expect(result.emitted).toBe(false)
+    expect(result.from).toBeNull()
+    expect(result.to).toBe('warning')
+  })
+})
+
+// 注: drizzle 経由の D1 read/write を fake する完全 path は drizzle 内部 SQL
+// 形式に依存して脆いため、severity 判定 (`classifyVixRegimeSeverity`) と
+// `db: undefined` 経路のみを unit test でカバー。
+// 「同 regime 連続では emit しない」「DB に書く / 読む」結合は
+// configStateChange と同じ pattern で動くことを既存実装で担保している。

--- a/test/infrastructure/notification/vixRegimeChange.test.ts
+++ b/test/infrastructure/notification/vixRegimeChange.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
+  atomicallyUpdateVixRegimeSnapshot,
   classifyVixRegimeSeverity,
   detectAndNotifyVixRegimeChange,
   loadVixRegimeSnapshot,
@@ -65,8 +66,11 @@ function fakeDb(initialRegime: string | null): {
   // drizzle は env.DB.prepare(sql).bind(args).all() / .run() / .first() / .raw()
   // の流れで叩く。`select({ value: ... })` の field 指定形式は drizzle 内部で
   // `.raw()` 経由 (= 配列で返す) になるため raw() も実装する。`select / delete /
-  // insert` だけ動かす最低限の fake。詳細は configStateChange と同様の構造。
-  const prepare = (sql: string): unknown => {
+  // insert / update` を動かす最低限の fake。詳細は configStateChange と同様の構造。
+  // 大文字 SQL (atomicallyUpdateVixRegimeSnapshot の raw prepare) と小文字 SQL
+  // (drizzle 経由) の両方に対応するため lowercase 化して比較する。
+  const prepare = (sqlOriginal: string): unknown => {
+    const sql = sqlOriginal.toLowerCase()
     return {
       bind(...args: unknown[]) {
         return {
@@ -86,6 +90,32 @@ function fakeDb(initialRegime: string | null): {
             return []
           },
           async run() {
+            if (sql.startsWith('insert or ignore')) {
+              // CAS 用 insert or ignore: 既に行があれば no-op (changes=0)。
+              if (stored) return { meta: { changes: 0 } }
+              const key = String(args[0])
+              const value = String(args[1])
+              stored = { key, value }
+              inserts.push({ key, value })
+              return { meta: { changes: 1 } }
+            }
+            if (sql.includes('update')) {
+              // CAS update: WHERE key=? AND value=? に一致したら書き換え。
+              // raw helper のバインド順は (newValue, snapshotAt, requestId, key, oldValue)。
+              const newValue = String(args[0])
+              const expectedKey = String(args[3])
+              const expectedOldValue = String(args[4])
+              if (
+                stored &&
+                stored.key === expectedKey &&
+                stored.value === expectedOldValue
+              ) {
+                stored = { key: expectedKey, value: newValue }
+                inserts.push({ key: expectedKey, value: newValue })
+                return { meta: { changes: 1 } }
+              }
+              return { meta: { changes: 0 } }
+            }
             if (sql.includes('delete')) {
               stored = null
               return { meta: { changes: 1 } }
@@ -100,6 +130,10 @@ function fakeDb(initialRegime: string | null): {
             return { meta: { changes: 0 } }
           },
           async first() {
+            // raw SELECT value FROM ... LIMIT 1 経由 — stored の {value} を返す。
+            if (sql.includes('select')) {
+              return stored
+            }
             return stored
           },
         }
@@ -280,5 +314,98 @@ describe('detectAndNotifyVixRegimeChange — sync throw from notify', () => {
     expect(inserts).toHaveLength(1)
     expect(inserts[0]!.value).toBe(JSON.stringify('critical'))
     warnSpy.mockRestore()
+  })
+})
+
+/**
+ * `atomicallyUpdateVixRegimeSnapshot` の race-safe 性 (CodeRabbit #216 4th)。
+ *
+ * 並行 cron で同 next regime を渡す 2 caller が居た場合、CAS 経由で必ず
+ * 片方だけが `updated=true` になり、もう片方は `updated=false`。これを使って
+ * `detectAndNotifyVixRegimeChange` 側で重複通知を防ぐ。
+ */
+describe('atomicallyUpdateVixRegimeSnapshot — CAS race safety', () => {
+  it('returns updated=false when the regime did not change (no-op)', async () => {
+    const { db, inserts } = fakeDb('warning')
+    const result = await atomicallyUpdateVixRegimeSnapshot(
+      db,
+      'warning',
+      new Date('2026-04-25T00:00:00.000Z'),
+      'req-noop',
+    )
+    expect(result.previous).toBe('warning')
+    expect(result.updated).toBe(false)
+    // CAS 起動せず、既存値も書き換えない。
+    expect(inserts).toHaveLength(0)
+  })
+
+  it('returns updated=true with previous=null on first observation', async () => {
+    const { db, inserts } = fakeDb(null)
+    const result = await atomicallyUpdateVixRegimeSnapshot(
+      db,
+      'warning',
+      new Date('2026-04-25T00:00:00.000Z'),
+      'req-first',
+    )
+    expect(result.previous).toBeNull()
+    expect(result.updated).toBe(true)
+    // INSERT OR IGNORE 経由で 1 件 insert される。
+    expect(inserts).toHaveLength(1)
+    expect(inserts[0]!.value).toBe(JSON.stringify('warning'))
+  })
+
+  it('only one of two parallel callers wins CAS for the same next regime', async () => {
+    // 2 caller が並行で normal → critical を書きに来る race を再現する。
+    // shared fakeDb で stored を共有し、両 promise を Promise.all で起動する。
+    const { db, inserts } = fakeDb('normal')
+    const [a, b] = await Promise.all([
+      atomicallyUpdateVixRegimeSnapshot(db, 'critical', new Date(), 'req-a'),
+      atomicallyUpdateVixRegimeSnapshot(db, 'critical', new Date(), 'req-b'),
+    ])
+    // どちらの previous も normal ('critical' に書き換わる前 / 書き換わった後の
+    // 再 SELECT のいずれか — どちらも 'normal' を見る/読む)。
+    // 重要なのは: updated=true は ちょうど 1 つ。
+    const updates = [a.updated, b.updated]
+    expect(updates.filter((u) => u === true)).toHaveLength(1)
+    expect(updates.filter((u) => u === false)).toHaveLength(1)
+    // 失敗側の previous は最新値 ('critical') を読み戻す。
+    const loser = a.updated ? b : a
+    const winner = a.updated ? a : b
+    expect(winner.previous).toBe('normal')
+    expect(loser.previous).toBe('critical')
+    // CAS 成功は 1 回だけ insert/update される (insert log にも 1 件)。
+    expect(inserts).toHaveLength(1)
+    expect(inserts[0]!.value).toBe(JSON.stringify('critical'))
+  })
+
+  it('detectAndNotifyVixRegimeChange dedups parallel callers via CAS', async () => {
+    // race-safe な dedup を end-to-end で確認: 2 caller が同 next regime で
+    // detectAndNotify を呼んでも、notifier には 1 回しか届かない。
+    const { db } = fakeDb('normal')
+    const { notifier, calls } = makeNotifier()
+    const [a, b] = await Promise.all([
+      detectAndNotifyVixRegimeChange({
+        db,
+        notifier,
+        current: decision('critical', 35.1),
+        requestId: 'req-a',
+      }),
+      detectAndNotifyVixRegimeChange({
+        db,
+        notifier,
+        current: decision('critical', 35.1),
+        requestId: 'req-b',
+      }),
+    ])
+    const emitted = [a.emitted, b.emitted]
+    expect(emitted.filter((e) => e === true)).toHaveLength(1)
+    expect(emitted.filter((e) => e === false)).toHaveLength(1)
+    // notifier 呼び出しはちょうど 1 回。
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.type).toBe('STATE_CHANGE')
+    if (calls[0]!.type === 'STATE_CHANGE') {
+      expect(calls[0]!.from).toBe('normal')
+      expect(calls[0]!.to).toBe('critical')
+    }
   })
 })

--- a/test/infrastructure/notification/vixRegimeChange.test.ts
+++ b/test/infrastructure/notification/vixRegimeChange.test.ts
@@ -52,13 +52,21 @@ describe('classifyVixRegimeSeverity', () => {
 /**
  * Fake D1 — drizzle が呼ぶ select / delete / insert を素朴に動かす最小限の
  * spy。`config_state_snapshot` 1 行のみ扱う。
+ *
+ * `corruptInitial: true` を渡すと「行は存在するが value が parse 不能」状態を
+ * 注入する (snapshot 破損 self-heal の test 用 — CodeRabbit #216 5th)。
  */
-function fakeDb(initialRegime: string | null): {
+function fakeDb(
+  initialRegime: string | null,
+  options: { corruptInitial?: boolean } = {},
+): {
   db: D1Database
   inserts: Array<{ key: string; value: string }>
+  getStored: () => { key: string; value: string } | null
 } {
-  let stored: { key: string; value: string } | null =
-    initialRegime !== null
+  let stored: { key: string; value: string } | null = options.corruptInitial
+    ? { key: 'vix_regime', value: '@@not-json@@' }
+    : initialRegime !== null
       ? { key: 'vix_regime', value: JSON.stringify(initialRegime) }
       : null
   const inserts: Array<{ key: string; value: string }> = []
@@ -100,16 +108,28 @@ function fakeDb(initialRegime: string | null): {
               return { meta: { changes: 1 } }
             }
             if (sql.includes('update')) {
-              // CAS update: WHERE key=? AND value=? に一致したら書き換え。
-              // raw helper のバインド順は (newValue, snapshotAt, requestId, key, oldValue)。
+              // 2 種類の UPDATE を処理する:
+              //   (a) CAS update: WHERE key=? AND value=? — bind 5 個 (CodeRabbit #216 4th)
+              //   (b) self-heal update: WHERE key=? のみ — bind 4 個 (CodeRabbit #216 5th)
+              // bind 数で分岐する (どちらも先頭は (newValue, snapshotAt, requestId, key, ...))。
               const newValue = String(args[0])
               const expectedKey = String(args[3])
-              const expectedOldValue = String(args[4])
-              if (
-                stored &&
-                stored.key === expectedKey &&
-                stored.value === expectedOldValue
-              ) {
+              if (args.length >= 5) {
+                // CAS path
+                const expectedOldValue = String(args[4])
+                if (
+                  stored &&
+                  stored.key === expectedKey &&
+                  stored.value === expectedOldValue
+                ) {
+                  stored = { key: expectedKey, value: newValue }
+                  inserts.push({ key: expectedKey, value: newValue })
+                  return { meta: { changes: 1 } }
+                }
+                return { meta: { changes: 0 } }
+              }
+              // self-heal path: 行が存在するなら問答無用で書き換える。
+              if (stored && stored.key === expectedKey) {
                 stored = { key: expectedKey, value: newValue }
                 inserts.push({ key: expectedKey, value: newValue })
                 return { meta: { changes: 1 } }
@@ -147,7 +167,7 @@ function fakeDb(initialRegime: string | null): {
       return []
     },
   } as unknown as D1Database
-  return { db, inserts }
+  return { db, inserts, getStored: () => stored }
 }
 
 function makeNotifier(): { notifier: Notifier; calls: NotificationEvent[] } {
@@ -376,6 +396,55 @@ describe('atomicallyUpdateVixRegimeSnapshot — CAS race safety', () => {
     // CAS 成功は 1 回だけ insert/update される (insert log にも 1 件)。
     expect(inserts).toHaveLength(1)
     expect(inserts[0]!.value).toBe(JSON.stringify('critical'))
+  })
+
+  it('self-heals a corrupted snapshot row by overwriting with next (no notify) (CodeRabbit #216 5th)', async () => {
+    // 行は存在するが value が parse 不能 (= readCurrentRegime → null)。
+    // INSERT OR IGNORE は既存行に当たって changes=0、その後の self-heal UPDATE で
+    // next が書き込まれる。previous=null を返すので caller 側で notify は skip される。
+    const { db, inserts, getStored } = fakeDb(null, { corruptInitial: true })
+    const result = await atomicallyUpdateVixRegimeSnapshot(
+      db,
+      'warning',
+      new Date('2026-04-25T00:00:00.000Z'),
+      'req-self-heal',
+    )
+    expect(result.previous).toBeNull()
+    expect(result.updated).toBe(true)
+    // self-heal UPDATE で書き込まれている。
+    expect(inserts).toHaveLength(1)
+    expect(inserts[0]!.value).toBe(JSON.stringify('warning'))
+    expect(getStored()?.value).toBe(JSON.stringify('warning'))
+  })
+
+  it('after self-heal, the next tick performs a normal compare-and-update (CodeRabbit #216 5th)', async () => {
+    // 1 回目: 壊れた snapshot を warning で self-heal (previous=null, updated=true)。
+    // 2 回目: 正常な warning → critical の compare-and-update が動く
+    //         (previous=warning, updated=true)。
+    const { db, inserts, getStored } = fakeDb(null, { corruptInitial: true })
+    const first = await atomicallyUpdateVixRegimeSnapshot(
+      db,
+      'warning',
+      new Date('2026-04-25T00:00:00.000Z'),
+      'req-heal',
+    )
+    expect(first.previous).toBeNull()
+    expect(first.updated).toBe(true)
+    expect(getStored()?.value).toBe(JSON.stringify('warning'))
+
+    const second = await atomicallyUpdateVixRegimeSnapshot(
+      db,
+      'critical',
+      new Date('2026-04-25T00:01:00.000Z'),
+      'req-next',
+    )
+    expect(second.previous).toBe('warning')
+    expect(second.updated).toBe(true)
+    expect(getStored()?.value).toBe(JSON.stringify('critical'))
+    // self-heal + 通常 CAS で 2 件分の書き込みが log されている。
+    expect(inserts).toHaveLength(2)
+    expect(inserts[0]!.value).toBe(JSON.stringify('warning'))
+    expect(inserts[1]!.value).toBe(JSON.stringify('critical'))
   })
 
   it('detectAndNotifyVixRegimeChange dedups parallel callers via CAS', async () => {

--- a/test/trading/risk/vixRegimeFilter.test.ts
+++ b/test/trading/risk/vixRegimeFilter.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_VIX_REGIME_CONFIG,
+  evaluateVixRegime,
+  type VixRegimeFilterConfig,
+} from '../../../src/trading/risk/vixRegimeFilter'
+
+/**
+ * Tests for the VIX regime filter (#196 3/3)。
+ *
+ * 観点:
+ *   - 4 ケースの境界 (normal / warning / critical / unavailable)
+ *   - 閾値ぴったりは normal 側に倒す (`>` で warning 判定なので等値は normal)
+ *   - 取得失敗 (vix=null / NaN / 0 / 負値) は fail-open で normal fallback
+ *   - 壊れた config (NaN / 順序逆 / scale 範囲外) は default に倒す (defensive)
+ *   - reason 文字列は localizeReason / dashboard の grep で識別可能な canonical 形式
+ */
+
+const baseConfig: VixRegimeFilterConfig = { ...DEFAULT_VIX_REGIME_CONFIG }
+
+describe('evaluateVixRegime — happy paths', () => {
+  it('returns normal for VIX well below the warning threshold', () => {
+    const decision = evaluateVixRegime(18.5, baseConfig)
+    expect(decision.regime).toBe('normal')
+    expect(decision.sizeScale).toBe(1.0)
+    expect(decision.vix).toBe(18.5)
+    expect(decision.reason).toBe('vix_normal: 18.50')
+  })
+
+  it('returns normal exactly at the warning threshold (boundary uses strict >)', () => {
+    // VIX === warningThreshold は normal 側に残す (`vix > warning` で判定)。
+    const decision = evaluateVixRegime(25.0, baseConfig)
+    expect(decision.regime).toBe('normal')
+    expect(decision.sizeScale).toBe(1.0)
+  })
+
+  it('returns warning between warning (excl.) and critical (incl.) thresholds', () => {
+    const decision = evaluateVixRegime(27.3, baseConfig)
+    expect(decision.regime).toBe('warning')
+    expect(decision.sizeScale).toBe(0.5)
+    expect(decision.reason).toBe('vix_warning: 27.30 (size x0.5)')
+    expect(decision.vix).toBe(27.3)
+  })
+
+  it('returns warning at the critical boundary (=== critical → still warning)', () => {
+    // VIX === criticalThreshold は warning 側 (`vix > critical` が false)。
+    const decision = evaluateVixRegime(30.0, baseConfig)
+    expect(decision.regime).toBe('warning')
+    expect(decision.sizeScale).toBe(0.5)
+  })
+
+  it('returns critical when VIX exceeds the critical threshold', () => {
+    const decision = evaluateVixRegime(35.1, baseConfig)
+    expect(decision.regime).toBe('critical')
+    expect(decision.sizeScale).toBe(0)
+    expect(decision.reason).toBe('vix_critical: 35.10 (block)')
+    expect(decision.vix).toBe(35.1)
+  })
+})
+
+describe('evaluateVixRegime — fail-open (unavailable)', () => {
+  it('falls back to normal when vix is null', () => {
+    const decision = evaluateVixRegime(null, baseConfig)
+    expect(decision.regime).toBe('normal')
+    expect(decision.sizeScale).toBe(1.0)
+    expect(decision.reason).toBe('vix_unavailable_fallback_normal')
+    expect(decision.vix).toBeNull()
+  })
+
+  it('falls back to normal when vix is NaN', () => {
+    const decision = evaluateVixRegime(Number.NaN, baseConfig)
+    expect(decision.regime).toBe('normal')
+    expect(decision.sizeScale).toBe(1.0)
+    expect(decision.reason).toBe('vix_unavailable_fallback_normal')
+    expect(decision.vix).toBeNull()
+  })
+
+  it('falls back to normal when vix is 0 or negative (data corruption)', () => {
+    expect(evaluateVixRegime(0, baseConfig).regime).toBe('normal')
+    expect(evaluateVixRegime(-5, baseConfig).regime).toBe('normal')
+  })
+
+  it('falls back to normal when vix is Infinity', () => {
+    const decision = evaluateVixRegime(Number.POSITIVE_INFINITY, baseConfig)
+    expect(decision.regime).toBe('normal')
+    expect(decision.reason).toBe('vix_unavailable_fallback_normal')
+  })
+})
+
+describe('evaluateVixRegime — defensive config sanitize', () => {
+  it('clamps invalid warningSizeScale to default (0.5)', () => {
+    const decision = evaluateVixRegime(27.3, {
+      warningThreshold: 25,
+      criticalThreshold: 30,
+      warningSizeScale: 2.5, // out of [0, 1]
+    })
+    expect(decision.sizeScale).toBe(0.5) // clamped to default
+  })
+
+  it('falls back to defaults when thresholds are inverted (warning > critical)', () => {
+    // warning=30, critical=25 のような逆転は normal/warning/critical 領域が
+    // 矛盾するので default (25 / 30) に倒す。
+    const decision = evaluateVixRegime(27.3, {
+      warningThreshold: 30,
+      criticalThreshold: 25,
+      warningSizeScale: 0.5,
+    })
+    expect(decision.regime).toBe('warning')
+    expect(decision.sizeScale).toBe(0.5)
+  })
+
+  it('falls back to defaults when warningThreshold is NaN', () => {
+    const decision = evaluateVixRegime(27.3, {
+      warningThreshold: Number.NaN,
+      criticalThreshold: 30,
+      warningSizeScale: 0.5,
+    })
+    expect(decision.regime).toBe('warning') // 25 default kicks in
+  })
+
+  it('honors a custom warningSizeScale (e.g., 0.25 quarter sizing)', () => {
+    const decision = evaluateVixRegime(27.3, {
+      warningThreshold: 25,
+      criticalThreshold: 30,
+      warningSizeScale: 0.25,
+    })
+    expect(decision.sizeScale).toBe(0.25)
+    expect(decision.reason).toBe('vix_warning: 27.30 (size x0.25)')
+  })
+})

--- a/test/trading/strategy/pullbackScheduler.test.ts
+++ b/test/trading/strategy/pullbackScheduler.test.ts
@@ -784,3 +784,190 @@ describe('runPullbackScheduler macro event gate (#196 2/3)', () => {
     expect(reject?.reason).not.toContain('macro_event_gate')
   })
 })
+
+describe('runPullbackScheduler VIX regime filter (#196 3/3)', () => {
+  // Probe で「VIX 無し時の qty / notional」を確定させ、warning 時の half qty
+  // を厳密に比較できるようにする。uptrendBars + equity 100k は決定的。
+  async function probeBaseQty(): Promise<number> {
+    const probe = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution: mockExecution(),
+      now: () => now,
+    })
+    return probe.decisions[0]?.order?.quantity ?? 0
+  }
+
+  it('blocks all BUY when VIX is critical (sizeScale = 0)', async () => {
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution,
+      vixDecision: {
+        regime: 'critical',
+        sizeScale: 0,
+        reason: 'vix_critical: 35.10 (block)',
+        vix: 35.1,
+      },
+      now: () => now,
+    })
+    expect(summary.buys).toBe(0)
+    expect(execution.calls).toHaveLength(0)
+    const reject = summary.decisions.find((d) => d.decision === 'REJECT')
+    expect(reject?.reason).toContain('risk: vix_critical')
+    expect(summary.vix?.regime).toBe('critical')
+  })
+
+  it('halves BUY quantity in warning regime (sizeScale = 0.5)', async () => {
+    const baseQty = await probeBaseQty()
+    expect(baseQty).toBeGreaterThan(1) // half になっても 1 以上残る前提
+
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution,
+      vixDecision: {
+        regime: 'warning',
+        sizeScale: 0.5,
+        reason: 'vix_warning: 27.30 (size x0.5)',
+        vix: 27.3,
+      },
+      now: () => now,
+    })
+    expect(summary.buys).toBe(1)
+    expect(execution.calls).toHaveLength(1)
+    const intent = execution.calls[0] as { side: string; quantity: number }
+    expect(intent.side).toBe('BUY')
+    // floor(baseQty * 0.5)
+    expect(intent.quantity).toBe(Math.floor(baseQty * 0.5))
+    expect(summary.vix?.regime).toBe('warning')
+  })
+
+  it('rejects BUY with VIX reason when warning sizeScale rounds qty below 1 share', async () => {
+    // sizeScale が極端に小さい (0.001) 場合、qty * 0.001 → floor で 0 になる。
+    // 「sizing は通ったが VIX 縮小で 0 になった」経路を確実に取りたいので、
+    // 通常 sizing が通る入力で sizeScale だけ極端にする (実運用では現れない値だが
+    // 境界条件として実装の正しさを担保する)。
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution,
+      vixDecision: {
+        regime: 'warning',
+        sizeScale: 0.001,
+        reason: 'vix_warning: 27.30 (size x0.001)',
+        vix: 27.3,
+      },
+      now: () => now,
+    })
+    expect(summary.buys).toBe(0)
+    expect(execution.calls).toHaveLength(0)
+    const reject = summary.decisions.find((d) => d.decision === 'REJECT')
+    expect(reject?.reason).toContain('vix_warning')
+    expect(reject?.reason).toContain('qty rounded to 0')
+  })
+
+  it('does not modify BUY in normal regime (sizeScale = 1)', async () => {
+    const baseQty = await probeBaseQty()
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution,
+      vixDecision: {
+        regime: 'normal',
+        sizeScale: 1.0,
+        reason: 'vix_normal: 18.50',
+        vix: 18.5,
+      },
+      now: () => now,
+    })
+    expect(summary.buys).toBe(1)
+    const intent = execution.calls[0] as { quantity: number }
+    expect(intent.quantity).toBe(baseQty)
+    expect(summary.vix?.regime).toBe('normal')
+  })
+
+  it('treats unavailable VIX (fail-open) as normal', async () => {
+    const baseQty = await probeBaseQty()
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution,
+      vixDecision: {
+        regime: 'normal',
+        sizeScale: 1.0,
+        reason: 'vix_unavailable_fallback_normal',
+        vix: null,
+      },
+      now: () => now,
+    })
+    expect(summary.buys).toBe(1)
+    const intent = execution.calls[0] as { quantity: number }
+    expect(intent.quantity).toBe(baseQty)
+    expect(summary.vix?.vix).toBeNull()
+  })
+
+  it('skips the VIX filter entirely when vixDecision is omitted (back-compat)', async () => {
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution,
+      now: () => now,
+    })
+    expect(summary.buys).toBe(1)
+    expect(summary.vix).toBeUndefined()
+  })
+
+  it('does not block SELL even when VIX is critical', async () => {
+    // existing position から SELL 経路を作る。SELL は VIX 関係なく通る前提。
+    // (uptrendBars の最後 4% pullback は BUY ではなく実際には HOLD/BUY 判定なので、
+    // SELL を出すには time stop / take profit / stop loss のいずれかが要る。
+    // 簡略のため take-profit を踏ませる: avgPrice を低く置いて pnl を +10% にする)
+    const sellingState: SymbolState = {
+      ...emptySymbolState('AAPL', () => now),
+      position: { qty: 5, avgPrice: 100, openedAt: now.toISOString() },
+    }
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({ AAPL: sellingState }),
+      execution,
+      vixDecision: {
+        regime: 'critical',
+        sizeScale: 0,
+        reason: 'vix_critical: 35.10 (block)',
+        vix: 35.1,
+      },
+      now: () => now,
+    })
+    // SELL 経路を取れたか buys/sells/holds で判定。BUY は確実に来ない。
+    expect(summary.buys).toBe(0)
+    // SELL は通る (or HOLD) — どちらにせよ vix_critical reject にはならない。
+    const vixReject = summary.decisions.find(
+      (d) => d.decision === 'REJECT' && (d.reason ?? '').includes('vix_critical'),
+    )
+    expect(vixReject).toBeUndefined()
+  })
+})

--- a/test/trading/strategy/pullbackScheduler.test.ts
+++ b/test/trading/strategy/pullbackScheduler.test.ts
@@ -962,9 +962,21 @@ describe('runPullbackScheduler VIX regime filter (#196 3/3)', () => {
       },
       now: () => now,
     })
-    // SELL 経路を取れたか buys/sells/holds で判定。BUY は確実に来ない。
+    // BUY は確実に来ない。
     expect(summary.buys).toBe(0)
-    // SELL は通る (or HOLD) — どちらにせよ vix_critical reject にはならない。
+    // SELL が確かに通っていることを証明 (CodeRabbit #216 4th):
+    //   - summary.sells === 1
+    //   - execution に SELL intent が渡っている
+    //   - decision log にも SELL が残っている
+    // これで「critical でも SELL は本当に通る」passthrough を実証する
+    // (HOLD で素通りしても通る test だと、回帰検知ができない)。
+    expect(summary.sells).toBe(1)
+    expect(execution.calls).toHaveLength(1)
+    expect(execution.calls[0]).toMatchObject({ side: 'SELL' })
+    const sellDecision = summary.decisions.find((d) => d.decision === 'SELL')
+    expect(sellDecision).toBeDefined()
+    expect(sellDecision?.order?.side).toBe('SELL')
+    // vix_critical 起因の REJECT が混ざっていないこと。
     const vixReject = summary.decisions.find(
       (d) => d.decision === 'REJECT' && (d.reason ?? '').includes('vix_critical'),
     )


### PR DESCRIPTION
## Summary

VIX regime filter を **size scaling 系** filter として導入し、issue #196 を完全に閉じる (1/3 earnings PR #211、2/3 macro PR #212、3/3 本 PR)。

- `^VIX` (Yahoo Finance) を cron tick で 1 本だけ取得、最新 close から regime を導出
- 閾値ロジック (`evaluateVixRegime`):
  - VIX <= 25 → `normal`   / sizeScale 1.0
  - 25 < VIX <= 30 → `warning`  / sizeScale 0.5 (qty を半分に縮小)
  - VIX > 30 → `critical` / sizeScale 0 (BUY 全停止)
  - 取得失敗 → `normal` fail-open warning log (POC 適切、fail-closed BUY 全停止は厳しすぎる)
- earnings / macro と異なり sizing 段で適用 (`pullbackScheduler` の sizing 直後 / bucket gate 直前)
  - critical: BUY 全 reject (`risk: vix_critical: 35.10 (block)`)
  - warning: `qty = floor(qty * scale / lot) * lot` で lot に揃える、0 になれば reject
  - SELL は VIX 関係なく通す (existing position の exit 妨げない)
- regime 遷移は `config_state_snapshot` で dedup して STATE_CHANGE 通知 (同 regime 連続では emit しない)
- 閾値は `global_config.vix_warning_threshold` / `vix_critical_threshold` / `vix_warning_size_scale` で runtime 変更可能 (migration `0015`)
- dashboard `/dashboard/portfolio` に regime badge (緑/黄/赤/灰)、`/dashboard/config` に 3 列の labelMap を追加

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test --run` 全 778 件 pass
- [x] `evaluateVixRegime` の 4 ケース + 境界 + fail-open + 壊れた config の defensive normalize
- [x] `pullbackScheduler`:
  - critical で BUY 全 reject
  - warning で qty が `floor(qty * 0.5)` に縮小 (BUY 経路は execute 成立)
  - normal で qty 変化なし
  - 取得失敗 (vix=null) で normal fallback
  - SELL は critical でも通る
  - lot 丸め後 0 になる極端 sizeScale で reject
- [x] `vixRegimeChange.classifyVixRegimeSeverity` の 7 遷移 + 初回 null → info dedup
- [x] `runStrategyCron` 既存 21 tests 全 pass (VIX fetch / regime change 経路の silent fallback)
- [x] migration `0015_vix_regime_thresholds.sql` は `ALTER TABLE ADD COLUMN ... DEFAULT` の 3 行のみ (table-rebuild 副作用なし)

## Closes

issue #196 — POC ファンダ系 risk gate 3 軸 (earnings / macro / VIX) 揃って完了。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - VIX レジームフィルタ導入：regime 判定・サイズスケール・理由を提供し、売買フローに反映
  - レジームスナップショット永続化と変化検知での通知（重複抑止）

- **改善**
  - グローバル設定に VIX 閾値と警告スケールを追加（DB マイグレーション・検証含む）
  - BUY サイズをレジームに応じて自動調整／拒否する挙動を追加
  - ダッシュボードに VIX レジーム表示を追加、requestId を伝播してログ追跡性向上

- **テスト**
  - 判定・通知・DBフォールバック・スケーリング挙動を網羅する単体テストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->