### PR TITLE
fix(risk): stale quote が SELL/stop hit を block する bug 修正

### DIFF
--- a/src/trading/risk/perSymbolRiskGate.ts
+++ b/src/trading/risk/perSymbolRiskGate.ts
@@ -8,11 +8,15 @@
  * 含まれる gate:
  *   1. settled cash (BUY only): notional > settledCash で reject
  *   2. inverse pair (BUY only): inverse 銘柄の建玉が残っていれば reject
- *   3. quote freshness (halt fallback): lastQuote.fetchedAt が staleQuoteMs を超えれば reject
- *   4. spread guard: bid/ask 欠損 / 異常 / spread% が limit 超で reject
- *   5. gap re-eval: avgPrice と lastQuote.price の |gap| > gapRejectPct で reject
- *   6. JP 値幅制限: JP 銘柄かつ band 外 limit price で reject
+ *   3. quote freshness (BUY only / halt fallback): lastQuote.fetchedAt が staleQuoteMs を超えれば reject
+ *   4. spread guard (BUY only): bid/ask 欠損 / 異常 / spread% が limit 超で reject
+ *   5. gap re-eval (BUY only): avgPrice と lastQuote.price の |gap| > gapRejectPct で reject
+ *   6. JP 値幅制限 (BUY only): JP 銘柄かつ band 外 limit price で reject
  *   7. (option) cooldown: state.cooldownUntil が未来なら reject
+ *
+ * Gate 3-6 は **エントリ抑止** が目的なので BUY only。SELL/exit (stop hit / 損切り)
+ * は stale quote / wide spread / 大 gap / JP band 外でも実行を優先する
+ * (= 損切りが永久 block されて position 塩漬けにならないように)。
  *
  * 含まれない gate (orchestrator 層が直接持つ):
  *   - portfolio-wide drawdown kill
@@ -114,8 +118,10 @@ export function evaluatePerSymbolRisk(
     }
   }
 
