### PR TITLE
feat(observability): broker error surge detection (#209)

### DIFF
--- a/src/infrastructure/notification/brokerErrorSurge.ts
+++ b/src/infrastructure/notification/brokerErrorSurge.ts
@@ -1,0 +1,276 @@
+import { and, eq, gte, inArray } from 'drizzle-orm'
+import {
+  BrokerAuthError,
+  BrokerClientError,
+  BrokerRateLimitError,
+  BrokerRequestError,
+  BrokerServerError,
+} from '../../shared/errors'
+import { configStateSnapshot, notificationEmitLog } from '../db/schema'
+import { createDb } from '../db/tradeJournalRepo'
+import type { Notifier } from './Notifier'
+
+/**
+ * Broker request の 4xx/5xx/429 急増検知 + dedup STATE_CHANGE 通知 (#209)。
+ *
+ * PR #210 (observability) で `notification_emit_log` に severity / event_type
+ * / cause / timestamp が記録されるようになった。これを source of truth と
+ * して、直近 lookback 分間の broker error 件数が threshold を超えたら 1 件だけ
+ * STATE_CHANGE 通知を出す。surge 中は同 state 連発を抑止し、解消したら
+ * resolve 通知を出す。
+ *
+ * 設計方針:
+ *   - lookback / threshold は hard-code (POC 段階の判断: tune は run 後に決まる、
+ *     global_config 拡張は test fixture 影響大)
+ *   - state 永続化は既存 `config_state_snapshot` table を流用 (新 migration 不要)
+ *   - vixRegime 系の dedup pattern (configStateChange.ts) を踏襲して実装統一
+ *   - fail-silent: D1 read / write が落ちても cron 本体には影響させない
+ */
+
+export interface BrokerSurgeConfig {
+  /** 直近 lookback 分間の broker error を集計する。default 5 分。 */
+  lookbackMinutes: number
+  /** lookback 内 errorCount >= surgeThreshold で surging=true。default 5 件。 */
+  surgeThreshold: number
+  /**
+   * 永続化 snapshot key (`config_state_snapshot.key`)。default
+   * `'broker_error_surge'`。test で衝突回避用に override 可能。
+   */
+  surgeStateKey: string
+}
+
+export const DEFAULT_BROKER_SURGE_CONFIG: BrokerSurgeConfig = {
+  lookbackMinutes: 5,
+  surgeThreshold: 5,
+  surgeStateKey: 'broker_error_surge',
+}
+
+/**
+ * 集計対象 cause。`pullbackScheduler` / `WebullExecution` 等で broker submit
+ * error を notify する時に使われる canonical 名 (#209)。`broker submit` は
+ * issue 以前の legacy だが互換のため含める。
+ */
+export const BROKER_ERROR_CAUSES: ReadonlyArray<string> = [
+  'broker_429',
+  'broker_4xx',
+  'broker_5xx',
+  'broker_other',
+  'broker submit',
+]
+
+export interface BrokerSurgeDetection {
+  surging: boolean
+  errorCount: number
+  threshold: number
+  lookbackMinutes: number
+  /** 内訳: 検出 cause の配列 (例: `['broker_5xx','broker_429']`)。dedup 済。 */
+  causes: string[]
+}
+
+/**
+ * `notification_emit_log` から直近 lookback 分の broker error を COUNT する。
+ * D1 失敗時は「surging=false / errorCount=0」として返す (false alert 防止)。
+ */
+export async function detectBrokerErrorSurge(
+  db: D1Database,
+  config: BrokerSurgeConfig,
+  now: Date,
+): Promise<BrokerSurgeDetection> {
+  const since = new Date(now.getTime() - config.lookbackMinutes * 60_000).toISOString()
+  try {
+    const drizzle = createDb(db)
+    const rows = await drizzle
+      .select({
+        cause: notificationEmitLog.cause,
+      })
+      .from(notificationEmitLog)
+      .where(
+        and(
+          eq(notificationEmitLog.eventType, 'ERROR'),
+          gte(notificationEmitLog.timestamp, since),
+          inArray(notificationEmitLog.cause, [...BROKER_ERROR_CAUSES]),
+        ),
+      )
+    const causes = new Set<string>()
+    for (const row of rows) {
+      if (row.cause) causes.add(row.cause)
+    }
+    const errorCount = rows.length
+    return {
+      surging: errorCount >= config.surgeThreshold,
+      errorCount,
+      threshold: config.surgeThreshold,
+      lookbackMinutes: config.lookbackMinutes,
+      causes: [...causes].sort(),
+    }
+  } catch (error) {
+    console.warn(
+      JSON.stringify({
+        event: 'broker_error_surge_detect_failed',
+        message: error instanceof Error ? error.message : String(error),
+      }),
+    )
+    return {
+      surging: false,
+      errorCount: 0,
+      threshold: config.surgeThreshold,
+      lookbackMinutes: config.lookbackMinutes,
+      causes: [],
+    }
+  }
+}
+
+/**
+ * `config_state_snapshot` から前回の surging 状態 (`'true'` / `'false'`) を
+ * 読む。値なし / parse 失敗 / D1 失敗は「初回 (= false 扱い)」を返す。
+ *
+ * 値は JSON.stringify(boolean) で持つ (configStateChange.ts と統一)。
+ */
+export async function loadPreviousSurgeState(
+  db: D1Database,
+  key: string,
+): Promise<boolean> {
+  try {
+    const drizzle = createDb(db)
+    const rows = await drizzle
+      .select({ value: configStateSnapshot.value })
+      .from(configStateSnapshot)
+      .where(eq(configStateSnapshot.key, key))
+    if (rows.length === 0) return false
+    const parsed = JSON.parse(rows[0]!.value) as unknown
+    return parsed === true
+  } catch (error) {
+    console.warn(
+      JSON.stringify({
+        event: 'broker_error_surge_snapshot_load_failed',
+        message: error instanceof Error ? error.message : String(error),
+      }),
+    )
+    return false
+  }
+}
+
+/**
+ * 現在の surging 状態を `config_state_snapshot` に永続化。delete + insert で
+ * upsert (sqlite portable upsert を avoid)。失敗は throw しない。
+ */
+export async function persistSurgeState(
+  db: D1Database,
+  key: string,
+  surging: boolean,
+  now: Date,
+  requestId: string | undefined,
+): Promise<void> {
+  try {
+    const drizzle = createDb(db)
+    await drizzle.delete(configStateSnapshot).where(eq(configStateSnapshot.key, key))
+    await drizzle.insert(configStateSnapshot).values({
+      key,
+      value: JSON.stringify(surging),
+      snapshotAt: now.toISOString(),
+      requestId: requestId ?? null,
+    })
+  } catch (error) {
+    console.warn(
+      JSON.stringify({
+        event: 'broker_error_surge_snapshot_persist_failed',
+        message: error instanceof Error ? error.message : String(error),
+      }),
+    )
+  }
+}
+
+export interface NotifyBrokerErrorSurgeArgs {
+  db: D1Database
+  notifier: Notifier
+  config?: BrokerSurgeConfig
+  now?: Date
+  requestId?: string
+}
+
+export interface NotifyBrokerErrorSurgeResult {
+  /** STATE_CHANGE notify を 1 件 emit したか。 */
+  emitted: boolean
+  /** 今 tick での surging 判定。 */
+  surging: boolean
+  detection: BrokerSurgeDetection
+}
+
+/**
+ * cron tick から呼ぶ top-level helper。
+ *
+ *   1. lookback 内の broker error を COUNT
+ *   2. snapshot と比較し、true ↔ false の遷移時のみ STATE_CHANGE 1 件 emit
+ *      - false → true: severity=critical (surge 開始)
+ *      - true → false: severity=info (resolve)
+ *   3. 同 state 継続時は emit しない (over-noise 抑止)
+ *   4. snapshot を必ず upsert する (notify が throw しても persist は走る)
+ *
+ * notify は fire-and-forget 相当 (`.notify()` は内部で握りつぶす契約)。
+ */
+export async function notifyBrokerErrorSurgeIfChanged(
+  args: NotifyBrokerErrorSurgeArgs,
+): Promise<NotifyBrokerErrorSurgeResult> {
+  const config = args.config ?? DEFAULT_BROKER_SURGE_CONFIG
+  const now = args.now ?? new Date()
+  const detection = await detectBrokerErrorSurge(args.db, config, now)
+  const previous = await loadPreviousSurgeState(args.db, config.surgeStateKey)
+  let emitted = false
+
+  if (previous !== detection.surging) {
+    const note = args.requestId ? `requestId=${args.requestId}` : undefined
+    try {
+      await args.notifier.notify({
+        type: 'STATE_CHANGE',
+        field: config.surgeStateKey,
+        from: previous,
+        to: detection.surging,
+        severity: detection.surging ? 'critical' : 'info',
+        ...(note !== undefined ? { note } : {}),
+      })
+      emitted = true
+    } catch (error) {
+      // notify 契約上は resolve するはずだが defensive。snapshot 更新は次の
+      // ステップで必ず走らせる (resolve 通知が永遠に出ない事故を回避)。
+      console.warn(
+        JSON.stringify({
+          event: 'broker_error_surge_notify_failed',
+          message: error instanceof Error ? error.message : String(error),
+        }),
+      )
+    }
+  }
+
+  // 通知有無に関わらず snapshot は今 tick の値で上書き — そうしないと
+  // 同 state 継続中の resolve 検知が遅れる (vixRegime と同じ pattern)。
+  await persistSurgeState(args.db, config.surgeStateKey, detection.surging, now, args.requestId)
+
+  return { emitted, surging: detection.surging, detection }
+}
+
+/**
+ * Broker error の cause 文字列を canonical 化する (#209)。`pullbackScheduler`
+ * / `WebullExecution` の broker submit error 通知で使う想定。
+ *
+ *   - `BrokerRateLimitError` (HTTP 429)        → `'broker_429'`
+ *   - `BrokerAuthError` (401/403) / `BrokerClientError` (other 4xx) → `'broker_4xx'`
+ *   - `BrokerServerError` (5xx)                → `'broker_5xx'`
+ *   - その他 `BrokerRequestError` (network 等) → `'broker_other'`
+ *   - broker error 以外                       → `null`
+ */
+export function classifyBrokerErrorCause(error: unknown): string | null {
+  if (error instanceof BrokerRateLimitError) return 'broker_429'
+  if (error instanceof BrokerAuthError) return 'broker_4xx'
+  if (error instanceof BrokerClientError) return 'broker_4xx'
+  if (error instanceof BrokerServerError) return 'broker_5xx'
+  if (error instanceof BrokerRequestError) {
+    const status = error.brokerStatus
+    if (status === 429) return 'broker_429'
+    if (typeof status === 'number') {
+      if (status >= 400 && status < 500) return 'broker_4xx'
+      if (status >= 500 && status < 600) return 'broker_5xx'
+    }
+    return 'broker_other'
+  }
+  return null
+}

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -1,5 +1,6 @@
 import type { BarClient } from '../../infrastructure/quotes/BarClient'
 import { logPostSubmit, logPreSubmit } from '../../infrastructure/logger/tradeJournal'
+import { classifyBrokerErrorCause } from '../../infrastructure/notification/brokerErrorSurge'
 import type { Notifier } from '../../infrastructure/notification/Notifier'
 import type { DecisionTraceStep } from '../domain/Signal'
 import { inferTradingMarket } from '../domain/tradingCalendar'
@@ -692,7 +693,10 @@ export async function runPullbackScheduler(
         type: 'ERROR',
         symbol: upper,
         message: messageOf(error),
-        cause: 'broker submit',
+        // surge detector が cause で count するため (#209)、broker submit
+        // failure を 4xx / 429 / 5xx / other に分類する。`null` (= broker
+        // error ではない) なら legacy の `'broker submit'` に戻す。
+        cause: classifyBrokerErrorCause(error) ?? 'broker submit',
       })
       try {
         logPostSubmit({

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -3,6 +3,7 @@ import { YahooBarClient } from '../../infrastructure/quotes/YahooBarClient'
 import { loadGlobalConfigFrom } from '../../infrastructure/db/globalConfigLoader'
 import { loadSymbolUniverse } from '../../infrastructure/db/symbolUniverse'
 import type { SymbolCurrency } from '../../infrastructure/db/symbolConfigRepo'
+import { notifyBrokerErrorSurgeIfChanged } from '../../infrastructure/notification/brokerErrorSurge'
 import {
   detectAndNotifyConfigStateChanges,
   type WatchedConfig,
@@ -172,6 +173,25 @@ export async function runStrategyCron(
       }),
     )
   })
