### PR TITLE
fix(reconcile): max-retry auto-abandon — sanity-stuck row のアラート無限発火を停止

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -159,16 +159,22 @@ export default {
               stillPending: summary.stillPending.length,
               notFound: summary.notFound.length,
               errorCount: summary.errors.length,
+              abandoned: summary.abandoned,
             }),
           )
           // reconcile の per-row error が出ていれば 1 件まとめて通知 (#141)。
           // 1 row 1 通知だと polling tick で連発するので summary 単位で 1 件。
+          //
+          // Auto-abandoned rows (sanity-stuck for >=5 attempts) は
+          // summary.errors に積まれずこの message 経路から抜ける。
+          // operator 側は `reconcile_auto_abandon` audit log を別経路で
+          // 拾えば良い。
           if (summary.errors.length > 0) {
             ctx.waitUntil(
               createNotifier(env, { requestId })
                 .notify({
                   type: 'ERROR',
-                  message: `reconcile fills had ${summary.errors.length} error(s) across ${summary.inspected} row(s)`,
+                  message: `reconcile fills had ${summary.errors.length} error(s), ${summary.abandoned} abandoned, across ${summary.inspected} row(s)`,
                   cause: 'reconcile_fills_partial',
                   severity: 'warning',
                 })

--- a/src/trading/reconciliation/reconcileFills.ts
+++ b/src/trading/reconciliation/reconcileFills.ts
@@ -50,6 +50,48 @@ export interface ReconcileSummary {
    * recovery activity in cron logs.
    */
   repaired: number
+  /**
+   * Number of rows that were force-stamped `state_applied_at` on this run
+   * because they exceeded `MAX_REPAIR_ATTEMPTS` with a permanent sanity
+   * failure. Bumps `state_apply_error` with an `auto_abandoned_after_*`
+   * prefix so an operator can audit them later. Excluded from `errors`
+   * (and from the per-row error count surfaced to the alert notifier) so a
+   * stuck row stops re-firing the same alarm forever.
+   */
+  abandoned: number
+}
+
+/**
+ * Hard cap on how many times the repair cohort retries a row whose
+ * `state_apply_error` indicates a permanent sanity-style failure. Beyond
+ * this we force-stamp `state_applied_at` to drop the row out of the cohort
+ * (see `markAsAbandoned`). Picked at 5 to give a few cron ticks of grace
+ * for transient DO blips without letting a structurally-broken row
+ * (e.g. broker forever returns `filled_price=10` for a 3516 limit) keep
+ * the alert siren going indefinitely.
+ *
+ * Tunable in code only — moving this to env / runtime config is out of
+ * scope (separate PR if needed).
+ */
+const MAX_REPAIR_ATTEMPTS = 5
+
+/**
+ * `state_apply_error` substrings that we treat as "no further retry will
+ * help" — repeated reconcile cycles will keep producing the same failure.
+ * Distinct from transient errors (`broker_5xx`, `network`, `DO unavailable`,
+ * etc.) which should keep retrying.
+ *
+ * Recognized substrings:
+ *   - `sanity_failed` — `resolveFilledPrice()` rejected the broker's price
+ *     via the ratio guard. Will keep failing as long as the broker echoes
+ *     the same stub.
+ *   - `repair_skipped_invalid_row` — repair branch detected a structurally
+ *     invalid FILLED row (qty<=0, missing symbol/side, etc.). Cannot be
+ *     fixed by retry — the journal row itself is malformed.
+ */
+function isPermanentSanityFailure(error: string | null | undefined): boolean {
+  if (!error) return false
+  return error.includes('sanity_failed') || error.includes('repair_skipped_invalid_row')
 }
 
 interface ReconcileOptions {
@@ -121,6 +163,7 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
     stateApplied: 0,
     stateApplyFailed: 0,
     repaired: 0,
+    abandoned: 0,
   }
 
   const now = options.now ?? (() => new Date())
@@ -169,6 +212,10 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
       realizedPnl: tradeJournal.realizedPnl,
       stateAppliedAt: tradeJournal.stateAppliedAt,
       stateApplyAttempts: tradeJournal.stateApplyAttempts,
+      // Required by the auto-abandon path so we can decide whether the
+      // prior failure was a permanent sanity-class error (retry will not
+      // help) vs a transient one. See `isPermanentSanityFailure`.
+      stateApplyError: tradeJournal.stateApplyError,
     })
     .from(tradeJournal)
     .leftJoin(
@@ -228,6 +275,51 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
     const isRepair = row.brokerStatus === 'FILLED' && row.stateAppliedAt === null
 
     if (isRepair) {
+      // Auto-abandon: a row that has tripped a permanent sanity-class
+      // error MAX_REPAIR_ATTEMPTS times in a row is not going to recover
+      // on the next tick. Force-stamp `state_applied_at` so:
+      //   - it falls out of the repair cohort SELECT,
+      //   - subsequent reconcile cycles do not include it in
+      //     `summary.errors` and so the `reconcile_fills_partial`
+      //     alarm stops re-firing for the same stuck row.
+      //
+      // The prior error is preserved (prefixed with
+      // `auto_abandoned_after_<n>_attempts:`) for operator audit. We
+      // emit a `reconcile_auto_abandon` audit log so dashboards / alert
+      // pipelines can pick up the event separately from the noisy
+      // partial-error alarm.
+      //
+      // Transient errors (broker_5xx, DO unavailable, network) are
+      // intentionally NOT auto-abandoned — those can clear on their own
+      // and should keep retrying past 5 attempts. See
+      // `isPermanentSanityFailure` for the included substrings.
+      if (
+        row.stateApplyAttempts >= MAX_REPAIR_ATTEMPTS &&
+        isPermanentSanityFailure(row.stateApplyError)
+      ) {
+        await markAsAbandoned(
+          db,
+          row.id,
+          row.stateApplyAttempts,
+          row.stateApplyError ?? '',
+          runNow.toISOString(),
+        )
+        console.warn(
+          JSON.stringify({
+            event: 'reconcile_auto_abandon',
+            requestId: options.requestId,
+            rowId: row.id,
+            clientOrderId: coid,
+            symbol: row.symbol,
+            side: row.side,
+            attempts: row.stateApplyAttempts,
+            priorError: row.stateApplyError,
+          }),
+        )
+        summary.abandoned += 1
+        continue
+      }
+
       // Use the canonical fill data already on the row. We must not
       // re-poll Webull — orders/history can rotate the row off the first
       // page after a few days, and re-polling would also waste a quota.
@@ -676,6 +768,40 @@ function dedupeCandidatesByRowId<T extends { id: number; side: string | null; pr
     }
   }
   return [...byId.values()]
+}
+
+/**
+ * Force-stamp `state_applied_at` on a permanently-stuck repair row. Used
+ * by the auto-abandon path: after MAX_REPAIR_ATTEMPTS retries on a
+ * sanity-class failure we accept that the next tick will not help and
+ * drop the row out of the repair cohort.
+ *
+ * The prior error is preserved verbatim, prefixed with
+ * `auto_abandoned_after_<attempts>_attempts:` so an operator running a
+ * journal query can tell at a glance which rows were force-closed vs
+ * applied normally.
+ *
+ * NOT a best-effort path: if this UPDATE fails the row stays in the
+ * cohort and the same alert keeps firing — surface the failure to the
+ * caller so the run summary reflects reality. Caller wraps it in a
+ * try/catch so a single row's failure does not kill the whole batch.
+ */
+async function markAsAbandoned(
+  db: ReturnType<typeof createDb>,
+  rowId: number,
+  attempts: number,
+  priorError: string,
+  nowIso: string,
+): Promise<void> {
+  const message = `auto_abandoned_after_${attempts}_attempts: ${priorError}`
+  await db
+    .update(tradeJournal)
+    .set({
+      stateAppliedAt: nowIso,
+      stateApplyError: message,
+      stateApplyAttempts: sql`${tradeJournal.stateApplyAttempts} + 1`,
+    })
+    .where(eq(tradeJournal.id, rowId))
 }
 
 async function recordApplyFailure(

--- a/src/trading/reconciliation/reconcileFills.ts
+++ b/src/trading/reconciliation/reconcileFills.ts
@@ -323,7 +323,6 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
             }),
           )
           summary.errors.push({ clientOrderId: coid, message: `auto_abandon_failed: ${message}` })
