### PR TITLE
feat(webull): error response body をログに含める (417 等の reject reason 可視化)

### DIFF
--- a/src/infrastructure/webull/WebullHttpClient.ts
+++ b/src/infrastructure/webull/WebullHttpClient.ts
@@ -124,6 +124,7 @@ export class WebullHttpClient {
     const resolvedUrl = buildRequestUrl(this.baseUrl, path, query)
     let lastFailure: Error | undefined
     let lastStatus: number | undefined
+    let lastBody: string | undefined
 
     let authHeaders: Record<string, string>
     try {
@@ -199,16 +200,28 @@ export class WebullHttpClient {
         return (await response.json()) as T
       }
 
+      // Capture response body for error diagnostics. Webull typically returns
+      // `{ code: "...", message: "..." }` JSON on errors, but some failures
+      // come from upstream CDN / proxies as HTML or plain text (502 etc.), so
+      // use `text()` rather than `json()` to keep the raw body either way.
+      // Truncate to avoid memory blowup on huge HTML error pages.
+      const bodyText = await readErrorBody(response)
+
       lastStatus = response.status
-      lastFailure = new Error(`Webull request failed with status ${response.status}`)
+      lastBody = bodyText
+      lastFailure = new Error(
+        `Webull request failed with status ${response.status}: ${bodyText}`,
+      )
 
       if (response.status >= 400 && response.status < 500) {
         // 4xx is the caller's fault or an auth/rate-limit problem — do not
         // retry. Map to the narrowest error subclass so downstream handlers
-        // can treat 401/429 differently from 400.
+        // can treat 401/429 differently from 400. Include the response body
+        // in the surfaced message so logs show why Webull rejected the
+        // request (e.g. 417 with `ORDER_INVALID_QTY`).
         throw brokerErrorForStatus(
           response.status,
-          `Webull request failed permanently with status ${response.status}`,
+          `Webull request failed permanently with status ${response.status}: ${bodyText}`,
           `${method} ${path}`,
           { cause: lastFailure },
         )
@@ -229,10 +242,11 @@ export class WebullHttpClient {
 
     if (lastStatus !== undefined) {
       // Retries exhausted on a 5xx. Surface as a server-class error so alerts
-      // can distinguish "Webull is down" from "we sent a bad request".
+      // can distinguish "Webull is down" from "we sent a bad request". Include
+      // the last response body so the log explains *why* the upstream gave up.
       throw brokerErrorForStatus(
         lastStatus,
-        `Webull request failed after ${this.retry.maxAttempts} attempts with last status ${lastStatus}`,
+        `Webull request failed after ${this.retry.maxAttempts} attempts with last status ${lastStatus}: ${lastBody ?? '<no body>'}`,
         `${method} ${path}`,
         { cause: lastFailure },
       )
@@ -306,6 +320,32 @@ function getRetryDelayMs({
 
 function wait(delayMs: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, delayMs))
+}
+
+/**
+ * Read an upstream error response body for diagnostics. Use `text()` rather
+ * than `json()` because non-JSON bodies are common (CDN HTML 502 pages, plain
+ * text proxy errors). The body is truncated to keep log lines bounded — the
+ * Webull error envelope `{code, message}` is well within this limit, and any
+ * larger blob is most likely an HTML error page that is not worth keeping in
+ * full.
+ */
+const ERROR_BODY_MAX_CHARS = 1000
+
+async function readErrorBody(response: Response): Promise<string> {
+  let text: string
+  try {
+    text = await response.text()
+  } catch {
+    return '<failed to read body>'
+  }
+  if (text.length === 0) {
+    return '<empty body>'
+  }
+  if (text.length > ERROR_BODY_MAX_CHARS) {
+    return `${text.slice(0, ERROR_BODY_MAX_CHARS)}...[truncated]`
+  }
+  return text
 }
 
 function buildRequestUrl(baseUrl: string, path: string, query?: Record<string, string>): URL {

--- a/test/infrastructure/webull/webullHttpClient.test.ts
+++ b/test/infrastructure/webull/webullHttpClient.test.ts
@@ -281,6 +281,63 @@ describe('WebullHttpClient', () => {
     expect(fetchMock).toHaveBeenCalledTimes(3)
   })
 
+  it('includes the JSON response body in the 4xx error message (Webull reject reason)', async () => {
+    // 417 with a typical Webull error envelope. Without this the operator only
+    // sees "status 417" in cron logs and cannot tell whether the rejection is
+    // ORDER_INVALID_QTY, MARKET_CLOSED, etc.
+    const body = JSON.stringify({
+      code: 'ORDER_INVALID_QTY',
+      message: 'requested quantity exceeds available holding',
+    })
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(body, { status: 417 }))
+    const client = createClient(fetchMock)
+
+    const err = await client.placeOrder(intent).catch((e: unknown) => e)
+    expect(err).toBeInstanceOf(BrokerClientError)
+    expect((err as Error).message).toContain('status 417')
+    expect((err as Error).message).toContain('ORDER_INVALID_QTY')
+    expect((err as Error).message).toContain('requested quantity exceeds available holding')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('includes the plain-text response body in the 5xx retried-out error message', async () => {
+    // A fresh Response per call — `Response.text()` consumes the body, so
+    // returning the same instance across retries would make later attempts
+    // see `<failed to read body>` instead of the real upstream message.
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockImplementation(async () => new Response('Internal Server Error', { status: 500 }))
+    const client = createClient(fetchMock)
+
+    const err = await client.placeOrder(intent).catch((e: unknown) => e)
+    expect(err).toBeInstanceOf(BrokerServerError)
+    expect((err as Error).message).toContain('Internal Server Error')
+    expect((err as Error).message).toContain('after 3 attempts with last status 500')
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('truncates oversized error bodies to keep log lines bounded', async () => {
+    // 10KB HTML page from a CDN — we keep at most 1000 chars + the truncation
+    // marker so the log line cannot blow up.
+    const huge = 'A'.repeat(10_000)
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockImplementation(async () => new Response(huge, { status: 502 }))
+    const client = createClient(fetchMock)
+
+    const err = await client.placeOrder(intent).catch((e: unknown) => e)
+    expect(err).toBeInstanceOf(BrokerServerError)
+    const msg = (err as Error).message
+    expect(msg).toContain('...[truncated]')
+    // The truncated body itself ends at 1000 'A's; the full message has
+    // additional surrounding text but should not contain anywhere near the
+    // original 10K characters.
+    expect(msg).not.toContain('A'.repeat(1100))
+    expect(msg).toContain('A'.repeat(1000))
+  })
+
   it('retries AbortError failures', async () => {
     const fetchMock = vi
       .fn<typeof fetch>()


### PR DESCRIPTION
## Motivation

現状 Webull が 4xx / 5xx で reject した時、ログには HTTP status code しか
残らない。実際 SOXL の stop-loss が 417 で permanent reject された時、
`Webull request failed permanently with status 417` までしか見えず、
ORDER_INVALID_QTY なのか MARKET_CLOSED なのか INSUFFICIENT_HOLDING なのか、
原因特定に再現実験が必要だった。

## Summary

- `WebullHttpClient.request` で response body (text) を読んで error message に含める。
  - 4xx fail-fast 経路: `Webull request failed permanently with status 417: {"code":"...","message":"..."}` の形に。
  - 5xx retry-exhausted 経路: 同様に最後のレスポンス body を埋め込む。
- `response.text()` を使う。Webull の error envelope は JSON だが、CDN / proxy の
  502 など non-JSON も混ざるので raw text で受ける。
- 1000 文字で truncate してログ行が膨らまないよう抑える。
- `BrokerRequestError` 配下のサブクラス (`BrokerAuthError` / `BrokerClientError` /
  `BrokerRateLimitError` / `BrokerServerError`) はそのまま — `.message` のみ拡張なので、
  下流 (`pullbackScheduler.ts` の `broker submit error: ${messageOf(error)}` 等) は
  追加変更なしで reject reason を出力できる。

## Sample log output (after)

```
broker submit error: Webull request failed permanently with status 417: {"code":"ORDER_INVALID_QTY","message":"requested quantity exceeds available holding"}
```

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test --run` (753 tests) 全 pass
- [x] 新規テスト 3 件追加:
  - 417 + JSON body → message に code / message が含まれる + `BrokerClientError` 維持
  - 500 + plain text body → retry されつつ最終 message に body が含まれる + `BrokerServerError` 維持
  - 10KB body → `...[truncated]` 付きで 1000 chars に切り詰められる

## Notes

- Webull の error response は通常 PII / credential を含まない (broker reject reason の
  symbolic code + 短文 message) ので raw 載せて問題なし。CDN HTML 等は truncate で抑制。
- `response.text()` は body を 1 度しか読めないので、retry 用の mock factory も
  `mockImplementation` に差し替え。

## Out of scope

- Cron 通知 / dashboard 表示側の文言整形は今回触らない。下流の `messageOf(error)`
  経路を経由して透過的に詳細化されるはず。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * Webull APIからのエラーレスポンス情報がエラーメッセージに含まれるようになり、問題の診断がしやすくなりました
  * 大きなレスポンスボディは自動的に切り詰められ、ログの安全性が向上しました

* **テスト**
  * エラーメッセージの内容と動作を検証するテストケースを追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->