+
+  // Broker 4xx/5xx/429 急増検知 (#209)。`notification_emit_log` を集計し、
+  // surge 開始 / 解消の遷移時に 1 件 STATE_CHANGE 通知。env.DB が無いと
+  // surge 検知は成立しないので skip。fail-silent で cron は止めない。
+  if (env.DB) {
+    await notifyBrokerErrorSurgeIfChanged({
+      db: env.DB,
+      notifier,
+      requestId: options.requestId,
+    }).catch((err) => {
+      console.warn(
+        JSON.stringify({
+          event: 'broker_error_surge_detect_failed',
+          requestId: options.requestId,
+          message: err instanceof Error ? err.message : String(err),
+        }),
+      )
+    })
+  }
 
   const defaultRule = {
     stopPct: global.pullbackDefaultStopPct,

--- a/test/infrastructure/notification/brokerErrorSurge.test.ts
+++ b/test/infrastructure/notification/brokerErrorSurge.test.ts
@@ -1,0 +1,339 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  BROKER_ERROR_CAUSES,
+  DEFAULT_BROKER_SURGE_CONFIG,
+  classifyBrokerErrorCause,
+  detectBrokerErrorSurge,
+  notifyBrokerErrorSurgeIfChanged,
+} from '../../../src/infrastructure/notification/brokerErrorSurge'
+import { createDb } from '../../../src/infrastructure/db/tradeJournalRepo'
+import {
+  BrokerAuthError,
+  BrokerClientError,
+  BrokerRateLimitError,
+  BrokerRequestError,
+  BrokerServerError,
+} from '../../../src/shared/errors'
+import type {
+  Notifier,
+  NotificationEvent,
+} from '../../../src/infrastructure/notification/Notifier'
+
+vi.mock('../../../src/infrastructure/db/tradeJournalRepo', () => ({
+  createDb: vi.fn(),
+}))
+
+const fakeD1 = {} as D1Database
+
+/**
+ * `detectBrokerErrorSurge` で使う drizzle chain の最小 stub。
+ *   db.select().from(...).where(...) が `rows` を返す。
+ */
+function fakeSelectChain(rows: Array<{ cause: string | null }>) {
+  const query = {
+    from: vi.fn(() => query),
+    where: vi.fn(async (_arg: unknown) => rows),
+  }
+  return {
+    query,
+    db: {
+      select: vi.fn(() => query),
+    },
+  }
+}
+
+describe('classifyBrokerErrorCause', () => {
+  it('classifies 429 as broker_429', () => {
+    expect(classifyBrokerErrorCause(new BrokerRateLimitError('rl', 'op'))).toBe('broker_429')
+  })
+  it('classifies BrokerAuthError as broker_4xx', () => {
+    expect(classifyBrokerErrorCause(new BrokerAuthError('auth', 'op'))).toBe('broker_4xx')
+  })
+  it('classifies BrokerClientError as broker_4xx', () => {
+    expect(classifyBrokerErrorCause(new BrokerClientError('bad', 'op'))).toBe('broker_4xx')
+  })
+  it('classifies BrokerServerError as broker_5xx', () => {
+    expect(classifyBrokerErrorCause(new BrokerServerError('500', 'op'))).toBe('broker_5xx')
+  })
+  it('falls back to brokerStatus for raw BrokerRequestError', () => {
+    expect(
+      classifyBrokerErrorCause(new BrokerRequestError('x', 'op', { brokerStatus: 503 })),
+    ).toBe('broker_5xx')
+    expect(
+      classifyBrokerErrorCause(new BrokerRequestError('x', 'op', { brokerStatus: 404 })),
+    ).toBe('broker_4xx')
+    expect(
+      classifyBrokerErrorCause(new BrokerRequestError('x', 'op', { brokerStatus: 429 })),
+    ).toBe('broker_429')
+  })
+  it('returns broker_other when status is unknown', () => {
+    expect(classifyBrokerErrorCause(new BrokerRequestError('x', 'op'))).toBe('broker_other')
+  })
+  it('returns null for non-broker errors', () => {
+    expect(classifyBrokerErrorCause(new Error('boom'))).toBeNull()
+    expect(classifyBrokerErrorCause('string')).toBeNull()
+  })
+})
+
+describe('detectBrokerErrorSurge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns surging=false when no rows in lookback window', async () => {
+    const { db } = fakeSelectChain([])
+    vi.mocked(createDb).mockReturnValue(db as unknown as ReturnType<typeof createDb>)
+    const result = await detectBrokerErrorSurge(fakeD1, DEFAULT_BROKER_SURGE_CONFIG, new Date())
+    expect(result.surging).toBe(false)
+    expect(result.errorCount).toBe(0)
+    expect(result.causes).toEqual([])
+  })
+
+  it('returns surging=false when count is below threshold', async () => {
+    const rows = Array.from({ length: 3 }, () => ({ cause: 'broker_5xx' }))
+    const { db } = fakeSelectChain(rows)
+    vi.mocked(createDb).mockReturnValue(db as unknown as ReturnType<typeof createDb>)
+    const result = await detectBrokerErrorSurge(
+      fakeD1,
+      { ...DEFAULT_BROKER_SURGE_CONFIG, surgeThreshold: 5 },
+      new Date(),
+    )
+    expect(result.surging).toBe(false)
+    expect(result.errorCount).toBe(3)
+    expect(result.causes).toEqual(['broker_5xx'])
+  })
+
+  it('returns surging=true at threshold with deduped sorted causes', async () => {
+    const rows = [
+      { cause: 'broker_5xx' },
+      { cause: 'broker_5xx' },
+      { cause: 'broker_429' },
+      { cause: 'broker_4xx' },
+      { cause: 'broker_5xx' },
+    ]
+    const { db } = fakeSelectChain(rows)
+    vi.mocked(createDb).mockReturnValue(db as unknown as ReturnType<typeof createDb>)
+    const result = await detectBrokerErrorSurge(
+      fakeD1,
+      { ...DEFAULT_BROKER_SURGE_CONFIG, surgeThreshold: 5 },
+      new Date(),
+    )
+    expect(result.surging).toBe(true)
+    expect(result.errorCount).toBe(5)
+    expect(result.causes).toEqual(['broker_429', 'broker_4xx', 'broker_5xx'])
+  })
+
+  it('returns safe defaults on D1 throw', async () => {
+    const query = {
+      from: vi.fn(() => query),
+      where: vi.fn(async () => {
+        throw new Error('db down')
+      }),
+    }
+    vi.mocked(createDb).mockReturnValue({
+      select: vi.fn(() => query),
+    } as unknown as ReturnType<typeof createDb>)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const result = await detectBrokerErrorSurge(fakeD1, DEFAULT_BROKER_SURGE_CONFIG, new Date())
+    expect(result.surging).toBe(false)
+    expect(result.errorCount).toBe(0)
+    warnSpy.mockRestore()
+  })
+
+  it('exports a non-empty BROKER_ERROR_CAUSES taxonomy including legacy', () => {
+    expect(BROKER_ERROR_CAUSES.length).toBeGreaterThan(0)
+    expect(BROKER_ERROR_CAUSES).toContain('broker_4xx')
+    expect(BROKER_ERROR_CAUSES).toContain('broker_5xx')
+    expect(BROKER_ERROR_CAUSES).toContain('broker_429')
+    // legacy from older notify call sites
+    expect(BROKER_ERROR_CAUSES).toContain('broker submit')
+  })
+})
+
+describe('notifyBrokerErrorSurgeIfChanged', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('emits STATE_CHANGE critical when first crossing threshold (no prev snapshot)', async () => {
+    const errorRows = Array.from({ length: 6 }, () => ({ cause: 'broker_5xx' }))
+    // 1st select: broker errors. 2nd select: snapshot row (empty = first run).
+    const ordered: Array<unknown[]> = [errorRows, []]
+    const where = vi.fn(async () => ordered.shift() ?? [])
+    const query = {
+      from: vi.fn(() => query),
+      where,
+    }
+    const deleteChain = { where: vi.fn(async () => undefined) }
+    const insertChain = {
+      values: vi.fn(async (_row: { value?: string; key?: string; snapshotAt?: string }) => undefined),
+    }
+    vi.mocked(createDb).mockReturnValue({
+      select: vi.fn(() => query),
+      delete: vi.fn(() => deleteChain),
+      insert: vi.fn(() => insertChain),
+    } as unknown as ReturnType<typeof createDb>)
+
+    const events: NotificationEvent[] = []
+    const notifier: Notifier = {
+      async notify(e) {
+        events.push(e)
+      },
+    }
+    const result = await notifyBrokerErrorSurgeIfChanged({
+      db: fakeD1,
+      notifier,
+      requestId: 'req-A',
+    })
+    expect(result.emitted).toBe(true)
+    expect(result.surging).toBe(true)
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      type: 'STATE_CHANGE',
+      field: 'broker_error_surge',
+      from: false,
+      to: true,
+      severity: 'critical',
+      note: 'requestId=req-A',
+    })
+    // snapshot persist must run (delete then insert, exactly once)
+    expect(deleteChain.where).toHaveBeenCalledTimes(1)
+    expect(insertChain.values).toHaveBeenCalledTimes(1)
+    const insertedRow = insertChain.values.mock.calls[0]![0]
+    expect(insertedRow.value).toBe(JSON.stringify(true))
+  })
+
+  it('does NOT emit when previous=false and current=false (no surge)', async () => {
+    const ordered: Array<unknown[]> = [[], [{ value: JSON.stringify(false) }]]
+    const where = vi.fn(async () => ordered.shift() ?? [])
+    const query = {
+      from: vi.fn(() => query),
+      where,
+    }
+    const deleteChain = { where: vi.fn(async () => undefined) }
+    const insertChain = {
+      values: vi.fn(async (_row: { value?: string; key?: string; snapshotAt?: string }) => undefined),
+    }
+    vi.mocked(createDb).mockReturnValue({
+      select: vi.fn(() => query),
+      delete: vi.fn(() => deleteChain),
+      insert: vi.fn(() => insertChain),
+    } as unknown as ReturnType<typeof createDb>)
+
+    const events: NotificationEvent[] = []
+    const notifier: Notifier = {
+      async notify(e) {
+        events.push(e)
+      },
+    }
+    const result = await notifyBrokerErrorSurgeIfChanged({ db: fakeD1, notifier })
+    expect(result.emitted).toBe(false)
+    expect(result.surging).toBe(false)
+    expect(events).toHaveLength(0)
+    // snapshot still re-persisted (idempotent — keeps snapshot_at fresh)
+    expect(insertChain.values).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT emit on continuous surge (true → true)', async () => {
+    const errorRows = Array.from({ length: 7 }, () => ({ cause: 'broker_429' }))
+    const ordered: Array<unknown[]> = [errorRows, [{ value: JSON.stringify(true) }]]
+    const where = vi.fn(async () => ordered.shift() ?? [])
+    const query = {
+      from: vi.fn(() => query),
+      where,
+    }
+    const deleteChain = { where: vi.fn(async () => undefined) }
+    const insertChain = {
+      values: vi.fn(async (_row: { value?: string; key?: string; snapshotAt?: string }) => undefined),
+    }
+    vi.mocked(createDb).mockReturnValue({
+      select: vi.fn(() => query),
+      delete: vi.fn(() => deleteChain),
+      insert: vi.fn(() => insertChain),
+    } as unknown as ReturnType<typeof createDb>)
+
+    const events: NotificationEvent[] = []
+    const notifier: Notifier = {
+      async notify(e) {
+        events.push(e)
+      },
+    }
+    const result = await notifyBrokerErrorSurgeIfChanged({ db: fakeD1, notifier })
+    expect(result.emitted).toBe(false)
+    expect(result.surging).toBe(true)
+    expect(events).toHaveLength(0)
+  })
+
+  it('emits STATE_CHANGE info on resolve (true → false)', async () => {
+    const ordered: Array<unknown[]> = [[], [{ value: JSON.stringify(true) }]]
+    const where = vi.fn(async () => ordered.shift() ?? [])
+    const query = {
+      from: vi.fn(() => query),
+      where,
+    }
+    const deleteChain = { where: vi.fn(async () => undefined) }
+    const insertChain = {
+      values: vi.fn(async (_row: { value?: string; key?: string; snapshotAt?: string }) => undefined),
+    }
+    vi.mocked(createDb).mockReturnValue({
+      select: vi.fn(() => query),
+      delete: vi.fn(() => deleteChain),
+      insert: vi.fn(() => insertChain),
+    } as unknown as ReturnType<typeof createDb>)
+
+    const events: NotificationEvent[] = []
+    const notifier: Notifier = {
+      async notify(e) {
+        events.push(e)
+      },
+    }
+    const result = await notifyBrokerErrorSurgeIfChanged({ db: fakeD1, notifier })
+    expect(result.emitted).toBe(true)
+    expect(result.surging).toBe(false)
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      type: 'STATE_CHANGE',
+      field: 'broker_error_surge',
+      from: true,
+      to: false,
+      severity: 'info',
+    })
+    const insertedRow = insertChain.values.mock.calls[0]![0]
+    expect(insertedRow.value).toBe(JSON.stringify(false))
+  })
+
+  it('persists snapshot even when notifier.notify() throws', async () => {
+    // first surge, prev=false, notifier blows up
+    const errorRows = Array.from({ length: 6 }, () => ({ cause: 'broker_5xx' }))
+    const ordered: Array<unknown[]> = [errorRows, []]
+    const where = vi.fn(async () => ordered.shift() ?? [])
+    const query = {
+      from: vi.fn(() => query),
+      where,
+    }
+    const deleteChain = { where: vi.fn(async () => undefined) }
+    const insertChain = {
+      values: vi.fn(async (_row: { value?: string; key?: string; snapshotAt?: string }) => undefined),
+    }
+    vi.mocked(createDb).mockReturnValue({
+      select: vi.fn(() => query),
+      delete: vi.fn(() => deleteChain),
+      insert: vi.fn(() => insertChain),
+    } as unknown as ReturnType<typeof createDb>)
+
+    const notifier: Notifier = {
+      async notify() {
+        throw new Error('webhook down')
+      },
+    }
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const result = await notifyBrokerErrorSurgeIfChanged({ db: fakeD1, notifier })
+    // notify rejected → emitted stays false, but snapshot still updated
+    expect(result.emitted).toBe(false)
+    expect(result.surging).toBe(true)
+    expect(insertChain.values).toHaveBeenCalledTimes(1)
+    const insertedRow = insertChain.values.mock.calls[0]![0]
+    expect(insertedRow.value).toBe(JSON.stringify(true))
+    warnSpy.mockRestore()
+  })
+})