-          summary.stateApplyFailed += 1
           continue
         }
         console.warn(

--- a/src/trading/reconciliation/reconcileFills.ts
+++ b/src/trading/reconciliation/reconcileFills.ts
@@ -297,13 +297,35 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
         row.stateApplyAttempts >= MAX_REPAIR_ATTEMPTS &&
         isPermanentSanityFailure(row.stateApplyError)
       ) {
-        await markAsAbandoned(
-          db,
-          row.id,
-          row.stateApplyAttempts,
-          row.stateApplyError ?? '',
-          runNow.toISOString(),
-        )
+        try {
+          await markAsAbandoned(
+            db,
+            row.id,
+            row.stateApplyAttempts,
+            row.stateApplyError ?? '',
+            runNow.toISOString(),
+          )
+        } catch (error) {
+          // The auto-abandon UPDATE itself failed (e.g. D1 throttled, transient
+          // bind error). Do not let a single row kill the whole batch — log,
+          // record the failure on the run summary, and move on to the next
+          // row. The cohort SELECT will pick this row up again next tick and
+          // retry the abandon.
+          const message = error instanceof Error ? error.message : String(error)
+          console.error(
+            JSON.stringify({
+              event: 'reconcile_auto_abandon_error',
+              requestId: options.requestId,
+              rowId: row.id,
+              clientOrderId: coid,
+              symbol: row.symbol,
+              message,
+            }),
+          )
+          summary.errors.push({ clientOrderId: coid, message: `auto_abandon_failed: ${message}` })
+          summary.stateApplyFailed += 1
+          continue
+        }
         console.warn(
           JSON.stringify({
             event: 'reconcile_auto_abandon',

--- a/test/routes/admin.test.ts
+++ b/test/routes/admin.test.ts
@@ -121,6 +121,7 @@ describe('POST /admin/orders/reconcile', () => {
       stateApplied: 0,
       stateApplyFailed: 0,
       repaired: 0,
+      abandoned: 0,
     }
   }
 

--- a/test/trading/reconciliation/reconcileFills.test.ts
+++ b/test/trading/reconciliation/reconcileFills.test.ts
@@ -243,6 +243,13 @@ interface CandidateRow {
   realizedPnl: number | null
   stateAppliedAt: string | null
   stateApplyAttempts: number
+  /**
+   * Last `state_apply_error` recorded on the journal row. Read by the
+   * auto-abandon path (`isPermanentSanityFailure`) to decide whether
+   * MAX_REPAIR_ATTEMPTS-exceeded rows should be force-stamped or left
+   * to keep retrying (transient errors).
+   */
+  stateApplyError?: string | null
 }
 
 interface UpdateCall {
@@ -1088,5 +1095,264 @@ describe('reconcileFills state-apply marker (issue #142)', () => {
     expect(fn(1, 50, 'FILLED')).toBe(false) // healthy fill
     expect(fn(1, null, 'CANCELLED')).toBe(false) // not FILLED
     expect(fn(1, null, null)).toBe(false) // no status
+  })
+
+  // ---------------------------------------------------------------------------
+  // auto-abandon (this PR): rows that have tripped a permanent sanity-class
+  // error MAX_REPAIR_ATTEMPTS times should be force-stamped state_applied_at
+  // so they fall out of the repair cohort and stop driving the
+  // reconcile_fills_partial alarm forever. Transient errors (broker_5xx,
+  // network) must keep retrying past 5 attempts.
+  //
+  // Real-world trigger: 9697 — 6 rows accumulated to attempts 12-24 with
+  // `state_apply_error='sanity_failed: filled_price rejected by ratio guard'`,
+  // and the operator received the same alert every 5-minute cron tick.
+  // ---------------------------------------------------------------------------
+  describe('auto-abandon for sanity-stuck repair rows', () => {
+    it('attempts >= 5 + sanity_failed → force-stamps state_applied_at and bumps abandoned count', async () => {
+      const row: CandidateRow = {
+        id: 9697,
+        clientOrderId: 'coid-stuck-sanity',
+        symbol: '9697',
+        side: 'BUY',
+        brokerStatus: 'FILLED',
+        // filled_price=null is the actual on-disk shape for sanity-rejected
+        // rows (resolveFilledPrice returned null and the journal UPDATE
+        // wrote NULL). Repair branch's invalid-row guard would normally
+        // catch this, but we want the auto-abandon path to fire FIRST so
+        // the row drops out of the cohort before consuming another
+        // `repair_skipped_invalid_row` slot.
+        filledQty: 1,
+        filledPrice: null,
+        realizedPnl: null,
+        stateAppliedAt: null,
+        stateApplyAttempts: 5,
+        stateApplyError: 'sanity_failed: filled_price rejected by ratio guard',
+      }
+      const { db, updates } = makeFakeDb([row])
+      vi.mocked(createDb).mockReturnValue(db)
+      vi.mocked(createWebullHttpClient).mockReturnValue(
+        makeWebullStub({}) as unknown as ReturnType<typeof createWebullHttpClient>,
+      )
+      // Quiet the audit-log warn so the test output stays readable.
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const symbolStub = emptySymbolStateStub()
+
+      const summary = await reconcileFills({
+        env: {
+          DB: FAKE_DB_BINDING,
+          SYMBOL_STATE: makeSymbolStateNamespace(symbolStub) as never,
+        } as never,
+        now: () => new Date('2026-04-25T12:00:00.000Z'),
+        retryStateApply: true,
+      })
+
+      // No DO call — abandoned rows are not re-applied.
+      expect(symbolStub.recordFillOnce).not.toHaveBeenCalled()
+      // Single UPDATE: the auto-abandon stamp.
+      expect(updates).toHaveLength(1)
+      expect(updates[0]!.set.stateAppliedAt).toBe('2026-04-25T12:00:00.000Z')
+      expect(updates[0]!.set.stateApplyError).toMatch(/^auto_abandoned_after_5_attempts:/)
+      expect(updates[0]!.set.stateApplyError).toMatch(/sanity_failed/)
+      expect(updates[0]!.set.stateApplyAttempts).toBeDefined()
+      // Counts: abandoned bumps, errors stays empty (so notifier stays quiet).
+      expect(summary.abandoned).toBe(1)
+      expect(summary.stateApplied).toBe(0)
+      expect(summary.stateApplyFailed).toBe(0)
+      expect(summary.errors).toEqual([])
+      // Audit log emitted so operator can see the abandon event.
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"event":"reconcile_auto_abandon"'),
+      )
+      const auditLog = JSON.parse(warnSpy.mock.calls[0]![0] as string)
+      expect(auditLog).toMatchObject({
+        event: 'reconcile_auto_abandon',
+        rowId: 9697,
+        clientOrderId: 'coid-stuck-sanity',
+        symbol: '9697',
+        attempts: 5,
+        priorError: 'sanity_failed: filled_price rejected by ratio guard',
+      })
+    })
+
+    it('attempts >= 5 + repair_skipped_invalid_row → also abandons', async () => {
+      // Second permanent sanity class: repair branch detected a structurally
+      // invalid FILLED row (qty<=0). Same outcome — keeps tripping the same
+      // error, no recovery possible.
+      const row: CandidateRow = {
+        id: 100,
+        clientOrderId: 'coid-stuck-invalid',
+        symbol: 'SOXL',
+        side: 'BUY',
+        brokerStatus: 'FILLED',
+        filledQty: 0,
+        filledPrice: 40,
+        realizedPnl: null,
+        stateAppliedAt: null,
+        stateApplyAttempts: 8,
+        stateApplyError: 'repair_skipped_invalid_row: symbol=SOXL side=BUY qty=0 price=40',
+      }
+      const { db, updates } = makeFakeDb([row])
+      vi.mocked(createDb).mockReturnValue(db)
+      vi.mocked(createWebullHttpClient).mockReturnValue(
+        makeWebullStub({}) as unknown as ReturnType<typeof createWebullHttpClient>,
+      )
+      vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const symbolStub = emptySymbolStateStub()
+
+      const summary = await reconcileFills({
+        env: {
+          DB: FAKE_DB_BINDING,
+          SYMBOL_STATE: makeSymbolStateNamespace(symbolStub) as never,
+        } as never,
+        now: () => new Date('2026-04-25T12:00:00.000Z'),
+        retryStateApply: true,
+      })
+
+      expect(updates).toHaveLength(1)
+      expect(updates[0]!.set.stateAppliedAt).toBe('2026-04-25T12:00:00.000Z')
+      expect(updates[0]!.set.stateApplyError).toMatch(/^auto_abandoned_after_8_attempts:/)
+      expect(updates[0]!.set.stateApplyError).toMatch(/repair_skipped_invalid_row/)
+      expect(summary.abandoned).toBe(1)
+      expect(summary.errors).toEqual([])
+    })
+
+    it('attempts < 5 + sanity_failed → keeps retrying (existing behaviour)', async () => {
+      // Below threshold: standard repair retry path. Because filledPrice is
+      // null on this row the repair branch's invalid-row guard fires (this
+      // is the existing `repair_skipped_invalid_row` path) — what we are
+      // asserting is that auto-abandon does NOT fire prematurely.
+      const row: CandidateRow = {
+        id: 200,
+        clientOrderId: 'coid-stuck-early',
+        symbol: '9697',
+        side: 'BUY',
+        brokerStatus: 'FILLED',
+        filledQty: 1,
+        filledPrice: null,
+        realizedPnl: null,
+        stateAppliedAt: null,
+        stateApplyAttempts: 4,
+        stateApplyError: 'sanity_failed: filled_price rejected by ratio guard',
+      }
+      const { db, updates } = makeFakeDb([row])
+      vi.mocked(createDb).mockReturnValue(db)
+      vi.mocked(createWebullHttpClient).mockReturnValue(
+        makeWebullStub({}) as unknown as ReturnType<typeof createWebullHttpClient>,
+      )
+      const symbolStub = emptySymbolStateStub()
+
+      const summary = await reconcileFills({
+        env: {
+          DB: FAKE_DB_BINDING,
+          SYMBOL_STATE: makeSymbolStateNamespace(symbolStub) as never,
+        } as never,
+        now: () => new Date('2026-04-25T12:00:00.000Z'),
+        retryStateApply: true,
+      })
+
+      // Existing path: repair_skipped_invalid_row fires (filledPrice=null).
+      // state_applied_at MUST NOT be stamped (= row stays in repair cohort).
+      expect(symbolStub.recordFillOnce).not.toHaveBeenCalled()
+      expect(updates).toHaveLength(1)
+      expect(updates[0]!.set.stateAppliedAt).toBeUndefined()
+      expect(updates[0]!.set.stateApplyError).toMatch(/repair_skipped_invalid_row/)
+      // Crucially: NOT abandoned, error counted (so the operator alert can
+      // still surface a fresh issue while it is recoverable).
+      expect(summary.abandoned).toBe(0)
+      expect(summary.stateApplyFailed).toBe(1)
+      expect(summary.errors).toHaveLength(1)
+    })
+
+    it('attempts >= 5 + transient error (DO unavailable) → keeps retrying (NOT abandoned)', async () => {
+      // Transient errors should never auto-abandon — the next tick may
+      // succeed even after dozens of failures. Here `state_apply_error`
+      // does NOT contain `sanity_failed` / `repair_skipped_invalid_row`,
+      // so `isPermanentSanityFailure` returns false.
+      //
+      // We give the row a usable filled_price so the standard repair
+      // path runs; the DO stub then throws to simulate a still-broken
+      // underlying.
+      const row: CandidateRow = {
+        id: 300,
+        clientOrderId: 'coid-stuck-transient',
+        symbol: 'SOXL',
+        side: 'BUY',
+        brokerStatus: 'FILLED',
+        filledQty: 3,
+        filledPrice: 40,
+        realizedPnl: null,
+        stateAppliedAt: null,
+        stateApplyAttempts: 10, // way past the threshold
+        stateApplyError: 'DO unavailable',
+      }
+      const { db, updates } = makeFakeDb([row])
+      vi.mocked(createDb).mockReturnValue(db)
+      vi.mocked(createWebullHttpClient).mockReturnValue(
+        makeWebullStub({}) as unknown as ReturnType<typeof createWebullHttpClient>,
+      )
+      const symbolStub = emptySymbolStateStub()
+      symbolStub.recordFillOnce.mockRejectedValueOnce(new Error('DO still unavailable'))
+
+      const summary = await reconcileFills({
+        env: {
+          DB: FAKE_DB_BINDING,
+          SYMBOL_STATE: makeSymbolStateNamespace(symbolStub) as never,
+        } as never,
+        now: () => new Date('2026-04-25T12:00:00.000Z'),
+        retryStateApply: true,
+      })
+
+      // Repair path actually ran (= we did not auto-abandon).
+      expect(symbolStub.recordFillOnce).toHaveBeenCalled()
+      // Single UPDATE — the recordApplyFailure error stamp. state_applied_at
+      // MUST NOT be set (= row remains in cohort for next tick).
+      expect(updates).toHaveLength(1)
+      expect(updates[0]!.set.stateAppliedAt).toBeUndefined()
+      expect(updates[0]!.set.stateApplyError).toBe('DO still unavailable')
+      expect(summary.abandoned).toBe(0)
+      expect(summary.stateApplyFailed).toBe(1)
+    })
+
+    it('attempts >= 5 + null state_apply_error → keeps retrying (NOT abandoned)', async () => {
+      // Defensive: a row could conceivably have high attempts with a null
+      // error column (e.g. attempts bump after marker UPDATE failure
+      // clears the prior error). isPermanentSanityFailure(null) is false →
+      // do not abandon, let the standard path run.
+      const row: CandidateRow = {
+        id: 400,
+        clientOrderId: 'coid-null-error',
+        symbol: 'SOXL',
+        side: 'BUY',
+        brokerStatus: 'FILLED',
+        filledQty: 2,
+        filledPrice: 35,
+        realizedPnl: null,
+        stateAppliedAt: null,
+        stateApplyAttempts: 7,
+        stateApplyError: null,
+      }
+      const { db, updates } = makeFakeDb([row])
+      vi.mocked(createDb).mockReturnValue(db)
+      vi.mocked(createWebullHttpClient).mockReturnValue(
+        makeWebullStub({}) as unknown as ReturnType<typeof createWebullHttpClient>,
+      )
+      const symbolStub = emptySymbolStateStub()
+
+      const summary = await reconcileFills({
+        env: {
+          DB: FAKE_DB_BINDING,
+          SYMBOL_STATE: makeSymbolStateNamespace(symbolStub) as never,
+        } as never,
+        now: () => new Date('2026-04-25T12:00:00.000Z'),
+        retryStateApply: true,
+      })
+
+      // Standard repair path runs (DO apply succeeded).
+      expect(symbolStub.recordFillOnce).toHaveBeenCalled()
+      expect(summary.abandoned).toBe(0)
+      expect(summary.stateApplied).toBe(1)
+      expect(updates[0]!.set.stateAppliedAt).toBe('2026-04-25T12:00:00.000Z')
+    })
   })
 })

--- a/test/trading/reconciliation/reconcileFills.test.ts
+++ b/test/trading/reconciliation/reconcileFills.test.ts
@@ -1354,5 +1354,88 @@ describe('reconcileFills state-apply marker (issue #142)', () => {
       expect(summary.stateApplied).toBe(1)
       expect(updates[0]!.set.stateAppliedAt).toBe('2026-04-25T12:00:00.000Z')
     })
+
+    it('markAsAbandoned UPDATE throws → loop continues, row goes to errors, abandoned not bumped', async () => {
+      // CodeRabbit #228: the auto-abandon UPDATE must be wrapped in
+      // try/catch so a single transient D1 failure does not abort the
+      // whole reconcile batch. Two rows both qualify for auto-abandon;
+      // the first row's UPDATE throws (simulated via
+      // `failStateAppliedAtOnce`) — the loop must continue to process
+      // the second row, which abandons normally.
+      const stuckRows: CandidateRow[] = [
+        {
+          id: 9697,
+          clientOrderId: 'coid-stuck-1',
+          symbol: '9697',
+          side: 'BUY',
+          brokerStatus: 'FILLED',
+          filledQty: 1,
+          filledPrice: null,
+          realizedPnl: null,
+          stateAppliedAt: null,
+          stateApplyAttempts: 5,
+          stateApplyError: 'sanity_failed: filled_price rejected by ratio guard',
+        },
+        {
+          id: 9698,
+          clientOrderId: 'coid-stuck-2',
+          symbol: '9697',
+          side: 'BUY',
+          brokerStatus: 'FILLED',
+          filledQty: 1,
+          filledPrice: null,
+          realizedPnl: null,
+          stateAppliedAt: null,
+          stateApplyAttempts: 6,
+          stateApplyError: 'sanity_failed: filled_price rejected by ratio guard',
+        },
+      ]
+      // Fail the first stateAppliedAt-bearing UPDATE (= first row's
+      // markAsAbandoned). Second row's UPDATE then succeeds.
+      const { db, updates } = makeFakeDb(stuckRows, { failStateAppliedAtOnce: true })
+      vi.mocked(createDb).mockReturnValue(db)
+      vi.mocked(createWebullHttpClient).mockReturnValue(
+        makeWebullStub({}) as unknown as ReturnType<typeof createWebullHttpClient>,
+      )
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const symbolStub = emptySymbolStateStub()
+
+      const summary = await reconcileFills({
+        env: {
+          DB: FAKE_DB_BINDING,
+          SYMBOL_STATE: makeSymbolStateNamespace(symbolStub) as never,
+        } as never,
+        now: () => new Date('2026-04-25T12:00:00.000Z'),
+        retryStateApply: true,
+      })
+
+      // Both rows attempted the auto-abandon UPDATE (= loop continued
+      // past the first row's failure). Both UPDATEs carry the abandon
+      // marker shape (`stateAppliedAt` + `auto_abandoned_after_*`).
+      expect(updates).toHaveLength(2)
+      expect(updates[0]!.set.stateAppliedAt).toBe('2026-04-25T12:00:00.000Z')
+      expect(updates[0]!.set.stateApplyError).toMatch(/^auto_abandoned_after_5_attempts:/)
+      expect(updates[1]!.set.stateAppliedAt).toBe('2026-04-25T12:00:00.000Z')
+      expect(updates[1]!.set.stateApplyError).toMatch(/^auto_abandoned_after_6_attempts:/)
+      // First row failed: surfaced as an error, NOT counted as abandoned.
+      // Second row succeeded: counted as abandoned.
+      expect(summary.abandoned).toBe(1)
+      expect(summary.stateApplyFailed).toBe(1)
+      expect(summary.errors).toEqual([
+        {
+          clientOrderId: 'coid-stuck-1',
+          message: expect.stringContaining('auto_abandon_failed:'),
+        },
+      ])
+      // Error log emitted for the failed row.
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"event":"reconcile_auto_abandon_error"'),
+      )
+      // Second row's success audit log emitted.
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"event":"reconcile_auto_abandon"'),
+      )
+    })
   })
 })

