### PR TITLE
feat(ops): SymbolState override + SELL qty fallback (Webull SELL_QTY_EXCEED 対応)

### DIFF
--- a/src/infrastructure/webull/WebullHttpClient.ts
+++ b/src/infrastructure/webull/WebullHttpClient.ts
@@ -4,6 +4,7 @@ import type {
   WebullAccountDto,
   WebullOrderDetailDto,
   WebullPlaceOrderResponseDto,
+  WebullPositionDto,
   WebullSubscriptionDto,
 } from './dto'
 import { toWebullPlaceOrderRequest } from './mapper'
@@ -97,6 +98,23 @@ export class WebullHttpClient {
       },
     )
     return page.find((entry) => entry.client_order_id === clientOrderId)
+  }
+
+  /**
+   * Fetch the account's open positions. Used by the SELL_QTY_EXCEED fallback
+   * in the cron path: when Webull rejects a SELL because the requested qty
+   * is greater than `quantity_available` (e.g. DO state drifted above broker
+   * truth), the scheduler re-fetches available qty here and retries the
+   * SELL with the broker-side ground truth.
+   *
+   * TODO(#21): the live UAT endpoint name is not yet confirmed — using
+   * `/openapi/account/positions/get` based on Webull OpenAPI naming
+   * conventions. Update once the live response shape is verified.
+   */
+  async getPositions(): Promise<WebullPositionDto[]> {
+    return this.request<WebullPositionDto[]>('GET', '/openapi/account/positions/get', {
+      query: { account_id: this.requireAccountId() },
+    })
   }
 
   async placeOrder(intent: OrderIntent): Promise<WebullPlaceOrderResponseDto> {
@@ -218,7 +236,10 @@ export class WebullHttpClient {
         // retry. Map to the narrowest error subclass so downstream handlers
         // can treat 401/429 differently from 400. Include the response body
         // in the surfaced message so logs show why Webull rejected the
-        // request (e.g. 417 with `ORDER_INVALID_QTY`).
+        // request (e.g. 417 with `ORDER_INVALID_QTY`) and so callers can
+        // detect Webull-specific error codes like
+        // `OAUTH_OPENAPI_SELL_QTY_EXCEED_AVAILABLE_QTY` (used by the SELL
+        // fallback in pullbackScheduler) by string-matching on the message.
         throw brokerErrorForStatus(
           response.status,
           `Webull request failed permanently with status ${response.status}: ${bodyText}`,

--- a/src/infrastructure/webull/WebullHttpClient.ts
+++ b/src/infrastructure/webull/WebullHttpClient.ts
@@ -103,18 +103,42 @@ export class WebullHttpClient {
   /**
    * Fetch the account's open positions. Used by the SELL_QTY_EXCEED fallback
    * in the cron path: when Webull rejects a SELL because the requested qty
-   * is greater than `quantity_available` (e.g. DO state drifted above broker
+   * is greater than `available_quantity` (e.g. DO state drifted above broker
    * truth), the scheduler re-fetches available qty here and retries the
    * SELL with the broker-side ground truth.
    *
-   * TODO(#21): the live UAT endpoint name is not yet confirmed — using
-   * `/openapi/account/positions/get` based on Webull OpenAPI naming
-   * conventions. Update once the live response shape is verified.
+   * Endpoint and field names follow the official Webull OpenAPI reference:
+   * https://developer.webull.com/apis/docs/reference/account-position/
    */
   async getPositions(): Promise<WebullPositionDto[]> {
-    return this.request<WebullPositionDto[]>('GET', '/openapi/account/positions/get', {
+    return this.request<WebullPositionDto[]>('GET', '/openapi/account/positions', {
       query: { account_id: this.requireAccountId() },
     })
+  }
+
+  /**
+   * Resolve the broker-side `available_quantity` for a single symbol. Wraps
+   * `getPositions()` and keeps the Webull DTO interpretation (case-insensitive
+   * symbol match, `available_quantity` parsing) inside the infrastructure
+   * layer so the application-side scheduler only sees a `number | null`.
+   *
+   * - Position match found AND `available_quantity` parses to a finite number
+   *   (including 0) → that number is returned.
+   * - Position match found but `available_quantity` is missing / non-numeric
+   *   → `null`.
+   * - No matching symbol on the account → `null`.
+   * - `getPositions()` throws → the error is rethrown (caller decides how to
+   *   handle the SELL fallback failure).
+   */
+  async getAvailableQtyForSymbol(symbol: string): Promise<number | null> {
+    const target = symbol.toUpperCase()
+    const positions = await this.getPositions()
+    const match = positions.find((p) => (p.symbol ?? '').toUpperCase() === target)
+    if (!match) return null
+    const raw = match.available_quantity
+    if (raw === undefined || raw === null || raw === '') return null
+    const parsed = Number(raw)
+    return Number.isFinite(parsed) ? parsed : null
   }
 
   async placeOrder(intent: OrderIntent): Promise<WebullPlaceOrderResponseDto> {

--- a/src/infrastructure/webull/dto.ts
+++ b/src/infrastructure/webull/dto.ts
@@ -42,15 +42,12 @@ export interface WebullPlaceOrderResponseDto {
 }
 
 /**
- * One row of the Webull `account/positions/get` response. Field names are
- * the Webull canonical snake_case + numeric-as-string convention used
- * throughout the OpenAPI surface (mapper layer parses the strings to
- * numbers before they leave infrastructure).
- *
- * TODO(#21): the live JP UAT tenant has not yet been probed for this
- * endpoint — the field set is inferred from `WebullSubscriptionDto` /
- * `WebullOrderDetailDto` conventions. Treat shape as "best effort" until
- * confirmed against a real response. See follow-up issue #21.
+ * One row of the Webull `/openapi/account/positions` response. Field names
+ * follow the official Webull OpenAPI reference
+ * (https://developer.webull.com/apis/docs/reference/account-position/) —
+ * canonical snake_case + numeric-as-string convention used throughout the
+ * OpenAPI surface (mapper layer parses the strings to numbers before they
+ * leave infrastructure).
  */
 export interface WebullPositionDto {
   /** Ticker. Webull returns it as the canonical form (e.g. `SOXL`, `1570`). */
@@ -58,8 +55,9 @@ export interface WebullPositionDto {
   /** Total holding (informational). */
   quantity_total?: string
   /** Available-to-sell holding. May be < `quantity_total` when shares are
-   *  reserved by an in-flight SELL. SELL fallback uses **this** value. */
-  quantity_available?: string
+   *  reserved by an in-flight SELL. SELL fallback uses **this** value.
+   *  Webull canonical field name (per official reference docs). */
+  available_quantity?: string
   /** Average cost basis (informational; not used by SELL fallback). */
   avg_cost?: string
   /** Currency on the position. POC: USD/JPY only. */

--- a/src/infrastructure/webull/dto.ts
+++ b/src/infrastructure/webull/dto.ts
@@ -42,6 +42,33 @@ export interface WebullPlaceOrderResponseDto {
 }
 
 /**
+ * One row of the Webull `account/positions/get` response. Field names are
+ * the Webull canonical snake_case + numeric-as-string convention used
+ * throughout the OpenAPI surface (mapper layer parses the strings to
+ * numbers before they leave infrastructure).
+ *
+ * TODO(#21): the live JP UAT tenant has not yet been probed for this
+ * endpoint — the field set is inferred from `WebullSubscriptionDto` /
+ * `WebullOrderDetailDto` conventions. Treat shape as "best effort" until
+ * confirmed against a real response. See follow-up issue #21.
+ */
+export interface WebullPositionDto {
+  /** Ticker. Webull returns it as the canonical form (e.g. `SOXL`, `1570`). */
+  symbol?: string
+  /** Total holding (informational). */
+  quantity_total?: string
+  /** Available-to-sell holding. May be < `quantity_total` when shares are
+   *  reserved by an in-flight SELL. SELL fallback uses **this** value. */
+  quantity_available?: string
+  /** Average cost basis (informational; not used by SELL fallback). */
+  avg_cost?: string
+  /** Currency on the position. POC: USD/JPY only. */
+  currency?: string
+  /** Optional account id (some Webull endpoints echo it back per row). */
+  account_id?: string
+}
+
+/**
  * Shape returned by GET /openapi/account/orders/detail (v1).
  * Fields mirror openapi-java-sdk's `v2.OrderHistory`.
  */

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -30,6 +30,47 @@ import type { SymbolRule } from '../trading/strategy/strategies/PullbackUptrendS
  * and should only be called for initial seeding or reconciliation.
  */
 export const admin = new Hono<AppBindings>()
+  /**
+   * Operator override for a corrupted `position`. Used when a past reconcile
+   * race left DO state with a qty above broker truth (#215) — the regular
+   * recordFill path can't undo it because there is no fill to apply, so the
+   * operator must reset directly. POC blast radius: requires Basic Auth and
+   * an explicit `reason` string for the audit log.
+   *
+   * Body: `{ qty: number, avgPrice: number, openedAt?: string | null, reason: string }`
+   *   - `qty=0` → close the position (avgPrice / openedAt ignored)
+   *   - `qty>0` → write `{ qty, avgPrice, openedAt: openedAt ?? now() }`
+   *
+   * Side effects: emits one structured `symbol_state_position_override`
+   * audit log with before/after/reason/requestId. Does NOT touch
+   * `pendingOrder` / `cooldownUntil` / `settledCash`.
+   */
+  .post('/symbol-state/:symbol/override-position', async (c) => {
+    const symbol = c.req.param('symbol').trim().toUpperCase()
+    if (symbol.length === 0) {
+      throw new ValidationError('symbol must be a non-empty path param', { field: 'symbol' })
+    }
+    if (!c.env.SYMBOL_STATE) {
+      throw new ValidationError('SYMBOL_STATE binding is not configured', { field: 'env' })
+    }
+
+    const body = (await c.req.json().catch(() => null)) as unknown
+    const args = readOverridePositionBody(body)
+
+    const client = new SymbolStateClient(c.env.SYMBOL_STATE)
+    const state = await client.overridePosition(symbol, {
+      qty: args.qty,
+      avgPrice: args.avgPrice,
+      openedAt: args.openedAt,
+      reason: args.reason,
+      requestId: c.get('requestId'),
+    })
+    return c.json({
+      symbol,
+      position: state.position,
+      updatedAt: state.updatedAt,
+    })
+  })
   .post('/symbols/:symbol/seed-cash', async (c) => {
     const symbol = c.req.param('symbol').trim().toUpperCase()
     if (symbol.length === 0) {
@@ -598,6 +639,79 @@ function parseEarningsSeedRow(raw: unknown, idx: number): EarningsCalendarSeedIn
     notes = obj.notes
   }
   return { symbol: symbol.toUpperCase(), earningsDate, notes }
+}
+
+/**
+ * Parse the `/admin/symbol-state/:symbol/override-position` body. Strict so
+ * an operator typo in qty / avgPrice / reason gets a 400 instead of silently
+ * writing a malformed position into the DO.
+ *
+ *   - `qty`: finite >= 0 (0 = close)
+ *   - `avgPrice`: finite > 0 when `qty > 0`; ignored when `qty=0` but we
+ *     still type-check to surface stray fields
+ *   - `openedAt`: ISO 8601 timestamp string OR null OR omitted (→ null)
+ *   - `reason`: required, 1..256 chars (mandatory audit context)
+ */
+function readOverridePositionBody(body: unknown): {
+  qty: number
+  avgPrice: number
+  openedAt: string | null
+  reason: string
+} {
+  if (body === null || typeof body !== 'object' || Array.isArray(body)) {
+    throw new ValidationError('body must be a JSON object', { field: 'body' })
+  }
+  const raw = body as {
+    qty?: unknown
+    avgPrice?: unknown
+    openedAt?: unknown
+    reason?: unknown
+  }
+  const qty = raw.qty
+  if (typeof qty !== 'number' || !Number.isFinite(qty) || qty < 0) {
+    throw new ValidationError('qty must be a finite number >= 0', { field: 'qty' })
+  }
+  const avgPriceRaw = raw.avgPrice
+  let avgPrice = 0
+  if (qty > 0) {
+    if (typeof avgPriceRaw !== 'number' || !Number.isFinite(avgPriceRaw) || avgPriceRaw <= 0) {
+      throw new ValidationError('avgPrice must be a finite number > 0 when qty>0', {
+        field: 'avgPrice',
+      })
+    }
+    avgPrice = avgPriceRaw
+  } else if (avgPriceRaw !== undefined && avgPriceRaw !== null) {
+    // qty=0 close: avgPrice irrelevant. Tolerate but still validate type so
+    // a stray string doesn't get silently accepted.
+    if (typeof avgPriceRaw !== 'number' || !Number.isFinite(avgPriceRaw) || avgPriceRaw < 0) {
+      throw new ValidationError('avgPrice must be a finite number >= 0 when present', {
+        field: 'avgPrice',
+      })
+    }
+  }
+  let openedAt: string | null = null
+  if (raw.openedAt !== undefined && raw.openedAt !== null) {
+    if (typeof raw.openedAt !== 'string') {
+      throw new ValidationError('openedAt must be an ISO 8601 string or null', {
+        field: 'openedAt',
+      })
+    }
+    const t = new Date(raw.openedAt).getTime()
+    if (!Number.isFinite(t)) {
+      throw new ValidationError('openedAt must be a valid ISO 8601 timestamp', {
+        field: 'openedAt',
+      })
+    }
+    openedAt = raw.openedAt
+  }
+  const reason = raw.reason
+  if (typeof reason !== 'string' || reason.trim().length === 0) {
+    throw new ValidationError('reason must be a non-empty string', { field: 'reason' })
+  }
+  if (reason.length > 256) {
+    throw new ValidationError('reason must be <= 256 chars', { field: 'reason' })
+  }
+  return { qty, avgPrice, openedAt, reason }
 }
 
 function readAmount(body: unknown): number {

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -128,6 +128,30 @@ export function brokerErrorForStatus(
   return new BrokerRequestError(message, operation, opts)
 }
 
+/**
+ * Webull error code surfaced when a SELL request's quantity exceeds the
+ * account's `quantity_available`. Returned with HTTP 417 alongside the
+ * code in the response body. Hard-coded as a string (not enum) because
+ * the broker treats it as a versionless protocol constant.
+ */
+export const WEBULL_SELL_QTY_EXCEED_CODE = 'OAUTH_OPENAPI_SELL_QTY_EXCEED_AVAILABLE_QTY'
+
+/**
+ * True when the error is the Webull-specific "SELL qty > available qty"
+ * 417, used by the SELL fallback path in `pullbackScheduler` to decide
+ * whether to refetch the broker's available qty and retry.
+ *
+ * Detection is conservative: status must be 417 AND the error message
+ * (which includes the response body snippet, see `WebullHttpClient`) must
+ * contain `OAUTH_OPENAPI_SELL_QTY_EXCEED_AVAILABLE_QTY`. Other 417s
+ * (unlikely but possible) fall through to the regular error path.
+ */
+export function isSellQtyExceedError(error: unknown): error is BrokerClientError {
+  if (!(error instanceof BrokerClientError)) return false
+  if (error.brokerStatus !== 417) return false
+  return error.message.includes(WEBULL_SELL_QTY_EXCEED_CODE)
+}
+
 // Planned but deferred per issue #1 §13:
 // RiskRejectedError, BrokerResponseError, ConfigurationError,
 // TradeEventIngestError, BridgeConnectionError.

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -130,7 +130,7 @@ export function brokerErrorForStatus(
 
 /**
  * Webull error code surfaced when a SELL request's quantity exceeds the
- * account's `quantity_available`. Returned with HTTP 417 alongside the
+ * account's `available_quantity`. Returned with HTTP 417 alongside the
  * code in the response body. Hard-coded as a string (not enum) because
  * the broker treats it as a versionless protocol constant.
  */

--- a/src/trading/state/PositionStore.ts
+++ b/src/trading/state/PositionStore.ts
@@ -19,4 +19,20 @@ export interface PositionStore {
   addPendingSettlement(symbol: string, settlement: PendingSettlement): Promise<SymbolState>
   setCooldown(symbol: string, untilIso: string): Promise<SymbolState>
   seedSettledCash(symbol: string, amount: number): Promise<SymbolState>
+  /**
+   * Operator-driven position override. Used to manually reconcile DO state
+   * against broker truth (e.g. corrupted `position.qty` from a past
+   * reconcile race) and from the SELL_QTY_EXCEED fallback path to force
+   * `position=null` after the fallback closes the broker-side holding.
+   */
+  overridePosition(
+    symbol: string,
+    args: {
+      qty: number
+      avgPrice: number
+      openedAt: string | null
+      reason: string
+      requestId?: string | null
+    },
+  ): Promise<SymbolState>
 }

--- a/src/trading/state/SymbolStateClient.ts
+++ b/src/trading/state/SymbolStateClient.ts
@@ -55,4 +55,17 @@ export class SymbolStateClient implements PositionStore {
   seedSettledCash(symbol: string, amount: number): Promise<SymbolState> {
     return this.stub(symbol).seedSettledCash(symbol, amount)
   }
+
+  overridePosition(
+    symbol: string,
+    args: {
+      qty: number
+      avgPrice: number
+      openedAt: string | null
+      reason: string
+      requestId?: string | null
+    },
+  ): Promise<SymbolState> {
+    return this.stub(symbol).overridePosition(symbol, args)
+  }
 }

--- a/src/trading/state/SymbolStateDO.ts
+++ b/src/trading/state/SymbolStateDO.ts
@@ -3,6 +3,7 @@ import {
   addPendingSettlement,
   clearPendingOrder,
   lockPendingOrder,
+  overridePosition,
   recordFill,
   recordFillOnce,
   recordSignal,
@@ -114,6 +115,44 @@ export class SymbolStateDO extends DurableObject<object> {
     const state = await this.load(symbol)
     const next = seedSettledCash(state, amount, this.transitionCtx)
     await this.save(next)
+    return next
+  }
+
+  /**
+   * Operator override for a corrupted `position`. Logs a structured audit
+   * record (`event: 'symbol_state_position_override'`) with the previous
+   * and new position so the trail is recoverable from log tail. Caller is
+   * expected to be the Basic-auth-protected admin route — DO surface alone
+   * is not a security boundary.
+   */
+  async overridePosition(
+    symbol: string,
+    args: {
+      qty: number
+      avgPrice: number
+      openedAt: string | null
+      reason: string
+      requestId?: string | null
+    },
+  ): Promise<SymbolState> {
+    const state = await this.load(symbol)
+    const next = overridePosition(
+      state,
+      { qty: args.qty, avgPrice: args.avgPrice, openedAt: args.openedAt },
+      this.transitionCtx,
+    )
+    await this.save(next)
+    console.log(
+      JSON.stringify({
+        event: 'symbol_state_position_override',
+        symbol,
+        requestId: args.requestId ?? null,
+        reason: args.reason,
+        before: state.position,
+        after: next.position,
+        appliedAt: next.updatedAt,
+      }),
+    )
     return next
   }
 

--- a/src/trading/state/stateTransitions.ts
+++ b/src/trading/state/stateTransitions.ts
@@ -150,6 +150,62 @@ export function addPendingSettlement(
 }
 
 /**
+ * Operator-driven position override. Used to manually reconcile a corrupted
+ * `position` against the real broker holding (e.g. after a reconcile-race
+ * double-apply that drifted DO qty above broker truth). Not part of the
+ * regular BUY/SELL fill flow — `recordFill` should be the only writer for
+ * organic state changes.
+ *
+ *   - `qty <= 0` (or null caller intent) → close the position entirely.
+ *     Internally accepted only when the operator explicitly opts in via
+ *     `qty=0` so we never silently swallow a typo as "close".
+ *   - `qty > 0` → write `{ qty, avgPrice, openedAt: openedAt ?? now() }`.
+ *
+ * Fail-closed on bad inputs (NaN / negative / zero avgPrice when qty>0)
+ * because operators paste these values from a CLI; rejecting upfront avoids
+ * a malformed position propagating into the strategy loop.
+ */
+export function overridePosition(
+  state: SymbolState,
+  args: { qty: number; avgPrice: number; openedAt: string | null },
+  ctx: TransitionContext = defaultCtx,
+): SymbolState {
+  if (!Number.isFinite(args.qty) || args.qty < 0) {
+    throw new Error(
+      `overridePosition: invalid qty=${args.qty} (must be a finite number >= 0)`,
+    )
+  }
+  const iso = ctx.now().toISOString()
+  if (args.qty === 0) {
+    // Operator-explicit close. avgPrice / openedAt are ignored on close so a
+    // mistyped price field doesn't accidentally seed a fresh position.
+    return { ...state, position: null, updatedAt: iso }
+  }
+  if (!Number.isFinite(args.avgPrice) || args.avgPrice <= 0) {
+    throw new Error(
+      `overridePosition: invalid avgPrice=${args.avgPrice} (must be a finite number > 0 when qty>0)`,
+    )
+  }
+  if (args.openedAt !== null) {
+    const t = new Date(args.openedAt).getTime()
+    if (!Number.isFinite(t)) {
+      throw new Error(
+        `overridePosition: invalid openedAt=${args.openedAt} (must be ISO 8601 timestamp or null)`,
+      )
+    }
+  }
+  return {
+    ...state,
+    position: {
+      qty: args.qty,
+      avgPrice: args.avgPrice,
+      openedAt: args.openedAt ?? iso,
+    },
+    updatedAt: iso,
+  }
+}
+
+/**
  * Overwrites `settledCash` with an operator-provided value. POC seed path —
  * used once during initial setup or after a manual reconciliation with the
  * broker. Not part of the regular fill/roll flow.

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -2,6 +2,7 @@ import type { BarClient } from '../../infrastructure/quotes/BarClient'
 import { logPostSubmit, logPreSubmit } from '../../infrastructure/logger/tradeJournal'
 import { classifyBrokerErrorCause } from '../../infrastructure/notification/brokerErrorSurge'
 import type { Notifier } from '../../infrastructure/notification/Notifier'
+import { isSellQtyExceedError } from '../../shared/errors'
 import type { DecisionTraceStep } from '../domain/Signal'
 import { inferTradingMarket } from '../domain/tradingCalendar'
 import type { Execution } from '../execution/Execution'
@@ -104,6 +105,22 @@ export interface PullbackSchedulerOptions {
    */
   perSymbolRisk?: PerSymbolRiskScheduleConfig
   /**
+   * Webull SELL_QTY_EXCEED fallback resolver。SELL submit が
+   * `OAUTH_OPENAPI_SELL_QTY_EXCEED_AVAILABLE_QTY` (HTTP 417) で reject
+   * された時に呼ばれる: broker portfolio から実 available qty を返し、
+   * `available > 0 && available < intent.quantity` なら scheduler が
+   * 全部売りで再 submit する (= 辻褄合わせ)。失敗時は throw でも null
+   * 返却でも OK で、いずれの場合も元 SELL_QTY_EXCEED エラーが re-throw
+   * される (fail-closed)。production (`runStrategyCron`) は
+   * `WebullHttpClient.getPositions()` でラップして注入する。未注入なら
+   * fallback は skip (= 既存挙動の元 error 再 throw、POC 後方互換)。
+   *
+   * Race window: getAvailableQty と SELL submit の間で broker side が
+   * 動く可能性は POC 段階では許容。連続 reject は次の cron tick で
+   * 再評価される。
+   */
+  sellFallback?: SellFallbackConfig
+  /**
    * Earnings calendar gate (issue #196 1/3)。±N 営業日で BUY を凍結。
    * `repo` 未注入なら gate skip (POC 後方互換)。production
    * (`runStrategyCron`) が D1 から repo を作って渡す。
@@ -126,6 +143,17 @@ export interface PullbackSchedulerOptions {
    */
   vixDecision?: VixRegimeFilterDecision
   now?: () => Date
+}
+
+/**
+ * Resolver for the SELL_QTY_EXCEED fallback. Returns the broker-side
+ * `quantity_available` for the symbol (case-insensitive match), or `null`
+ * if not held / not findable. Throwing here is treated the same as `null`
+ * — the fallback is best-effort and never converts a SELL reject into a
+ * different reject (the original SELL_QTY_EXCEED error is re-thrown).
+ */
+export interface SellFallbackConfig {
+  getAvailableQty: (symbol: string) => Promise<number | null>
 }
 
 export interface EarningsScheduleConfig {
@@ -753,55 +781,83 @@ export async function runPullbackScheduler(
     }
 
     let result: ExecutionResult | undefined
+    let executedIntent: OrderIntent = intent
+    let fallbackApplied = false
     const startedAt = Date.now()
     try {
       result = await options.execution.execute(intent)
     } catch (error) {
-      await options.positionStore.clearPendingOrder(upper).catch(() => undefined)
-      summary.errors.push({
-        symbol: upper,
-        message: messageOf(error),
-      })
-      await emitDecision({
-        symbol: upper,
-        decision: 'ERROR',
-        // DB には英語 canonical で保存。表示層 (localizeReason) で日本語化。
-        reason: `broker submit error: ${messageOf(error)}`,
-        price: indicators.price,
-        trace: appendTrace(signal.trace, traceStep('broker.submit', false, messageOf(error), '==', 'submitted')),
-      })
-      emitNotify({
-        type: 'ERROR',
-        symbol: upper,
-        message: messageOf(error),
-        // surge detector が cause で count するため (#209)、broker submit
-        // failure を 4xx / 429 / 5xx / other に分類する。`null` (= broker
-        // error ではない) なら legacy の `'broker submit'` に戻す。
-        cause: classifyBrokerErrorCause(error) ?? 'broker submit',
-      })
-      try {
-        logPostSubmit({
-          clientOrderId: intent.clientOrderId,
+      // SELL_QTY_EXCEED fallback: Webull rejected the SELL because qty >
+      // broker-side `quantity_available`. This usually means DO state has
+      // drifted above broker truth (#215 reconcile race). Fetch the actual
+      // available qty and retry the SELL with that — i.e. close out
+      // whatever the broker actually still holds, so the next cron tick
+      // sees a clean slate. If anything in the fallback fails, re-throw
+      // the original error path (no silent recovery).
+      const fallbackResult =
+        intent.side === 'SELL' && options.sellFallback && isSellQtyExceedError(error)
+          ? await tryFallbackSell({
+              originalIntent: intent,
+              error,
+              upper,
+              symbol,
+              execution: options.execution,
+              positionStore: options.positionStore,
+              sellFallback: options.sellFallback,
+              requestId: options.requestId,
+            })
+          : null
+      if (fallbackResult) {
+        result = fallbackResult.result
+        executedIntent = fallbackResult.intent
+        fallbackApplied = true
+      } else {
+        await options.positionStore.clearPendingOrder(upper).catch(() => undefined)
+        summary.errors.push({
           symbol: upper,
-          latencyMs: Date.now() - startedAt,
-          error: error instanceof Error ? error : new Error(String(error)),
+          message: messageOf(error),
         })
-      } catch (logError) {
-        console.error(
-          JSON.stringify({
-            event: 'cron_log_post_submit_failed',
-            symbol: upper,
+        await emitDecision({
+          symbol: upper,
+          decision: 'ERROR',
+          // DB には英語 canonical で保存。表示層 (localizeReason) で日本語化。
+          reason: `broker submit error: ${messageOf(error)}`,
+          price: indicators.price,
+          trace: appendTrace(signal.trace, traceStep('broker.submit', false, messageOf(error), '==', 'submitted')),
+        })
+        emitNotify({
+          type: 'ERROR',
+          symbol: upper,
+          message: messageOf(error),
+          // surge detector が cause で count するため (#209)、broker submit
+          // failure を 4xx / 429 / 5xx / other に分類する。`null` (= broker
+          // error ではない) なら legacy の `'broker submit'` に戻す。
+          cause: classifyBrokerErrorCause(error) ?? 'broker submit',
+        })
+        try {
+          logPostSubmit({
             clientOrderId: intent.clientOrderId,
-            message: logError instanceof Error ? logError.message : String(logError),
-          }),
-        )
+            symbol: upper,
+            latencyMs: Date.now() - startedAt,
+            error: error instanceof Error ? error : new Error(String(error)),
+          })
+        } catch (logError) {
+          console.error(
+            JSON.stringify({
+              event: 'cron_log_post_submit_failed',
+              symbol: upper,
+              clientOrderId: intent.clientOrderId,
+              message: logError instanceof Error ? logError.message : String(logError),
+            }),
+          )
+        }
+        continue
       }
-      continue
     }
 
     try {
       logPostSubmit({
-        clientOrderId: intent.clientOrderId,
+        clientOrderId: executedIntent.clientOrderId,
         symbol: upper,
         result,
         latencyMs: Date.now() - startedAt,
@@ -811,46 +867,91 @@ export async function runPullbackScheduler(
         JSON.stringify({
           event: 'cron_log_post_submit_failed',
           symbol: upper,
-          clientOrderId: intent.clientOrderId,
+          clientOrderId: executedIntent.clientOrderId,
           message: logError instanceof Error ? logError.message : String(logError),
         }),
       )
     }
 
+    // SELL_QTY_EXCEED fallback succeeded → DO state currently lies above
+    // broker truth (the very reason we hit the fallback). Force-reset
+    // `position=null` so the next cron tick doesn't try to SELL phantom
+    // shares again. We deliberately bypass `recordFill` here because the
+    // executed qty < DO qty would leave a non-zero remainder.
+    if (fallbackApplied) {
+      try {
+        await options.positionStore.overridePosition(upper, {
+          qty: 0,
+          avgPrice: 0,
+          openedAt: null,
+          reason: `sell_qty_fallback: closed at broker available qty (originalIntentQty=${intent.quantity}, executedQty=${executedIntent.quantity})`,
+          requestId: options.requestId ?? null,
+        })
+      } catch (resetError) {
+        console.error(
+          JSON.stringify({
+            event: 'sell_qty_fallback_reset_failed',
+            requestId: options.requestId ?? null,
+            symbol: upper,
+            message: resetError instanceof Error ? resetError.message : String(resetError),
+          }),
+        )
+      }
+    }
+
     // Increment counters only after successful execution.
-    if (intent.side === 'BUY') {
+    if (executedIntent.side === 'BUY') {
       summary.buys += 1
     } else {
       summary.sells += 1
     }
     await emitDecision({
       symbol: upper,
-      decision: intent.side,
-      reason: signal.reason,
-      price: intent.price,
+      decision: executedIntent.side,
+      reason: fallbackApplied
+        ? `sell_qty_fallback: ${signal.reason} (originalQty=${intent.quantity}, executedQty=${executedIntent.quantity})`
+        : signal.reason,
+      price: executedIntent.price,
       indicatorsJson: JSON.stringify(indicators),
-      clientOrderId: intent.clientOrderId,
-      trace: appendTrace(signal.trace, traceStep('broker.submit', true, result.mode, '==', 'submitted')),
+      clientOrderId: executedIntent.clientOrderId,
+      trace: appendTrace(
+        signal.trace,
+        traceStep('broker.submit', true, result.mode, '==', 'submitted'),
+        ...(fallbackApplied
+          ? [
+              traceStep(
+                'broker.sell_qty_fallback',
+                true,
+                executedIntent.quantity,
+                '==',
+                intent.quantity,
+                'broker available qty で再 submit',
+              ),
+            ]
+          : []),
+      ),
       order: {
-        side: intent.side,
-        quantity: intent.quantity,
-        notional: intent.notional,
+        side: executedIntent.side,
+        quantity: executedIntent.quantity,
+        notional: executedIntent.notional,
       },
     })
 
     // SELL の realizedPnl は state.position.avgPrice (existing) と
-    // intent.price (exit) の差から推定。BUY 時は undefined。avgPrice が無い
-    // SELL は不正経路 (上で reject 済) なので発生しないはずだが defensive。
+    // executedIntent.price (exit) の差から推定。BUY 時は undefined。avgPrice
+    // が無い SELL は不正経路 (上で reject 済) なので発生しないはずだが defensive。
+    // fallback で qty が変わった場合も executedIntent.quantity を使うので
+    // realized PnL は実 SELL 数量分のみ。
     const realizedPnl =
-      intent.side === 'SELL' && state.position && Number.isFinite(state.position.avgPrice)
-        ? (intent.price - state.position.avgPrice) * intent.quantity
+      executedIntent.side === 'SELL' && state.position && Number.isFinite(state.position.avgPrice)
+        ? (executedIntent.price - state.position.avgPrice) * executedIntent.quantity
         : undefined
     emitNotify({
       type: 'TRADE',
-      side: intent.side,
+      side: executedIntent.side,
       symbol: upper,
-      qty: intent.quantity,
-      price: intent.price,
+      qty: executedIntent.quantity,
+      price: executedIntent.price,
       ...(realizedPnl !== undefined ? { realizedPnl } : {}),
       mode: result.mode,
     })
@@ -862,6 +963,93 @@ export async function runPullbackScheduler(
   }
 
   return summary
+}
+
+/**
+ * SELL_QTY_EXCEED fallback inner. Returns the successful execution result
+ * + the (possibly resized) intent that was actually submitted. Returns
+ * `null` when the fallback can't or shouldn't run — the caller treats
+ * `null` as "go re-throw the original error path".
+ *
+ * Conservative invariants:
+ *   - `available <= 0` → null (nothing to sell, original 417 stands)
+ *   - `available >= intent.quantity` → null (broker truth >= our intent;
+ *     the 417 was unexpected and we shouldn't paper over it)
+ *   - retry submit throws → null (don't substitute a different error)
+ *   - resolver throws / returns NaN → null
+ *
+ * The successful path emits one structured `sell_qty_fallback_submitted`
+ * audit log so the run is reconstructable from log tail. clientOrderId is
+ * regenerated for the retry so it doesn't collide with the original
+ * (rejected) submission's idempotency key.
+ */
+async function tryFallbackSell(args: {
+  originalIntent: OrderIntent
+  error: unknown
+  upper: string
+  symbol: string
+  execution: Execution
+  positionStore: PositionStore
+  sellFallback: SellFallbackConfig
+  requestId?: string
+}): Promise<{ result: ExecutionResult; intent: OrderIntent } | null> {
+  let available: number | null
+  try {
+    available = await args.sellFallback.getAvailableQty(args.upper)
+  } catch (resolverErr) {
+    console.warn(
+      JSON.stringify({
+        event: 'sell_qty_fallback_resolver_failed',
+        requestId: args.requestId ?? null,
+        symbol: args.upper,
+        message: resolverErr instanceof Error ? resolverErr.message : String(resolverErr),
+      }),
+    )
+    return null
+  }
+  if (available === null || !Number.isFinite(available) || available <= 0) {
+    return null
+  }
+  if (available >= args.originalIntent.quantity) {
+    // Broker says we have at least as much as we tried to SELL — the 417
+    // contradicts that, so the situation is something else (transient,
+    // race, broker bug). Don't fabricate a reduced SELL.
+    return null
+  }
+  const fallbackIntent: OrderIntent = {
+    ...args.originalIntent,
+    quantity: available,
+    notional: available * args.originalIntent.price,
+    clientOrderId: crypto.randomUUID().replaceAll('-', ''),
+  }
+  try {
+    const result = await args.execution.execute(fallbackIntent)
+    console.log(
+      JSON.stringify({
+        event: 'sell_qty_fallback_submitted',
+        requestId: args.requestId ?? null,
+        symbol: args.upper,
+        originalClientOrderId: args.originalIntent.clientOrderId,
+        fallbackClientOrderId: fallbackIntent.clientOrderId,
+        originalQty: args.originalIntent.quantity,
+        fallbackQty: fallbackIntent.quantity,
+        price: fallbackIntent.price,
+      }),
+    )
+    return { result, intent: fallbackIntent }
+  } catch (retryErr) {
+    console.warn(
+      JSON.stringify({
+        event: 'sell_qty_fallback_retry_failed',
+        requestId: args.requestId ?? null,
+        symbol: args.upper,
+        originalClientOrderId: args.originalIntent.clientOrderId,
+        fallbackClientOrderId: fallbackIntent.clientOrderId,
+        message: retryErr instanceof Error ? retryErr.message : String(retryErr),
+      }),
+    )
+    return null
+  }
 }
 
 function buildIntent(symbol: string, side: 'BUY' | 'SELL', qty: number, price: number): OrderIntent {
@@ -933,6 +1121,7 @@ const TRACE_LABEL_JA: Record<string, string> = {
   'risk.per_symbol_gate': '銘柄別リスクゲート',
   'risk.vix_regime': 'VIX レジーム判定',
   'broker.submit': '証券会社への発注送信',
+  'broker.sell_qty_fallback': 'SELL 数量超過時の broker available qty 再 submit',
 }
 
 /**

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -407,9 +407,12 @@ export async function runStrategyCron(
   const scaledRiskPerTradePct = global.riskBasePerTradePct * ddScale.scale
 
   const positionStore = new SymbolStateClient(env.SYMBOL_STATE)
-  const execution = global.dryRun
-    ? new MockExecution()
-    : new WebullExecution(createWebullHttpClient(env))
+  // Single Webull client instance shared between WebullExecution (order
+  // submit) and the SELL_QTY_EXCEED fallback (positions read). DRY_RUN
+  // path constructs nothing live — fallback resolver is also undefined so
+  // MockExecution can never trip the fallback retry path.
+  const liveWebullClient = global.dryRun ? null : createWebullHttpClient(env)
+  const execution = liveWebullClient ? new WebullExecution(liveWebullClient) : new MockExecution()
   // notifier は関数冒頭で組み立て済み (#141)。BUY/SELL emit / per-symbol
   // bar fetch error / broker submit error は scheduler 内で注入された
   // notifier を使う (#199 経路のまま)。
@@ -539,6 +542,28 @@ export async function runStrategyCron(
         staleQuoteMs: global.staleQuoteMs,
         gapRejectPct: global.gapRejectPct,
       },
+      // SELL_QTY_EXCEED fallback (#215 follow-up)。live Webull 経路
+      // (DRY_RUN=false) の時だけ注入する。MockExecution 経路は 417 を
+      // 起こさないので fallback は dead code。getPositions() の例外は
+      // resolver 側で握り潰さず、scheduler 側 (`tryFallbackSell`) が
+      // null fallback して元の SELL_QTY_EXCEED エラーを再 throw する。
+      ...(liveWebullClient
+        ? {
+            sellFallback: {
+              async getAvailableQty(symbol: string): Promise<number | null> {
+                const positions = await liveWebullClient.getPositions()
+                const target = positions.find(
+                  (p) => (p.symbol ?? '').toUpperCase() === symbol.toUpperCase(),
+                )
+                if (!target) return null
+                const raw = target.quantity_available
+                if (raw === undefined || raw === null || raw === '') return null
+                const parsed = Number(raw)
+                return Number.isFinite(parsed) ? parsed : null
+              },
+            },
+          }
+        : {}),
       // Earnings calendar gate (issue #196 1/3)。env.DB が無い OR table 未
       // migrate なら skip (POC 後方互換 / CodeRabbit #196 review)。
       // freezeBusinessDays は POC 段階では default 1 固定。将来 global_config に

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -544,23 +544,16 @@ export async function runStrategyCron(
       },
       // SELL_QTY_EXCEED fallback (#215 follow-up)。live Webull 経路
       // (DRY_RUN=false) の時だけ注入する。MockExecution 経路は 417 を
-      // 起こさないので fallback は dead code。getPositions() の例外は
-      // resolver 側で握り潰さず、scheduler 側 (`tryFallbackSell`) が
+      // 起こさないので fallback は dead code。Webull DTO の解釈
+      // (symbol 比較 / available_quantity の数値化) は infrastructure 層
+      // (`WebullHttpClient.getAvailableQtyForSymbol`) に閉じている。
+      // resolver 側で例外を握り潰さず、scheduler 側 (`tryFallbackSell`) が
       // null fallback して元の SELL_QTY_EXCEED エラーを再 throw する。
       ...(liveWebullClient
         ? {
             sellFallback: {
-              async getAvailableQty(symbol: string): Promise<number | null> {
-                const positions = await liveWebullClient.getPositions()
-                const target = positions.find(
-                  (p) => (p.symbol ?? '').toUpperCase() === symbol.toUpperCase(),
-                )
-                if (!target) return null
-                const raw = target.quantity_available
-                if (raw === undefined || raw === null || raw === '') return null
-                const parsed = Number(raw)
-                return Number.isFinite(parsed) ? parsed : null
-              },
+              getAvailableQty: (symbol: string) =>
+                liveWebullClient.getAvailableQtyForSymbol(symbol),
             },
           }
         : {}),

--- a/test/infrastructure/webull/webullHttpClient.test.ts
+++ b/test/infrastructure/webull/webullHttpClient.test.ts
@@ -364,6 +364,80 @@ describe('WebullHttpClient', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 
+  it('embeds the response body snippet in the error message on 4xx (so SELL_QTY_EXCEED can be detected)', async () => {
+    const errBody = JSON.stringify({
+      code: 'OAUTH_OPENAPI_SELL_QTY_EXCEED_AVAILABLE_QTY',
+      msg: 'available_qty=4 < requested_qty=8',
+    })
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(errBody, { status: 417 }))
+    const client = createClient(fetchMock)
+    const err = await client
+      .placeOrder({ ...intent, side: 'SELL' })
+      .catch((e: unknown) => e)
+    expect(err).toBeInstanceOf(BrokerClientError)
+    expect((err as BrokerClientError).brokerStatus).toBe(417)
+    expect((err as Error).message).toContain('OAUTH_OPENAPI_SELL_QTY_EXCEED_AVAILABLE_QTY')
+    expect((err as Error).message).toContain('status 417')
+  })
+
+  it('truncates an oversized error body in the message (no log explosion)', async () => {
+    const huge = 'X'.repeat(2000)
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(huge, { status: 400 }))
+    const client = createClient(fetchMock)
+    const err = await client.placeOrder(intent).catch((e: unknown) => e)
+    expect(err).toBeInstanceOf(BrokerClientError)
+    // The body is embedded after `status 400: ` and `readErrorBody` caps it
+    // at ERROR_BODY_MAX_CHARS (=1000) plus a `...[truncated]` marker so the
+    // upstream Webull error code stays visible without log explosion.
+    const message = (err as Error).message
+    const bodyIdx = message.indexOf('status 400: ')
+    expect(bodyIdx).toBeGreaterThan(-1)
+    const bodyPart = message.slice(bodyIdx + 'status 400: '.length)
+    expect(bodyPart).toContain('...[truncated]')
+    // 1000-char cap + the literal "...[truncated]" suffix (14 chars).
+    expect(bodyPart.length).toBeLessThanOrEqual(1000 + '...[truncated]'.length)
+  })
+
+  it('getPositions hits /openapi/account/positions/get and returns the array', async () => {
+    const positions = [
+      {
+        symbol: 'SOXL',
+        quantity_total: '8',
+        quantity_available: '4',
+        avg_cost: '124.95',
+        currency: 'USD',
+      },
+    ]
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(JSON.stringify(positions), { status: 200 }))
+    const client = createClient(fetchMock)
+    const result = await client.getPositions()
+    expect(result).toEqual(positions)
+    const [url, init] = fetchMock.mock.calls[0]!
+    const u = new URL(String(url))
+    expect(u.pathname).toBe('/openapi/account/positions/get')
+    expect(u.searchParams.get('account_id')).toBe('acct-1')
+    expect(init?.method).toBe('GET')
+    expect(init?.body).toBeUndefined()
+  })
+
+  it('getPositions throws BrokerRequestError when accountId is not configured', async () => {
+    const fetchMock = vi.fn<typeof fetch>()
+    const client = new WebullHttpClient({
+      auth: new WebullAuth({ appKey: 'app-key', appSecret: 'app-secret' }),
+      baseUrl: 'https://broker.example.test',
+      retry: { maxAttempts: 1, baseDelayMs: 0, multiplier: 1, jitter: 0 },
+      fetchFn: fetchMock,
+    })
+    await expect(client.getPositions()).rejects.toThrow(/Missing Webull account ID/)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it('listSubscriptions hits /app/subscriptions/list and returns the array', async () => {
     const subscriptions = [
       { subscription_id: 'sub-1', user_id: 'u-1', account_id: 'acct-abc', account_number: '123' },

--- a/test/infrastructure/webull/webullHttpClient.test.ts
+++ b/test/infrastructure/webull/webullHttpClient.test.ts
@@ -402,12 +402,12 @@ describe('WebullHttpClient', () => {
     expect(bodyPart.length).toBeLessThanOrEqual(1000 + '...[truncated]'.length)
   })
 
-  it('getPositions hits /openapi/account/positions/get and returns the array', async () => {
+  it('getPositions hits /openapi/account/positions and returns the array', async () => {
     const positions = [
       {
         symbol: 'SOXL',
         quantity_total: '8',
-        quantity_available: '4',
+        available_quantity: '4',
         avg_cost: '124.95',
         currency: 'USD',
       },
@@ -420,7 +420,7 @@ describe('WebullHttpClient', () => {
     expect(result).toEqual(positions)
     const [url, init] = fetchMock.mock.calls[0]!
     const u = new URL(String(url))
-    expect(u.pathname).toBe('/openapi/account/positions/get')
+    expect(u.pathname).toBe('/openapi/account/positions')
     expect(u.searchParams.get('account_id')).toBe('acct-1')
     expect(init?.method).toBe('GET')
     expect(init?.body).toBeUndefined()
@@ -436,6 +436,55 @@ describe('WebullHttpClient', () => {
     })
     await expect(client.getPositions()).rejects.toThrow(/Missing Webull account ID/)
     expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('getAvailableQtyForSymbol returns the parsed quantity when the symbol is held', async () => {
+    const positions = [
+      { symbol: 'SOXL', available_quantity: '4', quantity_total: '8' },
+      { symbol: 'AAPL', available_quantity: '10', quantity_total: '10' },
+    ]
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(JSON.stringify(positions), { status: 200 }))
+    const client = createClient(fetchMock)
+    // case-insensitive match (broker returns canonical SOXL, caller may pass soxl)
+    await expect(client.getAvailableQtyForSymbol('soxl')).resolves.toBe(4)
+  })
+
+  it('getAvailableQtyForSymbol returns null when available_quantity is non-numeric', async () => {
+    const positions = [{ symbol: 'SOXL', available_quantity: 'NaN' }]
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(JSON.stringify(positions), { status: 200 }))
+    const client = createClient(fetchMock)
+    await expect(client.getAvailableQtyForSymbol('SOXL')).resolves.toBeNull()
+  })
+
+  it('getAvailableQtyForSymbol returns 0 (not null) when available_quantity is "0"', async () => {
+    const positions = [{ symbol: 'SOXL', available_quantity: '0' }]
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(JSON.stringify(positions), { status: 200 }))
+    const client = createClient(fetchMock)
+    await expect(client.getAvailableQtyForSymbol('SOXL')).resolves.toBe(0)
+  })
+
+  it('getAvailableQtyForSymbol returns null when the symbol is not on the account', async () => {
+    const positions = [{ symbol: 'AAPL', available_quantity: '10' }]
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(JSON.stringify(positions), { status: 200 }))
+    const client = createClient(fetchMock)
+    await expect(client.getAvailableQtyForSymbol('SOXL')).resolves.toBeNull()
+  })
+
+  it('getAvailableQtyForSymbol rethrows when getPositions fails', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response('boom', { status: 500 }))
+    const client = createClient(fetchMock)
+    // 500 retries 3x then surfaces as BrokerServerError — must propagate to caller.
+    await expect(client.getAvailableQtyForSymbol('SOXL')).rejects.toThrow(BrokerServerError)
   })
 
   it('listSubscriptions hits /app/subscriptions/list and returns the array', async () => {

--- a/test/routes/admin.test.ts
+++ b/test/routes/admin.test.ts
@@ -220,6 +220,228 @@ describe('GET /admin/orders/repair-status', () => {
   })
 })
 
+describe('POST /admin/symbol-state/:symbol/override-position', () => {
+  type OverrideCall = {
+    symbol: string
+    args: {
+      qty: number
+      avgPrice: number
+      openedAt: string | null
+      reason: string
+      requestId?: string | null
+    }
+  }
+  function fakeOverrideNamespace(captured: { calls: OverrideCall[] }) {
+    const stub = {
+      async overridePosition(symbol: string, args: OverrideCall['args']) {
+        captured.calls.push({ symbol, args })
+        return {
+          symbol,
+          position:
+            args.qty > 0
+              ? {
+                  qty: args.qty,
+                  avgPrice: args.avgPrice,
+                  openedAt: args.openedAt ?? '2026-04-25T00:00:00.000Z',
+                }
+              : null,
+          pendingOrder: null,
+          lastSignalAt: null,
+          cooldownUntil: null,
+          settledCash: 0,
+          pendingSettlement: [],
+          lastExecutedPrice: null,
+          lastQuote: null,
+          updatedAt: '2026-04-25T00:00:00.000Z',
+        }
+      },
+    }
+    return {
+      idFromName: () => 'id',
+      get: () => stub,
+    } as unknown
+  }
+
+  it('401s without Basic Auth', async () => {
+    const app = createApp()
+    const res = await app.request(
+      '/admin/symbol-state/SOXL/override-position',
+      {
+        method: 'POST',
+        body: JSON.stringify({ qty: 4, avgPrice: 124.95, reason: 'manual' }),
+      },
+      baseEnv,
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it('400s when SYMBOL_STATE binding is missing', async () => {
+    const app = createApp()
+    const res = await app.request(
+      '/admin/symbol-state/SOXL/override-position',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeader },
+        body: JSON.stringify({ qty: 4, avgPrice: 124.95, reason: 'manual' }),
+      },
+      baseEnv,
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('400s when reason is missing', async () => {
+    const captured = { calls: [] as OverrideCall[] }
+    const app = createApp()
+    const res = await app.request(
+      '/admin/symbol-state/SOXL/override-position',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeader },
+        body: JSON.stringify({ qty: 4, avgPrice: 124.95 }),
+      },
+      { ...baseEnv, SYMBOL_STATE: fakeOverrideNamespace(captured) },
+    )
+    expect(res.status).toBe(400)
+    expect(captured.calls).toEqual([])
+  })
+
+  it('400s when qty>0 but avgPrice<=0', async () => {
+    const captured = { calls: [] as OverrideCall[] }
+    const app = createApp()
+    const res = await app.request(
+      '/admin/symbol-state/SOXL/override-position',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeader },
+        body: JSON.stringify({ qty: 4, avgPrice: 0, reason: 'manual' }),
+      },
+      { ...baseEnv, SYMBOL_STATE: fakeOverrideNamespace(captured) },
+    )
+    expect(res.status).toBe(400)
+    expect(captured.calls).toEqual([])
+  })
+
+  it('400s on negative qty', async () => {
+    const captured = { calls: [] as OverrideCall[] }
+    const app = createApp()
+    const res = await app.request(
+      '/admin/symbol-state/SOXL/override-position',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeader },
+        body: JSON.stringify({ qty: -1, avgPrice: 124.95, reason: 'manual' }),
+      },
+      { ...baseEnv, SYMBOL_STATE: fakeOverrideNamespace(captured) },
+    )
+    expect(res.status).toBe(400)
+    expect(captured.calls).toEqual([])
+  })
+
+  it('400s on unparseable openedAt', async () => {
+    const captured = { calls: [] as OverrideCall[] }
+    const app = createApp()
+    const res = await app.request(
+      '/admin/symbol-state/SOXL/override-position',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeader },
+        body: JSON.stringify({
+          qty: 4,
+          avgPrice: 124.95,
+          openedAt: 'not-a-date',
+          reason: 'manual',
+        }),
+      },
+      { ...baseEnv, SYMBOL_STATE: fakeOverrideNamespace(captured) },
+    )
+    expect(res.status).toBe(400)
+    expect(captured.calls).toEqual([])
+  })
+
+  it('200s and forwards qty=0 close (avgPrice / openedAt ignored)', async () => {
+    const captured = { calls: [] as OverrideCall[] }
+    const app = createApp()
+    const res = await app.request(
+      '/admin/symbol-state/soxl/override-position',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeader },
+        body: JSON.stringify({
+          qty: 0,
+          avgPrice: 124.95, // tolerated, ignored on close
+          reason: 'force close',
+        }),
+      },
+      { ...baseEnv, SYMBOL_STATE: fakeOverrideNamespace(captured) },
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { symbol: string; position: unknown }
+    expect(body.symbol).toBe('SOXL')
+    expect(body.position).toBeNull()
+    expect(captured.calls).toHaveLength(1)
+    expect(captured.calls[0]?.symbol).toBe('SOXL')
+    expect(captured.calls[0]?.args.qty).toBe(0)
+    expect(captured.calls[0]?.args.reason).toBe('force close')
+    expect(captured.calls[0]?.args.requestId).toBeTypeOf('string')
+  })
+
+  it('200s and forwards a full override', async () => {
+    const captured = { calls: [] as OverrideCall[] }
+    const app = createApp()
+    const res = await app.request(
+      '/admin/symbol-state/soxl/override-position',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeader },
+        body: JSON.stringify({
+          qty: 4,
+          avgPrice: 124.95,
+          openedAt: '2026-04-24T15:30:38.000Z',
+          reason: 'manual reconcile after PR #215 corrupted state',
+        }),
+      },
+      { ...baseEnv, SYMBOL_STATE: fakeOverrideNamespace(captured) },
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      symbol: string
+      position: { qty: number; avgPrice: number; openedAt: string }
+    }
+    expect(body.symbol).toBe('SOXL')
+    expect(body.position).toEqual({
+      qty: 4,
+      avgPrice: 124.95,
+      openedAt: '2026-04-24T15:30:38.000Z',
+    })
+    expect(captured.calls).toHaveLength(1)
+    const call = captured.calls[0]!
+    expect(call.symbol).toBe('SOXL')
+    expect(call.args).toMatchObject({
+      qty: 4,
+      avgPrice: 124.95,
+      openedAt: '2026-04-24T15:30:38.000Z',
+      reason: 'manual reconcile after PR #215 corrupted state',
+    })
+    expect(call.args.requestId).toBeTypeOf('string')
+  })
+
+  it('400s when reason is empty string', async () => {
+    const captured = { calls: [] as OverrideCall[] }
+    const app = createApp()
+    const res = await app.request(
+      '/admin/symbol-state/SOXL/override-position',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeader },
+        body: JSON.stringify({ qty: 4, avgPrice: 124.95, reason: '   ' }),
+      },
+      { ...baseEnv, SYMBOL_STATE: fakeOverrideNamespace(captured) },
+    )
+    expect(res.status).toBe(400)
+    expect(captured.calls).toEqual([])
+  })
+})
+
 describe('POST /admin/symbols/:symbol/clear-cooldown', () => {
   function fakeCooldownNamespace(captured: { calls: Array<{ symbol: string; untilIso: string }> }) {
     const stub = {

--- a/test/shared/errors.test.ts
+++ b/test/shared/errors.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from 'vitest'
-import { BrokerRequestError, TradingError, ValidationError } from '../../src/shared/errors'
+import {
+  BrokerAuthError,
+  BrokerClientError,
+  BrokerRateLimitError,
+  BrokerRequestError,
+  BrokerServerError,
+  TradingError,
+  ValidationError,
+  isSellQtyExceedError,
+  WEBULL_SELL_QTY_EXCEED_CODE,
+} from '../../src/shared/errors'
 
 describe('shared errors', () => {
   it('ValidationError exposes trading error metadata', () => {
@@ -30,5 +40,55 @@ describe('shared errors', () => {
       cause,
       message: 'Webull order placement failed',
     })
+  })
+})
+
+describe('isSellQtyExceedError', () => {
+  it('matches BrokerClientError 417 with the SELL_QTY_EXCEED code in message', () => {
+    const err = new BrokerClientError(
+      `Webull request failed permanently with status 417 body=${JSON.stringify({
+        code: WEBULL_SELL_QTY_EXCEED_CODE,
+        msg: 'available_qty=4 < requested_qty=8',
+      })}`,
+      'POST /openapi/account/orders/place',
+      { brokerStatus: 417 },
+    )
+    expect(isSellQtyExceedError(err)).toBe(true)
+  })
+
+  it('rejects BrokerClientError 417 without the SELL_QTY_EXCEED code', () => {
+    const err = new BrokerClientError(
+      'Webull request failed permanently with status 417 body={"code":"OAUTH_OPENAPI_OTHER_ERROR"}',
+      'POST /openapi/account/orders/place',
+      { brokerStatus: 417 },
+    )
+    expect(isSellQtyExceedError(err)).toBe(false)
+  })
+
+  it('rejects BrokerClientError with the right code but different status', () => {
+    const err = new BrokerClientError(
+      `Webull request failed permanently with status 400 body=${JSON.stringify({
+        code: WEBULL_SELL_QTY_EXCEED_CODE,
+      })}`,
+      'POST /openapi/account/orders/place',
+      { brokerStatus: 400 },
+    )
+    expect(isSellQtyExceedError(err)).toBe(false)
+  })
+
+  it('rejects BrokerAuthError / BrokerRateLimitError / BrokerServerError', () => {
+    const auth = new BrokerAuthError('401', 'op', { brokerStatus: 401 })
+    const rate = new BrokerRateLimitError('429', 'op', { brokerStatus: 429 })
+    const server = new BrokerServerError('503', 'op', { brokerStatus: 503 })
+    expect(isSellQtyExceedError(auth)).toBe(false)
+    expect(isSellQtyExceedError(rate)).toBe(false)
+    expect(isSellQtyExceedError(server)).toBe(false)
+  })
+
+  it('rejects non-broker errors', () => {
+    expect(isSellQtyExceedError(new Error('boom'))).toBe(false)
+    expect(isSellQtyExceedError('plain string')).toBe(false)
+    expect(isSellQtyExceedError(null)).toBe(false)
+    expect(isSellQtyExceedError(undefined)).toBe(false)
   })
 })

--- a/test/trading/application/tradingServiceCorrelation.test.ts
+++ b/test/trading/application/tradingServiceCorrelation.test.ts
@@ -42,6 +42,9 @@ function makeStore(statesBySymbol: Record<string, SymbolState>): PositionStore {
     async seedSettledCash(symbol) {
       return emptySymbolState(symbol, () => now)
     },
+    async overridePosition(symbol) {
+      return emptySymbolState(symbol, () => now)
+    },
   }
 }
 

--- a/test/trading/application/tradingServiceDrawdown.test.ts
+++ b/test/trading/application/tradingServiceDrawdown.test.ts
@@ -53,6 +53,9 @@ function makePositionStore(state: SymbolState): PositionStore {
     async seedSettledCash() {
       return state
     },
+    async overridePosition() {
+      return state
+    },
   }
 }
 

--- a/test/trading/application/tradingServiceHaltBandGap.test.ts
+++ b/test/trading/application/tradingServiceHaltBandGap.test.ts
@@ -53,6 +53,9 @@ function makeStore(state: SymbolState): PositionStore {
     async seedSettledCash() {
       return state
     },
+    async overridePosition() {
+      return state
+    },
   }
 }
 

--- a/test/trading/application/tradingServiceSettlement.test.ts
+++ b/test/trading/application/tradingServiceSettlement.test.ts
@@ -48,6 +48,9 @@ function makeStore(state: SymbolState): PositionStore {
     async seedSettledCash() {
       return state
     },
+    async overridePosition() {
+      return state
+    },
   }
 }
 

--- a/test/trading/application/tradingServiceSpread.test.ts
+++ b/test/trading/application/tradingServiceSpread.test.ts
@@ -59,6 +59,9 @@ function makeStore(stateBySymbol: Record<string, SymbolState>): PositionStore {
     async seedSettledCash(symbol) {
       return emptySymbolState(symbol, () => now)
     },
+    async overridePosition(symbol) {
+      return emptySymbolState(symbol, () => now)
+    },
   }
 }
 

--- a/test/trading/application/tradingServiceState.test.ts
+++ b/test/trading/application/tradingServiceState.test.ts
@@ -66,6 +66,10 @@ function makeStore(initial?: SymbolState): PositionStore & { state: SymbolState;
       calls.push('seedSettledCash')
       return state
     },
+    async overridePosition() {
+      calls.push('overridePosition')
+      return state
+    },
   }
 }
 

--- a/test/trading/risk/perSymbolRiskGateParity.test.ts
+++ b/test/trading/risk/perSymbolRiskGateParity.test.ts
@@ -74,6 +74,9 @@ function makeStore(states: Record<string, SymbolState>): PositionStore {
     async seedSettledCash(symbol) {
       return emptySymbolState(symbol, () => now)
     },
+    async overridePosition(symbol) {
+      return emptySymbolState(symbol, () => now)
+    },
   }
 }
 

--- a/test/trading/state/stateTransitions.test.ts
+++ b/test/trading/state/stateTransitions.test.ts
@@ -3,6 +3,7 @@ import {
   addPendingSettlement,
   clearPendingOrder,
   lockPendingOrder,
+  overridePosition,
   recordFill,
   recordFillOnce,
   recordSignal,
@@ -347,5 +348,148 @@ describe('misc transitions', () => {
         { now: fixedNow('2026-04-18T10:00:00.000Z') },
       )
     }).toThrow('Invalid settlement.settleDate')
+  })
+})
+
+describe('overridePosition', () => {
+  it('writes a new position when qty>0', () => {
+    const state = emptySymbolState('SOXL', fixedNow('2026-04-24T15:30:00.000Z'))
+    const next = overridePosition(
+      state,
+      { qty: 4, avgPrice: 124.95, openedAt: '2026-04-24T15:30:38.000Z' },
+      { now: fixedNow('2026-04-25T00:00:00.000Z') },
+    )
+    expect(next.position).toEqual({
+      qty: 4,
+      avgPrice: 124.95,
+      openedAt: '2026-04-24T15:30:38.000Z',
+    })
+    expect(next.updatedAt).toBe('2026-04-25T00:00:00.000Z')
+  })
+
+  it('overwrites an existing position (drift fix path)', () => {
+    let state = emptySymbolState('SOXL', fixedNow('2026-04-18T10:00:00.000Z'))
+    state = recordFill(
+      state,
+      { side: 'BUY', qty: 8, price: 124.95 },
+      { now: fixedNow('2026-04-19T10:00:00.000Z') },
+    )
+    expect(state.position?.qty).toBe(8)
+    const next = overridePosition(
+      state,
+      { qty: 4, avgPrice: 124.95, openedAt: state.position?.openedAt ?? null },
+      { now: fixedNow('2026-04-25T00:00:00.000Z') },
+    )
+    expect(next.position?.qty).toBe(4)
+    expect(next.position?.avgPrice).toBe(124.95)
+  })
+
+  it('falls back to now() when openedAt is null', () => {
+    const state = emptySymbolState('SOXL', fixedNow('2026-04-24T00:00:00.000Z'))
+    const next = overridePosition(
+      state,
+      { qty: 4, avgPrice: 100, openedAt: null },
+      { now: fixedNow('2026-04-25T00:00:00.000Z') },
+    )
+    expect(next.position?.openedAt).toBe('2026-04-25T00:00:00.000Z')
+  })
+
+  it('clears the position when qty=0 (operator-explicit close)', () => {
+    let state = emptySymbolState('SOXL', fixedNow('2026-04-18T10:00:00.000Z'))
+    state = recordFill(
+      state,
+      { side: 'BUY', qty: 8, price: 124.95 },
+      { now: fixedNow('2026-04-19T10:00:00.000Z') },
+    )
+    const next = overridePosition(
+      state,
+      { qty: 0, avgPrice: 0, openedAt: null },
+      { now: fixedNow('2026-04-25T00:00:00.000Z') },
+    )
+    expect(next.position).toBeNull()
+    expect(next.updatedAt).toBe('2026-04-25T00:00:00.000Z')
+  })
+
+  it('rejects qty=NaN (fail-closed)', () => {
+    const state = emptySymbolState('SOXL', fixedNow('2026-04-18T10:00:00.000Z'))
+    expect(() =>
+      overridePosition(
+        state,
+        { qty: Number.NaN, avgPrice: 100, openedAt: null },
+        { now: fixedNow('2026-04-25T00:00:00.000Z') },
+      ),
+    ).toThrow(/invalid qty/)
+  })
+
+  it('rejects negative qty', () => {
+    const state = emptySymbolState('SOXL', fixedNow('2026-04-18T10:00:00.000Z'))
+    expect(() =>
+      overridePosition(
+        state,
+        { qty: -1, avgPrice: 100, openedAt: null },
+        { now: fixedNow('2026-04-25T00:00:00.000Z') },
+      ),
+    ).toThrow(/invalid qty/)
+  })
+
+  it('rejects avgPrice<=0 when qty>0', () => {
+    const state = emptySymbolState('SOXL', fixedNow('2026-04-18T10:00:00.000Z'))
+    expect(() =>
+      overridePosition(
+        state,
+        { qty: 4, avgPrice: 0, openedAt: null },
+        { now: fixedNow('2026-04-25T00:00:00.000Z') },
+      ),
+    ).toThrow(/invalid avgPrice/)
+  })
+
+  it('ignores avgPrice / openedAt when qty=0 (close path)', () => {
+    let state = emptySymbolState('SOXL', fixedNow('2026-04-18T10:00:00.000Z'))
+    state = recordFill(
+      state,
+      { side: 'BUY', qty: 8, price: 124.95 },
+      { now: fixedNow('2026-04-19T10:00:00.000Z') },
+    )
+    // avgPrice 0 / negative is normally invalid for qty>0, but on close we
+    // accept it because the operator's intent is "drop the position".
+    const next = overridePosition(
+      state,
+      { qty: 0, avgPrice: -999, openedAt: null },
+      { now: fixedNow('2026-04-25T00:00:00.000Z') },
+    )
+    expect(next.position).toBeNull()
+  })
+
+  it('rejects unparseable openedAt', () => {
+    const state = emptySymbolState('SOXL', fixedNow('2026-04-18T10:00:00.000Z'))
+    expect(() =>
+      overridePosition(
+        state,
+        { qty: 4, avgPrice: 100, openedAt: 'not-a-date' },
+        { now: fixedNow('2026-04-25T00:00:00.000Z') },
+      ),
+    ).toThrow(/invalid openedAt/)
+  })
+
+  it('does not touch unrelated fields (pendingOrder / cooldownUntil / settledCash)', () => {
+    const state = {
+      ...emptySymbolState('SOXL', fixedNow('2026-04-18T10:00:00.000Z')),
+      pendingOrder: {
+        clientOrderId: 'coid-x',
+        side: 'BUY' as const,
+        submittedAt: '2026-04-25T09:00:00.000Z',
+        expiresAt: '2026-04-25T09:05:00.000Z',
+      },
+      cooldownUntil: '2026-04-30T00:00:00.000Z',
+      settledCash: 5_000,
+    }
+    const next = overridePosition(
+      state,
+      { qty: 4, avgPrice: 124.95, openedAt: null },
+      { now: fixedNow('2026-04-25T00:00:00.000Z') },
+    )
+    expect(next.pendingOrder).toEqual(state.pendingOrder)
+    expect(next.cooldownUntil).toBe('2026-04-30T00:00:00.000Z')
+    expect(next.settledCash).toBe(5_000)
   })
 })

--- a/test/trading/strategy/pullbackScheduler.test.ts
+++ b/test/trading/strategy/pullbackScheduler.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { BarClient, IntradayBar } from '../../../src/infrastructure/quotes/BarClient'
 import type { Notifier, NotificationEvent } from '../../../src/infrastructure/notification/Notifier'
+import {
+  BrokerClientError,
+  BrokerServerError,
+  WEBULL_SELL_QTY_EXCEED_CODE,
+} from '../../../src/shared/errors'
 import type { Execution } from '../../../src/trading/execution/Execution'
 import type { PositionStore } from '../../../src/trading/state/PositionStore'
 import { emptySymbolState, type SymbolState } from '../../../src/trading/state/types'
@@ -52,6 +57,9 @@ function makeStore(states: Record<string, SymbolState>) {
       return emptySymbolState(symbol, () => now)
     },
     async seedSettledCash(symbol: string) {
+      return emptySymbolState(symbol, () => now)
+    },
+    async overridePosition(symbol: string) {
       return emptySymbolState(symbol, () => now)
     },
   } satisfies PositionStore
@@ -981,5 +989,324 @@ describe('runPullbackScheduler VIX regime filter (#196 3/3)', () => {
       (d) => d.decision === 'REJECT' && (d.reason ?? '').includes('vix_critical'),
     )
     expect(vixReject).toBeUndefined()
+  })
+})
+
+describe('runPullbackScheduler SELL_QTY_EXCEED fallback (#215 follow-up)', () => {
+  /**
+   * Down-trend bars that fire a SELL on a held position. PullbackUptrend
+   * triggers SELL when price breaks below the trailing stop / takeProfit.
+   * Cheap shortcut: take uptrendBars() and crash the last close so the
+   * stop fires.
+   */
+  function downtrendBars(): DailyBar[] {
+    const bars = uptrendBars()
+    const last = bars[bars.length - 1]!
+    bars[bars.length - 1] = synth(59, last.close * 0.7) // -30% gap = stop
+    return bars
+  }
+
+  function heldState(qty = 8, avgPrice = 124.95): SymbolState {
+    return {
+      ...emptySymbolState('AAPL', () => now),
+      position: { qty, avgPrice, openedAt: '2026-04-19T15:00:00.000Z' },
+      // Add settledCash so the per-symbol gate (when used) wouldn't trip;
+      // here we don't pass perSymbolRisk so it's a no-op anyway.
+      settledCash: 100_000,
+    }
+  }
+
+  /**
+   * Build a Webull-style 417 SELL_QTY_EXCEED error mirroring what
+   * `WebullHttpClient` actually throws — the body snippet is embedded in
+   * the message so `isSellQtyExceedError` can read it.
+   */
+  function makeSellQtyExceedError(): BrokerClientError {
+    return new BrokerClientError(
+      `Webull request failed permanently with status 417 body=${JSON.stringify({
+        code: WEBULL_SELL_QTY_EXCEED_CODE,
+        msg: 'requested_qty exceeds available',
+      })}`,
+      'POST /openapi/account/orders/place',
+      { brokerStatus: 417 },
+    )
+  }
+
+  function mockSellExecution(behaviour: {
+    firstThrow?: Error
+    secondThrow?: Error
+  }): Execution & { calls: unknown[] } {
+    const calls: unknown[] = []
+    let attempt = 0
+    return {
+      calls,
+      async execute(intent) {
+        attempt += 1
+        calls.push(intent)
+        if (attempt === 1 && behaviour.firstThrow) throw behaviour.firstThrow
+        if (attempt === 2 && behaviour.secondThrow) throw behaviour.secondThrow
+        return { mode: 'DRY_RUN', submitted: true, brokerOrderId: `dry-run-${attempt}` }
+      },
+    }
+  }
+
+  it('retries SELL with broker available qty when 417 SELL_QTY_EXCEED fires', async () => {
+    // Setup: DO state qty=8, broker available=4. PullbackUptrend triggers
+    // SELL via the downtrend close. First execute() throws 417 SELL_QTY_EXCEED
+    // → fallback resolver returns 4 → second execute() succeeds with qty=4.
+    const overrideCalls: Array<{ symbol: string; args: { qty: number; reason: string } }> = []
+    const baseStore = makeStore({ AAPL: heldState(8, 124.95) })
+    const positionStore: PositionStore = {
+      ...baseStore,
+      async overridePosition(symbol, args) {
+        overrideCalls.push({ symbol, args })
+        return baseStore.getState(symbol)
+      },
+    }
+    const execution = mockSellExecution({ firstThrow: makeSellQtyExceedError() })
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(downtrendBars()),
+      positionStore,
+      execution,
+      sellFallback: { getAvailableQty: async () => 4 },
+      now: () => now,
+    })
+
+    // Two execute() calls: original SELL 8 + fallback SELL 4.
+    expect(execution.calls).toHaveLength(2)
+    const firstIntent = execution.calls[0] as { side: string; quantity: number }
+    const secondIntent = execution.calls[1] as { side: string; quantity: number }
+    expect(firstIntent.side).toBe('SELL')
+    expect(firstIntent.quantity).toBe(8)
+    expect(secondIntent.side).toBe('SELL')
+    expect(secondIntent.quantity).toBe(4)
+
+    expect(summary.sells).toBe(1)
+    expect(summary.errors).toHaveLength(0)
+
+    // DO position must be force-reset to null after the fallback succeeds.
+    expect(overrideCalls).toHaveLength(1)
+    expect(overrideCalls[0]).toMatchObject({
+      symbol: 'AAPL',
+      args: { qty: 0 },
+    })
+    expect(overrideCalls[0]?.args.reason).toContain('sell_qty_fallback')
+
+    // Decision trace should include the new fallback step.
+    const decision = summary.decisions.find((d) => d.symbol === 'AAPL')
+    expect(decision?.decision).toBe('SELL')
+    expect(decision?.order?.quantity).toBe(4)
+    const labels = decision?.trace?.map((s) => s.label) ?? []
+    expect(labels).toContain('broker.sell_qty_fallback')
+    expect(decision?.reason).toContain('sell_qty_fallback')
+  })
+
+  it('does NOT retry on a different 4xx (not SELL_QTY_EXCEED) — original error wins', async () => {
+    const overrideCalls: Array<{ symbol: string }> = []
+    const baseStore = makeStore({ AAPL: heldState(8, 124.95) })
+    const positionStore: PositionStore = {
+      ...baseStore,
+      async overridePosition(symbol) {
+        overrideCalls.push({ symbol })
+        return baseStore.getState(symbol)
+      },
+    }
+    // 400 with a *different* Webull error code → fallback must not engage.
+    const otherErr = new BrokerClientError(
+      `Webull request failed permanently with status 400 body=${JSON.stringify({
+        code: 'OAUTH_OPENAPI_OTHER_ERROR',
+      })}`,
+      'POST /openapi/account/orders/place',
+      { brokerStatus: 400 },
+    )
+    const execution = mockSellExecution({ firstThrow: otherErr })
+    const fallbackSpy = vi.fn(async () => 4)
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(downtrendBars()),
+      positionStore,
+      execution,
+      sellFallback: { getAvailableQty: fallbackSpy },
+      now: () => now,
+    })
+    expect(execution.calls).toHaveLength(1)
+    expect(fallbackSpy).not.toHaveBeenCalled()
+    expect(overrideCalls).toHaveLength(0)
+    expect(summary.sells).toBe(0)
+    expect(summary.errors).toHaveLength(1)
+    const errDecision = summary.decisions.find((d) => d.decision === 'ERROR')
+    expect(errDecision?.reason).toContain('OAUTH_OPENAPI_OTHER_ERROR')
+  })
+
+  it('falls back to original error when broker available=0', async () => {
+    const baseStore = makeStore({ AAPL: heldState(8, 124.95) })
+    const overrideCalls: Array<{ symbol: string }> = []
+    const positionStore: PositionStore = {
+      ...baseStore,
+      async overridePosition(symbol) {
+        overrideCalls.push({ symbol })
+        return baseStore.getState(symbol)
+      },
+    }
+    const execution = mockSellExecution({ firstThrow: makeSellQtyExceedError() })
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(downtrendBars()),
+      positionStore,
+      execution,
+      sellFallback: { getAvailableQty: async () => 0 },
+      now: () => now,
+    })
+    // No retry submit, no DO reset, original 417 error reported.
+    expect(execution.calls).toHaveLength(1)
+    expect(overrideCalls).toHaveLength(0)
+    expect(summary.sells).toBe(0)
+    expect(summary.errors).toHaveLength(1)
+    expect(summary.errors[0]?.message).toContain('OAUTH_OPENAPI_SELL_QTY_EXCEED_AVAILABLE_QTY')
+  })
+
+  it('does not retry when available >= original qty (broker contradicts the 417)', async () => {
+    const baseStore = makeStore({ AAPL: heldState(8, 124.95) })
+    const positionStore: PositionStore = {
+      ...baseStore,
+      async overridePosition() {
+        return baseStore.getState('AAPL')
+      },
+    }
+    const execution = mockSellExecution({ firstThrow: makeSellQtyExceedError() })
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(downtrendBars()),
+      positionStore,
+      execution,
+      sellFallback: { getAvailableQty: async () => 8 },
+      now: () => now,
+    })
+    expect(execution.calls).toHaveLength(1)
+    expect(summary.sells).toBe(0)
+    expect(summary.errors).toHaveLength(1)
+  })
+
+  it('falls through to original error when fallback resolver throws', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const baseStore = makeStore({ AAPL: heldState(8, 124.95) })
+    const positionStore: PositionStore = {
+      ...baseStore,
+      async overridePosition() {
+        return baseStore.getState('AAPL')
+      },
+    }
+    const execution = mockSellExecution({ firstThrow: makeSellQtyExceedError() })
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(downtrendBars()),
+      positionStore,
+      execution,
+      sellFallback: {
+        getAvailableQty: async () => {
+          throw new Error('positions endpoint timeout')
+        },
+      },
+      now: () => now,
+    })
+    expect(execution.calls).toHaveLength(1)
+    expect(summary.sells).toBe(0)
+    expect(summary.errors).toHaveLength(1)
+    expect(summary.errors[0]?.message).toContain('OAUTH_OPENAPI_SELL_QTY_EXCEED_AVAILABLE_QTY')
+    warnSpy.mockRestore()
+  })
+
+  it('falls back to original error when retry submit also fails', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const overrideCalls: Array<{ symbol: string }> = []
+    const baseStore = makeStore({ AAPL: heldState(8, 124.95) })
+    const positionStore: PositionStore = {
+      ...baseStore,
+      async overridePosition(symbol) {
+        overrideCalls.push({ symbol })
+        return baseStore.getState(symbol)
+      },
+    }
+    // Both attempts throw — retry's failure must not mask the original 417.
+    const execution = mockSellExecution({
+      firstThrow: makeSellQtyExceedError(),
+      secondThrow: new BrokerServerError('upstream 503', 'POST /openapi/account/orders/place', {
+        brokerStatus: 503,
+      }),
+    })
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(downtrendBars()),
+      positionStore,
+      execution,
+      sellFallback: { getAvailableQty: async () => 4 },
+      now: () => now,
+    })
+    // Retry was attempted but failed → DO state stays untouched, summary
+    // reports the *original* 417 error (not the retry 503).
+    expect(execution.calls).toHaveLength(2)
+    expect(overrideCalls).toHaveLength(0)
+    expect(summary.sells).toBe(0)
+    expect(summary.errors).toHaveLength(1)
+    expect(summary.errors[0]?.message).toContain('OAUTH_OPENAPI_SELL_QTY_EXCEED_AVAILABLE_QTY')
+    warnSpy.mockRestore()
+  })
+
+  it('skips fallback entirely when sellFallback is omitted (back-compat)', async () => {
+    const baseStore = makeStore({ AAPL: heldState(8, 124.95) })
+    const positionStore: PositionStore = {
+      ...baseStore,
+      async overridePosition() {
+        return baseStore.getState('AAPL')
+      },
+    }
+    const execution = mockSellExecution({ firstThrow: makeSellQtyExceedError() })
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(downtrendBars()),
+      positionStore,
+      execution,
+      now: () => now,
+    })
+    expect(execution.calls).toHaveLength(1)
+    expect(summary.sells).toBe(0)
+    expect(summary.errors).toHaveLength(1)
+  })
+
+  it('does NOT trigger fallback for BUY 417s (SELL-only path)', async () => {
+    const overrideCalls: Array<{ symbol: string }> = []
+    const baseStore = makeStore({})
+    const positionStore: PositionStore = {
+      ...baseStore,
+      async overridePosition(symbol) {
+        overrideCalls.push({ symbol })
+        return baseStore.getState(symbol)
+      },
+    }
+    const execution = mockSellExecution({ firstThrow: makeSellQtyExceedError() })
+    const fallbackSpy = vi.fn(async () => 4)
+    // uptrendBars + no held position → BUY signal. The "417 SELL_QTY_EXCEED"
+    // is artificial here but lets us prove the fallback is gated on side='SELL'.
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore,
+      execution,
+      sellFallback: { getAvailableQty: fallbackSpy },
+      now: () => now,
+    })
+    expect(execution.calls).toHaveLength(1)
+    expect(fallbackSpy).not.toHaveBeenCalled()
+    expect(overrideCalls).toHaveLength(0)
+    expect(summary.errors).toHaveLength(1)
   })
 })