-  // 4. halt / stale quote。lastQuote=null は未 seed 扱いで skip (POC 後方互換)。
-  if (state.lastQuote) {
+  // 4. halt / stale quote (BUY only)。SELL は stale でも exit 実行を優先する
+  //    (stop hit / 損切りが stale quote で永久に block されないように)。
+  //    lastQuote=null は未 seed 扱いで skip (POC 後方互換)。
+  if (side === 'BUY' && state.lastQuote) {
     const ageMs = now.getTime() - new Date(state.lastQuote.fetchedAt).getTime()
     if (!Number.isFinite(ageMs) || ageMs > config.staleQuoteMs) {
       return reject(
@@ -124,20 +130,28 @@ export function evaluatePerSymbolRisk(
     }
   }
 
-  // 5. spread guard: bid/ask 欠損は fail-closed (lastQuote 有り前提)。
-  const spreadReason = evaluateSpreadGate(symbol, state.lastQuote, config.spreadLimits)
-  if (spreadReason !== null) {
-    return reject(spreadReason)
+  // 5. spread guard (BUY only)。SELL/exit は wide spread でも実行優先。
+  //    bid/ask 欠損は fail-closed (lastQuote 有り前提)。
+  if (side === 'BUY') {
+    const spreadReason = evaluateSpreadGate(symbol, state.lastQuote, config.spreadLimits)
+    if (spreadReason !== null) {
+      return reject(spreadReason)
+    }
   }
 
-  // 6. gap re-eval。open position が無い / avgPrice が不正なら skip。
-  const gapReason = evaluateGap(state, config.gapRejectPct)
-  if (gapReason !== null) {
-    return reject(gapReason)
+  // 6. gap re-eval (BUY only)。SELL は大 gap (= stop hit) こそ fire させたい。
+  //    open position が無い / avgPrice が不正なら skip。
+  if (side === 'BUY') {
+    const gapReason = evaluateGap(state, config.gapRejectPct)
+    if (gapReason !== null) {
+      return reject(gapReason)
+    }
   }
 
-  // 7. JP price band。JP 銘柄かつ lastQuote 有りで limit が band 外なら reject。
+  // 7. JP price band (BUY only)。SELL/exit は band 外でも通す。
+  //    JP 銘柄かつ lastQuote 有りで limit が band 外なら reject。
   if (
+    side === 'BUY' &&
     inferWebullMarket(symbol) === 'JP' &&
     state.lastQuote &&
     !isWithinJpPriceBand(state.lastQuote.price, intentPrice)

--- a/test/trading/risk/perSymbolRiskGate.test.ts
+++ b/test/trading/risk/perSymbolRiskGate.test.ts
@@ -157,6 +157,21 @@ describe('evaluatePerSymbolRisk — stale quote / halt fallback', () => {
     )
     expect(decision.approved).toBe(true)
   })
+
+  it('approves SELL even when lastQuote is days-stale (stop hit / exit priority)', () => {
+    // SOXL stop hit scenario from prod: lastQuote 4 days old must NOT block SELL.
+    const state: SymbolState = {
+      ...emptySymbolState('SOXL', () => now),
+      position: { qty: 10, avgPrice: 124.95, openedAt: now.toISOString() },
+      lastQuote: quote(119.38, 4 * 24 * 60 * 60 * 1_000),
+    }
+    const decision = evaluatePerSymbolRisk(
+      { symbol: 'SOXL', side: 'SELL', intentPrice: 119.38, intentNotional: 1_193.8, state, now },
+      baseConfig,
+    )
+    expect(decision.approved).toBe(true)
+    expect(decision.reasons).toEqual([])
+  })
 })
 
 describe('evaluatePerSymbolRisk — spread guard', () => {
@@ -184,6 +199,33 @@ describe('evaluatePerSymbolRisk — spread guard', () => {
     )
     expect(decision.approved).toBe(false)
     expect(decision.reasons[0]).toContain('bid/ask missing')
+  })
+
+  it('approves SELL when spread is wide (exit priority)', () => {
+    const state: SymbolState = {
+      ...emptySymbolState('SPY', () => now),
+      position: { qty: 1, avgPrice: 100, openedAt: now.toISOString() },
+      lastQuote: quote(100, 1_000, { bid: 99.85, ask: 100.15 }),
+    }
+    const decision = evaluatePerSymbolRisk(
+      { symbol: 'SPY', side: 'SELL', intentPrice: 100, intentNotional: 100, state, now },
+      baseConfig,
+    )
+    expect(decision.approved).toBe(true)
+    expect(decision.reasons).toEqual([])
+  })
+
+  it('approves SELL even when bid/ask is missing (exit priority)', () => {
+    const state: SymbolState = {
+      ...emptySymbolState('SPY', () => now),
+      position: { qty: 1, avgPrice: 100, openedAt: now.toISOString() },
+      lastQuote: quote(100, 1_000, { bid: undefined, ask: 100.1 }),
+    }
+    const decision = evaluatePerSymbolRisk(
+      { symbol: 'SPY', side: 'SELL', intentPrice: 100, intentNotional: 100, state, now },
+      baseConfig,
+    )
+    expect(decision.approved).toBe(true)
   })
 })
 
@@ -213,6 +255,21 @@ describe('evaluatePerSymbolRisk — gap re-eval', () => {
     )
     expect(decision.approved).toBe(true)
   })
+
+  it('approves SELL even when |gap| exceeds threshold (stop hit fires)', () => {
+    // SOXL stop hit shape: avgPrice 124.95 vs current 119.38 (~-4.5%) > 3% threshold.
+    const state: SymbolState = {
+      ...emptySymbolState('SOXL', () => now),
+      position: { qty: 10, avgPrice: 124.95, openedAt: now.toISOString() },
+      lastQuote: quote(119.38),
+    }
+    const decision = evaluatePerSymbolRisk(
+      { symbol: 'SOXL', side: 'SELL', intentPrice: 119.38, intentNotional: 1_193.8, state, now },
+      baseConfig,
+    )
+    expect(decision.approved).toBe(true)
+    expect(decision.reasons).toEqual([])
+  })
 })
 
 describe('evaluatePerSymbolRisk — JP price band', () => {
@@ -239,6 +296,20 @@ describe('evaluatePerSymbolRisk — JP price band', () => {
       baseConfig,
     )
     expect(decision.approved).toBe(true)
+  })
+
+  it('approves SELL outside JP price band (exit priority)', () => {
+    const state: SymbolState = {
+      ...emptySymbolState('7203', () => now),
+      position: { qty: 100, avgPrice: 5_000, openedAt: now.toISOString() },
+      lastQuote: quote(5_000),
+    }
+    const decision = evaluatePerSymbolRisk(
+      { symbol: '7203', side: 'SELL', intentPrice: 5_800, intentNotional: 580_000, state, now },
+      baseConfig,
+    )
+    expect(decision.approved).toBe(true)
+    expect(decision.reasons).toEqual([])
   })
 })
 

--- a/test/trading/risk/perSymbolRiskGateParity.test.ts
+++ b/test/trading/risk/perSymbolRiskGateParity.test.ts
@@ -218,6 +218,41 @@ describe('per-symbol risk gate parity (TradingService vs runPullbackScheduler) �
     expect(reject?.reason).toContain('inverse-pair exposure')
   })
 