--- a/test/trading/reconciliation/reconcileFills.test.ts
+++ b/test/trading/reconciliation/reconcileFills.test.ts
@@ -1421,7 +1421,10 @@ describe('reconcileFills state-apply marker (issue #142)', () => {
       // First row failed: surfaced as an error, NOT counted as abandoned.
       // Second row succeeded: counted as abandoned.
       expect(summary.abandoned).toBe(1)
-      expect(summary.stateApplyFailed).toBe(1)
+      // CodeRabbit #228 minor: stateApplyFailed counts DO state apply
+      // failures, not auto-abandon DB UPDATE failures. The latter is
+      // tracked via summary.errors.
+      expect(summary.stateApplyFailed).toBe(0)
       expect(summary.errors).toEqual([
         {
           clientOrderId: 'coid-stuck-1',


### PR DESCRIPTION
## 動機

PR #225 で導入した sanity check (`resolveFilledPrice` の ratio guard) が
broker の stub price を reject すると、その row は永久に repair cohort
に残存し続け、5 分毎の cron tick で同じ `reconcile_fills_partial` アラート
が発火し続ける状態だった。

実例: 9697 (JP) で 6 row が以下の状態のまま attempts 12〜24 まで蓄積、
ユーザーに 1 時間あたり 12 回ペースで同じ警告通知が飛び続けた。

```
broker_status = 'FILLED'
state_applied_at = NULL
filled_price = NULL
state_apply_error = 'sanity_failed: filled_price rejected by ratio guard'
state_apply_attempts = 12〜24
```

各 cycle で:
1. repair cohort SELECT で再選択
2. `recordFill` が price=null で apply 不可
3. `state_apply_error='repair_skipped_invalid_row'` 更新 → attempts++
4. notifier が `reconcile fills had N error(s) ...` 通知

→ 自動回復しない構造で、アラートが永遠に鳴り続ける。

## 設計

`reconcileFills` の repair branch 冒頭に max-retry threshold を追加:

```ts
const MAX_REPAIR_ATTEMPTS = 5

if (
  row.stateApplyAttempts >= MAX_REPAIR_ATTEMPTS &&
  isPermanentSanityFailure(row.stateApplyError)
) {
  await markAsAbandoned(...) // state_applied_at を強制 stamp
  // reconcile_auto_abandon の audit log emit
  summary.abandoned += 1
  continue // summary.errors には積まない
}
```

### 設計判断

- **threshold = 5** (hard-coded): 5 回 = 約 25 分の grace period。transient な
  D1 / DO blip は十分吸収しつつ、構造的に壊れた row が 1 時間以上アラート
  を鳴らし続ける状態を作らない。tunable 化は別 PR (scope 外)。
- **対象は permanent sanity-class エラーのみ** (`sanity_failed` /
  `repair_skipped_invalid_row` 包含):
  - これらは broker が同じ stub を返し続ける限り永遠に同じ結果。
  - retry しても recovery 期待値ゼロ。
- **transient error (broker_5xx / DO unavailable / network) は対象外**:
  - 自動回復可能性があるので、attempts に関わらず retry を継続。
  - `isPermanentSanityFailure` が false を返すので auto-abandon path を
    通らない。
- **`state_apply_error` は preserve**: `auto_abandoned_after_<n>_attempts:`
  接頭辞を付けて元のエラーを残す。operator が後から journal を確認した時に
  「自動 close されたのか」「何が原因だったか」を追跡可能。
- **`reconcile_auto_abandon` audit log emit**: `console.warn` で symbol /
  rowId / clientOrderId / attempts / priorError を JSON 出力。dashboard /
  alerts pipeline で別経路で拾える。
- **summary message に abandoned count 追加**:
  - 旧: `reconcile fills had 6 error(s) across 7 row(s)`
  - 新: `reconcile fills had 6 error(s), 0 abandoned, across 7 row(s)`

## test plan

`test/trading/reconciliation/reconcileFills.test.ts` に 5 ケース追加:

- [x] `attempts=5 + sanity_failed` → auto-abandon (`state_applied_at` set,
      `state_apply_error='auto_abandoned_after_5_attempts: ...'`,
      `summary.abandoned=1`, `summary.errors=[]`, audit log emit)
- [x] `attempts=8 + repair_skipped_invalid_row` → 同様に abandon
- [x] `attempts=4 + sanity_failed` → 既存挙動 (state_applied_at NULL,
      summary.errors に積まれる)
- [x] `attempts=10 + 'DO unavailable'` (transient) → 通常 retry 継続
      (state_applied_at NULL, abandoned=0)
- [x] `attempts=7 + state_apply_error=null` → 通常 retry 継続

検証:

- [x] `pnpm typecheck` clean
- [x] `pnpm test --run` → 928 tests pass (新 5 件含む)
- [ ] 本番では cron tick で観測 (deploy 後)

## scope 外 (別 PR)

- threshold の env tunable 化
- `/dashboard/alerts` での abandoned event 可視化
- 自動 abandon 後の cleanup script (古い row の bulk archive)

## 関連

- 元 issue: [#225](https://github.com/ochanuco/webull-trading/pull/225) (sanity check 導入)
- POC follow-up: 監視運用 (#24) の一部

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 注文調整プロセスで「自動放棄」された行を数える新しいメトリクス（放棄カウント）を追加しました。
  * 放棄カウントが実行イベントのペイロードと部分通知メッセージに含まれるようになりました。

* **テスト**
  * 自動放棄の挙動（放棄、再試行、更新失敗時の継続など）を検証するテストスイートとテスト用サマリ更新を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->