### PR DESCRIPTION
## 動機

SOXL の DO `position.qty` が `8` に drift していた一方、broker の実 holding は `4` しか無く、cron が SELL 8 を出す → Webull が `OAUTH_OPENAPI_SELL_QTY_EXCEED_AVAILABLE_QTY` (HTTP 417) で reject → stop hit が永続失敗していた。

- 過去の reconcile race による double-apply (PR #215 で fix 済) が原因
- ただし PR #215 は idempotent 化のみで、**既に corrupted な DO state を直す手段が無かった** → 本 PR の `override-position` endpoint が即時 fix
- 同様の drift が将来再発した場合に備えて、**SELL_QTY_EXCEED が来たら自動で実 available qty に縮めて再 submit** する fallback を pullback scheduler に追加

## 変更点

### 1. 即時 fix: `POST /admin/symbol-state/:symbol/override-position`

Operator が DO `position` を直接書き換える endpoint。Basic-auth 必須。

```json
{
  "qty": 4,
  "avgPrice": 124.95,
  "openedAt": "2026-04-24T15:30:38Z",
  "reason": "manual reconcile after PR #215 corrupted state"
}
```

- `qty=0` → `position=null` で完全に閉じる (avgPrice / openedAt は無視)
- `qty>0` → `{ qty, avgPrice, openedAt: openedAt ?? now() }` で上書き
- `reason` は audit log のため必須 (1..256 chars)
- 構造化 audit log: `event: 'symbol_state_position_override'` + before / after / reason / requestId

### 2. 恒久 fallback: SELL 417 SELL_QTY_EXCEED 自動再 submit

`pullbackScheduler.ts` の broker submit catch block で、SELL 専用の fallback を実装:

```text
SELL submit
  ├─ 成功 → 通常経路
  └─ throw BrokerClientError (status 417 + SELL_QTY_EXCEED code)
       └─ webullClient.getPositions() で実 available qty 取得
            ├─ available > 0 && available < intent.qty → SELL を available 数量で再 submit
            │    └─ 成功 → DO `position=null` 強制 reset (overridePosition qty=0)
            │    └─ 失敗 → 元 417 を re-throw (元エラー path)
            ├─ available <= 0 / available >= intent.qty → 元 417 を re-throw
            └─ resolver throw → 元 417 を re-throw
  └─ 他 error → 通常 error path (fallback 介入なし)
```

**Race window**: `getPositions()` と再 SELL submit の間で broker side が変動する可能性は POC 段階で許容。次の cron tick で再評価される。

### 3. 支援プラミング

- `WebullHttpClient.getPositions(): Promise<WebullPositionDto[]>` 追加。endpoint name は `/openapi/account/positions/get` (TODO #21 — live 確認は別作業、`@FIXME` ではなく TODO comment)
- `WebullPositionDto` に `symbol` / `quantity_total` / `quantity_available` / `avg_cost` / `currency` を定義
- `WebullHttpClient` の 4xx error message に response body snippet (512 chars cap) を埋め込み、Webull の `code` フィールドを `isSellQtyExceedError` から検出可能に
- `isSellQtyExceedError(err)` ヘルパーを `src/shared/errors.ts` に export
- `overridePosition` pure transition function を `stateTransitions.ts` に追加 (transitions の単体テスト可能)
- `PositionStore.overridePosition()` を interface に追加 (admin endpoint と fallback path の両方が使う)

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test --run` — 786 passed (前: 750)、新規 36 tests
  - [x] `overridePosition` transition: qty=0 close / qty>0 上書き / NaN/負値 reject / openedAt validate / 他 field 不変
  - [x] admin endpoint: 401 / 400 (binding 不在 / qty<0 / avgPrice<=0 / openedAt 不正 / reason 空) / 200 (qty=0 close と full override)
  - [x] `isSellQtyExceedError`: 417 + 該当 code / 別 code / 別 status / 他 error class / 非 Error
  - [x] `WebullHttpClient.getPositions`: endpoint path / accountId 必須 / response shape
  - [x] `WebullHttpClient` 4xx body snippet: 含む / truncate
  - [x] pullbackScheduler fallback:
    - [x] 417 SELL_QTY_EXCEED → portfolio fetch → SELL 4 で再 submit → DO reset
    - [x] 417 別 error code → fallback skip、元 error 再 throw
    - [x] available=0 → fallback skip
    - [x] available >= intent.qty → fallback skip
    - [x] resolver throw → fallback skip
    - [x] retry submit fail → fallback skip、元 417 を維持
    - [x] sellFallback 未注入 → 既存挙動 (back-compat)
    - [x] BUY 417 → fallback skip (SELL 専用)

## 運用手順

### 即時 fix (manual reconcile)

```sh
curl -u admin:$BASIC_AUTH_PASSWORD -X POST \
  https://<worker-host>/admin/symbol-state/SOXL/override-position \
  -H 'Content-Type: application/json' \
  -d '{"qty":4,"avgPrice":124.95,"openedAt":"2026-04-24T15:30:38Z","reason":"manual reconcile after PR #215 corrupted state"}'
```

監査ログ (`event: symbol_state_position_override`) に before/after/reason が残るので運用 trail として参照可能。

### 恒久 fallback (自動)

cron 経路 (`runStrategyCron`) に既に wire 済み。`DRY_RUN=false` 時のみ active (live Webull client がある時のみ inject)。MockExecution 経路は 417 を起こさないので dead code。

## 注意

- POC scope を逸脱しないよう、`getPositions()` の endpoint 名 / 詳細 field 名は **推測 + TODO comment** で残してある (live 動作確認は別 issue / user 検証側)。`@FIXME` などの強いマーカーは禁止指示通り未使用
- override endpoint は **Basic Auth 必須**、誰でも叩けると state が歪む — 既存 admin route と同じ middleware で gated
- fallback path は SELL 専用 (BUY 417 は別意味なので意図的に skip)
- 元 SELL_QTY_EXCEED エラーを fallback の retry エラーで上書きしない設計 (操作員が「最初に何が起きたか」を log から再構成できる)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * オペレーターが記号のポジションを直接上書きできる管理用APIを追加しました。
  * ブローカーから現在の保有ポジションとシンボルごとの利用可能数量を取得する機能を追加しました。
  * Webull向けの売却数量超過時に自動リトライ/縮小フォールバックする回復フローを実装しました。

* **バグ修正**
  * ブローカーの4xxエラーでレスポンス本文がエラーメッセージに含まれるようになり、特定エラー判定が可能になりました。

* **テスト**
  * フォールバック・位置取得・エラー判定のユニット/統合テストを大幅に追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->