+  it('SELL passes the stale-quote gate (exit priority — TradingService)', async () => {
+    // Anchors the SOXL stop-hit bug: SELL must NOT be blocked by stale lastQuote.
+    // (cron path drives BUY-only via runPullbackScheduler, so this assertion is
+    // limited to TradingService — the manual / liquidate / exit code path.)
+    const state: SymbolState = {
+      ...emptySymbolState('AAPL', () => now),
+      position: { qty: 1, avgPrice: 124.95, openedAt: now.toISOString() },
+      lastQuote: {
+        price: 119.38,
+        asOf: new Date(now.getTime() - 4 * 24 * 60 * 60 * 1_000).toISOString(),
+        fetchedAt: new Date(now.getTime() - 4 * 24 * 60 * 60 * 1_000).toISOString(),
+        source: 'test',
+        bid: 119.3,
+        ask: 119.46,
+      },
+    }
+
+    // Pure helper: SELL bypasses the stale gate entirely.
+    const pure = evaluatePerSymbolRisk(
+      { symbol: 'AAPL', side: 'SELL', intentPrice: 119.38, intentNotional: 119.38, state, now },
+      riskConfig,
+    )
+    expect(pure.approved).toBe(true)
+
+    // TradingService route: price >= sellAbove (20_000) triggers SELL via FixedRuleStrategy.
+    const result = await tradingService(makeStore({ AAPL: state })).executeTrade(
+      { symbol: 'AAPL', price: 25_000, quantity: 1 },
+      tradingConfig,
+    )
+    expect(result.riskDecision.allowed).toBe(true)
+    expect(
+      result.riskDecision.reasons.some((r) => r.includes('halt or stale quote')),
+    ).toBe(false)
+  })
+
   it('clean state approves in all 3 evaluators', async () => {
     const cleanState = emptySymbolState('AAPL', () => now)
 


### PR DESCRIPTION
## 動機

PR #206 で `evaluatePerSymbolRisk` が cron と TradingService の per-symbol gate を unify した際、 **エントリ抑止系 gate (stale quote / spread / gap / JP band) が side 区別なく評価されていた**。

実際に発生した事象 (user 報告):

- SOXL position (avg 124.95, stop -4% ≒ 119.95) を保有
- 2026-04-25 14:30Z に price=119.38 (stop 割れ) → 戦略が SELL 判定
- だが `evaluatePerSymbolRisk` が `halt or stale quote: lastQuote 04-23T... exceeds staleQuoteMs 900000` で **REJECT**
- 結果: stop が発動せず position が放置されていた

## 影響

**損切り (stop hit) が発動できず position が塩漬け** になる。これは fail-closed 設計の意図とも逆 (= exit を止めるのは安全側ではなく、更なる損失拡大を招く)。

同等 risk のある gate:
- 4. halt / stale quote
- 5. spread guard (wide spread)
- 6. gap re-eval (avg vs current の |gap| 大)
- 7. JP price band (band 外 limit)

すべて **エントリ抑止** が目的なので **BUY only** にすべき。

## 修正

`src/trading/risk/perSymbolRiskGate.ts` の gate 4-7 を `side === 'BUY'` でガード:

- gate 1 (cooldown / option) は変更なし — `evaluateCooldown` 経由のみ評価で挙動互換
- gate 2 (settled cash) / gate 3 (inverse pair) は既に BUY only

## 別 issue 推奨 (今回 scope 外)

- cooldown も SELL を block する risk あり (`evaluateCooldown=true` の TradingService 経路)。今回の scope は **「stale quote が SELL を block する」だけ修正**、cooldown 側は別 issue で扱うのが妥当。

## test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test --run` 全 pass (756/756)
- [x] `evaluatePerSymbolRisk` の SELL passthrough cases 追加:
  - SELL + stale lastQuote (4 日前) → APPROVED
  - SELL + wide spread → APPROVED
  - SELL + bid/ask 欠損 → APPROVED
  - SELL + 大 gap (avg 124.95 vs 119.38) → APPROVED
  - SELL + JP price band 外 → APPROVED
- [x] 既存 BUY reject cases は regression なく pass
- [x] parity test に SELL passthrough (TradingService 経由) 追加

## scope

- 触ったのは gate 4-7 の `side` 条件追加 (各 1 行) と doc comment / unit test / parity test のみ
- `evaluateGap` / `evaluateSpreadGate` の内部実装は touch せず caller 側で BUY only check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 売却・ポジション終了時の優先度を高め、古い相場情報、スプレッド、ギャップ、価格帯などのリスク検査をバイパスできるようになりました。買い注文の制限は変わりません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->