### PR TITLE
fix(webull): JP 株 filled_price=10 stub による DO avgPrice cascade を防止 (sanity check + raw log)

### DIFF
--- a/src/infrastructure/webull/dto.ts
+++ b/src/infrastructure/webull/dto.ts
@@ -67,6 +67,29 @@ export interface WebullPositionDto {
 }
 
 /**
+ * Per-fill leg inside a Webull order detail. Field names follow the
+ * openapi-java-sdk `v2.OrderHistory.Item` mirror — keep them as free strings
+ * (the OpenAPI surface returns numeric-as-string consistently). Only the
+ * fields we actually consume are typed; unknown ones are tolerated.
+ *
+ * Note: the official doc does not formally declare `filled_price` /
+ * `filled_quantity` here, but the production US tenant returns them and
+ * `pickFilledPrice` averages across them. The JP UAT tenant has been
+ * observed returning `filled_price=10` as a stub on otherwise-realistic
+ * orders (see `webull_order_detail_raw` log in reconcileFills) — that is
+ * the trigger for the sanity-ratio guard in `resolveFilledPrice`.
+ */
+export interface WebullOrderItemDto {
+  order_id?: string
+  symbol?: string
+  side?: 'BUY' | 'SELL'
+  quantity?: string
+  filled_quantity?: string
+  filled_price?: string
+  status?: string
+}
+
+/**
  * Shape returned by GET /openapi/account/orders/detail (v1).
  * Fields mirror openapi-java-sdk's `v2.OrderHistory`.
  */
@@ -85,11 +108,5 @@ export interface WebullOrderDetailDto {
   // CANCELLED, REJECTED, EXPIRED, etc. Keep as free string for forward-compat.
   status?: string
   support_trading_session?: string
-  items?: Array<{
-    order_id?: string
-    symbol?: string
-    quantity?: string
-    filled_quantity?: string
-    status?: string
-  }>
+  items?: WebullOrderItemDto[]
 }

--- a/src/trading/reconciliation/reconcileFills.ts
+++ b/src/trading/reconciliation/reconcileFills.ts
@@ -5,6 +5,7 @@ import { createDb } from '../../infrastructure/db/tradeJournalRepo'
 import { tradeJournal } from '../../infrastructure/db/schema'
 import { createWebullHttpClient } from '../../infrastructure/webull/WebullHttpClient'
 import type { WebullOrderDetailDto } from '../../infrastructure/webull/dto'
+import { inferWebullMarket } from '../../infrastructure/webull/mapper'
 import { inferTradingMarket, nextTradingDay } from '../domain/tradingCalendar'
 import { PortfolioStateClient } from '../state/PortfolioStateClient'
 import { SymbolStateClient } from '../state/SymbolStateClient'
@@ -287,6 +288,43 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
       continue
     }
 
+    // P0 raw response capture for JP tenant. We've observed the JP UAT
+    // returning `items[].filled_price=10` as a stub on orders that should
+    // have filled near 2683 (issue: 6971 ping-pong loop). The official doc
+    // does not pin down the unit, so emit the raw response (response body
+    // only — never the request body / signature / auth headers) so the
+    // parser can be confirmed against real data. Limited to JP and one log
+    // per row per reconcile cycle (cron is 5min, so this is not noisy).
+    // Once the unit is confirmed, this log can be removed or guarded by a
+    // debug flag.
+    {
+      const logSymbol = row.symbol ?? detail.symbol
+      if (logSymbol && inferWebullMarket(logSymbol) === 'JP') {
+        console.log(
+          JSON.stringify({
+            event: 'webull_order_detail_raw',
+            requestId: options.requestId,
+            symbol: logSymbol,
+            clientOrderId: coid,
+            detail_status: detail.status,
+            detail_side: detail.side,
+            detail_limit_price: detail.limit_price,
+            detail_quantity: detail.quantity,
+            detail_filled_quantity: detail.filled_quantity,
+            items_count: detail.items?.length ?? 0,
+            items_summary: detail.items?.map((item) => ({
+              filled_price: item.filled_price,
+              filled_quantity: item.filled_quantity,
+              side: item.side,
+              status: item.status,
+              raw_keys: Object.keys(item ?? {}),
+            })),
+            detail_keys: Object.keys(detail ?? {}),
+          }),
+        )
+      }
+    }
+
     const status = detail.status
     if (!status || !TERMINAL_STATUSES.has(status)) {
       summary.stillPending.push({ clientOrderId: coid, status })
@@ -294,7 +332,11 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
     }
 
     const filledQty = toNumberOrNull(detail.filled_quantity)
