### PR TITLE
feat(ops): broker holding reconcile endpoint (#221 follow-up)

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -6,7 +6,9 @@ import { createWebullHttpClient } from '../infrastructure/webull/WebullHttpClien
 import { PortfolioStateClient } from '../trading/state/PortfolioStateClient'
 import { SymbolStateClient } from '../trading/state/SymbolStateClient'
 import { reconcileFills } from '../trading/reconciliation/reconcileFills'
+import { syncHoldings } from '../trading/reconciliation/syncHoldings'
 import { runStrategyCron } from '../trading/strategy/runStrategyCron'
+import { loadSymbolUniverse } from '../infrastructure/db/symbolUniverse'
 import { YahooBarClient } from '../infrastructure/quotes/YahooBarClient'
 import { loadGlobalConfigFrom } from '../infrastructure/db/globalConfigLoader'
 import { createDb } from '../infrastructure/db/tradeJournalRepo'
@@ -285,6 +287,68 @@ export const admin = new Hono<AppBindings>()
       )
     const pendingApply = Number(rows[0]?.count ?? 0)
     return c.json({ pendingApply })
+  })
+  /**
+   * Reconcile broker-side holdings into the per-symbol DO `position`.
+   *
+   * Pulls Webull `/openapi/account/positions` once and walks the symbol
+   * universe (or `?symbol=SOXL` for a single ticker), comparing the DO
+   * `position.qty` against broker `available_quantity`. When they disagree
+   * the DO row is overwritten via the same `overridePosition` path used by
+   * `/admin/symbol-state/:symbol/override-position` — one structured
+   * `symbol_state_position_override` log per write plus an outer
+   * `holdings_sync_applied` log keyed by `requestId`.
+   *
+   * Use this as the manual recovery tool for DO state that drifted before
+   * PR #215 (idempotency) / PR #221 (SELL fallback) landed. Both fixes
+   * prevent **future** corruption but neither rewrites existing rows.
+   *
+   * Query:
+   *   - `symbol`  (optional)  restrict to one ticker (case-insensitive)
+   *   - `dryRun`  (optional)  `1`/`true`/`yes` → diff-only, no DO writes
+   *
+   * Body: ignored (POST kept for "this mutates state" intent — `dryRun`
+   *   path obviously doesn't, but the verb stays consistent).
+   */
+  .post('/orders/sync-holdings', async (c) => {
+    if (!c.env.SYMBOL_STATE) {
+      throw new ValidationError('SYMBOL_STATE binding is not configured', { field: 'env' })
+    }
+    const symbolRaw = c.req.query('symbol')?.trim()
+    const dryRun = parseTruthyQuery(c.req.query('dryRun'))
+    const symbol = symbolRaw && symbolRaw.length > 0 ? symbolRaw.toUpperCase() : undefined
+
+    // Single-symbol mode skips the universe load: lets the operator sync a
+    // ticker even if it's been removed from `symbol_config` (e.g. retired
+    // strategy that still has a stale DO row). All-symbols mode needs D1;
+    // reject early so the operator gets 400-with-field instead of a 500
+    // from deeper in `loadSymbolUniverse`.
+    let allowedSymbols: string[]
+    if (symbol !== undefined) {
+      allowedSymbols = [symbol]
+    } else {
+      if (!c.env.DB) {
+        throw new ValidationError('DB binding is not configured', { field: 'env' })
+      }
+      const universe = await loadSymbolUniverse(c.env)
+      allowedSymbols = universe.allowedSymbols
+    }
+
+    const webull = createWebullHttpClient(c.env)
+    const positionStore = new SymbolStateClient(c.env.SYMBOL_STATE)
+    const result = await syncHoldings(
+      {
+        ...(symbol !== undefined ? { symbol } : {}),
+        dryRun,
+        requestId: c.get('requestId') ?? null,
+      },
+      {
+        allowedSymbols,
+        fetchPositions: () => webull.getPositions(),
+        positionStore,
+      },
+    )
+    return c.json(result)
   })
   .get('/orders/:clientOrderId', async (c) => {
     const clientOrderId = c.req.param('clientOrderId').trim()

--- a/src/trading/reconciliation/syncHoldings.ts
+++ b/src/trading/reconciliation/syncHoldings.ts
@@ -1,0 +1,332 @@
+import type { Env } from '../../config/env'
+import type { WebullPositionDto } from '../../infrastructure/webull/dto'
+import type { PositionStore } from '../state/PositionStore'
+import type { PositionState, SymbolState } from '../state/types'
+
+/**
+ * Operator-driven reconcile of per-symbol DO position against broker truth.
+ *
+ * Backstory: PR #215 fixed the reconcile idempotency race that originally
+ * corrupted DO state, and PR #221 added an in-flight SELL_QTY_EXCEED fallback
+ * that re-reads broker `available_quantity` before retrying a SELL. Neither
+ * touches **already-corrupted** DO rows that pre-date those fixes (e.g. the
+ * SOXL row with DO qty=8 vs broker actual=4). This module is the manual one-
+ * shot tool to walk the universe, compare DO `position.qty` against the
+ * Webull `/openapi/account/positions` truth, and overwrite the DO row when
+ * they disagree.
+ *
+ * Safety stance:
+ *   - Read-only against the broker (`getPositions()` only — no orders).
+ *   - Mutates DO state via `PositionStore.overridePosition`, which already
+ *     emits a structured audit log per write. We add an outer
+ *     `holdings_sync_applied` log so the caller's request id is correlated
+ *     with the symbol-level diff.
+ *   - `dryRun=true` returns the same diff shape but skips every override —
+ *     intended for "show me what would change" before letting it loose.
+ *   - `avgPrice` policy: prefer broker `avg_cost` when finite + positive,
+ *     else keep the existing DO `avgPrice`. Falling through to `0` would
+ *     break realized-PnL math in `recordFill` so we explicitly avoid that.
+ */
+export interface SyncHoldingResult {
+  symbol: string
+  /** DO position before the override (null if there was none). */
+  before: PositionState | null
+  /** DO position after the override (null if `dryRun` or `brokerQty=0`). */
+  after: PositionState | null
+  /** Broker-side `available_quantity`. `null` = symbol not held on broker. */
+  broker_qty: number | null
+  /** Broker-side `avg_cost` if parseable, else `null`. */
+  broker_avg: number | null
+  /**
+   * Set when the row was a no-op:
+   *   - `'no_drift'`: broker_qty == DO qty, nothing to do.
+   *   - `'dry_run'`:  drift detected but `options.dryRun=true`, so we report
+   *                   the planned `before/after` without mutating DO state.
+   */
+  skipped?: 'no_drift' | 'dry_run'
+}
+
+export interface SyncHoldingError {
+  symbol: string
+  error: string
+}
+
+export interface SyncHoldingsSummary {
+  synced: SyncHoldingResult[]
+  errors: SyncHoldingError[]
+  summary: {
+    total: number
+    synced: number
+    no_drift: number
+    errors: number
+  }
+  dryRun: boolean
+}
+
+export interface SyncHoldingsOptions {
+  /** Restrict to a single symbol (already upper-cased by caller). */
+  symbol?: string
+  /** When true, compute diffs but do not write to the DO. */
+  dryRun: boolean
+  /** Audit-correlation id from the route layer (`c.get('requestId')`). */
+  requestId: string | null
+}
+
+export interface SyncHoldingsDeps {
+  /** Universe to walk when `options.symbol` is undefined. */
+  allowedSymbols: string[]
+  /** Webull positions snapshot loader (read-only). */
+  fetchPositions: () => Promise<WebullPositionDto[]>
+  /** DO surface — `getState` + `overridePosition`. */
+  positionStore: Pick<PositionStore, 'getState' | 'overridePosition'>
+}
+
+/**
+ * Walk `allowedSymbols` (or the single symbol filter), pull broker positions
+ * once, diff against DO state, and emit overrides where they disagree.
+ *
+ * One broker round-trip per call (positions endpoint is account-wide). The
+ * `errors[]` channel keeps a per-symbol failure from poisoning the rest of
+ * the run — a 500 from `overridePosition` on AAPL still lets MSFT proceed.
+ */
+export async function syncHoldings(
+  options: SyncHoldingsOptions,
+  deps: SyncHoldingsDeps,
+): Promise<SyncHoldingsSummary> {
+  const target = options.symbol?.toUpperCase()
+  const symbols = target
+    ? [target]
+    : deps.allowedSymbols.map((s) => s.toUpperCase())
+
+  // Single positions fetch shared across the loop. If it throws (auth /
+  // network), every symbol gets the same error rather than each retrying.
+  let brokerByUpper: Map<string, WebullPositionDto> | null = null
+  let brokerFetchError: string | null = null
+  try {
+    const positions = await deps.fetchPositions()
+    brokerByUpper = new Map(
+      positions
+        .filter((p) => typeof p.symbol === 'string' && p.symbol.length > 0)
+        .map((p) => [(p.symbol as string).toUpperCase(), p]),
+    )
+  } catch (err) {
+    brokerFetchError = `broker positions fetch failed: ${messageOf(err)}`
+  }
+
+  const synced: SyncHoldingResult[] = []
+  const errors: SyncHoldingError[] = []
+
+  for (const sym of symbols) {
+    if (brokerFetchError !== null) {
+      errors.push({ symbol: sym, error: brokerFetchError })
+      continue
+    }
+    try {
+      const brokerPos = brokerByUpper!.get(sym)
+      const brokerQty = parseBrokerQty(brokerPos)
+      const brokerAvg = parseBrokerAvg(brokerPos)
+      const state = await deps.positionStore.getState(sym)
+      const before = state.position
+      const doQty = before?.qty ?? 0
+
+      // No-drift fast path. We treat "broker has no row" as `brokerQty=0`
+      // for comparison purposes (Webull omits zero-quantity positions). If
+      // DO is already null/0, this is a true no-op.
+      const effectiveBrokerQty = brokerQty ?? 0
+      if (effectiveBrokerQty === doQty) {
+        synced.push({
+          symbol: sym,
+          before,
+          after: before,
+          broker_qty: brokerQty,
+          broker_avg: brokerAvg,
+          skipped: 'no_drift',
+        })
+        continue
+      }
+
+      // Drift detected. dryRun returns the planned shape without writing.
+      if (options.dryRun) {
+        const plannedAfter = computePlannedAfter({
+          brokerQty: effectiveBrokerQty,
+          brokerAvg,
+          before,
+        })
+        synced.push({
+          symbol: sym,
+          before,
+          after: plannedAfter,
+          broker_qty: brokerQty,
+          broker_avg: brokerAvg,
+          skipped: 'dry_run',
+        })
+        continue
+      }
+
+      const after = await applyOverride({
+        positionStore: deps.positionStore,
+        symbol: sym,
+        before,
+        brokerQty: effectiveBrokerQty,
+        brokerAvg,
+        requestId: options.requestId,
+      })
+      console.log(
+        JSON.stringify({
+          event: 'holdings_sync_applied',
+          symbol: sym,
+          before,
+          after,
+          broker_qty: brokerQty,
+          broker_avg: brokerAvg,
+          requestId: options.requestId,
+          dryRun: false,
+        }),
+      )
+      synced.push({
+        symbol: sym,
+        before,
+        after,
+        broker_qty: brokerQty,
+        broker_avg: brokerAvg,
+      })
+    } catch (err) {
+      errors.push({ symbol: sym, error: messageOf(err) })
+    }
+  }
+
+  const noDriftCount = synced.filter((r) => r.skipped === 'no_drift').length
+  const syncedCount = synced.length - noDriftCount
+  return {
+    synced,
+    errors,
+    summary: {
+      total: synced.length + errors.length,
+      synced: syncedCount,
+      no_drift: noDriftCount,
+      errors: errors.length,
+    },
+    dryRun: options.dryRun,
+  }
+}
+
+interface ApplyOverrideArgs {
+  positionStore: Pick<PositionStore, 'overridePosition'>
+  symbol: string
+  before: PositionState | null
+  brokerQty: number
+  brokerAvg: number | null
+  requestId: string | null
+}
+
+/**
+ * Apply the override and return the post-state's `position`. Encapsulates
+ * the avg-price fallback policy: prefer broker `avg_cost`, else preserve DO
+ * `avgPrice`, else (only when broker forces a `qty>0` row with no usable
+ * avg) refuse — `overridePosition` rejects `avgPrice<=0` for a non-zero
+ * qty, which is the right behaviour (a synthetic 0 would corrupt PnL).
+ */
+async function applyOverride(args: ApplyOverrideArgs): Promise<PositionState | null> {
+  const { positionStore, symbol, before, brokerQty, brokerAvg, requestId } = args
+
+  // Broker says zero (or omits the row): close the DO position.
+  if (brokerQty <= 0) {
+    const state = await positionStore.overridePosition(symbol, {
+      qty: 0,
+      avgPrice: 0,
+      openedAt: null,
+      reason: buildReason(before?.qty ?? 0, 0),
+      requestId,
+    })
+    return state.position
+  }
+
+  const avgPrice = pickAvgPrice(brokerAvg, before?.avgPrice ?? null)
+  if (avgPrice === null) {
+    // Should be very rare: broker has shares but reports no avg_cost AND we
+    // have no prior DO avgPrice to preserve. Surface as an error rather
+    // than silently writing avgPrice=0 (would break recordFill PnL math).
+    throw new Error(
+      `cannot determine avgPrice for ${symbol}: broker avg_cost missing and no DO avgPrice to preserve`,
+    )
+  }
+  const openedAt = before?.openedAt ?? null
+  const state = await positionStore.overridePosition(symbol, {
+    qty: brokerQty,
+    avgPrice,
+    openedAt,
+    reason: buildReason(before?.qty ?? 0, brokerQty),
+    requestId,
+  })
+  return state.position
+}
+
+function computePlannedAfter(args: {
+  brokerQty: number
+  brokerAvg: number | null
+  before: PositionState | null
+}): PositionState | null {
+  const { brokerQty, brokerAvg, before } = args
+  if (brokerQty <= 0) return null
+  const avgPrice = pickAvgPrice(brokerAvg, before?.avgPrice ?? null)
+  if (avgPrice === null) {
+    // Mirror the live error path — a dryRun shouldn't pretend it can write
+    // `avgPrice=0`. Returning the existing `before` keeps the diff
+    // visible (qty changes) while signalling no usable avg via null.
+    return null
+  }
+  return {
+    qty: brokerQty,
+    avgPrice,
+    openedAt: before?.openedAt ?? new Date(0).toISOString(),
+  }
+}
+
+/**
+ * Choose the avgPrice to write back. Broker `avg_cost` wins when usable;
+ * otherwise we fall through to the existing DO avgPrice rather than zero.
+ * Returns `null` when neither source yields a positive finite number.
+ */
+function pickAvgPrice(brokerAvg: number | null, doAvg: number | null): number | null {
+  if (brokerAvg !== null && Number.isFinite(brokerAvg) && brokerAvg > 0) return brokerAvg
+  if (doAvg !== null && Number.isFinite(doAvg) && doAvg > 0) return doAvg
+  return null
+}
+
+function parseBrokerQty(pos: WebullPositionDto | undefined): number | null {
+  if (pos === undefined) return null
+  const raw = pos.available_quantity
+  if (raw === undefined || raw === null || raw === '') return null
+  const parsed = Number(raw)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function parseBrokerAvg(pos: WebullPositionDto | undefined): number | null {
+  if (pos === undefined) return null
+  const raw = pos.avg_cost
+  if (raw === undefined || raw === null || raw === '') return null
+  const parsed = Number(raw)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function buildReason(beforeQty: number, afterQty: number): string {
+  return `holdings_sync_endpoint: DO qty=${beforeQty} → broker qty=${afterQty}`
+}
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+/**
+ * Re-export for the route layer — keeps the typed `Env` import close to the
+ * call site so the route doesn't need to know about the WebullClient
+ * factory.
+ */
+export type SyncHoldingsEnv = Env
+
+export const _internal = {
+  pickAvgPrice,
+  parseBrokerQty,
+  parseBrokerAvg,
+  computePlannedAfter,
+}

--- a/test/routes/admin.test.ts
+++ b/test/routes/admin.test.ts
@@ -1041,3 +1041,300 @@ describe('Macro event calendar admin endpoints (#196 2/3)', () => {
     })
   })
 })
