### PR TITLE
feat(dashboard): JP 銘柄表示を 番号-会社名 形式に

### DIFF
--- a/src/infrastructure/db/symbolConfigRepo.ts
+++ b/src/infrastructure/db/symbolConfigRepo.ts
@@ -3,6 +3,7 @@ import type { DrizzleD1Database } from 'drizzle-orm/d1'
 import { inversePairs, symbolConfig } from './schema'
 
 export type SymbolCurrency = 'USD' | 'JPY'
+export type SymbolMarket = 'US' | 'JP'
 
 export interface SymbolConfigSnapshot {
   /** Uppercased symbols where `active = 1`. */
@@ -20,6 +21,17 @@ export interface SymbolConfigSnapshot {
    * = 個別銘柄判定)。相関集約 cap (#23 Lane 3) で使う。
    */
   symbolBucket: Record<string, string>
+  /**
+   * symbol → market ('US' | 'JP')。dashboard が JP 銘柄表示を「番号-会社名」
+   * に切り替える判定に使う。CHECK 制約は schema 側に無いので 'US' / 'JP'
+   * 以外が混ざる場合は 'US' fallback (defensive)。
+   */
+  symbolMarket: Record<string, SymbolMarket>
+  /**
+   * symbol → 人間可読な銘柄名 (symbol_config.name)。NULL / 空文字は map に
+   * 含めない。dashboard が JP の `${symbol}-${name}` 表示で使う。
+   */
+  symbolName: Record<string, string>
 }
 
 /**
@@ -35,6 +47,8 @@ export async function loadSymbolConfig(
   const symbolMaxNotional: Record<string, number> = {}
   const symbolCurrency: Record<string, SymbolCurrency> = {}
   const symbolBucket: Record<string, string> = {}
+  const symbolMarket: Record<string, SymbolMarket> = {}
+  const symbolName: Record<string, string> = {}
   for (const row of rows) {
     const symbol = row.symbol.toUpperCase()
     allowedSymbols.push(symbol)
@@ -48,8 +62,23 @@ export async function loadSymbolConfig(
     if (normalizedBucket) {
       symbolBucket[symbol] = normalizedBucket
     }
+    // schema 上 market は 'US' | 'JP' 想定だが CHECK 制約は無いので
+    // 不正値は 'US' fallback (defensive)。dashboard 表示の「JP のみ
+    // 番号-会社名」判定に使う。
+    symbolMarket[symbol] = row.market === 'JP' ? 'JP' : 'US'
+    const trimmedName = row.name?.trim()
+    if (trimmedName && trimmedName.length > 0) {
+      symbolName[symbol] = trimmedName
+    }
   }
-  return { allowedSymbols, symbolMaxNotional, symbolCurrency, symbolBucket }
+  return {
+    allowedSymbols,
+    symbolMaxNotional,
+    symbolCurrency,
+    symbolBucket,
+    symbolMarket,
+    symbolName,
+  }
 }
 
 /**

--- a/src/infrastructure/db/symbolUniverse.ts
+++ b/src/infrastructure/db/symbolUniverse.ts
@@ -1,11 +1,20 @@
 import { createDb } from './tradeJournalRepo'
-import { loadInversePairs, loadSymbolConfig, type SymbolCurrency } from './symbolConfigRepo'
+import {
+  loadInversePairs,
+  loadSymbolConfig,
+  type SymbolCurrency,
+  type SymbolMarket,
+} from './symbolConfigRepo'
 
 export interface SymbolUniverse {
   allowedSymbols: string[]
   symbolMaxNotional: Record<string, number>
   symbolCurrency: Record<string, SymbolCurrency>
   symbolBucket: Record<string, string>
+  /** symbol → 'US' | 'JP'。dashboard が JP 銘柄表示を切り替えるのに使う。 */
+  symbolMarket: Record<string, SymbolMarket>
+  /** symbol → 人間可読 name (symbol_config.name、null は map に不在)。 */
+  symbolName: Record<string, string>
   inversePairs: Record<string, string>
   source: 'd1'
 }
@@ -31,6 +40,8 @@ export async function loadSymbolUniverse(env: UniverseEnv): Promise<SymbolUniver
     symbolMaxNotional: config.symbolMaxNotional,
     symbolCurrency: config.symbolCurrency,
     symbolBucket: config.symbolBucket,
+    symbolMarket: config.symbolMarket,
+    symbolName: config.symbolName,
     inversePairs: pairs,
     source: 'd1',
   }

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -384,18 +384,17 @@ function messageOf(error: unknown): string {
 }
 
 /**
- * `SymbolUniverse` から JP 銘柄向け 番号-会社名 表示文字列を返す薄い helper。
+ * `SymbolUniverse` から 番号/ticker - 会社名 表示文字列を返す薄い helper。
  * universe が無い (load 失敗等) ケースは symbol そのまま (= 既存挙動)。
  *
  * `URL ?symbol=7974` の routing は変更しない。表示テキストだけが
- * `7974-任天堂` 形式に切り替わる。
+ * `7974-任天堂` / `AAPL-Apple Inc.` 形式に切り替わる。
  */
 function displaySymbol(symbol: string, universe?: SymbolUniverse | null): string {
   if (!universe) return symbol
   const upper = symbol.toUpperCase()
   return formatSymbolDisplay({
     symbol,
-    market: universe.symbolMarket[upper] ?? null,
     name: universe.symbolName[upper] ?? null,
   })
 }

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -2,7 +2,8 @@ import { Hono } from 'hono'
 import type { AppBindings } from '../app'
 import type { Env } from '../config/env'
 import { loadGlobalConfigFrom } from '../infrastructure/db/globalConfigLoader'
