### PR TITLE
fix(ops): sync-holdings safe-fail — broker API 異常時の destructive zero 防止

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -306,6 +306,11 @@ export const admin = new Hono<AppBindings>()
    * Query:
    *   - `symbol`  (optional)  restrict to one ticker (case-insensitive)
    *   - `dryRun`  (optional)  `1`/`true`/`yes` → diff-only, no DO writes
+   *   - `force`   (optional)  `1`/`true`/`yes` → bypass the "broker empty +
+   *                            DO has positions" safe-fail guard. Use only
+   *                            when the operator has *confirmed* the broker
+   *                            is genuinely empty (e.g. liquidation) and
+   *                            the DO rows are stale ghosts to be cleared.
    *
    * Body: ignored (POST kept for "this mutates state" intent — `dryRun`
    *   path obviously doesn't, but the verb stays consistent).
@@ -316,6 +321,7 @@ export const admin = new Hono<AppBindings>()
     }
     const symbolRaw = c.req.query('symbol')?.trim()
     const dryRun = parseTruthyQuery(c.req.query('dryRun'))
+    const force = parseTruthyQuery(c.req.query('force'))
     const symbol = symbolRaw && symbolRaw.length > 0 ? symbolRaw.toUpperCase() : undefined
 
     // Single-symbol mode skips the universe load: lets the operator sync a