+
+/**
+ * `POST /admin/orders/sync-holdings` (broker holding reconcile, #221 follow-up).
+ *
+ * Verifies route-level wiring only — the broker / DO / drift logic is covered
+ * end-to-end by `test/trading/reconciliation/syncHoldings.test.ts`. Here we
+ * just confirm the route extracts query params, mounts the WebullHttpClient
+ * + SymbolStateClient, gates on bindings, and forwards results.
+ */
+describe('POST /admin/orders/sync-holdings', () => {
+  type SyncOverrideCall = {
+    symbol: string
+    args: {
+      qty: number
+      avgPrice: number
+      openedAt: string | null
+      reason: string
+      requestId?: string | null
+    }
+  }
+  function fakeSyncNamespace(
+    captured: { calls: SyncOverrideCall[] },
+    initial: Record<string, { qty: number; avgPrice: number; openedAt: string } | null>,
+  ) {
+    const stub = {
+      async getState(symbol: string) {
+        const pos = initial[symbol] ?? null
+        return {
+          symbol,
+          position: pos,
+          appliedClientOrderIds: [],
+          pendingOrder: null,
+          lastSignalAt: null,
+          cooldownUntil: null,
+          settledCash: 0,
+          pendingSettlement: [],
+          lastExecutedPrice: null,
+          lastQuote: null,
+          updatedAt: '2026-04-25T00:00:00.000Z',
+        }
+      },
+      async overridePosition(symbol: string, args: SyncOverrideCall['args']) {
+        captured.calls.push({ symbol, args })
+        return {
+          symbol,
+          position:
+            args.qty > 0
+              ? { qty: args.qty, avgPrice: args.avgPrice, openedAt: args.openedAt ?? '2026-04-25T00:00:00.000Z' }
+              : null,
+          appliedClientOrderIds: [],
+          pendingOrder: null,
+          lastSignalAt: null,
+          cooldownUntil: null,
+          settledCash: 0,
+          pendingSettlement: [],
+          lastExecutedPrice: null,
+          lastQuote: null,
+          updatedAt: '2026-04-25T00:00:00.000Z',
+        }
+      },
+    }
+    return {
+      idFromName: () => 'id',
+      get: () => stub,
+    } as unknown
+  }
+
+  async function withMocks<T>(
+    mocks: {
+      universe?: { allowedSymbols: string[] }
+      positions?: Array<{ symbol: string; available_quantity: string; avg_cost?: string }>
+      positionsThrows?: string
+    },
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    const universeMod = await import('../../src/infrastructure/db/symbolUniverse')
+    const webullMod = await import('../../src/infrastructure/webull/WebullHttpClient')
+    const universeSpy = vi.spyOn(universeMod, 'loadSymbolUniverse').mockResolvedValue({
+      allowedSymbols: mocks.universe?.allowedSymbols ?? [],
+      symbolMaxNotional: {},
+      symbolCurrency: {},
+      symbolBucket: {},
+      inversePairs: {},
+      source: 'd1',
+    })
+    const fakeWebull = {
+      async getPositions() {
+        if (mocks.positionsThrows) throw new Error(mocks.positionsThrows)
+        return mocks.positions ?? []
+      },
+    } as never
+    const webullSpy = vi
+      .spyOn(webullMod, 'createWebullHttpClient')
+      .mockReturnValue(fakeWebull)
+    try {
+      return await fn()
+    } finally {
+      universeSpy.mockRestore()
+      webullSpy.mockRestore()
+    }
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('401s without Basic Auth', async () => {
+    const app = createApp()
+    const res = await app.request(
+      '/admin/orders/sync-holdings',
+      { method: 'POST' },
+      baseEnv,
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it('400s when SYMBOL_STATE binding is missing', async () => {
+    const app = createApp()
+    const res = await app.request(
+      '/admin/orders/sync-holdings',
+      { method: 'POST', headers: { ...authHeader } },
+      { ...baseEnv, DB: {} as unknown as D1Database },
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('400s when DB binding is missing in all-symbols mode (universe loader needs it)', async () => {
+    const captured = { calls: [] as SyncOverrideCall[] }
+    const app = createApp()
+    const res = await app.request(
+      '/admin/orders/sync-holdings',
+      { method: 'POST', headers: { ...authHeader } },
+      { ...baseEnv, SYMBOL_STATE: fakeSyncNamespace(captured, {}) },
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('200s in single-symbol mode without DB binding (universe load skipped)', async () => {
+    const captured = { calls: [] as SyncOverrideCall[] }
+    const res = await withMocks(
+      { positions: [{ symbol: 'SOXL', available_quantity: '4', avg_cost: '125.50' }] },
+      async () => {
+        const app = createApp()
+        return app.request(
+          '/admin/orders/sync-holdings?symbol=SOXL',
+          { method: 'POST', headers: { ...authHeader } },
+          {
+            ...baseEnv,
+            // Deliberately no DB binding — single-symbol mode must not need it.
+            SYMBOL_STATE: fakeSyncNamespace(captured, {
+              SOXL: { qty: 8, avgPrice: 124.95, openedAt: '2026-04-20T00:00:00.000Z' },
+            }),
+          },
+        )
+      },
+    )
+    expect(res.status).toBe(200)
+    expect(captured.calls.map((c) => c.symbol)).toEqual(['SOXL'])
+  })
+
+  it('200s and applies broker truth across the universe', async () => {
+    const captured = { calls: [] as SyncOverrideCall[] }
+    const res = await withMocks(
+      {
+        universe: { allowedSymbols: ['SOXL', 'AAPL'] },
+        positions: [{ symbol: 'SOXL', available_quantity: '4', avg_cost: '125.50' }],
+      },
+      async () => {
+        const app = createApp()
+        return app.request(
+          '/admin/orders/sync-holdings',
+          { method: 'POST', headers: { ...authHeader } },
+          {
+            ...baseEnv,
+            DB: {} as unknown as D1Database,
+            SYMBOL_STATE: fakeSyncNamespace(captured, {
+              SOXL: { qty: 8, avgPrice: 124.95, openedAt: '2026-04-20T00:00:00.000Z' },
+              AAPL: null,
+            }),
+          },
+        )
+      },
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      synced: Array<{ symbol: string; broker_qty: number | null; skipped?: string }>
+      errors: unknown[]
+      summary: { total: number; synced: number; no_drift: number; errors: number }
+      dryRun: boolean
+    }
+    expect(body.dryRun).toBe(false)
+    expect(body.summary).toEqual({ total: 2, synced: 1, no_drift: 1, errors: 0 })
+    expect(captured.calls.map((c) => c.symbol)).toEqual(['SOXL'])
+    expect(captured.calls[0]!.args.qty).toBe(4)
+    expect(captured.calls[0]!.args.avgPrice).toBe(125.5)
+    expect(captured.calls[0]!.args.requestId).toBeTypeOf('string')
+  })
+
+  it('200s with ?symbol=SOXL — single-symbol mode skips universe override', async () => {
+    const captured = { calls: [] as SyncOverrideCall[] }
+    const res = await withMocks(
+      {
+        universe: { allowedSymbols: ['NEVER_USED'] },
+        positions: [{ symbol: 'SOXL', available_quantity: '4', avg_cost: '125.50' }],
+      },
+      async () => {
+        const app = createApp()
+        return app.request(
+          '/admin/orders/sync-holdings?symbol=soxl',
+          { method: 'POST', headers: { ...authHeader } },
+          {
+            ...baseEnv,
+            DB: {} as unknown as D1Database,
+            SYMBOL_STATE: fakeSyncNamespace(captured, {
+              SOXL: { qty: 8, avgPrice: 124.95, openedAt: '2026-04-20T00:00:00.000Z' },
+            }),
+          },
+        )
+      },
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      synced: Array<{ symbol: string }>
+      summary: { total: number }
+    }
+    expect(body.synced.map((r) => r.symbol)).toEqual(['SOXL'])
+    expect(body.summary.total).toBe(1)
+    expect(captured.calls.map((c) => c.symbol)).toEqual(['SOXL'])
+  })
+
+  it('200s with ?dryRun=1 and emits diff without writing', async () => {
+    const captured = { calls: [] as SyncOverrideCall[] }
+    const res = await withMocks(
+      {
+        universe: { allowedSymbols: ['SOXL'] },
+        positions: [{ symbol: 'SOXL', available_quantity: '4', avg_cost: '125.50' }],
+      },
+      async () => {
+        const app = createApp()
+        return app.request(
+          '/admin/orders/sync-holdings?dryRun=1',
+          { method: 'POST', headers: { ...authHeader } },
+          {
+            ...baseEnv,
+            DB: {} as unknown as D1Database,
+            SYMBOL_STATE: fakeSyncNamespace(captured, {
+              SOXL: { qty: 8, avgPrice: 124.95, openedAt: '2026-04-20T00:00:00.000Z' },
+            }),
+          },
+        )
+      },
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      synced: Array<{ symbol: string; skipped?: string; before: { qty: number }; after: { qty: number } }>
+      dryRun: boolean
+    }
+    expect(body.dryRun).toBe(true)
+    expect(body.synced[0]!.skipped).toBe('dry_run')
+    expect(body.synced[0]!.before.qty).toBe(8)
+    expect(body.synced[0]!.after.qty).toBe(4)
+    expect(captured.calls).toEqual([])
+  })
+
+  it('200s and reports broker fetch failures per-symbol (no overrides)', async () => {
+    const captured = { calls: [] as SyncOverrideCall[] }
+    const res = await withMocks(
+      {
+        universe: { allowedSymbols: ['SOXL', 'AAPL'] },
+        positionsThrows: 'broker auth failed',
+      },
+      async () => {
+        const app = createApp()
+        return app.request(
+          '/admin/orders/sync-holdings',
+          { method: 'POST', headers: { ...authHeader } },
+          {
+            ...baseEnv,
+            DB: {} as unknown as D1Database,
+            SYMBOL_STATE: fakeSyncNamespace(captured, {
+              SOXL: { qty: 4, avgPrice: 125, openedAt: '2026-04-20T00:00:00.000Z' },
+            }),
+          },
+        )
+      },
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      synced: unknown[]
+      errors: Array<{ symbol: string; error: string }>
+      summary: { errors: number }
+    }
+    expect(body.summary.errors).toBe(2)
+    expect(body.errors.map((e) => e.symbol).sort()).toEqual(['AAPL', 'SOXL'])
+    expect(captured.calls).toEqual([])
+  })
+})

--- a/test/trading/reconciliation/syncHoldings.test.ts
+++ b/test/trading/reconciliation/syncHoldings.test.ts
@@ -1,0 +1,376 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { _internal, syncHoldings } from '../../../src/trading/reconciliation/syncHoldings'
+import type { WebullPositionDto } from '../../../src/infrastructure/webull/dto'
+import type { PositionStore } from '../../../src/trading/state/PositionStore'
+import type { SymbolState, PositionState } from '../../../src/trading/state/types'
+
+/**
+ * Build a minimal `SymbolState` for a given `position`. Other fields are
+ * defaulted so the test only has to specify what it cares about (qty / avg).
+ */
+function stateWith(symbol: string, position: PositionState | null, updatedAt = '2026-04-25T00:00:00.000Z'): SymbolState {
+  return {
+    symbol,
+    position,
+    appliedClientOrderIds: [],
+    pendingOrder: null,
+    lastSignalAt: null,
+    cooldownUntil: null,
+    settledCash: 0,
+    pendingSettlement: [],
+    lastExecutedPrice: null,
+    lastQuote: null,
+    updatedAt,
+  }
+}
+
+interface OverrideCall {
+  symbol: string
+  args: Parameters<PositionStore['overridePosition']>[1]
+}
+
+/**
+ * In-memory PositionStore stub that records every override call and lets
+ * each test seed `getState` results per symbol. Returns the post-override
+ * state shaped after the args (mirrors what the real DO would do).
+ */
+function createFakeStore(initial: Record<string, PositionState | null>): {
+  store: Pick<PositionStore, 'getState' | 'overridePosition'>
+  overrides: OverrideCall[]
+} {
+  const overrides: OverrideCall[] = []
+  const map = new Map<string, PositionState | null>(Object.entries(initial))
+  const store: Pick<PositionStore, 'getState' | 'overridePosition'> = {
+    async getState(symbol: string) {
+      return stateWith(symbol, map.get(symbol) ?? null)
+    },
+    async overridePosition(symbol, args) {
+      overrides.push({ symbol, args })
+      const next = args.qty > 0
+        ? {
+            qty: args.qty,
+            avgPrice: args.avgPrice,
+            openedAt: args.openedAt ?? '2026-04-25T00:00:00.000Z',
+          }
+        : null
+      map.set(symbol, next)
+      return stateWith(symbol, next)
+    },
+  }
+  return { store, overrides }
+}
+
+describe('syncHoldings internals', () => {
+  it('pickAvgPrice prefers broker avg over DO avg', () => {
+    expect(_internal.pickAvgPrice(124.95, 100)).toBe(124.95)
+  })
+
+  it('pickAvgPrice falls back to DO avg when broker avg is missing/zero/non-finite', () => {
+    expect(_internal.pickAvgPrice(null, 100)).toBe(100)
+    expect(_internal.pickAvgPrice(0, 100)).toBe(100)
+    expect(_internal.pickAvgPrice(Number.NaN, 100)).toBe(100)
+  })
+
+  it('pickAvgPrice returns null when neither source is usable', () => {
+    expect(_internal.pickAvgPrice(null, null)).toBeNull()
+    expect(_internal.pickAvgPrice(0, 0)).toBeNull()
+  })
+
+  it('parseBrokerQty handles the Webull DTO conventions', () => {
+    expect(_internal.parseBrokerQty(undefined)).toBeNull()
+    expect(_internal.parseBrokerQty({ available_quantity: '' })).toBeNull()
+    expect(_internal.parseBrokerQty({ available_quantity: '4' })).toBe(4)
+    expect(_internal.parseBrokerQty({ available_quantity: '0' })).toBe(0)
+    expect(_internal.parseBrokerQty({ available_quantity: 'banana' })).toBeNull()
+  })
+
+  it('computePlannedAfter returns null when broker qty is zero', () => {
+    expect(
+      _internal.computePlannedAfter({ brokerQty: 0, brokerAvg: 100, before: null }),
+    ).toBeNull()
+  })
+
+  it('computePlannedAfter prefers broker avg when available', () => {
+    expect(
+      _internal.computePlannedAfter({
+        brokerQty: 4,
+        brokerAvg: 124.95,
+        before: { qty: 8, avgPrice: 100, openedAt: '2026-04-20T00:00:00.000Z' },
+      }),
+    ).toEqual({
+      qty: 4,
+      avgPrice: 124.95,
+      openedAt: '2026-04-20T00:00:00.000Z',
+    })
+  })
+})
+
+describe('syncHoldings', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    logSpy.mockRestore()
+  })
+
+  function brokerPosition(
+    symbol: string,
+    available: string,
+    avgCost?: string,
+  ): WebullPositionDto {
+    return {
+      symbol,
+      available_quantity: available,
+      ...(avgCost !== undefined ? { avg_cost: avgCost } : {}),
+    }
+  }
+
+  it('all-symbols mode: mixes drift / no-drift / not-held / errors', async () => {
+    const { store, overrides } = createFakeStore({
+      SOXL: { qty: 8, avgPrice: 124.95, openedAt: '2026-04-20T00:00:00.000Z' },
+      AAPL: null,
+      MSFT: { qty: 5, avgPrice: 410, openedAt: '2026-04-21T00:00:00.000Z' },
+      NVDA: { qty: 2, avgPrice: 900, openedAt: '2026-04-22T00:00:00.000Z' },
+    })
+    // Wrap NVDA's getState to throw — exercises the per-symbol error path.
+    const realGetState = store.getState
+    store.getState = async (symbol: string) => {
+      if (symbol === 'NVDA') throw new Error('DO unreachable')
+      return realGetState.call(store, symbol)
+    }
+    const result = await syncHoldings(
+      { dryRun: false, requestId: 'req-1' },
+      {
+        allowedSymbols: ['SOXL', 'AAPL', 'MSFT', 'NVDA'],
+        fetchPositions: async () => [
+          brokerPosition('SOXL', '4', '125.50'),
+          brokerPosition('MSFT', '5', '410'),
+          // AAPL omitted = not held on broker; DO already null → no_drift
+          // NVDA throws via getState wrapper above
+        ],
+        positionStore: store,
+      },
+    )
+
+    // SOXL: drift 8 → 4 — write happens, broker avg used
+    const soxl = result.synced.find((r) => r.symbol === 'SOXL')!
+    expect(soxl.before).toEqual({ qty: 8, avgPrice: 124.95, openedAt: '2026-04-20T00:00:00.000Z' })
+    expect(soxl.after).toEqual({ qty: 4, avgPrice: 125.5, openedAt: '2026-04-20T00:00:00.000Z' })
+    expect(soxl.broker_qty).toBe(4)
+    expect(soxl.broker_avg).toBe(125.5)
+    expect(soxl.skipped).toBeUndefined()
+
+    // AAPL: not held, DO null → no_drift
+    const aapl = result.synced.find((r) => r.symbol === 'AAPL')!
+    expect(aapl.skipped).toBe('no_drift')
+    expect(aapl.broker_qty).toBeNull()
+
+    // MSFT: equal qty → no_drift
+    const msft = result.synced.find((r) => r.symbol === 'MSFT')!
+    expect(msft.skipped).toBe('no_drift')
+
+    // NVDA: error
+    expect(result.errors).toEqual([{ symbol: 'NVDA', error: 'DO unreachable' }])
+
+    // Summary
+    expect(result.summary).toEqual({ total: 4, synced: 1, no_drift: 2, errors: 1 })
+    expect(result.dryRun).toBe(false)
+
+    // Only SOXL was written; AAPL/MSFT untouched.
+    expect(overrides).toHaveLength(1)
+    expect(overrides[0]!.symbol).toBe('SOXL')
+    expect(overrides[0]!.args.qty).toBe(4)
+    expect(overrides[0]!.args.avgPrice).toBe(125.5)
+    expect(overrides[0]!.args.requestId).toBe('req-1')
+    expect(overrides[0]!.args.reason).toContain('8')
+    expect(overrides[0]!.args.reason).toContain('4')
+
+    // Audit log emitted once for the actual sync (NVDA error path doesn't log).
+    const syncLogs = logSpy.mock.calls
+      .map((c) => (typeof c[0] === 'string' ? safeParse(c[0]) : null))
+      .filter((p): p is { event: string } => p !== null && p.event === 'holdings_sync_applied')
+    expect(syncLogs).toHaveLength(1)
+  })
+
+  it('single-symbol mode: only the requested ticker is synced', async () => {
+    const { store, overrides } = createFakeStore({
+      SOXL: { qty: 8, avgPrice: 124.95, openedAt: '2026-04-20T00:00:00.000Z' },
+      AAPL: { qty: 10, avgPrice: 200, openedAt: '2026-04-21T00:00:00.000Z' },
+    })
+    const result = await syncHoldings(
+      { symbol: 'SOXL', dryRun: false, requestId: 'req-2' },
+      {
+        // allowedSymbols irrelevant when symbol is set; pass [] to prove it.
+        allowedSymbols: [],
+        fetchPositions: async () => [
+          brokerPosition('SOXL', '4', '125.50'),
+          brokerPosition('AAPL', '10', '200'),
+        ],
+        positionStore: store,
+      },
+    )
+    expect(result.synced.map((r) => r.symbol)).toEqual(['SOXL'])
+    expect(overrides).toHaveLength(1)
+    expect(overrides[0]!.symbol).toBe('SOXL')
+  })
+
+  it('dryRun=true: drift detected but no overrides written', async () => {
+    const { store, overrides } = createFakeStore({
+      SOXL: { qty: 8, avgPrice: 124.95, openedAt: '2026-04-20T00:00:00.000Z' },
+    })
+    const result = await syncHoldings(
+      { dryRun: true, requestId: 'req-3' },
+      {
+        allowedSymbols: ['SOXL'],
+        fetchPositions: async () => [brokerPosition('SOXL', '4', '125.50')],
+        positionStore: store,
+      },
+    )
+    const soxl = result.synced[0]!
+    expect(soxl.skipped).toBe('dry_run')
+    expect(soxl.before?.qty).toBe(8)
+    expect(soxl.after?.qty).toBe(4)
+    expect(soxl.after?.avgPrice).toBe(125.5)
+    expect(overrides).toEqual([])
+    expect(result.dryRun).toBe(true)
+  })
+
+  it('broker not held (qty=0) → DO position is closed (null)', async () => {
+    const { store, overrides } = createFakeStore({
+      SOXL: { qty: 4, avgPrice: 124.95, openedAt: '2026-04-20T00:00:00.000Z' },
+    })
+    const result = await syncHoldings(
+      { dryRun: false, requestId: 'req-4' },
+      {
+        allowedSymbols: ['SOXL'],
+        // Webull omits zero-qty rows entirely.
+        fetchPositions: async () => [],
+        positionStore: store,
+      },
+    )
+    expect(overrides).toHaveLength(1)
+    expect(overrides[0]!.args.qty).toBe(0)
+    expect(result.synced[0]!.after).toBeNull()
+    expect(result.synced[0]!.broker_qty).toBeNull()
+  })
+
+  it('broker has shares but DO is empty → DO position is created from broker truth', async () => {
+    const { store, overrides } = createFakeStore({ SOXL: null })
+    const result = await syncHoldings(
+      { dryRun: false, requestId: 'req-5' },
+      {
+        allowedSymbols: ['SOXL'],
+        fetchPositions: async () => [brokerPosition('SOXL', '3', '120')],
+        positionStore: store,
+      },
+    )
+    expect(overrides).toHaveLength(1)
+    expect(overrides[0]!.args).toMatchObject({
+      qty: 3,
+      avgPrice: 120,
+      openedAt: null,
+    })
+    expect(result.synced[0]!.after).toMatchObject({ qty: 3, avgPrice: 120 })
+  })
+
+  it('DO has shares but broker reports none → DO position is closed', async () => {
+    const { store, overrides } = createFakeStore({
+      SOXL: { qty: 4, avgPrice: 124.95, openedAt: '2026-04-20T00:00:00.000Z' },
+    })
+    const result = await syncHoldings(
+      { dryRun: false, requestId: 'req-6' },
+      {
+        allowedSymbols: ['SOXL'],
+        fetchPositions: async () => [brokerPosition('SOXL', '0', '0')],
+        positionStore: store,
+      },
+    )
+    expect(overrides).toHaveLength(1)
+    expect(overrides[0]!.args.qty).toBe(0)
+    expect(result.synced[0]!.after).toBeNull()
+  })
+
+  it('broker fetch failure → every symbol surfaces the same error, no overrides', async () => {
+    const { store, overrides } = createFakeStore({
+      SOXL: { qty: 4, avgPrice: 124.95, openedAt: '2026-04-20T00:00:00.000Z' },
+    })
+    const result = await syncHoldings(
+      { dryRun: false, requestId: 'req-7' },
+      {
+        allowedSymbols: ['SOXL', 'AAPL'],
+        fetchPositions: async () => {
+          throw new Error('broker auth failed')
+        },
+        positionStore: store,
+      },
+    )
+    expect(result.synced).toEqual([])
+    expect(result.errors).toEqual([
+      { symbol: 'SOXL', error: 'broker positions fetch failed: broker auth failed' },
+      { symbol: 'AAPL', error: 'broker positions fetch failed: broker auth failed' },
+    ])
+    expect(overrides).toEqual([])
+  })
+
+  it('falls back to DO avgPrice when broker avg_cost is missing', async () => {
+    const { store, overrides } = createFakeStore({
+      SOXL: { qty: 8, avgPrice: 124.95, openedAt: '2026-04-20T00:00:00.000Z' },
+    })
+    const result = await syncHoldings(
+      { dryRun: false, requestId: 'req-8' },
+      {
+        allowedSymbols: ['SOXL'],
+        // No avg_cost on the broker row — fallback to DO 124.95.
+        fetchPositions: async () => [brokerPosition('SOXL', '4')],
+        positionStore: store,
+      },
+    )
+    expect(overrides[0]!.args.avgPrice).toBe(124.95)
+    expect(result.synced[0]!.after?.avgPrice).toBe(124.95)
+  })
+
+  it('errors when broker has shares but no avg available from any source', async () => {
+    // DO row missing AND broker avg_cost missing → cannot synthesize avg
+    const { store, overrides } = createFakeStore({ SOXL: null })
+    const result = await syncHoldings(
+      { dryRun: false, requestId: 'req-9' },
+      {
+        allowedSymbols: ['SOXL'],
+        fetchPositions: async () => [brokerPosition('SOXL', '3')],
+        positionStore: store,
+      },
+    )
+    expect(overrides).toEqual([])
+    expect(result.synced).toEqual([])
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]!.symbol).toBe('SOXL')
+    expect(result.errors[0]!.error).toMatch(/cannot determine avgPrice/)
+  })
+
+  it('matches symbols case-insensitively against broker payload', async () => {
+    const { store, overrides } = createFakeStore({
+      SOXL: { qty: 8, avgPrice: 124.95, openedAt: '2026-04-20T00:00:00.000Z' },
+    })
+    await syncHoldings(
+      { dryRun: false, requestId: 'req-10' },
+      {
+        allowedSymbols: ['SOXL'],
+        // Lowercase broker symbol — should still match SOXL.
+        fetchPositions: async () => [brokerPosition('soxl', '4', '125')],
+        positionStore: store,
+      },
+    )
+    expect(overrides).toHaveLength(1)
+    expect(overrides[0]!.symbol).toBe('SOXL')
+    expect(overrides[0]!.args.qty).toBe(4)
+  })
+})
+
+function safeParse(s: string): { event: string } | null {
+  try {
+    return JSON.parse(s) as { event: string }
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## 動機

PR #215 で reconcile idempotency race を fix し、PR #221 で SELL_QTY_EXCEED 自動 fallback を入れたが、**既に corrupted state は手動修正のみ**。実例では SOXL DO qty=8 vs broker actual=4 の drift がそのまま残っていた。

これまでは銘柄ごとに `POST /admin/symbol-state/:symbol/override-position` を curl で叩く運用だったが、複数銘柄を一発で broker truth に同期する運用ツールが必要。

## 仕様

新エンドポイント `POST /admin/orders/sync-holdings` (Basic Auth + 既存 `/admin/*` middleware)。

- `?symbol=SOXL` (optional): 単一銘柄のみ sync。`symbol_config` から外れた retired ticker でも操作可能 (single-symbol mode は universe 不要 = D1 binding 不要)
- `?dryRun=1` (optional): drift 検出のみ、override は実行せず diff を return
- Body 不要

ロジック:

1. broker `/openapi/account/positions` を 1 回取得
2. 各銘柄について DO `position.qty` と broker `available_quantity` を比較
3. drift があれば `overridePosition` 経由で qty/avgPrice を更新
   - `avgPrice` は broker `avg_cost` を優先、なければ DO 既存値を維持 (synthetic 0 にして PnL を壊すのを回避)
   - broker holding 0 / not held → DO position=null
4. dryRun=true 時は計算のみで write せず

レスポンス:

```json
{
  "synced": [
    { "symbol": "SOXL", "before": {"qty":8,...}, "after": {"qty":4,...}, "broker_qty": 4, "broker_avg": 125.50 },
    { "symbol": "AAPL", "skipped": "no_drift", "broker_qty": null, ... }
  ],
  "errors": [{ "symbol": "NVDA", "error": "..." }],
  "summary": { "total": 9, "synced": 1, "no_drift": 7, "errors": 1 },
  "dryRun": false
}
```

監査ログ: `holdings_sync_applied` event を override 1 回ごとに emit (既存 `symbol_state_position_override` の上に重ねる)。

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test --run` 全 pass (898 → 899 tests, +90 net for sync-holdings + route)
- [x] all-symbols mode: drift / no_drift / not_held / per-symbol error mix
- [x] single-symbol mode: 1 ticker のみ override、universe 無視
- [x] dryRun mode: override 呼ばれず計算結果のみ
- [x] broker not held (qty=0) → DO position=null
- [x] broker has but DO empty → DO position=created
- [x] DO has but broker not held → DO position=null
- [x] broker fetch error: 全銘柄に同じ error を立てて override skip
- [x] avgPrice fallback: broker avg_cost 欠損時は DO 既存値、両方無ければ error (silent qty>0 + avg=0 を避ける)
- [x] route gates: 401 (no auth) / 400 (no SYMBOL_STATE) / 400 (no DB only in all-symbols mode) / single-symbol mode は DB 不要

## 運用フロー

1. `POST /admin/orders/sync-holdings?dryRun=1` → planned diff を確認
2. 中身 OK なら `POST /admin/orders/sync-holdings` で本実行
3. 1 銘柄のみ pinpoint 修正したい時は `?symbol=SOXL`

## 関連

- PR #215 (reconcile idempotency)
- PR #221 (SELL_QTY_EXCEED fallback、`overridePosition` の本実装)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * オペレーター専用のポジション同期機能を追加しました。Webullブローカーのデータをシステムに自動調和させることができます。
  * 単一シンボルまたは全シンボルの同期に対応し、ドライランモードでプレビュー確認が可能です。
  * エラー発生時もシンボルごとに継続して処理し、監査ログで記録されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->