-import { loadSymbolUniverse } from '../infrastructure/db/symbolUniverse'
+import { loadSymbolUniverse, type SymbolUniverse } from '../infrastructure/db/symbolUniverse'
+import { formatSymbolDisplay } from '../shared/format'
 import { createDb } from '../infrastructure/db/tradeJournalRepo'
 import { MAX_TIME_STOP_DAYS, strategyDecisionLog, tradeJournal } from '../infrastructure/db/schema'
 import {
@@ -46,7 +47,7 @@ export const dashboard = new Hono<AppBindings>()
       ),
       loadLatestStrategyPrices(c.env.DB, universe.allowedSymbols),
     ])
-    return c.html(layout('保有状況', positionsBody(rows, strategyPriceMap)))
+    return c.html(layout('保有状況', positionsBody(rows, strategyPriceMap, universe)))
   })
   .get('/portfolio', async (c) => {
     if (!c.env.PORTFOLIO_STATE) {
@@ -70,8 +71,13 @@ export const dashboard = new Hono<AppBindings>()
     }
     const limit = clampLimit(c.req.query('limit'))
     const db = createDb(c.env.DB)
-    const rows = await db.select().from(tradeJournal).orderBy(desc(tradeJournal.id)).limit(limit)
-    return c.html(layout('約定履歴', tradesBody(rows, limit)))
+    // universe を並行 load して銘柄表示を「番号-会社名」(JP) に整形。
+    // load 失敗時は `null` を tradesBody に渡し、symbol そのまま表示で fallback。
+    const [rows, universe] = await Promise.all([
+      db.select().from(tradeJournal).orderBy(desc(tradeJournal.id)).limit(limit),
+      loadSymbolUniverse(c.env).catch(() => null),
+    ])
+    return c.html(layout('約定履歴', tradesBody(rows, limit, universe)))
   })
   .get('/config', async (c) => {
     if (!c.env.DB) {
@@ -144,6 +150,7 @@ export const dashboard = new Hono<AppBindings>()
               tab,
               charts,
               zoom,
+              universe,
             }),
           ),
         )
@@ -203,6 +210,7 @@ export const dashboard = new Hono<AppBindings>()
             availableSymbols: universe.allowedSymbols,
             strategyParams,
             zoom,
+            universe,
           }),
         ),
       )
@@ -320,15 +328,18 @@ export const dashboard = new Hono<AppBindings>()
             eq(tradeJournal.tradeEventType, 'post_submit'),
           ),
         )