@@ -340,6 +346,7 @@ export const admin = new Hono<AppBindings>()
       {
         ...(symbol !== undefined ? { symbol } : {}),
         dryRun,
+        force,
         requestId: c.get('requestId') ?? null,
       },
       {

--- a/src/trading/reconciliation/syncHoldings.ts
+++ b/src/trading/reconciliation/syncHoldings.ts
@@ -61,6 +61,14 @@ export interface SyncHoldingsSummary {
     errors: number
   }
   dryRun: boolean
+  /**
+   * Soft signals surfaced to the operator without abort semantics. Currently
+   * one literal: `'broker_returned_empty_diff_suspicious'` — emitted only on
+   * `dryRun=true` to flag that the live (non-dryRun) call would safe-fail.
+   * Absent on the happy path; never present alongside a safe-fail abort
+   * (those go through `errors`).
+   */
+  warnings?: string[]
 }
 
 export interface SyncHoldingsOptions {
@@ -68,6 +76,14 @@ export interface SyncHoldingsOptions {
   symbol?: string
   /** When true, compute diffs but do not write to the DO. */
   dryRun: boolean
+  /**
+   * Operator escape hatch for the safe-fail guard. When the broker returns
+   * no usable holdings AND the DO has positions for the targeted symbols,
+   * we refuse to zero-out the DO unless `force=true` — that pattern most
+   * often indicates a broker auth / sandbox glitch, not actual liquidation.
+   * Default `false` keeps existing callers on the safe path.
+   */
+  force?: boolean
   /** Audit-correlation id from the route layer (`c.get('requestId')`). */
   requestId: string | null
 }
@@ -116,17 +132,83 @@ export async function syncHoldings(
   const synced: SyncHoldingResult[] = []
   const errors: SyncHoldingError[] = []
 
-  for (const sym of symbols) {
-    if (brokerFetchError !== null) {
+  // Short-circuit when the broker fetch itself failed — every symbol gets
+  // the same error and the safe-fail guard is moot.
+  if (brokerFetchError !== null) {
+    for (const sym of symbols) {
       errors.push({ symbol: sym, error: brokerFetchError })
+    }
+    return summarize(synced, errors, options.dryRun)
+  }
+
+  // Read-only pass: gather broker + DO state for each target symbol so we
+  // can run the safe-fail guard *before* any destructive write. The guard
+  // catches the "broker getPositions returned all-null but DO holds shares"
+  // pattern (most often a sandbox / auth glitch — see PR motivating bug:
+  // SOXL qty=8 + AAPL qty=1 zeroed out by a single bad fetch).
+  interface SymbolPlan {
+    sym: string
+    before: PositionState | null
+    brokerQty: number | null
+    brokerAvg: number | null
+    /** Captured at scan time so we don't refetch in the apply pass. */
+    fetchError: string | null
+  }
+  const plans: SymbolPlan[] = []
+  for (const sym of symbols) {
+    const brokerPos = brokerByUpper!.get(sym)
+    const brokerQty = parseBrokerQty(brokerPos)
+    const brokerAvg = parseBrokerAvg(brokerPos)
+    try {
+      const state = await deps.positionStore.getState(sym)
+      plans.push({
+        sym,
+        before: state.position,
+        brokerQty,
+        brokerAvg,
+        fetchError: null,
+      })
+    } catch (err) {
+      plans.push({
+        sym,
+        before: null,
+        brokerQty,
+        brokerAvg,
+        fetchError: messageOf(err),
+      })
+    }
+  }
+
+  // Safe-fail predicate: zero broker holdings AND DO has at least one row
+  // for a targeted symbol. We deliberately check `qty>0` rather than
+  // `position!==null` so a stale `{qty:0}` row doesn't block the guard.
+  const hasAnyBrokerQty = plans.some(
+    (p) => p.brokerQty !== null && p.brokerQty > 0,
+  )
+  const doHasAnyPosition = plans.some(
+    (p) => p.before !== null && p.before.qty > 0,
+  )
+  const safeFailTriggered = !hasAnyBrokerQty && doHasAnyPosition
+
+  if (safeFailTriggered && !options.dryRun && !options.force) {
+    // Refuse the destructive zero-out. Surface a single error rather than
+    // per-symbol noise — the operator's recovery action is "investigate or
+    // re-run with ?force=true", not "retry per symbol".
+    errors.push({
+      symbol: '*',
+      error:
+        'broker_returned_empty_but_do_has_positions: broker getPositions returned no holdings, but DO has positions. Refusing to zero-out DO. Use ?force=true to override.',
+    })
+    return summarize(synced, errors, options.dryRun)
+  }
+
+  for (const plan of plans) {
+    const { sym, before, brokerQty, brokerAvg, fetchError } = plan
+    if (fetchError !== null) {
+      errors.push({ symbol: sym, error: fetchError })
       continue
     }
     try {
-      const brokerPos = brokerByUpper!.get(sym)
-      const brokerQty = parseBrokerQty(brokerPos)
-      const brokerAvg = parseBrokerAvg(brokerPos)
-      const state = await deps.positionStore.getState(sym)
-      const before = state.position
       const doQty = before?.qty ?? 0
 
       // No-drift fast path. We treat "broker has no row" as `brokerQty=0`
@@ -181,6 +263,7 @@ export async function syncHoldings(
           broker_avg: brokerAvg,
           requestId: options.requestId,
           dryRun: false,
+          forced: options.force === true && safeFailTriggered,
         }),
       )
       synced.push({
@@ -195,9 +278,25 @@ export async function syncHoldings(
     }
   }
 
+  // dryRun + safe-fail-would-trigger: surface as a soft warning so the
+  // operator sees the diff but also knows the live call would refuse.
+  const warnings: string[] = []
+  if (safeFailTriggered && options.dryRun) {
+    warnings.push('broker_returned_empty_diff_suspicious')
+  }
+
+  return summarize(synced, errors, options.dryRun, warnings)
+}
+
+function summarize(
+  synced: SyncHoldingResult[],
+  errors: SyncHoldingError[],
+  dryRun: boolean,
+  warnings: string[] = [],
+): SyncHoldingsSummary {
   const noDriftCount = synced.filter((r) => r.skipped === 'no_drift').length
   const syncedCount = synced.length - noDriftCount
-  return {
+  const base: SyncHoldingsSummary = {
     synced,
     errors,
     summary: {
@@ -206,8 +305,9 @@ export async function syncHoldings(
       no_drift: noDriftCount,
       errors: errors.length,
     },
-    dryRun: options.dryRun,
+    dryRun,
   }
+  return warnings.length > 0 ? { ...base, warnings } : base
 }
 
 interface ApplyOverrideArgs {

--- a/src/trading/reconciliation/syncHoldings.ts
+++ b/src/trading/reconciliation/syncHoldings.ts
@@ -281,7 +281,7 @@ export async function syncHoldings(
   // dryRun + safe-fail-would-trigger: surface as a soft warning so the
   // operator sees the diff but also knows the live call would refuse.
   const warnings: string[] = []
-  if (safeFailTriggered && options.dryRun) {
+  if (safeFailTriggered && options.dryRun && !options.force) {
     warnings.push('broker_returned_empty_diff_suspicious')
   }
 

--- a/test/routes/admin.test.ts
+++ b/test/routes/admin.test.ts
@@ -1305,6 +1305,116 @@ describe('POST /admin/orders/sync-holdings', () => {
     expect(captured.calls).toEqual([])
   })
 
+  /**
+   * Safe-fail guard smoke: when broker returns nothing but DO holds shares,
+   * the route must NOT zero out the DO unless ?force=true is explicit. The
+   * full guard semantics live in `test/trading/reconciliation/syncHoldings.test.ts`;
+   * here we just confirm the route parses `force` correctly and forwards it.
+   */
+  it('safe-fails (no overrides) when broker returns empty + DO has positions + force=false', async () => {
+    const captured = { calls: [] as SyncOverrideCall[] }
+    const res = await withMocks(
+      {
+        universe: { allowedSymbols: ['SOXL', 'AAPL'] },
+        positions: [], // broker returns nothing — bug-reproducer pattern
+      },
+      async () => {
+        const app = createApp()
+        return app.request(
+          '/admin/orders/sync-holdings',
+          { method: 'POST', headers: { ...authHeader } },
+          {
+            ...baseEnv,
+            DB: {} as unknown as D1Database,
+            SYMBOL_STATE: fakeSyncNamespace(captured, {
+              SOXL: { qty: 8, avgPrice: 124.95, openedAt: '2026-04-20T00:00:00.000Z' },
+              AAPL: { qty: 1, avgPrice: 200, openedAt: '2026-04-21T00:00:00.000Z' },
+            }),
+          },
+        )
+      },
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      synced: unknown[]
+      errors: Array<{ symbol: string; error: string }>
+      summary: { synced: number; errors: number }
+    }
+    expect(body.synced).toEqual([])
+    expect(body.summary.errors).toBe(1)
+    expect(body.errors[0]!.error).toMatch(/broker_returned_empty_but_do_has_positions/)
+    expect(captured.calls).toEqual([])
+  })
+
+  it('?force=true bypasses safe-fail and applies destructive zero-out', async () => {
+    const captured = { calls: [] as SyncOverrideCall[] }
+    const res = await withMocks(
+      {
+        universe: { allowedSymbols: ['SOXL'] },
+        positions: [], // broker empty
+      },
+      async () => {
+        const app = createApp()
+        return app.request(
+          '/admin/orders/sync-holdings?force=true',
+          { method: 'POST', headers: { ...authHeader } },
+          {
+            ...baseEnv,
+            DB: {} as unknown as D1Database,
+            SYMBOL_STATE: fakeSyncNamespace(captured, {
+              SOXL: { qty: 8, avgPrice: 124.95, openedAt: '2026-04-20T00:00:00.000Z' },
+            }),
+          },
+        )
+      },
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      synced: Array<{ symbol: string; after: unknown }>
+      errors: unknown[]
+    }
+    expect(body.errors).toEqual([])
+    expect(captured.calls).toHaveLength(1)
+    expect(captured.calls[0]!.symbol).toBe('SOXL')
+    expect(captured.calls[0]!.args.qty).toBe(0)
+    expect(body.synced[0]!.after).toBeNull()
+  })
+
+  it('?dryRun=1 + broker empty + DO has positions: surfaces warning, no overrides', async () => {
+    const captured = { calls: [] as SyncOverrideCall[] }
+    const res = await withMocks(
+      {
+        universe: { allowedSymbols: ['SOXL'] },
+        positions: [],
+      },
+      async () => {
+        const app = createApp()
+        return app.request(
+          '/admin/orders/sync-holdings?dryRun=1',
+          { method: 'POST', headers: { ...authHeader } },
+          {
+            ...baseEnv,
+            DB: {} as unknown as D1Database,
+            SYMBOL_STATE: fakeSyncNamespace(captured, {
+              SOXL: { qty: 8, avgPrice: 124.95, openedAt: '2026-04-20T00:00:00.000Z' },
+            }),
+          },
+        )
+      },
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      synced: Array<{ skipped?: string; before: { qty: number }; after: unknown }>
+      warnings?: string[]
+      dryRun: boolean
+    }
+    expect(body.dryRun).toBe(true)
+    expect(body.warnings).toEqual(['broker_returned_empty_diff_suspicious'])
+    expect(body.synced[0]!.skipped).toBe('dry_run')
+    expect(body.synced[0]!.before.qty).toBe(8)
+    expect(captured.calls).toEqual([])
+  })
+
   it('200s and reports broker fetch failures per-symbol (no overrides)', async () => {
     const captured = { calls: [] as SyncOverrideCall[] }
     const res = await withMocks(

--- a/test/trading/reconciliation/syncHoldings.test.ts
+++ b/test/trading/reconciliation/syncHoldings.test.ts
@@ -236,12 +236,14 @@ describe('syncHoldings', () => {
     expect(result.dryRun).toBe(true)
   })
 
-  it('broker not held (qty=0) → DO position is closed (null)', async () => {
+  it('broker not held (qty=0) → DO position is closed (null) [force=true required]', async () => {
     const { store, overrides } = createFakeStore({
       SOXL: { qty: 4, avgPrice: 124.95, openedAt: '2026-04-20T00:00:00.000Z' },
     })
+    // PR #222 follow-up: this destructive zero-out now requires force=true.
+    // The bare-call equivalent is covered by the safe-fail guard tests above.
     const result = await syncHoldings(
-      { dryRun: false, requestId: 'req-4' },
+      { dryRun: false, force: true, requestId: 'req-4' },
       {
         allowedSymbols: ['SOXL'],
         // Webull omits zero-qty rows entirely.
@@ -274,12 +276,15 @@ describe('syncHoldings', () => {
     expect(result.synced[0]!.after).toMatchObject({ qty: 3, avgPrice: 120 })
   })
 
-  it('DO has shares but broker reports none → DO position is closed', async () => {
+  it('DO has shares but broker reports none → DO position is closed [force=true required]', async () => {
     const { store, overrides } = createFakeStore({
       SOXL: { qty: 4, avgPrice: 124.95, openedAt: '2026-04-20T00:00:00.000Z' },
     })
+    // Broker explicitly reports qty=0 (vs. omitting the row). Either way the
+    // safe-fail guard sees "no usable broker qty + DO has positions" and
+    // requires force=true to proceed with the destructive zero-out.
     const result = await syncHoldings(
-      { dryRun: false, requestId: 'req-6' },
+      { dryRun: false, force: true, requestId: 'req-6' },
       {
         allowedSymbols: ['SOXL'],
         fetchPositions: async () => [brokerPosition('SOXL', '0', '0')],
@@ -346,6 +351,209 @@ describe('syncHoldings', () => {
     expect(result.errors).toHaveLength(1)
     expect(result.errors[0]!.symbol).toBe('SOXL')
     expect(result.errors[0]!.error).toMatch(/cannot determine avgPrice/)
+  })
+
+  /**
+   * Safe-fail guard: PR #222 follow-up. The bug being defended against was
+   * a broker getPositions response that returned all 14 universe symbols
+   * with `available_quantity: null` (UAT auth glitch), which sync-holdings
+   * happily interpreted as "broker has nothing → zero out the DO". That
+   * destroyed real DO rows (SOXL qty=8, AAPL qty=1). The guard refuses the
+   * write when broker has zero usable rows AND DO has any qty>0 row;
+   * `force=true` is the operator escape hatch for genuine liquidations.
+   */
+  describe('safe-fail guard (broker empty + DO non-empty)', () => {
+    it('aborts with safe-fail error when broker returns no qty and DO has positions (force=false, dryRun=false)', async () => {
+      const { store, overrides } = createFakeStore({
+        SOXL: { qty: 8, avgPrice: 124.95, openedAt: '2026-04-20T00:00:00.000Z' },
+        AAPL: { qty: 1, avgPrice: 200, openedAt: '2026-04-21T00:00:00.000Z' },
+      })
+      const result = await syncHoldings(
+        { dryRun: false, requestId: 'req-safe-1' },
+        {
+          allowedSymbols: ['SOXL', 'AAPL'],
+          // Broker returns nothing — the bug pattern.
+          fetchPositions: async () => [],
+          positionStore: store,
+        },
+      )
+      expect(overrides).toEqual([])
+      expect(result.synced).toEqual([])
+      expect(result.errors).toHaveLength(1)
+      expect(result.errors[0]!.symbol).toBe('*')
+      expect(result.errors[0]!.error).toMatch(/broker_returned_empty_but_do_has_positions/)
+      expect(result.errors[0]!.error).toMatch(/force=true/)
+      expect(result.summary).toEqual({ total: 1, synced: 0, no_drift: 0, errors: 1 })
+      expect(result.dryRun).toBe(false)
+      expect(result.warnings).toBeUndefined()
+    })
+
+    it('also triggers when broker returns rows but every available_quantity is null', async () => {
+      // Mirrors the actual incident: 14 symbols returned but `available_quantity: null`
+      // on every row. The guard treats that the same as "no rows".
+      const { store, overrides } = createFakeStore({
+        SOXL: { qty: 8, avgPrice: 124.95, openedAt: '2026-04-20T00:00:00.000Z' },
+      })
+      const result = await syncHoldings(
+        { dryRun: false, requestId: 'req-safe-1b' },
+        {
+          allowedSymbols: ['SOXL'],
+          fetchPositions: async () => [
+            // null/empty available_quantity → parseBrokerQty returns null
+            { symbol: 'SOXL', available_quantity: null as unknown as string },
+          ],
+          positionStore: store,
+        },
+      )
+      expect(overrides).toEqual([])
+      expect(result.errors[0]!.error).toMatch(/broker_returned_empty_but_do_has_positions/)
+    })
+
+    it('force=true bypasses the guard and applies the destructive zero-out', async () => {
+      const { store, overrides } = createFakeStore({
+        SOXL: { qty: 8, avgPrice: 124.95, openedAt: '2026-04-20T00:00:00.000Z' },
+        AAPL: { qty: 1, avgPrice: 200, openedAt: '2026-04-21T00:00:00.000Z' },
+      })
+      const result = await syncHoldings(
+        { dryRun: false, force: true, requestId: 'req-safe-2' },
+        {
+          allowedSymbols: ['SOXL', 'AAPL'],
+          fetchPositions: async () => [],
+          positionStore: store,
+        },
+      )
+      // Both DO rows zeroed out (intentional liquidation cleanup).
+      expect(overrides).toHaveLength(2)
+      expect(overrides.map((o) => o.symbol).sort()).toEqual(['AAPL', 'SOXL'])
+      for (const o of overrides) {
+        expect(o.args.qty).toBe(0)
+      }
+      expect(result.synced).toHaveLength(2)
+      for (const r of result.synced) {
+        expect(r.after).toBeNull()
+      }
+      expect(result.errors).toEqual([])
+    })
+
+    it('broker empty + DO empty → no-op (no positions anywhere, nothing destructive)', async () => {
+      const { store, overrides } = createFakeStore({
+        SOXL: null,
+        AAPL: null,
+      })
+      const result = await syncHoldings(
+        { dryRun: false, requestId: 'req-safe-3' },
+        {
+          allowedSymbols: ['SOXL', 'AAPL'],
+          fetchPositions: async () => [],
+          positionStore: store,
+        },
+      )
+      // Guard does NOT trigger — no DO position to protect.
+      expect(overrides).toEqual([])
+      expect(result.errors).toEqual([])
+      expect(result.synced.every((r) => r.skipped === 'no_drift')).toBe(true)
+      expect(result.summary).toEqual({ total: 2, synced: 0, no_drift: 2, errors: 0 })
+    })
+
+    it('mixed broker (some null, some qty>0) does NOT trigger guard — partial API works', async () => {
+      const { store, overrides } = createFakeStore({
+        SOXL: { qty: 8, avgPrice: 124.95, openedAt: '2026-04-20T00:00:00.000Z' },
+        AAPL: { qty: 1, avgPrice: 200, openedAt: '2026-04-21T00:00:00.000Z' },
+      })
+      const result = await syncHoldings(
+        { dryRun: false, requestId: 'req-safe-4' },
+        {
+          allowedSymbols: ['SOXL', 'AAPL'],
+          // SOXL has qty (broker partly works), AAPL omitted (zero-out is real).
+          fetchPositions: async () => [brokerPosition('SOXL', '4', '125.50')],
+          positionStore: store,
+        },
+      )
+      // Guard does NOT trigger because broker reported at least one qty>0.
+      // SOXL drifts 8 → 4 (write), AAPL DO 1 → 0 (write).
+      expect(overrides).toHaveLength(2)
+      const byName = new Map(overrides.map((o) => [o.symbol, o]))
+      expect(byName.get('SOXL')!.args.qty).toBe(4)
+      expect(byName.get('AAPL')!.args.qty).toBe(0)
+      expect(result.errors).toEqual([])
+    })
+
+    it('dryRun=true + safe-fail-would-trigger: shows diff and surfaces warning', async () => {
+      const { store, overrides } = createFakeStore({
+        SOXL: { qty: 8, avgPrice: 124.95, openedAt: '2026-04-20T00:00:00.000Z' },
+      })
+      const result = await syncHoldings(
+        { dryRun: true, requestId: 'req-safe-5' },
+        {
+          allowedSymbols: ['SOXL'],
+          fetchPositions: async () => [],
+          positionStore: store,
+        },
+      )
+      // dryRun is non-destructive, so we still emit the diff for inspection.
+      expect(overrides).toEqual([])
+      expect(result.synced).toHaveLength(1)
+      expect(result.synced[0]!.skipped).toBe('dry_run')
+      expect(result.synced[0]!.before?.qty).toBe(8)
+      expect(result.synced[0]!.after).toBeNull()
+      // Warning communicates "the live call would refuse this".
+      expect(result.warnings).toEqual(['broker_returned_empty_diff_suspicious'])
+      expect(result.errors).toEqual([])
+      expect(result.dryRun).toBe(true)
+    })
+
+    it('single-symbol mode: same guard applies (broker null + DO has qty)', async () => {
+      const { store, overrides } = createFakeStore({
+        SOXL: { qty: 8, avgPrice: 124.95, openedAt: '2026-04-20T00:00:00.000Z' },
+      })
+      const result = await syncHoldings(
+        { symbol: 'SOXL', dryRun: false, requestId: 'req-safe-6' },
+        {
+          allowedSymbols: [],
+          fetchPositions: async () => [],
+          positionStore: store,
+        },
+      )
+      expect(overrides).toEqual([])
+      expect(result.errors[0]!.error).toMatch(/broker_returned_empty_but_do_has_positions/)
+    })
+
+    it('single-symbol mode + force=true: bypasses guard for one ticker', async () => {
+      const { store, overrides } = createFakeStore({
+        SOXL: { qty: 8, avgPrice: 124.95, openedAt: '2026-04-20T00:00:00.000Z' },
+      })
+      const result = await syncHoldings(
+        { symbol: 'SOXL', dryRun: false, force: true, requestId: 'req-safe-7' },
+        {
+          allowedSymbols: [],
+          fetchPositions: async () => [],
+          positionStore: store,
+        },
+      )
+      expect(overrides).toHaveLength(1)
+      expect(overrides[0]!.args.qty).toBe(0)
+      expect(result.synced[0]!.after).toBeNull()
+    })
+
+    it('stale {qty:0} DO row does NOT count as "DO has positions" (guard not triggered)', async () => {
+      const { store, overrides } = createFakeStore({
+        // Edge case: DO has a position record but qty=0 (already closed).
+        // Zeroing it again is a no-op, not destructive — guard should let it through.
+        SOXL: { qty: 0, avgPrice: 124.95, openedAt: '2026-04-20T00:00:00.000Z' },
+      })
+      const result = await syncHoldings(
+        { dryRun: false, requestId: 'req-safe-8' },
+        {
+          allowedSymbols: ['SOXL'],
+          fetchPositions: async () => [],
+          positionStore: store,
+        },
+      )
+      // No safe-fail error; symbol is just no-drift (DO=0, broker=0).
+      expect(overrides).toEqual([])
+      expect(result.errors).toEqual([])
+      expect(result.synced[0]!.skipped).toBe('no_drift')
+    })
   })
 
   it('matches symbols case-insensitively against broker payload', async () => {

--- a/test/trading/reconciliation/syncHoldings.test.ts
+++ b/test/trading/reconciliation/syncHoldings.test.ts
@@ -502,6 +502,29 @@ describe('syncHoldings', () => {
       expect(result.dryRun).toBe(true)
     })
 
+    it('dryRun=true + force=true: no warning (operator already acknowledged the destructive intent)', async () => {
+      const { store, overrides } = createFakeStore({
+        SOXL: { qty: 8, avgPrice: 124.95, openedAt: '2026-04-20T00:00:00.000Z' },
+      })
+      const result = await syncHoldings(
+        { dryRun: true, force: true, requestId: 'req-safe-5b' },
+        {
+          allowedSymbols: ['SOXL'],
+          fetchPositions: async () => [],
+          positionStore: store,
+        },
+      )
+      expect(overrides).toEqual([])
+      expect(result.synced).toHaveLength(1)
+      expect(result.synced[0]!.skipped).toBe('dry_run')
+      expect(result.synced[0]!.after).toBeNull()
+      // force=true means the operator already opted into the destructive
+      // zero-out, so the "suspicious" warning is silenced.
+      expect(result.warnings).toBeUndefined()
+      expect(result.errors).toEqual([])
+      expect(result.dryRun).toBe(true)
+    })
+
     it('single-symbol mode: same guard applies (broker null + DO has qty)', async () => {
       const { store, overrides } = createFakeStore({
         SOXL: { qty: 8, avgPrice: 124.95, openedAt: '2026-04-20T00:00:00.000Z' },


### PR DESCRIPTION
## 動機

PR #222 (sync-holdings) の運用で、broker getPositions が UAT auth 起因で全 14 symbol を `available_quantity: null` で返した際に、sync-holdings が「broker has nothing」と解釈して **DO の保有 position を destructive に zero-out** する事故が発生した。

実例 (今日の運用ログより):
- 全 14 symbol で broker_qty: null
- DO 側の SOXL (qty=8) と AAPL (qty=1) が null reset
- 結果として保有 position が DO 上から消失 → split-brain 拡大

`POST /admin/orders/sync-holdings` は本来「broker truth に DO を合わせる」ツールだが、broker 側が機能停止していると逆に DO を破壊する方向に働く。

## 修正内容

### 1. safe-fail guard

`syncHoldings()` を **read-only pre-pass + apply pass** の 2 段構成に再構成し、apply 前に「broker 全空 + DO は qty>0 を持っている」パターンを検知:

- `hasAnyBrokerQty = plans.some(p => p.brokerQty !== null && p.brokerQty > 0)`
- `doHasAnyPosition = plans.some(p => p.before !== null && p.before.qty > 0)`
- `!hasAnyBrokerQty && doHasAnyPosition` → safe-fail

safe-fail 時は **DO に一切書かず**、`errors[*]` に `broker_returned_empty_but_do_has_positions` として返す。

### 2. `?force=true` operator escape hatch

operator が「broker は本当に空、DO の幽霊 position をクリアしたい」と判明している場合 (= 実際の liquidation など) は `?force=true` で safe-fail を bypass。route 層で `parseTruthyQuery` 経由で読む。

### 3. dryRun は引き続き diff を返す

`dryRun=true` は read-only なので safe-fail で早期 return せず、通常通り diff を返す。ただし live call なら safe-fail することを示すため `warnings: ['broker_returned_empty_diff_suspicious']` をレスポンスに付与。

### 4. backward compat

- 既存 caller は `force=false` 既定で **安全側に取り込まれる** (= 偶発的な destructive zero-out を防ぐ)
- 既存 test 2 件 (broker omits zero-qty / broker reports 0) は意図的な zero-out なので `force: true` を追加して維持

### 5. 単一 symbol mode も同 logic

`?symbol=SOXL` でも broker 該当 symbol が null + DO 該当が persist position あり → safe-fail に取り込まれる。

## test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test --run` 全 921 件 pass
- [x] 新規テストカバレッジ:
  - broker 全 null + DO に position + dryRun=false + force=false → safe-fail (DO 変更なし)
  - 同上 + force=true → 通常実行 (DO null reset)
  - broker 全 null + DO 全 null → no-op
  - broker 一部 null / 一部 qty>0 → 通常通り (= API 部分機能、symbol 単位で reconcile)
  - dryRun=true + 全 null + DO に position → diff 表示 + warnings に safe-fail 警告
  - 単一 symbol mode + force=true → 単一 ticker のみ bypass
  - stale `{qty:0}` DO row は guard 対象外 (= 既に閉じてる)
  - route 層 smoke: `?force=true` / `?dryRun=1 + broker empty + DO has positions`

## 関連

- PR #222 (元の sync-holdings 実装)
- 影響: `src/trading/reconciliation/syncHoldings.ts`, `src/routes/admin.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ホールディングス同期エンドポイントに強制実行を許可する `force` オプションを追加しました。
  * 同期結果に警告情報を含めるよう出力を拡張しました。

* **バグ修正**
  * ブローカーが実質的に空の場合に意図しない削除を防ぐ安全ガードを導入。強制時のみ上書きを許可し、監査ログに強制フラグを残します。
  * ブローカー取得失敗時の即時終了処理を改善しました。

* **テスト**
  * 各種挙動（既定、force、dry-run）を網羅するテストを追加・更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->