### PR TITLE
fix(reconcile): sanity check の limit reference を pre_submit に (broker stub 通過 bug 修正)

### DIFF
--- a/src/trading/reconciliation/reconcileFills.ts
+++ b/src/trading/reconciliation/reconcileFills.ts
@@ -156,6 +156,13 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
       symbol: tradeJournal.symbol,
       side: tradeJournal.side,
       preSubmitSide: preSubmit.side,
+      // pre_submit の limit_price は intent 時に我々が signed した値で、
+      // D1 内に確定している。broker が JP sandbox stub で
+      // detail.limit_price=10 を返しても、こちらの値は影響を受けない。
+      // PR #223 sanity check が broker の stub limit_price と stub
+      // filled_price の両方が同値で ratio=1 になり pass してしまう穴を
+      // 塞ぐため、reference 候補として優先利用する。
+      preSubmitLimitPrice: preSubmit.limitPrice,
       brokerStatus: tradeJournal.brokerStatus,
       filledQty: tradeJournal.filledQty,
       filledPrice: tradeJournal.filledPrice,
@@ -336,6 +343,8 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
       requestId: options.requestId,
       clientOrderId: coid,
       symbol: row.symbol ?? detail.symbol ?? null,
+      // 我々が intent で signed した limit。broker stub に依存しない。
+      referenceLimitPrice: row.preSubmitLimitPrice ?? null,
     })
 
     // Compute realized P&L for SELL fills BEFORE we touch any state. Needs
@@ -881,6 +890,18 @@ const FILLED_PRICE_RATIO_MAX = 2
  *
  * Also rejects fills whose price is wildly inconsistent with the signed
  * limit (`<0.5x` or `>2x`) — see `FILLED_PRICE_RATIO_*` for the rationale.