-      const rows = symbolFilter
-        ? await baseQuery
-            .where(eq(strategyDecisionLog.symbol, symbolFilter))
-            .orderBy(desc(strategyDecisionLog.id))
-            .limit(limit)
-        : await baseQuery
-            .orderBy(desc(strategyDecisionLog.id))
-            .limit(limit)
-      return c.html(layout('Cron 判定', cronBody(rows, limit, symbolFilter)))
+      const [rows, universe] = await Promise.all([
+        symbolFilter
+          ? baseQuery
+              .where(eq(strategyDecisionLog.symbol, symbolFilter))
+              .orderBy(desc(strategyDecisionLog.id))
+              .limit(limit)
+          : baseQuery
+              .orderBy(desc(strategyDecisionLog.id))
+              .limit(limit),
+        loadSymbolUniverse(c.env).catch(() => null),
+      ])
+      return c.html(layout('Cron 判定', cronBody(rows, limit, symbolFilter, universe)))
     } catch (err) {
       // migration 未適用 / 一時的な D1 エラーで 500 にせず unavailable に落とす
       // (CodeRabbit #132)。段階的デプロイ時の自己保護。
@@ -351,11 +362,14 @@ export const dashboard = new Hono<AppBindings>()
       options.severities = severityFilter
     }
     try {
-      const rows = await loadRecentAlerts(c.env.DB, options)
+      const [rows, universe] = await Promise.all([
+        loadRecentAlerts(c.env.DB, options),
+        loadSymbolUniverse(c.env).catch(() => null),
+      ])
       return c.html(
         layout(
           'アラート',
-          alertsBody({ rows, limit, severityFilter, eventTypeFilter, currentQuery }),
+          alertsBody({ rows, limit, severityFilter, eventTypeFilter, currentQuery, universe }),
         ),
       )
     } catch (err) {
@@ -367,6 +381,23 @@ export const dashboard = new Hono<AppBindings>()
 
 function messageOf(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
+}
+
+/**
+ * `SymbolUniverse` から JP 銘柄向け 番号-会社名 表示文字列を返す薄い helper。
+ * universe が無い (load 失敗等) ケースは symbol そのまま (= 既存挙動)。
+ *
+ * `URL ?symbol=7974` の routing は変更しない。表示テキストだけが
+ * `7974-任天堂` 形式に切り替わる。
+ */
+function displaySymbol(symbol: string, universe?: SymbolUniverse | null): string {
+  if (!universe) return symbol
+  const upper = symbol.toUpperCase()
+  return formatSymbolDisplay({
+    symbol,
+    market: universe.symbolMarket[upper] ?? null,
+    name: universe.symbolName[upper] ?? null,
+  })
 }
 
 function clampLimit(raw: string | undefined): number {
@@ -590,12 +621,13 @@ export function pickFreshQuote(
 function positionsBody(
   rows: Array<{ sym: string; state: SymbolState | null; error: string | null }>,
   strategyPriceMap: Map<string, { price: number; asOf: string }>,
+  universe?: SymbolUniverse | null,
 ): string {
   if (rows.length === 0) return `<p class="muted">有効な銘柄がありません。</p>`
   const tbody = rows
     .map((r) => {
       if (r.error !== null || r.state === null) {
-        return `<tr><td>${esc(r.sym)}</td><td colspan="7" class="err">${esc(r.error ?? '状態取得不可')}</td></tr>`
+        return `<tr><td>${esc(displaySymbol(r.sym, universe))}</td><td colspan="7" class="err">${esc(r.error ?? '状態取得不可')}</td></tr>`
       }
       const s = r.state
       const pos = s.position
@@ -614,7 +646,7 @@ function positionsBody(
         ? `${fmtNumber(quote.price, 2)} <span class="muted" style="font-size:11px">(${esc(quote.source)}, ${esc(formatQuoteAsOf(quote.asOf))})</span>`
         : '<span class="muted">—</span>'
       return `<tr>
-        <td><strong>${esc(s.symbol)}</strong></td>
+        <td><strong>${esc(displaySymbol(s.symbol, universe))}</strong></td>
         <td>${pos ? esc(pos.qty) : '<span class="muted">—</span>'}</td>
         <td>${pos ? fmtNumber(pos.avgPrice, 2) : '<span class="muted">—</span>'}</td>
         <td>${quoteCell}</td>
@@ -738,6 +770,7 @@ function tradesBody(
     errorMessage: string | null
   }>,
   limit: number,
+  universe?: SymbolUniverse | null,
 ): string {
   if (rows.length === 0) {
     return `<p class="muted">trade_journal にレコードがありません (limit=${limit})。</p>`
@@ -757,11 +790,12 @@ function tradesBody(
       // しやすい粒度を保つ。
       const statusText =
         r.errorMessage ? `エラー: ${r.errorMessage}` : r.brokerStatus ?? r.tradeEventType
+      const symbolText = r.symbol ? displaySymbol(r.symbol, universe) : '—'
       return `<tr>
         <td>${r.id}</td>
         <td class="muted">${esc(fmtJst(r.timestamp))}</td>
         <td>${esc(r.tradeEventType)}</td>
-        <td><strong>${esc(r.symbol ?? '—')}</strong></td>
+        <td><strong>${esc(symbolText)}</strong></td>
         <td>${esc(r.side ?? '—')}</td>
         <td>${r.quantity === null ? '—' : esc(r.quantity)}</td>
         <td>${r.limitPrice === null ? '—' : fmtNumber(r.limitPrice, 2)}</td>
@@ -810,7 +844,7 @@ function configBody(
     .map(
       (sym) =>
         `<tr>
-          <td><strong>${esc(sym)}</strong></td>
+          <td><strong>${esc(displaySymbol(sym, universe))}</strong></td>
           <td>${esc(universe.symbolCurrency[sym] ?? '—')}</td>
           <td>${universe.symbolMaxNotional[sym] != null ? esc(universe.symbolMaxNotional[sym]) : '<span class="muted">—</span>'}</td>
           <td>${universe.inversePairs[sym] ? esc(universe.inversePairs[sym]) : '<span class="muted">—</span>'}</td>
@@ -1205,6 +1239,8 @@ interface AlertsBodyArgs {
   eventTypeFilter: NotificationEvent['type'] | undefined
   /** 現在の query string。filter pill が他の param (limit 等) を保持するために使う。 */
   currentQuery: URLSearchParams
+  /** symbol 列の表示を JP 銘柄向け 番号-会社名 形式にするための universe (load 失敗は null)。 */
+  universe?: SymbolUniverse | null
 }
 
 /**
@@ -1216,7 +1252,7 @@ interface AlertsBodyArgs {
  *   - 行クリックで Slack/Discord に出したのと同じ message を JST 時刻と一緒に確認
  */
 function alertsBody(args: AlertsBodyArgs): string {
-  const { rows, limit, severityFilter, eventTypeFilter, currentQuery } = args
+  const { rows, limit, severityFilter, eventTypeFilter, currentQuery, universe } = args
   const filterDescription =
     severityFilter.length === 0 && eventTypeFilter === undefined
       ? '全件'
@@ -1240,7 +1276,7 @@ function alertsBody(args: AlertsBodyArgs): string {
             ? 'warn'
             : 'muted'
       const symbolCell = r.symbol
-        ? `<a href="/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(r.symbol)}">${esc(r.symbol)}</a>`
+        ? `<a href="/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(r.symbol)}">${esc(displaySymbol(r.symbol, universe))}</a>`
         : '<span class="muted">-</span>'
       return `<tr>
         <td class="muted">${esc(fmtJst(r.timestamp))}</td>
@@ -1334,9 +1370,10 @@ function cronBody(
   }>,
   limit: number,
   symbolFilter: string | undefined,
+  universe?: SymbolUniverse | null,
 ): string {
   const header = symbolFilter
-    ? `<p class="muted">Showing ${rows.length} decisions for <strong>${esc(symbolFilter)}</strong> (limit=${limit}, max 200)。<a href="/dashboard/cron">全銘柄へ戻る</a> / <a href="/dashboard/cron/json" target="_blank" rel="noreferrer">最新run JSON</a></p>`
+    ? `<p class="muted">Showing ${rows.length} decisions for <strong>${esc(displaySymbol(symbolFilter, universe))}</strong> (limit=${limit}, max 200)。<a href="/dashboard/cron">全銘柄へ戻る</a> / <a href="/dashboard/cron/json" target="_blank" rel="noreferrer">最新run JSON</a></p>`
     : `<p class="muted">Showing ${rows.length} decisions (limit=${limit}, max 200)。<code>?symbol=SOXL</code> で絞り込み可能。<a href="/dashboard/cron/json" target="_blank" rel="noreferrer">最新run JSON</a></p>`
   if (rows.length === 0) {
     return `${header}<p class="muted">判定ログがまだありません。</p>`
@@ -1365,7 +1402,7 @@ function cronBody(
           : `${fmtNumber(r.filledPrice, 2)} × ${r.filledQty ?? '?'}`
       return `<tr>
         <td class="muted">${esc(fmtJst(r.timestamp))}</td>
-        <td><a href="/dashboard/cron?symbol=${encodeURIComponent(r.symbol)}"><strong>${esc(r.symbol)}</strong></a></td>
+        <td><a href="/dashboard/cron?symbol=${encodeURIComponent(r.symbol)}"><strong>${esc(displaySymbol(r.symbol, universe))}</strong></a></td>
         <td class="${cls}">${esc(r.decision)}</td>
         <td>${cronReasonCell(r)}</td>
         <td>${r.price === null ? '-' : fmtNumber(r.price, 2)}</td>
@@ -2606,6 +2643,8 @@ interface ChartsBodySymbol {
   strategyParams: StrategyParamsSnapshot
   /** dataZoom 初期範囲。null なら全期間 (full data) */
   zoom: { from: Date; to: Date } | null
+  /** symbol picker / chart title を JP 銘柄向け 番号-会社名 形式に整形するための universe。 */
+  universe?: SymbolUniverse | null
 }
 
 /**
@@ -2620,6 +2659,8 @@ interface ChartsBodyGrid {
   charts: Array<{ symbol: string; chart: SymbolChartData | null; error: string | null }>
   /** dataZoom 初期範囲。null なら全期間 */
   zoom: { from: Date; to: Date } | null
+  /** panel header の銘柄表示を JP 銘柄向け 番号-会社名 形式にするための universe。 */
+  universe?: SymbolUniverse | null
 }
 
 type ChartsBodyArgs =
@@ -3172,8 +3213,12 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
       ];
 
       var symChart = echarts.init(document.getElementById('symbol-chart'));
+      // displayName は server 側で symbol_config.market='JP' なら "番号-会社名" を
+      // 入れている。US / fallback は symbol そのまま。chart 内 string concat 時の
+      // 安全フォールバックとして '|| sc.symbol' を残す。
+      var titleSymbol = sc.displayName || sc.symbol;
       symChart.setOption({
-        title: { text: sc.symbol + ' price + トレンドライン + 押し目ゾーン + entry/exit', left: 'center', textStyle: { fontSize: 14 } },
+        title: { text: titleSymbol + ' price + トレンドライン + 押し目ゾーン + entry/exit', left: 'center', textStyle: { fontSize: 14 } },
         tooltip: {
           trigger: 'axis',
           axisPointer: { label: { formatter: function (p) { return jstLabelForX(p.value); } } },
@@ -3546,13 +3591,18 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
       }
     });
   `
+  // chart payload に displayName を注入。client 側の chart title / tooltip header
+  // は `sc.displayName || sc.symbol` で読む (US 銘柄は displayName === symbol)。
+  const symbolChartPayload = args.symbolChart
+    ? { ...args.symbolChart, displayName: displaySymbol(args.symbolChart.symbol, args.universe) }
+    : null
   return `${renderSymbolPickerForTab(args)}
   ${renderCurrentIndicatorsBadge(args.symbolChart)}
   <div id="symbol-chart" style="width:100%;height:460px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;margin-top:12px"></div>
   ${renderZoomPresetButtons(args.symbolChart)}
   ${renderStrategyParamsPanel(args.strategyParams)}
   ${safeJsonScript('__chartData', {
-    symbolChart: args.symbolChart,
+    symbolChart: symbolChartPayload,
     zoomFromMs: args.zoom ? args.zoom.from.getTime() : null,
     zoomToMs: args.zoom ? args.zoom.to.getTime() : null,
   })}
@@ -3591,7 +3641,8 @@ export function renderGridTab(args: ChartsBodyGrid): string {
   const panelsHtml = args.charts
     .map((entry, idx) => {
       const symbolLink = `/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(entry.symbol)}`
-      const headerLink = `<a href="${symbolLink}" style="font-weight:600;font-size:14px;color:#06c;text-decoration:none">${esc(entry.symbol)}</a>`
+      const headerText = displaySymbol(entry.symbol, args.universe)
+      const headerLink = `<a href="${symbolLink}" style="font-weight:600;font-size:14px;color:#06c;text-decoration:none">${esc(headerText)}</a>`
       if (entry.chart === null) {
         const errMsg = entry.error ?? 'チャートデータ取得失敗'
         return `<div class="grid-panel" style="border:1px solid #d0d0d5;border-radius:6px;padding:8px;background:#fff">
@@ -3614,10 +3665,19 @@ export function renderGridTab(args: ChartsBodyGrid): string {
     .join('')
 
   // client 側に渡す全銘柄分の chart payload。各 panel が個別 echarts.init で
-  // 消費する。__chartData.charts は array of { symbol, chart } (chart は load
-  // 失敗で null)。zoomFromMs / zoomToMs は preset toolbar・初期 dataZoom で共有。
+  // 消費する。__chartData.charts は array of { symbol, chart, displayName }
+  // (chart は load 失敗で null)。displayName は server 側で JP 銘柄なら
+  // "番号-会社名" を入れている (US は symbol そのまま) — tooltip header
+  // (`sc.displayName || sc.symbol`) で読まれる。
   const payload = {
-    charts: args.charts.map((c) => ({ symbol: c.symbol, chart: c.chart, error: c.error })),
+    charts: args.charts.map((c) => ({
+      symbol: c.symbol,
+      chart: c.chart
+        ? { ...c.chart, displayName: displaySymbol(c.chart.symbol, args.universe) }
+        : null,
+      error: c.error,
+      displayName: displaySymbol(c.symbol, args.universe),
+    })),
     zoomFromMs: args.zoom ? args.zoom.from.getTime() : null,
     zoomToMs: args.zoom ? args.zoom.to.getTime() : null,
   }
@@ -3854,7 +3914,7 @@ export function renderGridTab(args: ChartsBodyGrid): string {
             formatter: function (params) {
               if (!Array.isArray(params) || params.length === 0) return '';
               var ts = params[0].axisValue;
-              var lines = ['<div style="font-weight:600;font-size:11px">' + sc.symbol + ' ' + jstLabelForX(ts) + '</div>'];
+              var lines = ['<div style="font-weight:600;font-size:11px">' + (sc.displayName || sc.symbol) + ' ' + jstLabelForX(ts) + '</div>'];
               for (var i = 0; i < params.length; i += 1) {
                 var p = params[i];
                 if (p.seriesType === 'candlestick' && Array.isArray(p.value)) {
@@ -4242,10 +4302,12 @@ function renderSymbolPickerForTab(args: ChartsBodySymbol): string {
       (s) =>
         `<a href="/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(s)}${zoomQs}" style="margin-right:6px;${
           s === args.focusSymbol ? 'font-weight:600;text-decoration:underline' : ''
-        }">${esc(s)}</a>`,
+        }">${esc(displaySymbol(s, args.universe))}</a>`,
     )
     .join('')
-  const focusLabel = args.focusSymbol ?? '—'
+  const focusLabel = args.focusSymbol
+    ? displaySymbol(args.focusSymbol, args.universe)
+    : '—'
   return `<p class="muted" style="font-size:12px">
     銘柄: <strong>${esc(focusLabel)}</strong> | 切替: ${opts}
   </p>`

--- a/src/shared/format.ts
+++ b/src/shared/format.ts
@@ -1,29 +1,28 @@
 /**
  * Display formatting helpers shared across routes.
  *
- * 4 桁の数字コードだけだと operator が dashboard 上で日本株を識別しづらい
- * ので、`market === 'JP'` のときに `symbol_config.name` を併記する。US 銘柄
- * (AAPL, SOXL 等) は ticker 自体が一意で識別性が高いので変更しない。
+ * 銘柄コードだけだと operator が dashboard 上で銘柄を識別しづらいので、
+ * `symbol_config.name` がある場合は併記する。market は問わない:
+ * JP (`7974` → `7974-任天堂`) も US (`AAPL` → `AAPL-Apple Inc.`) も同じ
+ * フォーマット。
  */
 
 export interface SymbolDisplayInput {
   symbol: string
   name?: string | null
-  market?: string | null
 }
 
 /**
  * Format a symbol for human display.
  *
- * - JP + name 有り → `${symbol}-${name}` (例: `7974-任天堂`)
- * - JP + name 空 / null → `${symbol}` のみ (defensive fallback)
- * - US / その他 / market 不明 → `${symbol}` のみ (既存挙動を維持)
+ * - name 有り → `${symbol}-${name}` (例: `7974-任天堂`, `AAPL-Apple Inc.`)
+ * - name 空 / null / 空白のみ → `${symbol}` のみ (defensive fallback)
  *
  * URL routing (`?symbol=7974`) は変更しない。dashboard の表示テキストだけが
- * 番号-会社名 形式に変わる。
+ * 番号-会社名 形式になる。
  */
 export function formatSymbolDisplay(input: SymbolDisplayInput): string {
-  if (input.market === 'JP' && input.name && input.name.trim().length > 0) {
+  if (input.name && input.name.trim().length > 0) {
     return `${input.symbol}-${input.name.trim()}`
   }
   return input.symbol

--- a/src/shared/format.ts
+++ b/src/shared/format.ts
@@ -1,0 +1,30 @@
+/**
+ * Display formatting helpers shared across routes.
+ *
+ * 4 桁の数字コードだけだと operator が dashboard 上で日本株を識別しづらい
+ * ので、`market === 'JP'` のときに `symbol_config.name` を併記する。US 銘柄
+ * (AAPL, SOXL 等) は ticker 自体が一意で識別性が高いので変更しない。
+ */
+
+export interface SymbolDisplayInput {
+  symbol: string
+  name?: string | null
+  market?: string | null
+}
+
+/**
+ * Format a symbol for human display.
+ *
+ * - JP + name 有り → `${symbol}-${name}` (例: `7974-任天堂`)
+ * - JP + name 空 / null → `${symbol}` のみ (defensive fallback)
+ * - US / その他 / market 不明 → `${symbol}` のみ (既存挙動を維持)
+ *
+ * URL routing (`?symbol=7974`) は変更しない。dashboard の表示テキストだけが
+ * 番号-会社名 形式に変わる。
+ */
+export function formatSymbolDisplay(input: SymbolDisplayInput): string {
+  if (input.market === 'JP' && input.name && input.name.trim().length > 0) {
+    return `${input.symbol}-${input.name.trim()}`
+  }
+  return input.symbol
+}

--- a/test/helpers/configFixtures.ts
+++ b/test/helpers/configFixtures.ts
@@ -50,6 +50,8 @@ export function makeSymbolUniverse(overrides: Partial<SymbolUniverse> = {}): Sym
     symbolMaxNotional: {},
     symbolCurrency: { SOXL: 'USD', SOXS: 'USD' },
     symbolBucket: {},
+    symbolMarket: { SOXL: 'US', SOXS: 'US' },
+    symbolName: {},
     inversePairs: {},
     source: 'd1',
     ...overrides,

--- a/test/infrastructure/db/symbolConfigRepo.test.ts
+++ b/test/infrastructure/db/symbolConfigRepo.test.ts
@@ -48,6 +48,40 @@ describe('loadSymbolConfig', () => {
     const result = await loadSymbolConfig(fakeDb(rows))
     expect(result.symbolMaxNotional).toEqual({ C: 100 })
   })
+
+  it('exposes per-symbol market and name maps for dashboard display', async () => {
+    const rows = [
+      { symbol: 'aapl', name: 'Apple Inc.', market: 'US', active: true, maxNotional: null },
+      { symbol: '7974', name: '任天堂', market: 'JP', active: true, maxNotional: null },
+      { symbol: '6971', name: '  京セラ  ', market: 'JP', active: true, maxNotional: null },
+      { symbol: 'NONAME', name: null, market: 'US', active: true, maxNotional: null },
+      { symbol: 'EMPTY', name: '   ', market: 'JP', active: true, maxNotional: null },
+    ]
+    const result = await loadSymbolConfig(fakeDb(rows))
+    expect(result.symbolMarket).toEqual({
+      AAPL: 'US',
+      '7974': 'JP',
+      '6971': 'JP',
+      NONAME: 'US',
+      EMPTY: 'JP',
+    })
+    // null / 空白だけの name は map に含めない (defensive、display 層が
+    // formatSymbolDisplay で symbol そのままに fallback)。
+    expect(result.symbolName).toEqual({
+      AAPL: 'Apple Inc.',
+      '7974': '任天堂',
+      '6971': '京セラ',
+    })
+  })
+
+  it('falls back unknown market values to US (defensive against bad rows)', async () => {
+    const rows = [
+      { symbol: 'X', name: null, market: 'HK', active: true, maxNotional: null },
+      { symbol: 'Y', name: null, market: '', active: true, maxNotional: null },
+    ]
+    const result = await loadSymbolConfig(fakeDb(rows))
+    expect(result.symbolMarket).toEqual({ X: 'US', Y: 'US' })
+  })
 })
 
 describe('loadInversePairs', () => {

--- a/test/routes/admin.test.ts
+++ b/test/routes/admin.test.ts
@@ -1123,6 +1123,8 @@ describe('POST /admin/orders/sync-holdings', () => {
       symbolMaxNotional: {},
       symbolCurrency: {},
       symbolBucket: {},
+      symbolMarket: {},
+      symbolName: {},
       inversePairs: {},
       source: 'd1',
     })

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -118,6 +118,31 @@ describe('dashboard', () => {
     expect(body).toContain('5.00%')
   })
 
+  it('formats JP positions as `${symbol}-${name}` while leaving US untouched', async () => {
+    vi.mocked(loadSymbolUniverse).mockResolvedValue(
+      makeSymbolUniverse({
+        allowedSymbols: ['7974', 'SOXL'],
+        symbolCurrency: { '7974': 'JPY', SOXL: 'USD' },
+        symbolMarket: { '7974': 'JP', SOXL: 'US' },
+        symbolName: { '7974': '任天堂', SOXL: 'Direxion Semiconductor Bull 3X' },
+      }),
+    )
+    const env = {
+      ...baseEnv,
+      DB: {} as D1Database,
+      SYMBOL_STATE: fakeSymbolStateNamespace(),
+    }
+    const app = createApp()
+    const res = await app.request('/dashboard/positions', { headers: authHeader }, env)
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    // JP は 番号-会社名 形式に整形される
+    expect(body).toContain('7974-任天堂')
+    // US 銘柄は ticker のみ (US 名は使わない、URL routing も含め symbol そのまま)
+    expect(body).toContain('>SOXL<')
+    expect(body).not.toContain('SOXL-Direxion')
+  })
+
   it('renders positions with "unavailable" when SYMBOL_STATE is missing', async () => {
     const env = { ...baseEnv, DB: {} as D1Database }
     const app = createApp()

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -118,7 +118,7 @@ describe('dashboard', () => {
     expect(body).toContain('5.00%')
   })
 
-  it('formats JP positions as `${symbol}-${name}` while leaving US untouched', async () => {
+  it('formats positions as `${symbol}-${name}` for both JP and US when name is set', async () => {
     vi.mocked(loadSymbolUniverse).mockResolvedValue(
       makeSymbolUniverse({
         allowedSymbols: ['7974', 'SOXL'],
@@ -136,11 +136,9 @@ describe('dashboard', () => {
     const res = await app.request('/dashboard/positions', { headers: authHeader }, env)
     expect(res.status).toBe(200)
     const body = await res.text()
-    // JP は 番号-会社名 形式に整形される
+    // JP / US 共に 番号-会社名 形式に整形される (URL routing は symbol のまま)
     expect(body).toContain('7974-任天堂')
-    // US 銘柄は ticker のみ (US 名は使わない、URL routing も含め symbol そのまま)
-    expect(body).toContain('>SOXL<')
-    expect(body).not.toContain('SOXL-Direxion')
+    expect(body).toContain('SOXL-Direxion Semiconductor Bull 3X')
   })
 
   it('renders positions with "unavailable" when SYMBOL_STATE is missing', async () => {

--- a/test/shared/format.test.ts
+++ b/test/shared/format.test.ts
@@ -3,39 +3,30 @@ import { formatSymbolDisplay } from '../../src/shared/format'
 
 describe('formatSymbolDisplay', () => {
   it('returns `${symbol}-${name}` for JP symbols with a non-empty name', () => {
-    expect(formatSymbolDisplay({ symbol: '7974', name: '任天堂', market: 'JP' })).toBe(
-      '7974-任天堂',
-    )
-    expect(formatSymbolDisplay({ symbol: '6971', name: '京セラ', market: 'JP' })).toBe(
-      '6971-京セラ',
+    expect(formatSymbolDisplay({ symbol: '7974', name: '任天堂' })).toBe('7974-任天堂')
+    expect(formatSymbolDisplay({ symbol: '6971', name: '京セラ' })).toBe('6971-京セラ')
+  })
+
+  it('returns `${symbol}-${name}` for US symbols with a non-empty name', () => {
+    expect(formatSymbolDisplay({ symbol: 'AAPL', name: 'Apple Inc.' })).toBe('AAPL-Apple Inc.')
+    expect(formatSymbolDisplay({ symbol: 'SOXL', name: 'Direxion Semiconductor Bull 3X' })).toBe(
+      'SOXL-Direxion Semiconductor Bull 3X',
     )
   })
 
-  it('trims whitespace around JP names before concatenation', () => {
-    expect(formatSymbolDisplay({ symbol: '7203', name: '  トヨタ自動車  ', market: 'JP' })).toBe(
+  it('trims whitespace around names before concatenation', () => {
+    expect(formatSymbolDisplay({ symbol: '7203', name: '  トヨタ自動車  ' })).toBe(
       '7203-トヨタ自動車',
     )
+    expect(formatSymbolDisplay({ symbol: 'AAPL', name: '  Apple Inc.  ' })).toBe('AAPL-Apple Inc.')
   })
 
-  it('falls back to symbol when JP name is null / undefined / empty / whitespace', () => {
-    expect(formatSymbolDisplay({ symbol: '7974', name: null, market: 'JP' })).toBe('7974')
-    expect(formatSymbolDisplay({ symbol: '7974', market: 'JP' })).toBe('7974')
-    expect(formatSymbolDisplay({ symbol: '7974', name: '', market: 'JP' })).toBe('7974')
-    expect(formatSymbolDisplay({ symbol: '7974', name: '   ', market: 'JP' })).toBe('7974')
-  })
-
-  it('returns symbol unchanged for US symbols even when name is set', () => {
-    expect(formatSymbolDisplay({ symbol: 'AAPL', name: 'Apple Inc.', market: 'US' })).toBe('AAPL')
-    expect(formatSymbolDisplay({ symbol: 'SOXL', name: 'Direxion Semiconductor Bull 3X', market: 'US' })).toBe(
-      'SOXL',
-    )
-  })
-
-  it('returns symbol unchanged when market is unknown / null / undefined', () => {
-    expect(formatSymbolDisplay({ symbol: '7974', name: '任天堂', market: null })).toBe('7974')
-    expect(formatSymbolDisplay({ symbol: '7974', name: '任天堂' })).toBe('7974')
-    expect(formatSymbolDisplay({ symbol: 'XYZ', name: 'Unknown Market', market: 'HK' })).toBe(
-      'XYZ',
-    )
+  it('falls back to symbol when name is null / undefined / empty / whitespace', () => {
+    expect(formatSymbolDisplay({ symbol: '7974', name: null })).toBe('7974')
+    expect(formatSymbolDisplay({ symbol: '7974' })).toBe('7974')
+    expect(formatSymbolDisplay({ symbol: '7974', name: '' })).toBe('7974')
+    expect(formatSymbolDisplay({ symbol: '7974', name: '   ' })).toBe('7974')
+    expect(formatSymbolDisplay({ symbol: 'AAPL', name: null })).toBe('AAPL')
+    expect(formatSymbolDisplay({ symbol: 'AAPL' })).toBe('AAPL')
   })
 })

--- a/test/shared/format.test.ts
+++ b/test/shared/format.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { formatSymbolDisplay } from '../../src/shared/format'
+
+describe('formatSymbolDisplay', () => {
+  it('returns `${symbol}-${name}` for JP symbols with a non-empty name', () => {
+    expect(formatSymbolDisplay({ symbol: '7974', name: '任天堂', market: 'JP' })).toBe(
+      '7974-任天堂',
+    )
+    expect(formatSymbolDisplay({ symbol: '6971', name: '京セラ', market: 'JP' })).toBe(
+      '6971-京セラ',
+    )
+  })
+
+  it('trims whitespace around JP names before concatenation', () => {
+    expect(formatSymbolDisplay({ symbol: '7203', name: '  トヨタ自動車  ', market: 'JP' })).toBe(
+      '7203-トヨタ自動車',
+    )
+  })
+
+  it('falls back to symbol when JP name is null / undefined / empty / whitespace', () => {
+    expect(formatSymbolDisplay({ symbol: '7974', name: null, market: 'JP' })).toBe('7974')
+    expect(formatSymbolDisplay({ symbol: '7974', market: 'JP' })).toBe('7974')
+    expect(formatSymbolDisplay({ symbol: '7974', name: '', market: 'JP' })).toBe('7974')
+    expect(formatSymbolDisplay({ symbol: '7974', name: '   ', market: 'JP' })).toBe('7974')
+  })
+
+  it('returns symbol unchanged for US symbols even when name is set', () => {
+    expect(formatSymbolDisplay({ symbol: 'AAPL', name: 'Apple Inc.', market: 'US' })).toBe('AAPL')
+    expect(formatSymbolDisplay({ symbol: 'SOXL', name: 'Direxion Semiconductor Bull 3X', market: 'US' })).toBe(
+      'SOXL',
+    )
+  })
+
+  it('returns symbol unchanged when market is unknown / null / undefined', () => {
+    expect(formatSymbolDisplay({ symbol: '7974', name: '任天堂', market: null })).toBe('7974')
+    expect(formatSymbolDisplay({ symbol: '7974', name: '任天堂' })).toBe('7974')
+    expect(formatSymbolDisplay({ symbol: 'XYZ', name: 'Unknown Market', market: 'HK' })).toBe(
+      'XYZ',
+    )
+  })
+})


### PR DESCRIPTION
## 動機

JP 株は 4 桁数字の銘柄コードだけだと、dashboard 上で「これ何の会社だっけ?」と毎回 SBI や Yahoo Finance で引き直しに行く運用負担が出ている (米株は `AAPL` / `SOXL` 等 ticker 自体が一意で識別性が高いので発生しない問題)。`symbol_config.name` 列にはすでに「任天堂」「京セラ」等の和名が入っているので、これを表示層だけで活用する。

## 変更概要

- `src/shared/format.ts` 新設、`formatSymbolDisplay()` を追加
  - JP + name あり → `${symbol}-${name}` (例: `7974-任天堂`)
  - JP + name 空 → `${symbol}` (defensive fallback)
  - US / market 不明 → `${symbol}` (既存挙動維持)
- `loadSymbolConfig` / `SymbolUniverse` に `symbolMarket` / `symbolName` map を追加 (dashboard が JP 判定 + 和名取得に使う)
- `src/routes/dashboard.ts` の以下表示箇所を `displaySymbol(symbol, universe)` 経由に切替:
  - `/dashboard/positions` 銘柄列
  - `/dashboard/trades` 銘柄列 (universe を並行 load、失敗時は symbol そのまま fallback)
  - `/dashboard/cron` 銘柄列 + filter header
  - `/dashboard/alerts` 銘柄列
  - `/dashboard/config` 銘柄一覧
  - `/dashboard/charts?tab=symbol` chart title / picker / focus label
  - `/dashboard/charts?tab=grid` panel header / tooltip header
- chart の client side payload に `displayName` を inject、`sc.displayName || sc.symbol` で参照 (US 銘柄は両者一致なので動作に影響なし)

## 変更しないもの

- **URL routing**: `?symbol=7974` のままで、link click 後の chart も `?symbol=7974` で render される
- **DB / log の canonical 値**: `trade_journal.symbol` / `strategy_decision_log.symbol` 等は引き続き ticker のみ
- **US 銘柄の表示**: `AAPL`, `SOXL`, `SOXS` 等は従前通り ticker のみ表示
- **戦略 / risk / broker 系の挙動**: 表示層のみの変更でロジック側は無改変

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test --run` 全 pass (917 / 917)
- [x] `formatSymbolDisplay` の unit test (JP w/ name / JP w/o name / US / market 不明 / whitespace trim)
- [x] `loadSymbolConfig` の `symbolMarket` / `symbolName` map test (null name / 空白 / 不正 market 値)
- [x] `/dashboard/positions` smoke test: JP 銘柄 (`7974`) が `7974-任天堂` で render され、US (`SOXL`) は ticker のみ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ダッシュボード全体でシンボル表示を拡張。日本銘柄は「シンボル-名称」形式で表示され、チャートや一覧の見出し／ツールチップにも反映されます。表示が利用できない場合は従来のティッカーを表示します。
* **テスト**
  * 表示フォーマットと設定読み込みの検証テストを追加。市場コードと名称の処理・トリムやフォールバックを確認します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->