### PR DESCRIPTION
## Motivation

Closes #209 (deferred from PR #210 observability work).

Operator wants to be paged when broker (Webull) request failures spike — not on a single 5xx, but when the rate suggests a real outage / rate-limit storm. PR #210 made `notification_emit_log` the durable record of every emitted notification; this PR adds a small detector on top of that table so we get a clean, deduped alert instead of one webhook per failed broker call.

## Design

- `src/infrastructure/notification/brokerErrorSurge.ts`
  - `detectBrokerErrorSurge(db, config, now)` — counts `event_type='ERROR' AND cause IN (broker_4xx, broker_5xx, broker_429, broker_other, broker submit)` rows where `timestamp >= now - lookbackMinutes`.
  - `notifyBrokerErrorSurgeIfChanged()` — compares against `config_state_snapshot[key='broker_error_surge']`, emits **one** STATE_CHANGE only on `false→true` (severity `critical`) and `true→false` (severity `info`). Continuous same-state ticks emit nothing.
  - Snapshot is upserted unconditionally so a notify failure cannot leave the state stuck (mirrors the `configStateChange.ts` pattern).
- Defaults are hard-coded: lookback 5 min, threshold 5 events. POC stage — tune values are run-data dependent and pulling them through `global_config` would expand a lot of test fixtures for negligible gain. Centralised as `DEFAULT_BROKER_SURGE_CONFIG` and overridable per call.
- `classifyBrokerErrorCause(error)` returns `'broker_429' | 'broker_4xx' | 'broker_5xx' | 'broker_other' | null`. Used in `pullbackScheduler.ts` to refine the legacy `cause: 'broker submit'` notify into the canonical taxonomy the detector counts.
- Wired into `runStrategyCron.ts` right after `detectAndNotifyConfigStateChanges` so the existing 15-min strategy cron drives the check. Fail-silent: caller `.catch()` keeps the cron alive, and `env.DB` absence is a no-op.
- No new migration. Reuses `notification_emit_log` (PR #210) and `config_state_snapshot` (PR #141).

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test --run` — 64 files / 767 tests pass
- [x] `test/infrastructure/notification/brokerErrorSurge.test.ts` (17 new tests):
  - `classifyBrokerErrorCause` covers 429 / auth / client / server / raw `BrokerRequestError` w/ status / unknown status / non-broker error
  - `detectBrokerErrorSurge` covers below-threshold, exact-threshold (with deduped sorted causes), zero rows, D1 throw → safe defaults
  - `notifyBrokerErrorSurgeIfChanged` covers initial surge / continuous false / continuous surge / resolve / notify-throw-still-persists-snapshot

## Out of scope

- Dashboard badge for surge state — `/dashboard/alerts` already exposes the underlying rows; standalone badge can be a follow-up.
- Configurable threshold via `global_config` — defer until POC tune surfaces a real number.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ブローカーエラーが急増した場合に通知が発行されるようになりました。エラー数が閾値を超えたときに重大度「critical」の通知が、解決したときに「info」の通知が送信されます。

* **テスト**
  * ブローカーエラー急増検出および通知ロジックの包括的なテストスイートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->