+ *
+ * Reference limit price selection (issue: 9697 ping-pong loop):
+ *   1. `context.referenceLimitPrice` (= our intent, persisted on the
+ *      `pre_submit` trade_journal row at signing time). Preferred because
+ *      it does not depend on broker behaviour — JP sandbox has been
+ *      observed to echo a stub `detail.limit_price` that matches its stub
+ *      `filled_price` (e.g. both 10) so the ratio collapses to 1 and the
+ *      sanity guard passes a wildly wrong fill.
+ *   2. `detail.limit_price` (broker response) as fallback for paths that
+ *      can't surface the pre_submit reference (e.g. older callers).
+ *   3. Neither available → ratio check is skipped (defensive: better to
+ *      keep the fill than to drop a healthy MARKET-style order).
  */
 function resolveFilledPrice(
   filledQty: number | null,
@@ -889,13 +910,26 @@ function resolveFilledPrice(
     requestId?: string
     clientOrderId?: string
     symbol?: string | null
+    /**
+     * Limit price we recorded at intent time (pre_submit row). Takes
+     * precedence over `detail.limit_price` because it is broker-stub-proof.
+     */
+    referenceLimitPrice?: number | null
   },
 ): number | null {
   if (filledQty === null || filledQty <= 0) return null
   const candidate = pickFilledPrice(detail)
   if (candidate === null || !Number.isFinite(candidate) || candidate <= 0) return null
 
-  const limit = toNumberOrNull(detail.limit_price)
+  const brokerLimit = toNumberOrNull(detail.limit_price)
+  const preSubmitLimit =
+    context?.referenceLimitPrice !== undefined && context.referenceLimitPrice !== null &&
+    Number.isFinite(context.referenceLimitPrice) && context.referenceLimitPrice > 0
+      ? context.referenceLimitPrice
+      : null
+  // Prefer pre_submit (our signed intent) over broker echo. Falls back to
+  // broker for legacy callers that don't pass referenceLimitPrice.
+  const limit = preSubmitLimit !== null ? preSubmitLimit : brokerLimit
   if (limit !== null && limit > 0) {
     const ratio = candidate / limit
     if (ratio < FILLED_PRICE_RATIO_MIN || ratio > FILLED_PRICE_RATIO_MAX) {
@@ -906,6 +940,11 @@ function resolveFilledPrice(
           clientOrderId: context?.clientOrderId,
           symbol: context?.symbol,
           candidate,
+          // Both reference candidates included so the diff between our
+          // intent and the broker echo is easy to inspect during ops.
+          pre_submit_limit: preSubmitLimit,
+          broker_limit: brokerLimit,
+          // Effective reference used for the ratio check.
           limit_price: limit,
           ratio,
           detail_status: detail.status,

--- a/test/trading/reconciliation/reconcileFills.test.ts
+++ b/test/trading/reconciliation/reconcileFills.test.ts
@@ -126,6 +126,98 @@ describe('reconcileFills internals', () => {
       expect(_internal.resolveFilledPrice(1, detail)).toBeNull()
     })
   })
+
+  // ---------------------------------------------------------------------------
+  // referenceLimitPrice (issue: 9697 ping-pong loop where broker echoes the
+  // same stub for both filled_price and limit_price → ratio=1 silently
+  // passes the PR #223 sanity guard and a $10 stub fills DO state.
+  //
+  // Fix: prefer the pre_submit row's limit_price (= our signed intent) over
+  // detail.limit_price as the ratio reference.
+  // ---------------------------------------------------------------------------
+  describe('resolveFilledPrice with referenceLimitPrice (pre_submit intent)', () => {
+    beforeEach(() => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {})
+    })
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('rejects 9697-style stub (filled=10, broker.limit=10, pre_submit=3516)', () => {
+      // The exact bug: broker echoes a stub limit_price that matches its
+      // stub filled_price, so ratio = 10/10 = 1 and the prior implementation
+      // accepted the bogus fill. With the pre_submit reference, ratio
+      // = 10/3516 = 0.00284 → reject.
+      const detail = {
+        items: [{ filled_price: '10' }],
+        limit_price: '10',
+      }
+      expect(
+        _internal.resolveFilledPrice(1, detail, { referenceLimitPrice: 3516 }),
+      ).toBeNull()
+    })
+
+    it('accepts a healthy fill against the pre_submit reference (215 vs 215.42)', () => {
+      const detail = {
+        items: [{ filled_price: '215' }],
+        limit_price: '215.42',
+      }
+      expect(
+        _internal.resolveFilledPrice(1, detail, { referenceLimitPrice: 215.42 }),
+      ).toBe(215)
+    })
+
+    it('falls back to broker limit when referenceLimitPrice is null', () => {
+      // No pre_submit reference (= legacy caller). Existing behaviour:
+      // ratio uses broker limit. Stub-vs-stub still passes (ratio=1) — this
+      // is the bug we are fixing for the new caller, but the fallback is
+      // preserved to avoid regression for any non-reconcile call site.
+      const detail = {
+        items: [{ filled_price: '10' }],
+        limit_price: '10',
+      }
+      expect(
+        _internal.resolveFilledPrice(1, detail, { referenceLimitPrice: null }),
+      ).toBe(10)
+    })
+
+    it('skips ratio check when both references are absent (defensive)', () => {
+      const detail = {
+        items: [{ filled_price: '10' }],
+      }
+      expect(
+        _internal.resolveFilledPrice(1, detail, { referenceLimitPrice: null }),
+      ).toBe(10)
+    })
+
+    it('treats non-positive referenceLimitPrice as missing (falls back to broker limit)', () => {
+      // Defensive against malformed pre_submit rows. 0 / negative → ignore
+      // and fall back to broker echo.
+      const detail = {
+        items: [{ filled_price: '10' }],
+        limit_price: '2683',
+      }
+      expect(
+        _internal.resolveFilledPrice(1, detail, { referenceLimitPrice: 0 }),
+      ).toBeNull()
+      expect(
+        _internal.resolveFilledPrice(1, detail, { referenceLimitPrice: -1 }),
+      ).toBeNull()
+    })
+
+    it('preferred: pre_submit accepts even if broker limit would reject', () => {
+      // Pre-submit limit aligns with reality (3516); broker echoes a stub
+      // 215.42 that would reject 3500. Trusting pre_submit lets the
+      // healthy fill through.
+      const detail = {
+        items: [{ filled_price: '3500' }],
+        limit_price: '215.42',
+      }
+      expect(
+        _internal.resolveFilledPrice(1, detail, { referenceLimitPrice: 3516 }),
+      ).toBe(3500)
+    })
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -138,6 +230,13 @@ interface CandidateRow {
   symbol: string | null
   side: string | null
   preSubmitSide?: string | null
+  /**
+   * pre_submit 行の limit_price (= 我々が intent で signed した値)。
+   * sanity check の ratio reference として broker.limit_price より優先
+   * 利用される。null の場合 (= MARKET order without limit) は broker
+   * echo にフォールバック、それも無ければ ratio check skip。
+   */
+  preSubmitLimitPrice?: number | null
   brokerStatus: string | null
   filledQty: number | null
   filledPrice: number | null
@@ -900,6 +999,81 @@ describe('reconcileFills state-apply marker (issue #142)', () => {
     expect(updates[1]!.set.stateAppliedAt).toBe('2026-04-25T12:00:00.000Z')
     expect(summary.stateApplied).toBe(0)
     expect(summary.stateApplyFailed).toBe(0)
+  })
+
+  // ---------------------------------------------------------------------------
+  // 9697 ping-pong scenario (this PR): broker echoes detail.limit_price=10 to
+  // match its stub filled_price=10 → ratio=1 silently passes the PR #223
+  // sanity check. Pre_submit limit_price (3516, our signed intent) is the
+  // fix: ratio collapses to 10/3516 = 0.00284, sanity rejects, DO is spared.
+  // ---------------------------------------------------------------------------
+  it('JP 9697 stub: broker echoes limit=10 matching filled=10 — pre_submit limit catches it', async () => {
+    const row: CandidateRow = {
+      id: 92, // matches the post_submit row id from the bug report
+      clientOrderId: 'coid-9697-stub',
+      symbol: '9697',
+      side: 'BUY',
+      preSubmitSide: 'BUY',
+      // Pre_submit row id 91 with limit_price=3516. JOIN attaches it here.
+      preSubmitLimitPrice: 3516,
+      brokerStatus: null,
+      filledQty: null,
+      filledPrice: null,
+      realizedPnl: null,
+      stateAppliedAt: null,
+      stateApplyAttempts: 0,
+    }
+    const { db, updates } = makeFakeDb([row])
+    vi.mocked(createDb).mockReturnValue(db)
+    vi.mocked(createWebullHttpClient).mockReturnValue(
+      makeWebullStub({
+        'coid-9697-stub': {
+          status: 'FILLED',
+          filled_quantity: '1',
+          // BUG: broker echoes the same stub for both fields. Without the
+          // pre_submit reference, ratio = 10/10 = 1 and PR #223 sanity
+          // wrongly accepts the fill.
+          limit_price: '10',
+          items: [{ filled_price: '10' }],
+          side: 'BUY',
+          symbol: '9697',
+        },
+      }) as unknown as ReturnType<typeof createWebullHttpClient>,
+    )
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const symbolStub = emptySymbolStateStub()
+
+    const summary = await reconcileFills({
+      env: {
+        DB: FAKE_DB_BINDING,
+        SYMBOL_STATE: makeSymbolStateNamespace(symbolStub) as never,
+      } as never,
+      now: () => new Date('2026-04-25T12:00:00.000Z'),
+    })
+
+    // DO state must NOT be touched — that's the whole point. avgPrice=10
+    // would have triggered a TP→SELL→re-fill ping-pong against a real
+    // entry near 3516.
+    expect(symbolStub.recordFillOnce).not.toHaveBeenCalled()
+
+    // Two UPDATEs:
+    //   (1) journal fill columns: broker_status=FILLED, filled_qty=1,
+    //       filled_price=null (sanity rejected via pre_submit reference)
+    //   (2) failure marker — state_applied_at must NOT be stamped so the
+    //       row stays in the repair cohort for next tick.
+    expect(updates).toHaveLength(2)
+    expect(updates[0]!.set.brokerStatus).toBe('FILLED')
+    expect(updates[0]!.set.filledQty).toBe(1)
+    expect(updates[0]!.set.filledPrice).toBeNull()
+    expect(updates[0]!.set.stateAppliedAt).toBeUndefined()
+    expect(updates[1]!.set.stateAppliedAt).toBeUndefined()
+    expect(updates[1]!.set.stateApplyError).toMatch(/sanity_failed/)
+
+    expect(summary.stateApplied).toBe(0)
+    expect(summary.stateApplyFailed).toBe(1)
+    expect(summary.errors).toEqual([
+      { clientOrderId: 'coid-9697-stub', message: expect.stringContaining('sanity_failed') },
+    ])
   })
 
   it('shouldRetryStateApply: true only for FILLED + qty>0 + price=null', () => {


### PR DESCRIPTION
## 動機

PR #223 で実装した `resolveFilledPrice` の sanity check (filled / limit ratio < 0.5 or > 2 で reject) は、broker の `detail.limit_price` を ratio reference に使っている。これが JP sandbox の stub 挙動で機能しなかった実例:

- 9697 (カプコン) で観測:
  - `pre_submit` (id 91) `limit_price=3516` (BUY を intent 時に signed)
  - `post_submit` (id 92) `filled_price=10`, `broker_status=FILLED`, `state_applied_at` 立った (sanity 通過)
  - 結果 DO `avgPrice=10` → TP 誤判定 (`pnl 349.60 >= 0.07`) で SELL → ping-pong loop
- 原因: broker が `detail.limit_price=10` を `filled_price=10` と同じ stub で echo していた → ratio = 10/10 = 1 で PR #223 sanity が無条件 pass

## 修正

trade_journal `pre_submit` 行の `limit_price` (= 我々が intent で signed した値) を ratio reference に**優先利用**する。これは broker 挙動に依存せず D1 内で確定値。

### 変更点

1. `reconcileFills` の SELECT に `pre_submit.limit_price` を追加 (既存の `pre_submit` self-JOIN を再利用、追加 join 無し)
2. `resolveFilledPrice(filledQty, detail, options)` に `referenceLimitPrice?: number | null` を追加
3. limit reference 決定の優先順位:
   - `referenceLimitPrice` (= pre_submit, our intent) > 0 なら採用
   - そうでなければ `detail.limit_price` (broker response) にフォールバック (legacy caller のため)
   - どちらも null なら ratio check skip (= 既存挙動、後方互換)
4. sanity reject 時の warn ログに `pre_submit_limit` / `broker_limit` 両方を含める (diff 切り分け容易化)

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test --run` 全 916 tests pass
- [x] 単体 (`resolveFilledPrice` の `referenceLimitPrice` 分岐):
  - 9697 stub (filled=10, broker.limit=10, pre_submit=3516) → null reject (新挙動)
  - healthy (filled=215 vs pre_submit=215.42) → 215 (正常)
  - referenceLimit=null fallback で broker stub-vs-stub は依然 pass (legacy 互換)
  - 両 reference null は skip (defensive)
  - 非正の referenceLimit (0 / -1) は無視して broker fallback
  - pre_submit が真値を持てば broker stub limit が reject 判定するレンジでも accept
- [x] reconcile end-to-end (9697 シナリオ):
  - pre_submit limit=3516 + post_submit FILLED + filled_price=10 + broker.limit=10
  - DO `recordFillOnce` 呼ばれない
  - `state_applied_at` NULL のまま (repair cohort 残留)
  - `state_apply_error` に `sanity_failed` 記録、summary.errors に sanity_failed 含む

## 副次効果

- raw warn log の key 拡張 (`pre_submit_limit` / `broker_limit`) で broker stub と我々の intent の diff が即座に確認できる

## Notes

- pre_submit limit_price が null/0 の場合 (= MARKET order without limit) は broker fallback に流れ、それも無ければ ratio check skip — 安全側 defensive
- 既存 `pre_submit` JOIN を流用しているので追加クエリコストは無い (同じ row から `side` と `limit_price` を select するだけ)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 取引約定の価格検証機能を改善しました。注文の予定指値を約定検証時に参照でき、ブローカー返却価格との整合性がより正確に検証されます。検証に失敗した場合、予定指値と実際の価格を含む詳細なエラーログが記録されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->