-    const filledPrice = resolveFilledPrice(filledQty, detail)
+    const filledPrice = resolveFilledPrice(filledQty, detail, {
+      requestId: options.requestId,
+      clientOrderId: coid,
+      symbol: row.symbol ?? detail.symbol ?? null,
+    })
 
     // Compute realized P&L for SELL fills BEFORE we touch any state. Needs
     // the symbol's current avg cost from SymbolStateDO, which is only
@@ -746,7 +788,7 @@ function pickFilledPrice(detail: WebullOrderDetailDto): number | null {
   // to walk items[] directly instead.
   if (detail.items && detail.items.length > 0) {
     const prices = detail.items
-      .map((item) => toNumberOrNull((item as { filled_price?: string }).filled_price))
+      .map((item) => toNumberOrNull(item.filled_price))
       .filter((n): n is number => n !== null && n > 0)
     if (prices.length > 0) {
       const sum = prices.reduce((acc, n) => acc + n, 0)
@@ -761,18 +803,69 @@ function pickFilledPrice(detail: WebullOrderDetailDto): number | null {
 }
 
 /**
+ * Sanity guardrail: a fill price more than 2x or less than 0.5x the
+ * signed limit price is treated as a stub / parse error and rejected. The
+ * trigger was JP UAT returning `items[].filled_price=10` on a 6971 order
+ * with limit ~2683 (~268x deviation), which then propagated as
+ * `avgPrice=10` into SymbolStateDO and produced a +26730% pnl in
+ * pullbackScheduler — kicking off a TP→SELL→re-fill ping-pong loop.
+ *
+ * Returning `null` here causes the reconcile loop to leave
+ * `state_applied_at` NULL and skip the DO apply path, so the bogus price
+ * never lands in DO state. The next reconcile tick retries; if the
+ * broker eventually returns a realistic price we apply normally, and if
+ * not we never poison the DO.
+ *
+ * The threshold is intentionally loose (2x band) because:
+ *   - MARKET orders can fill outside the limit on a fast-moving symbol,
+ *   - intraday gap-ups / haltreopens also produce >1x moves.
+ *   2x catches order-of-magnitude stubs without flagging realistic vol.
+ */
+const FILLED_PRICE_RATIO_MIN = 0.5
+const FILLED_PRICE_RATIO_MAX = 2
+
+/**
  * Only record a fill price when there's actually a fill, and only if it
  * passes the "finite and > 0" guideline. For CANCELLED / REJECTED rows
  * (filledQty=0) this returns null so we don't misrepresent the row as if
  * it had transacted at the signed limit price.
+ *
+ * Also rejects fills whose price is wildly inconsistent with the signed
+ * limit (`<0.5x` or `>2x`) — see `FILLED_PRICE_RATIO_*` for the rationale.
  */
 function resolveFilledPrice(
   filledQty: number | null,
   detail: WebullOrderDetailDto,
+  context?: {
+    requestId?: string
+    clientOrderId?: string
+    symbol?: string | null
+  },
 ): number | null {
   if (filledQty === null || filledQty <= 0) return null
   const candidate = pickFilledPrice(detail)
   if (candidate === null || !Number.isFinite(candidate) || candidate <= 0) return null
+
+  const limit = toNumberOrNull(detail.limit_price)
+  if (limit !== null && limit > 0) {
+    const ratio = candidate / limit
+    if (ratio < FILLED_PRICE_RATIO_MIN || ratio > FILLED_PRICE_RATIO_MAX) {
+      console.warn(
+        JSON.stringify({
+          event: 'webull_filled_price_sanity_failed',
+          requestId: context?.requestId,
+          clientOrderId: context?.clientOrderId,
+          symbol: context?.symbol,
+          candidate,
+          limit_price: limit,
+          ratio,
+          detail_status: detail.status,
+          detail_side: detail.side,
+        }),
+      )
+      return null
+    }
+  }
   return candidate
 }
 

--- a/src/trading/reconciliation/reconcileFills.ts
+++ b/src/trading/reconciliation/reconcileFills.ts
@@ -420,17 +420,41 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
           })
         }
       } else if (status === 'FILLED') {
-        // FILLED but missing one of the apply prerequisites. Mark
-        // `state_applied_at` anyway so we don't retry forever — there's
-        // nothing to apply.
-        await db
-          .update(tradeJournal)
-          .set({
-            stateAppliedAt: runNow.toISOString(),
-            stateApplyError: null,
-            stateApplyAttempts: sql`${tradeJournal.stateApplyAttempts} + 1`,
+        // FILLED but missing one of the apply prerequisites. Two sub-cases:
+        //
+        //   (a) Genuine no-op — e.g. filledQty=0 (CANCELLED-then-FILLED edge,
+        //       or REJECTED-then-FILLED) or symbol/side missing on the row.
+        //       Nothing to apply now and nothing the next tick will recover,
+        //       so stamp `state_applied_at` to prevent forever-retry.
+        //
+        //   (b) Transient sanity failure — `filledQty > 0` but
+        //       `filledPrice === null` because `resolveFilledPrice()`
+        //       rejected the candidate (e.g. JP `items[].filled_price=10`
+        //       stub vs limit ~2683 → ratio 0.0037 → null). The next
+        //       reconcile tick may get a realistic price from the broker;
+        //       leave `state_applied_at` NULL so the row stays in the
+        //       repair cohort.
+        //
+        // `shouldRetryStateApply` distinguishes (b). For it we still record
+        // the reason via `state_apply_error` for operator visibility, but
+        // do NOT stamp the marker.
+        if (shouldRetryStateApply(filledQty, filledPrice, status)) {
+          await recordApplyFailure(db, row.id, 'sanity_failed: filled_price rejected by ratio guard')
+          summary.stateApplyFailed += 1
+          summary.errors.push({
+            clientOrderId: coid,
+            message: 'state_apply_failed (sanity_failed: filled_price rejected by ratio guard)',
           })
-          .where(eq(tradeJournal.id, row.id))
+        } else {
+          await db
+            .update(tradeJournal)
+            .set({
+              stateAppliedAt: runNow.toISOString(),
+              stateApplyError: null,
+              stateApplyAttempts: sql`${tradeJournal.stateApplyAttempts} + 1`,
+            })
+            .where(eq(tradeJournal.id, row.id))
+        }
       }
 
       // Release the pending-order lock on every terminal status — FILLED,
@@ -597,6 +621,31 @@ function resolveJournalSide(
   if (primary === 'BUY' || primary === 'SELL') return primary
   if (fallback === 'BUY' || fallback === 'SELL') return fallback
   return null
+}
+
+/**
+ * True when a FILLED row has a positive filledQty but `filledPrice` came back
+ * null from `resolveFilledPrice` — i.e. the broker reported a fill but the
+ * sanity guardrail rejected the price as a stub. We deliberately keep
+ * `state_applied_at = NULL` for these rows so the repair cohort
+ * (broker_status='FILLED' AND state_applied_at IS NULL) re-selects them on
+ * the next reconcile tick. If the broker eventually returns a realistic
+ * price, the apply runs normally; if it never does, we never poison DO state.
+ *
+ * Genuine no-ops (filledQty=0, missing symbol/side, etc.) fall through to the
+ * marker stamp so they don't retry forever.
+ */
+function shouldRetryStateApply(
+  filledQty: number | null,
+  filledPrice: number | null,
+  brokerStatus: string | null,
+): boolean {
+  return (
+    brokerStatus === 'FILLED' &&
+    filledQty !== null &&
+    filledQty > 0 &&
+    filledPrice === null
+  )
 }
 
 function dedupeCandidatesByRowId<T extends { id: number; side: string | null; preSubmitSide?: string | null }>(
@@ -870,4 +919,9 @@ function resolveFilledPrice(
 }
 
 // Exposed for tests.
-export const _internal = { TERMINAL_STATUSES, pickFilledPrice, resolveFilledPrice }
+export const _internal = {
+  TERMINAL_STATUSES,
+  pickFilledPrice,
+  resolveFilledPrice,
+  shouldRetryStateApply,
+}

--- a/test/trading/reconciliation/reconcileFills.test.ts
+++ b/test/trading/reconciliation/reconcileFills.test.ts
@@ -718,4 +718,201 @@ describe('reconcileFills state-apply marker (issue #142)', () => {
   it('throws when env.DB binding is missing', async () => {
     await expect(reconcileFills({ env: {} as never })).rejects.toThrow(/env\.DB/)
   })
+
+  // ---------------------------------------------------------------------------
+  // sanity failure → repair cohort retention (PR #223 CodeRabbit Major)
+  //
+  // When `resolveFilledPrice()` rejects a fill price as a stub (ratio guard),
+  // the row must be left WITHOUT `state_applied_at` so the next reconcile
+  // tick re-selects it from the repair cohort and tries again with whatever
+  // the broker now reports.
+  // ---------------------------------------------------------------------------
+
+  it('sanity failure: keeps state_applied_at NULL so next tick retries', async () => {
+    // JP UAT 6971-style stub: filled_quantity > 0 but filled_price=10 vs
+    // limit_price=2683 — sanity ratio guard rejects.
+    const row: CandidateRow = {
+      id: 31,
+      clientOrderId: 'coid-jp-stub-1',
+      symbol: '6971',
+      side: 'BUY',
+      brokerStatus: null,
+      filledQty: null,
+      filledPrice: null,
+      realizedPnl: null,
+      stateAppliedAt: null,
+      stateApplyAttempts: 0,
+    }
+    const { db, updates } = makeFakeDb([row])
+    vi.mocked(createDb).mockReturnValue(db)
+    vi.mocked(createWebullHttpClient).mockReturnValue(
+      makeWebullStub({
+        'coid-jp-stub-1': {
+          status: 'FILLED',
+          filled_quantity: '1',
+          limit_price: '2683',
+          items: [{ filled_price: '10' }],
+          side: 'BUY',
+          symbol: '6971',
+        },
+      }) as unknown as ReturnType<typeof createWebullHttpClient>,
+    )
+    // Quiet sanity warn log.
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const symbolStub = emptySymbolStateStub()
+
+    const summary = await reconcileFills({
+      env: {
+        DB: FAKE_DB_BINDING,
+        SYMBOL_STATE: makeSymbolStateNamespace(symbolStub) as never,
+      } as never,
+      now: () => new Date('2026-04-25T12:00:00.000Z'),
+    })
+
+    // DO state apply must NOT happen — the stub price would poison avgPrice.
+    expect(symbolStub.recordFillOnce).not.toHaveBeenCalled()
+
+    // Two UPDATEs:
+    //   (1) journal fill columns (broker_status=FILLED, filled_qty=1,
+    //       filled_price=null because sanity rejected)
+    //   (2) failure marker (state_apply_error set, attempts++) — but
+    //       crucially state_applied_at must NOT be stamped.
+    expect(updates).toHaveLength(2)
+    expect(updates[0]!.set.brokerStatus).toBe('FILLED')
+    expect(updates[0]!.set.filledQty).toBe(1)
+    expect(updates[0]!.set.filledPrice).toBeNull()
+    expect(updates[0]!.set.stateAppliedAt).toBeUndefined()
+    // Failure marker UPDATE: error recorded, marker NOT stamped → row
+    // remains in repair cohort for next tick.
+    expect(updates[1]!.set.stateAppliedAt).toBeUndefined()
+    expect(updates[1]!.set.stateApplyError).toMatch(/sanity_failed/)
+    expect(updates[1]!.set.stateApplyAttempts).toBeDefined()
+
+    expect(summary.stateApplied).toBe(0)
+    expect(summary.stateApplyFailed).toBe(1)
+    expect(summary.repaired).toBe(0)
+    expect(summary.errors).toEqual([
+      { clientOrderId: 'coid-jp-stub-1', message: expect.stringContaining('sanity_failed') },
+    ])
+  })
+
+  it('next reconcile tick: realistic broker price → DO apply succeeds, marker stamped', async () => {
+    // Same row from the sanity failure — broker_status='FILLED' already
+    // recorded but state_applied_at still NULL. retryStateApply=true sweeps
+    // it back. This time the broker returns a realistic 2680 vs 2683 (within
+    // the 0.5–2x band) — but note the repair branch uses the canonical
+    // filled_price already on the row, NOT the broker's response. So we
+    // simulate the row having been updated (e.g. by a prior cron tick that
+    // saw a realistic broker price between #1 and #2 — equivalent to the row
+    // gaining a usable price by some path).
+    //
+    // Practical model: imagine the prior cron tick observed the new healthy
+    // price and the journal UPDATE wrote `filled_price=2680`, but the DO
+    // apply still failed transiently. retryStateApply now picks it up.
+    const row: CandidateRow = {
+      id: 31,
+      clientOrderId: 'coid-jp-stub-1',
+      symbol: '6971',
+      side: 'BUY',
+      brokerStatus: 'FILLED',
+      filledQty: 1,
+      filledPrice: 2680,
+      realizedPnl: null,
+      stateAppliedAt: null,
+      stateApplyAttempts: 1,
+    }
+    const { db, updates } = makeFakeDb([row])
+    vi.mocked(createDb).mockReturnValue(db)
+    const webullStub = makeWebullStub({})
+    vi.mocked(createWebullHttpClient).mockReturnValue(
+      webullStub as unknown as ReturnType<typeof createWebullHttpClient>,
+    )
+    const symbolStub = emptySymbolStateStub()
+
+    const summary = await reconcileFills({
+      env: {
+        DB: FAKE_DB_BINDING,
+        SYMBOL_STATE: makeSymbolStateNamespace(symbolStub) as never,
+      } as never,
+      now: () => new Date('2026-04-25T12:05:00.000Z'),
+      retryStateApply: true,
+    })
+
+    // Repair path doesn't re-poll Webull.
+    expect(webullStub.findOrderByClientId).not.toHaveBeenCalled()
+    // DO apply now runs with the healthy price.
+    expect(symbolStub.recordFillOnce).toHaveBeenCalledWith('6971', 'coid-jp-stub-1', {
+      side: 'BUY',
+      qty: 1,
+      price: 2680,
+    })
+    expect(summary.stateApplied).toBe(1)
+    expect(summary.repaired).toBe(1)
+    expect(updates).toHaveLength(1)
+    expect(updates[0]!.set.stateAppliedAt).toBe('2026-04-25T12:05:00.000Z')
+    expect(updates[0]!.set.stateApplyError).toBeNull()
+  })
+
+  it('FILLED with filledQty=0 (genuine no-op): stamps marker — no retry forever', async () => {
+    // Distinguishes (b) sanity failure from (a) genuine "FILLED but nothing
+    // to apply". CANCELLED-then-FILLED shaped rows (filledQty=0) have no
+    // recoverable state — stamp the marker so the row exits the repair
+    // cohort.
+    const row: CandidateRow = {
+      id: 33,
+      clientOrderId: 'coid-zero-qty',
+      symbol: 'SOXL',
+      side: 'BUY',
+      brokerStatus: null,
+      filledQty: null,
+      filledPrice: null,
+      realizedPnl: null,
+      stateAppliedAt: null,
+      stateApplyAttempts: 0,
+    }
+    const { db, updates } = makeFakeDb([row])
+    vi.mocked(createDb).mockReturnValue(db)
+    vi.mocked(createWebullHttpClient).mockReturnValue(
+      makeWebullStub({
+        'coid-zero-qty': {
+          status: 'FILLED',
+          filled_quantity: '0',
+          limit_price: '50',
+          side: 'BUY',
+          symbol: 'SOXL',
+        },
+      }) as unknown as ReturnType<typeof createWebullHttpClient>,
+    )
+    const symbolStub = emptySymbolStateStub()
+
+    const summary = await reconcileFills({
+      env: {
+        DB: FAKE_DB_BINDING,
+        SYMBOL_STATE: makeSymbolStateNamespace(symbolStub) as never,
+      } as never,
+      now: () => new Date('2026-04-25T12:00:00.000Z'),
+    })
+
+    expect(symbolStub.recordFillOnce).not.toHaveBeenCalled()
+    // Two UPDATEs: journal fill columns + state_applied_at marker (no-op
+    // path — nothing to apply, stamp so we don't retry forever).
+    expect(updates).toHaveLength(2)
+    expect(updates[1]!.set.stateAppliedAt).toBe('2026-04-25T12:00:00.000Z')
+    expect(summary.stateApplied).toBe(0)
+    expect(summary.stateApplyFailed).toBe(0)
+  })
+
+  it('shouldRetryStateApply: true only for FILLED + qty>0 + price=null', () => {
+    const fn = _internal.shouldRetryStateApply as (
+      qty: number | null,
+      price: number | null,
+      status: string | null,
+    ) => boolean
+    expect(fn(1, null, 'FILLED')).toBe(true) // sanity failure: retry
+    expect(fn(0, null, 'FILLED')).toBe(false) // genuine no-op
+    expect(fn(null, null, 'FILLED')).toBe(false) // missing qty
+    expect(fn(1, 50, 'FILLED')).toBe(false) // healthy fill
+    expect(fn(1, null, 'CANCELLED')).toBe(false) // not FILLED
+    expect(fn(1, null, null)).toBe(false) // no status
+  })
 })

--- a/test/trading/reconciliation/reconcileFills.test.ts
+++ b/test/trading/reconciliation/reconcileFills.test.ts
@@ -68,6 +68,64 @@ describe('reconcileFills internals', () => {
     expect(_internal.resolveFilledPrice(1, { limit_price: 'NaN' })).toBeNull()
     expect(_internal.resolveFilledPrice(1, {})).toBeNull()
   })
+
+  // ratio sanity guardrail (issue: 6971 ping-pong from filled_price=10 stub)
+  describe('resolveFilledPrice ratio sanity', () => {
+    beforeEach(() => {
+      // Quiet the JSON warn log so test output stays readable.
+      vi.spyOn(console, 'warn').mockImplementation(() => {})
+    })
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('rejects a JP-style stub fill (filled=10 vs limit=2683)', () => {
+      const detail = {
+        items: [{ filled_price: '10' }],
+        limit_price: '2683',
+      }
+      expect(_internal.resolveFilledPrice(1, detail)).toBeNull()
+    })
+
+    it('accepts a US fill with realistic limit/fill spread (215 vs 215.42)', () => {
+      const detail = {
+        items: [{ filled_price: '215' }],
+        limit_price: '215.42',
+      }
+      expect(_internal.resolveFilledPrice(1, detail)).toBe(215)
+    })
+
+    it('accepts a 1.07x slippage fill (120.43 vs 112.77) inside the 0.5–2x band', () => {
+      const detail = {
+        items: [{ filled_price: '120.43' }],
+        limit_price: '112.77',
+      }
+      expect(_internal.resolveFilledPrice(1, detail)).toBeCloseTo(120.43)
+    })
+
+    it('accepts a JP fill close to the signed limit (2680 vs 2683)', () => {
+      const detail = {
+        items: [{ filled_price: '2680' }],
+        limit_price: '2683',
+      }
+      expect(_internal.resolveFilledPrice(1, detail)).toBe(2680)
+    })
+
+    it('skips the ratio check when limit_price is missing (candidate kept as-is)', () => {
+      const detail = {
+        items: [{ filled_price: '10' }],
+      }
+      expect(_internal.resolveFilledPrice(1, detail)).toBe(10)
+    })
+
+    it('rejects a 3x overshoot (candidate above the 2x ceiling)', () => {
+      const detail = {
+        items: [{ filled_price: '300' }],
+        limit_price: '100',
+      }
+      expect(_internal.resolveFilledPrice(1, detail)).toBeNull()
+    })
+  })
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 動機

JP UAT (6971) で **`items[].filled_price=10` という stub** が返却され、reconcile が DO に `avgPrice=10` を反映 → pullbackScheduler が `pnl = (2683 - 10) / 10 = 267 = +26730%` を観測 → **TP 即発動 → SELL → broker 再 fill 10 → 即 BUY → 無限 ping-pong loop** という事故。

US 株経路は問題なし (limit 215.42 → fill 214.99 等、realistic)。JP 経路だけで stub が観測される。公式 doc は `items[].filled_price` の単位明記なし。

## 変更点

### P0: JP order raw response log (1 回 / row / reconcile cycle)

`reconcileFills.ts` で `findOrderByClientId` の戻り値を **JP 銘柄のみ** raw で `console.log`。
- `event=webull_order_detail_raw` で JSON 1 行
- response body のみ (request body / signature / authHeaders は **絶対に出さない**)
- `inferWebullMarket(symbol) === 'JP'` で gate
- 後で実物データを見て parser 確定したら、log 削除 or debug-flag 化する想定 (別 PR)

### P1: filled_price sanity check

`resolveFilledPrice` に **比率チェック** を追加:
- candidate (= fill price) と signed `limit_price` の比が `<0.5x` または `>2x` なら **null を返す**
- `console.warn(event=webull_filled_price_sanity_failed, ...)` で観測可能化
- `null` を返すと既存 path で:
  - `trade_journal.filled_price / realized_pnl` が NULL のまま
  - DO state apply は **スキップ** (state_applied_at NULL のまま、リトライサイクル)
  - 次 cron tick で broker から正常値が返れば apply される
  - ずっと stub のままでも DO に poison が伝播しないので **avg=10 cascade も ping-pong loop も発生しない**

しきい値 `0.5x–2x` は意図的に loose:
- MARKET の slippage、intraday gap-up / halt-reopen 等で `>1x` の動きはあり得る
- 2x は order-of-magnitude stub (`>100x`, `<0.01x` 等) を確実に捕まえるが realistic vol を flag しない幅

### P2: DTO 型補強 (副次)

`WebullOrderItemDto` を正式 type として宣言し、`WebullOrderDetailDto.items` の inline 型を置き換え。`reconcileFills.pickFilledPrice` の `as { filled_price?: string }` cast も削除。

## test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test --run` 全 pass (905/905)
- [x] 新規テスト (resolveFilledPrice ratio sanity):
  - `candidate=10, limit=2683` → null (JP stub の実例; ratio 0.0037 で reject)
  - `candidate=215, limit=215.42` → 215 (US 通常範囲)
  - `candidate=120.43, limit=112.77` → 120.43 (1.07x slippage; 範囲内)
  - `candidate=2680, limit=2683` → 2680 (JP 通常範囲)
  - `candidate=10, limit=undefined` → 10 (limit 不在なら ratio check skip)
  - `candidate=300, limit=100` → null (3x; 上限超過で reject)
- [x] 既存 `pickFilledPrice` / `resolveFilledPrice` テスト維持 (regression なし)

## scope 外 (別 PR)

- raw log の中身判明後の **parser 確定** (e.g. `items[].filled_price` を `quantity * price` に切り替える 等)
- raw log の **debug-flag 化 / 削除**
- JP cron への DRY_RUN 強制
- limit price 自体が壊れている場合の fallback (今回は limit を anchor に信用する設計)

## 注意

- 既存 US 株経路への影響ゼロ (sanity check は両 market 共通だが、ratio 0.5–2x 内なら通る)
- DRY_RUN 既定の fail-closed 設計を破らない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ブローカーの生データ（注文詳細）をログ化して解析検証を容易化

* **バグ修正**
  * 約定価格の整合性チェックを強化し、極端な外れ値は無効扱いに
  * 異常検出時は適用済みタイムスタンプを保留し、修復処理で再試行されるよう挙動を変更

* **テスト**
  * 価格検証と再試行ロジックに対する単体テストを追加し網羅性を向上
<!-- end of auto-generated comment: release notes by coderabbit.ai -->