### PR TITLE
feat(dashboard): disabled 銘柄を grayed-out で表示

### DIFF
--- a/src/infrastructure/db/symbolConfigRepo.ts
+++ b/src/infrastructure/db/symbolConfigRepo.ts
@@ -1,4 +1,3 @@
-import { eq } from 'drizzle-orm'
 import type { DrizzleD1Database } from 'drizzle-orm/d1'
 import { inversePairs, symbolConfig } from './schema'
 
@@ -6,52 +5,75 @@ export type SymbolCurrency = 'USD' | 'JPY'
 export type SymbolMarket = 'US' | 'JP'
 
 export interface SymbolConfigSnapshot {
-  /** Uppercased symbols where `active = 1`. */
+  /** Uppercased symbols where `active = 1`. cron / risk gate はこの list だけを評価対象とする。 */
   allowedSymbols: string[]
+  /**
+   * Uppercased symbols where `active = 0`. Operator visibility 用 — dashboard
+   * の picker / table は disabled でも表示し続ける必要がある (operator が
+   * disable 経緯を判断して再有効化判断するため)。cron / risk gate からは見えない。
+   */
+  inactiveSymbols: string[]
   /**
    * symbol → max_notional (positive number). Symbols with `max_notional` NULL
    * are absent from the map — caller falls through to the global
-   * `MAX_ORDER_NOTIONAL`.
+   * `MAX_ORDER_NOTIONAL`. active=0 の銘柄も含む (display 用)。
    */
   symbolMaxNotional: Record<string, number>
-  /** symbol → currency ('USD' / 'JPY')。Risk gate が global 通貨別 cap を引くのに使う。 */
+  /** symbol → currency ('USD' / 'JPY')。Risk gate が global 通貨別 cap を引くのに使う。active=0 含む。 */
   symbolCurrency: Record<string, SymbolCurrency>
   /**
    * symbol → bucket tag。NULL bucket は map に含めない (gate 側で未分類扱い
-   * = 個別銘柄判定)。相関集約 cap (#23 Lane 3) で使う。
+   * = 個別銘柄判定)。相関集約 cap (#23 Lane 3) で使う。active=0 含む。
    */
   symbolBucket: Record<string, string>
   /**
    * symbol → market ('US' | 'JP')。dashboard が JP 銘柄表示を「番号-会社名」
    * に切り替える判定に使う。CHECK 制約は schema 側に無いので 'US' / 'JP'
-   * 以外が混ざる場合は 'US' fallback (defensive)。
+   * 以外が混ざる場合は 'US' fallback (defensive)。active=0 含む。
    */
   symbolMarket: Record<string, SymbolMarket>
   /**
    * symbol → 人間可読な銘柄名 (symbol_config.name)。NULL / 空文字は map に
-   * 含めない。dashboard が JP の `${symbol}-${name}` 表示で使う。
+   * 含めない。dashboard が JP の `${symbol}-${name}` 表示で使う。active=0 含む。
    */
   symbolName: Record<string, string>
+  /**
+   * symbol → notes (symbol_config.notes)。disable 理由などを operator が memo
+   * しておく自由 text。NULL / 空文字は map に含めない。dashboard が disabled
+   * 銘柄の tooltip 表示に使う。active=0 / active=1 両方含む。
+   */
+  symbolNotes: Record<string, string>
 }
 
 /**
  * Loads the per-symbol config from D1. A single query is cheap; no cache at
  * this layer — call sites hold the snapshot for the duration of one handler.
+ *
+ * active=1 / active=0 の両方を取得し、`allowedSymbols` (active=1) と
+ * `inactiveSymbols` (active=0) に振り分ける。cron / risk gate は
+ * `allowedSymbols` のみを参照するため挙動は変えない。dashboard が
+ * disabled 銘柄を grayed-out で表示するために両方を返す (operator visibility)。
  */
 export async function loadSymbolConfig(
   db: DrizzleD1Database,
 ): Promise<SymbolConfigSnapshot> {
-  const rows = await db.select().from(symbolConfig).where(eq(symbolConfig.active, true))
+  const rows = await db.select().from(symbolConfig)
 
   const allowedSymbols: string[] = []
+  const inactiveSymbols: string[] = []
   const symbolMaxNotional: Record<string, number> = {}
   const symbolCurrency: Record<string, SymbolCurrency> = {}
   const symbolBucket: Record<string, string> = {}
   const symbolMarket: Record<string, SymbolMarket> = {}
   const symbolName: Record<string, string> = {}
+  const symbolNotes: Record<string, string> = {}
   for (const row of rows) {
     const symbol = row.symbol.toUpperCase()
-    allowedSymbols.push(symbol)
+    if (row.active) {
+      allowedSymbols.push(symbol)
+    } else {
+      inactiveSymbols.push(symbol)
+    }
     if (row.maxNotional !== null && Number.isFinite(row.maxNotional) && row.maxNotional > 0) {
       symbolMaxNotional[symbol] = row.maxNotional
     }
@@ -70,14 +92,20 @@ export async function loadSymbolConfig(
     if (trimmedName && trimmedName.length > 0) {
       symbolName[symbol] = trimmedName
     }
+    const trimmedNotes = row.notes?.trim()
+    if (trimmedNotes && trimmedNotes.length > 0) {
+      symbolNotes[symbol] = trimmedNotes
+    }
   }
   return {
     allowedSymbols,
+    inactiveSymbols,
     symbolMaxNotional,
     symbolCurrency,
     symbolBucket,
     symbolMarket,
     symbolName,
+    symbolNotes,
   }
 }
 

--- a/src/infrastructure/db/symbolUniverse.ts
+++ b/src/infrastructure/db/symbolUniverse.ts
@@ -7,7 +7,14 @@ import {
 } from './symbolConfigRepo'
 
 export interface SymbolUniverse {
+  /** active=1 のみ。cron / risk gate の評価対象。 */
   allowedSymbols: string[]
+  /**
+   * active=0 (一時停止扱い) の symbols。dashboard 表示専用 — operator が
+   * disable 経緯を確認できるよう grayed-out で picker / table に出す。
+   * cron / risk gate からは参照されない (= 評価対象は allowedSymbols のみ)。
+   */
+  inactiveSymbols: string[]
   symbolMaxNotional: Record<string, number>
   symbolCurrency: Record<string, SymbolCurrency>
   symbolBucket: Record<string, string>
@@ -15,6 +22,11 @@ export interface SymbolUniverse {
   symbolMarket: Record<string, SymbolMarket>
   /** symbol → 人間可読 name (symbol_config.name、null は map に不在)。 */
   symbolName: Record<string, string>
+  /**
+   * symbol → notes (symbol_config.notes)。disable 理由などの自由 text。
+   * dashboard が disabled 銘柄の tooltip 表示に使う。null / 空文字は map に不在。
+   */
+  symbolNotes: Record<string, string>
   inversePairs: Record<string, string>
   source: 'd1'
 }
@@ -37,11 +49,13 @@ export async function loadSymbolUniverse(env: UniverseEnv): Promise<SymbolUniver
   const [config, pairs] = await Promise.all([loadSymbolConfig(db), loadInversePairs(db)])
   return {
     allowedSymbols: config.allowedSymbols,
+    inactiveSymbols: config.inactiveSymbols,
     symbolMaxNotional: config.symbolMaxNotional,
     symbolCurrency: config.symbolCurrency,
     symbolBucket: config.symbolBucket,
     symbolMarket: config.symbolMarket,
     symbolName: config.symbolName,
+    symbolNotes: config.symbolNotes,
     inversePairs: pairs,
     source: 'd1',
   }

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -35,7 +35,7 @@ export const dashboard = new Hono<AppBindings>()
     }
     const universe = await loadSymbolUniverse(c.env)
     const client = new SymbolStateClient(c.env.SYMBOL_STATE)
-    // disabled 銘柄も表示する (operator visibility) — chart に飛んで状態を確認したり
+    // inactive 銘柄も表示する (operator visibility) — chart に飛んで状態を確認したり
     // 再有効化判断したりするのに必要。cron / risk gate は引き続き allowedSymbols のみ評価。
     const allDisplaySymbols = [...universe.allowedSymbols, ...universe.inactiveSymbols]
     const [rows, strategyPriceMap] = await Promise.all([
@@ -140,10 +140,16 @@ export const dashboard = new Hono<AppBindings>()
           takeProfitPct: global.pullbackDefaultTakeProfitPct,
           timeStopDays: global.pullbackDefaultTimeStopDays,
         }
-        // disabled 銘柄も grid に出す (operator visibility)。cron 評価対象は変えない
-        // (= allowedSymbols だけ)。表示時に panel が grayed-out になる。
-        const allGridSymbols = [...universe.allowedSymbols, ...universe.inactiveSymbols]
-        const charts = await loadAllSymbolCharts(c.env, allGridSymbols, rules)
+        // 重い chart データ取得 (Yahoo daily + intraday + D1 + DO で銘柄あたり
+        // ~5 subrequest) は active 銘柄に限定する。inactive 銘柄が増えると
+        // Workers subrequest budget を逼迫させるため、grid では fetch なしの
+        // 静的 placeholder panel として表示する (operator は個別タブへ遷移して
+        // 必要に応じて深掘る)。
+        const charts = await loadAllSymbolCharts(c.env, universe.allowedSymbols, rules)
+        const inactivePlaceholders = universe.inactiveSymbols.map((symbol) => ({
+          symbol,
+          note: universe.symbolNotes[symbol] ?? null,
+        }))
         // grid の zoom 基準: 全 panel 共通の dataZoom 同期があるため、最初に
         // load 成功した chart の lastTimestamp を基準に直近 7 日 (default) を
         // 採用する。URL ?from / ?to があればそれを優先 (既存と同挙動)。
@@ -155,6 +161,7 @@ export const dashboard = new Hono<AppBindings>()
             chartsBody({
               tab,
               charts,
+              inactivePlaceholders,
               zoom,
               universe,
             }),
@@ -167,8 +174,8 @@ export const dashboard = new Hono<AppBindings>()
         loadSymbolUniverse(c.env),
         loadGlobalConfigFrom(c.env, c.get('requestId')),
       ])
-      // 表示候補: active + inactive 銘柄。focusSymbol は disabled でも valid と扱う
-      // (operator が chart で disable 後の動向を確認できるよう)。default は active を優先。
+      // 表示候補: active + inactive 銘柄。focusSymbol は inactive でも valid と扱う
+      // (operator が chart で inactivate 後の動向を確認できるよう)。default は active を優先。
       const allDisplaySymbols = [...universe.allowedSymbols, ...universe.inactiveSymbols]
       const allDisplaySet = new Set(allDisplaySymbols)
       const allowed = new Set(universe.allowedSymbols)
@@ -411,23 +418,27 @@ function displaySymbol(symbol: string, universe?: SymbolUniverse | null): string
 
 /**
  * symbol が universe.inactiveSymbols (= active=0) に含まれていれば true。
- * universe が null / 未配線の時は false (= 既存挙動を変えない)。
+ * `inactiveSymbols` は active=0 全般 (disable / pause 含む) なので "inactive"
+ * と中立的に呼ぶ。universe が null / 未配線の時は false (= 既存挙動を変えない)。
  */
-function isSymbolDisabled(symbol: string, universe?: SymbolUniverse | null): boolean {
+function isSymbolInactive(symbol: string, universe?: SymbolUniverse | null): boolean {
   if (!universe) return false
   const upper = symbol.toUpperCase()
   return universe.inactiveSymbols.includes(upper)
 }
 
 /**
- * disabled 銘柄の tooltip 用テキスト ("DISABLED: <notes>" 形式)。notes が
- * 無ければ単に "DISABLED"。HTML escape は呼び出し側の責任。
+ * inactive 銘柄の tooltip 用テキスト ("INACTIVE: <notes>" 形式)。notes が
+ * 無ければ単に "INACTIVE"。HTML escape は呼び出し側の責任。
+ *
+ * `inactiveSymbols` は disable (恒久) と pause (一時停止) を区別しないため、
+ * 中立的な "INACTIVE" を採用 (元の "DISABLED" は pause 銘柄を誤認させる)。
  */
-function disabledTooltip(symbol: string, universe?: SymbolUniverse | null): string {
+function inactiveTooltip(symbol: string, universe?: SymbolUniverse | null): string {
   if (!universe) return ''
   const upper = symbol.toUpperCase()
   const note = universe.symbolNotes[upper]
-  return note ? `DISABLED: ${note}` : 'DISABLED'
+  return note ? `INACTIVE: ${note}` : 'INACTIVE'
 }
 
 function clampLimit(raw: string | undefined): number {
@@ -659,10 +670,10 @@ function positionsBody(
   if (rows.length === 0) return `<p class="muted">有効な銘柄がありません。</p>`
   const tbody = rows
     .map((r) => {
-      const disabled = isSymbolDisabled(r.sym, universe)
-      const rowClass = disabled ? ' class="symbol-disabled-row"' : ''
-      const symbolClass = disabled ? ' class="symbol-disabled"' : ''
-      const titleAttr = disabled ? ` title="${esc(disabledTooltip(r.sym, universe))}"` : ''
+      const inactive = isSymbolInactive(r.sym, universe)
+      const rowClass = inactive ? ' class="symbol-disabled-row"' : ''
+      const symbolClass = inactive ? ' class="symbol-disabled"' : ''
+      const titleAttr = inactive ? ` title="${esc(inactiveTooltip(r.sym, universe))}"` : ''
       if (r.error !== null || r.state === null) {
         return `<tr${rowClass}><td><span${symbolClass}${titleAttr}>${esc(displaySymbol(r.sym, universe))}</span></td><td colspan="7" class="err">${esc(r.error ?? '状態取得不可')}</td></tr>`
       }
@@ -828,9 +839,9 @@ function tradesBody(
       const statusText =
         r.errorMessage ? `エラー: ${r.errorMessage}` : r.brokerStatus ?? r.tradeEventType
       const symbolText = r.symbol ? displaySymbol(r.symbol, universe) : '—'
-      const disabled = r.symbol ? isSymbolDisabled(r.symbol, universe) : false
-      const symbolCellInner = r.symbol && disabled
-        ? `<span class="symbol-disabled" title="${esc(disabledTooltip(r.symbol, universe))}">${esc(symbolText)}</span>`
+      const inactive = r.symbol ? isSymbolInactive(r.symbol, universe) : false
+      const symbolCellInner = r.symbol && inactive
+        ? `<span class="symbol-disabled" title="${esc(inactiveTooltip(r.symbol, universe))}">${esc(symbolText)}</span>`
         : esc(symbolText)
       return `<tr>
         <td>${r.id}</td>
@@ -887,12 +898,12 @@ function configBody(
   const allConfigSymbols = [...universe.allowedSymbols, ...universe.inactiveSymbols]
   const symRows = allConfigSymbols
     .map((sym) => {
-      const disabled = isSymbolDisabled(sym, universe)
-      const rowClass = disabled ? ' class="symbol-disabled-row"' : ''
-      const symbolClass = disabled ? ' class="symbol-disabled"' : ''
-      const titleAttr = disabled ? ` title="${esc(disabledTooltip(sym, universe))}"` : ''
-      const stateCell = disabled
-        ? '<span class="muted">disabled</span>'
+      const inactive = isSymbolInactive(sym, universe)
+      const rowClass = inactive ? ' class="symbol-disabled-row"' : ''
+      const symbolClass = inactive ? ' class="symbol-disabled"' : ''
+      const titleAttr = inactive ? ` title="${esc(inactiveTooltip(sym, universe))}"` : ''
+      const stateCell = inactive
+        ? '<span class="muted">inactive</span>'
         : '<span class="ok">active</span>'
       const noteText = universe.symbolNotes[sym] ?? null
       const noteCell = noteText ? esc(noteText) : '<span class="muted">—</span>'
@@ -914,10 +925,10 @@ function configBody(
     </table>
   </details>
   <details open>
-    <summary>銘柄別設定 (symbol_config) — active ${universe.allowedSymbols.length} / disabled ${universe.inactiveSymbols.length} 銘柄</summary>
+    <summary>銘柄別設定 (symbol_config) — active ${universe.allowedSymbols.length} / inactive ${universe.inactiveSymbols.length} 銘柄</summary>
     <p class="muted" style="font-size:12px">
-      disabled (active=0) 銘柄も表示しています。cron / risk gate の評価対象は active=1 のみで、
-      disabled 銘柄は灰色斜体・取消線で区別しています。再有効化は <code>UPDATE symbol_config SET active = 1 WHERE symbol = '...'</code>。
+      inactive (active=0) 銘柄も表示しています。cron / risk gate の評価対象は active=1 のみで、
+      inactive 銘柄は灰色斜体・取消線で区別しています。再有効化は <code>UPDATE symbol_config SET active = 1 WHERE symbol = '...'</code>。
     </p>
     <table>
       <thead><tr><th>銘柄</th><th>状態</th><th>通貨</th><th>1注文あたり上限 (max_notional)</th><th>インバース対 (inverse)</th><th>メモ (notes)</th></tr></thead>
@@ -1334,9 +1345,9 @@ function alertsBody(args: AlertsBodyArgs): string {
           : r.severity === 'warning'
             ? 'warn'
             : 'muted'
-      const symbolDisabled = r.symbol ? isSymbolDisabled(r.symbol, universe) : false
+      const symbolInactive = r.symbol ? isSymbolInactive(r.symbol, universe) : false
       const symbolCell = r.symbol
-        ? `<a href="/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(r.symbol)}"${symbolDisabled ? ` title="${esc(disabledTooltip(r.symbol, universe))}"` : ''}><span${symbolDisabled ? ' class="symbol-disabled"' : ''}>${esc(displaySymbol(r.symbol, universe))}</span></a>`
+        ? `<a href="/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(r.symbol)}"${symbolInactive ? ` title="${esc(inactiveTooltip(r.symbol, universe))}"` : ''}><span${symbolInactive ? ' class="symbol-disabled"' : ''}>${esc(displaySymbol(r.symbol, universe))}</span></a>`
         : '<span class="muted">-</span>'
       return `<tr>
         <td class="muted">${esc(fmtJst(r.timestamp))}</td>
@@ -1460,9 +1471,9 @@ function cronBody(
         r.filledPrice === null || r.filledPrice === undefined
           ? '-'
           : `${fmtNumber(r.filledPrice, 2)} × ${r.filledQty ?? '?'}`
-      const disabled = isSymbolDisabled(r.symbol, universe)
-      const symbolClass = disabled ? ' class="symbol-disabled"' : ''
-      const titleAttr = disabled ? ` title="${esc(disabledTooltip(r.symbol, universe))}"` : ''
+      const inactive = isSymbolInactive(r.symbol, universe)
+      const symbolClass = inactive ? ' class="symbol-disabled"' : ''
+      const titleAttr = inactive ? ` title="${esc(inactiveTooltip(r.symbol, universe))}"` : ''
       return `<tr>
         <td class="muted">${esc(fmtJst(r.timestamp))}</td>
         <td><a href="/dashboard/cron?symbol=${encodeURIComponent(r.symbol)}"${titleAttr}><strong><span${symbolClass}>${esc(displaySymbol(r.symbol, universe))}</span></strong></a></td>
@@ -2718,8 +2729,20 @@ interface ChartsBodySymbol {
  */
 interface ChartsBodyGrid {
   tab: 'grid'
-  /** 全銘柄の SymbolChartData (load 失敗銘柄は値 null。1 銘柄失敗で全 grid を 500 にしない) */
+  /**
+   * Active (cron 評価対象) 銘柄の SymbolChartData (load 失敗銘柄は値 null。
+   * 1 銘柄失敗で全 grid を 500 にしない)。
+   */
   charts: Array<{ symbol: string; chart: SymbolChartData | null; error: string | null }>
+  /**
+   * Inactive (active=0) 銘柄の static placeholder。chart データは fetch せず、
+   * grid 上では灰色の panel + INACTIVE バッジ + notes tooltip だけを描画する。
+   * 個別タブ (?tab=symbol&symbol=...) へ link して operator が深掘りできる。
+   *
+   * 旧実装は inactive も `loadAllSymbolCharts` に投げていたが、銘柄あたり
+   * ~5 subrequest かかるため Workers の budget を圧迫する (CodeRabbit #229)。
+   */
+  inactivePlaceholders?: Array<{ symbol: string; note: string | null }>
   /** dataZoom 初期範囲。null なら全期間 */
   zoom: { from: Date; to: Date } | null
   /** panel header の銘柄表示を JP 銘柄向け 番号-会社名 形式にするための universe。 */
@@ -3688,7 +3711,8 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
  * - SMA50 / band / 詳細パネルは省略 (panel size に合わせて視認性を優先)
  */
 export function renderGridTab(args: ChartsBodyGrid): string {
-  if (args.charts.length === 0) {
+  const inactivePlaceholders = args.inactivePlaceholders ?? []
+  if (args.charts.length === 0 && inactivePlaceholders.length === 0) {
     return `<p class="muted">ALLOWED_SYMBOLS が空です。<code>symbol_config</code> に少なくとも 1 銘柄登録してください。</p>`
   }
   // grid 共通 toolbar の preset zoom buttons。reference chart (最初に load 成功)
@@ -3697,31 +3721,23 @@ export function renderGridTab(args: ChartsBodyGrid): string {
   const referenceChart = args.charts.find((c) => c.chart !== null)?.chart ?? null
   const presetButtonsHtml = renderZoomPresetButtons(referenceChart)
 
-  // 各 panel の HTML container。chart 本体は client side で echarts.init される。
+  // Active panel: chart 本体は client side で echarts.init される。
   // panel header に symbol 名 (詳細タブへの link) と最新 indicators (price /
   // SMA50 / high20d / low20d) を出して「市場全体ビュー」で trader が銘柄を
   // 一目で識別できるようにする。
-  const panelsHtml = args.charts
+  // Note: args.charts は active 銘柄だけで構成される (inactive は別経路)。
+  const activePanelsHtml = args.charts
     .map((entry, idx) => {
-      const disabled = isSymbolDisabled(entry.symbol, args.universe)
-      const panelStyle = disabled
-        ? 'border:1px solid #d0d0d5;border-radius:6px;padding:8px;background:#fafafa;opacity:0.65'
-        : 'border:1px solid #d0d0d5;border-radius:6px;padding:8px;background:#fff'
+      const panelStyle = 'border:1px solid #d0d0d5;border-radius:6px;padding:8px;background:#fff'
       const symbolLink = `/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(entry.symbol)}`
       const headerText = displaySymbol(entry.symbol, args.universe)
-      const linkClass = disabled ? ' class="symbol-disabled"' : ''
-      const titleAttr = disabled ? ` title="${esc(disabledTooltip(entry.symbol, args.universe))}"` : ''
-      const headerLink = `<a href="${symbolLink}"${linkClass}${titleAttr} style="font-weight:600;font-size:14px;color:#06c;text-decoration:none">${esc(headerText)}</a>`
-      const disabledBadge = disabled
-        ? `<span class="muted" style="font-size:11px">disabled</span>`
-        : ''
+      const headerLink = `<a href="${symbolLink}" style="font-weight:600;font-size:14px;color:#06c;text-decoration:none">${esc(headerText)}</a>`
       if (entry.chart === null) {
         const errMsg = entry.error ?? 'チャートデータ取得失敗'
         return `<div class="grid-panel" style="${panelStyle}">
           <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:4px;gap:8px">
             ${headerLink}
             <span class="warn" style="font-size:11px">取得失敗</span>
-            ${disabledBadge}
           </div>
           <div class="muted" style="font-size:12px;padding:24px 8px;text-align:center">${esc(errMsg)}</div>
         </div>`
@@ -3731,12 +3747,40 @@ export function renderGridTab(args: ChartsBodyGrid): string {
         <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:4px;gap:8px">
           ${headerLink}
           ${badge}
-          ${disabledBadge}
         </div>
         <div id="grid-chart-${idx}" style="width:100%;height:280px"></div>
       </div>`
     })
     .join('')
+
+  // Inactive placeholder panel: chart データを fetch せず、symbol header と
+  // INACTIVE バッジ + notes tooltip だけ描画する。個別タブへ link することで
+  // operator が必要な時だけ chart を fetch できる (subrequest 軽量化)。
+  const inactivePanelsHtml = inactivePlaceholders
+    .map((entry) => {
+      const panelStyle = 'border:1px solid #d0d0d5;border-radius:6px;padding:8px;background:#fafafa;opacity:0.65'
+      const symbolLink = `/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(entry.symbol)}`
+      const headerText = displaySymbol(entry.symbol, args.universe)
+      const tooltipText = entry.note ? `INACTIVE: ${entry.note}` : 'INACTIVE'
+      const titleAttr = ` title="${esc(tooltipText)}"`
+      const headerLink = `<a href="${symbolLink}" class="symbol-disabled"${titleAttr} style="font-weight:600;font-size:14px;color:#06c;text-decoration:none">${esc(headerText)}</a>`
+      const noteHtml = entry.note
+        ? `<div class="muted" style="font-size:11px;padding:4px 0 0">${esc(entry.note)}</div>`
+        : ''
+      return `<div class="grid-panel" style="${panelStyle}">
+        <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:4px;gap:8px">
+          ${headerLink}
+          <span class="muted" style="font-size:11px">INACTIVE</span>
+        </div>
+        <div class="muted" style="font-size:12px;padding:24px 8px;text-align:center">
+          チャート未取得 (cron 評価対象外) — <a href="${symbolLink}">個別タブで表示</a>
+        </div>
+        ${noteHtml}
+      </div>`
+    })
+    .join('')
+
+  const panelsHtml = activePanelsHtml + inactivePanelsHtml
 
   // client 側に渡す全銘柄分の chart payload。各 panel が個別 echarts.init で
   // 消費する。__chartData.charts は array of { symbol, chart, displayName }
@@ -4373,10 +4417,10 @@ function renderSymbolPickerForTab(args: ChartsBodySymbol): string {
     : ''
   const opts = args.availableSymbols
     .map((s) => {
-      const disabled = isSymbolDisabled(s, args.universe)
+      const inactive = isSymbolInactive(s, args.universe)
       const isFocus = s === args.focusSymbol
-      const linkClass = disabled ? ' class="symbol-disabled"' : ''
-      const titleAttr = disabled ? ` title="${esc(disabledTooltip(s, args.universe))}"` : ''
+      const linkClass = inactive ? ' class="symbol-disabled"' : ''
+      const titleAttr = inactive ? ` title="${esc(inactiveTooltip(s, args.universe))}"` : ''
       return `<a href="/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(s)}${zoomQs}"${linkClass}${titleAttr} style="margin-right:6px;${
         isFocus ? 'font-weight:600;text-decoration:underline' : ''
       }">${esc(displaySymbol(s, args.universe))}</a>`
@@ -4385,11 +4429,11 @@ function renderSymbolPickerForTab(args: ChartsBodySymbol): string {
   const focusLabel = args.focusSymbol
     ? displaySymbol(args.focusSymbol, args.universe)
     : '—'
-  const focusDisabled = args.focusSymbol
-    ? isSymbolDisabled(args.focusSymbol, args.universe)
+  const focusInactive = args.focusSymbol
+    ? isSymbolInactive(args.focusSymbol, args.universe)
     : false
-  const focusBadge = focusDisabled
-    ? ` <span class="muted" style="font-size:11px">(disabled — ${esc(args.universe?.symbolNotes[args.focusSymbol!.toUpperCase()] ?? 'cron 評価対象外')})</span>`
+  const focusBadge = focusInactive
+    ? ` <span class="muted" style="font-size:11px">(inactive — ${esc(args.universe?.symbolNotes[args.focusSymbol!.toUpperCase()] ?? 'cron 評価対象外')})</span>`
     : ''
   return `<p class="muted" style="font-size:12px">
     銘柄: <strong>${esc(focusLabel)}</strong>${focusBadge} | 切替: ${opts}

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -35,9 +35,12 @@ export const dashboard = new Hono<AppBindings>()
     }
     const universe = await loadSymbolUniverse(c.env)
     const client = new SymbolStateClient(c.env.SYMBOL_STATE)
+    // disabled 銘柄も表示する (operator visibility) — chart に飛んで状態を確認したり
+    // 再有効化判断したりするのに必要。cron / risk gate は引き続き allowedSymbols のみ評価。
+    const allDisplaySymbols = [...universe.allowedSymbols, ...universe.inactiveSymbols]
     const [rows, strategyPriceMap] = await Promise.all([
       Promise.all(
-        universe.allowedSymbols.map(async (sym) => {
+        allDisplaySymbols.map(async (sym) => {
           try {
             return { sym, state: await client.getState(sym), error: null as string | null }
           } catch (err) {
@@ -45,7 +48,7 @@ export const dashboard = new Hono<AppBindings>()
           }
         }),
       ),
-      loadLatestStrategyPrices(c.env.DB, universe.allowedSymbols),
+      loadLatestStrategyPrices(c.env.DB, allDisplaySymbols),
     ])
     return c.html(layout('保有状況', positionsBody(rows, strategyPriceMap, universe)))
   })
@@ -137,7 +140,10 @@ export const dashboard = new Hono<AppBindings>()
           takeProfitPct: global.pullbackDefaultTakeProfitPct,
           timeStopDays: global.pullbackDefaultTimeStopDays,
         }
-        const charts = await loadAllSymbolCharts(c.env, universe.allowedSymbols, rules)
+        // disabled 銘柄も grid に出す (operator visibility)。cron 評価対象は変えない
+        // (= allowedSymbols だけ)。表示時に panel が grayed-out になる。
+        const allGridSymbols = [...universe.allowedSymbols, ...universe.inactiveSymbols]
+        const charts = await loadAllSymbolCharts(c.env, allGridSymbols, rules)
         // grid の zoom 基準: 全 panel 共通の dataZoom 同期があるため、最初に
         // load 成功した chart の lastTimestamp を基準に直近 7 日 (default) を
         // 採用する。URL ?from / ?to があればそれを優先 (既存と同挙動)。
@@ -161,14 +167,18 @@ export const dashboard = new Hono<AppBindings>()
         loadSymbolUniverse(c.env),
         loadGlobalConfigFrom(c.env, c.get('requestId')),
       ])
+      // 表示候補: active + inactive 銘柄。focusSymbol は disabled でも valid と扱う
+      // (operator が chart で disable 後の動向を確認できるよう)。default は active を優先。
+      const allDisplaySymbols = [...universe.allowedSymbols, ...universe.inactiveSymbols]
+      const allDisplaySet = new Set(allDisplaySymbols)
       const allowed = new Set(universe.allowedSymbols)
       const defaultSymbol = await pickDefaultSymbol(c.env.DB)
       const focusSymbol =
-        symbolParam && allowed.has(symbolParam)
+        symbolParam && allDisplaySet.has(symbolParam)
           ? symbolParam
           : defaultSymbol && allowed.has(defaultSymbol)
             ? defaultSymbol
-            : universe.allowedSymbols[0] ?? null
+            : universe.allowedSymbols[0] ?? universe.inactiveSymbols[0] ?? null
       // ルール閾値は global_config から。per-symbol override は POC で未対応
       // (symbol_rules table が無い、env-var 経由なので動的反映困難)。
       const strategyParams: StrategyParamsSnapshot = {
@@ -207,7 +217,7 @@ export const dashboard = new Hono<AppBindings>()
             tab,
             focusSymbol,
             symbolChart,
-            availableSymbols: universe.allowedSymbols,
+            availableSymbols: allDisplaySymbols,
             strategyParams,
             zoom,
             universe,
@@ -399,6 +409,27 @@ function displaySymbol(symbol: string, universe?: SymbolUniverse | null): string
   })
 }
 
+/**
+ * symbol が universe.inactiveSymbols (= active=0) に含まれていれば true。
+ * universe が null / 未配線の時は false (= 既存挙動を変えない)。
+ */
+function isSymbolDisabled(symbol: string, universe?: SymbolUniverse | null): boolean {
+  if (!universe) return false
+  const upper = symbol.toUpperCase()
+  return universe.inactiveSymbols.includes(upper)
+}
+
+/**
+ * disabled 銘柄の tooltip 用テキスト ("DISABLED: <notes>" 形式)。notes が
+ * 無ければ単に "DISABLED"。HTML escape は呼び出し側の責任。
+ */
+function disabledTooltip(symbol: string, universe?: SymbolUniverse | null): string {
+  if (!universe) return ''
+  const upper = symbol.toUpperCase()
+  const note = universe.symbolNotes[upper]
+  return note ? `DISABLED: ${note}` : 'DISABLED'
+}
+
 function clampLimit(raw: string | undefined): number {
   const n = raw === undefined ? 50 : Number.parseInt(raw, 10)
   if (!Number.isFinite(n) || n <= 0) return 50
@@ -475,6 +506,9 @@ const STYLE = `
   .reason-panel ul{margin:4px 0 10px;padding-left:20px}
   .reason-panel code{white-space:pre-wrap;word-break:break-word}
   .reason-panel pre{margin:4px 0 0;white-space:pre-wrap;word-break:break-word;font-size:12px}
+  .symbol-disabled{opacity:0.5;font-style:italic;text-decoration:line-through}
+  tr.symbol-disabled-row{background:#fafafa}
+  tr.symbol-disabled-row td{color:#86868b}
 `
 
 function layout(title: string, body: string): string {
@@ -625,8 +659,12 @@ function positionsBody(
   if (rows.length === 0) return `<p class="muted">有効な銘柄がありません。</p>`
   const tbody = rows
     .map((r) => {
+      const disabled = isSymbolDisabled(r.sym, universe)
+      const rowClass = disabled ? ' class="symbol-disabled-row"' : ''
+      const symbolClass = disabled ? ' class="symbol-disabled"' : ''
+      const titleAttr = disabled ? ` title="${esc(disabledTooltip(r.sym, universe))}"` : ''
       if (r.error !== null || r.state === null) {
-        return `<tr><td>${esc(displaySymbol(r.sym, universe))}</td><td colspan="7" class="err">${esc(r.error ?? '状態取得不可')}</td></tr>`
+        return `<tr${rowClass}><td><span${symbolClass}${titleAttr}>${esc(displaySymbol(r.sym, universe))}</span></td><td colspan="7" class="err">${esc(r.error ?? '状態取得不可')}</td></tr>`
       }
       const s = r.state
       const pos = s.position
@@ -644,8 +682,8 @@ function positionsBody(
       const quoteCell = quote
         ? `${fmtNumber(quote.price, 2)} <span class="muted" style="font-size:11px">(${esc(quote.source)}, ${esc(formatQuoteAsOf(quote.asOf))})</span>`
         : '<span class="muted">—</span>'
-      return `<tr>
-        <td><strong>${esc(displaySymbol(s.symbol, universe))}</strong></td>
+      return `<tr${rowClass}>
+        <td><strong><span${symbolClass}${titleAttr}>${esc(displaySymbol(s.symbol, universe))}</span></strong></td>
         <td>${pos ? esc(pos.qty) : '<span class="muted">—</span>'}</td>
         <td>${pos ? fmtNumber(pos.avgPrice, 2) : '<span class="muted">—</span>'}</td>
         <td>${quoteCell}</td>
@@ -790,11 +828,15 @@ function tradesBody(
       const statusText =
         r.errorMessage ? `エラー: ${r.errorMessage}` : r.brokerStatus ?? r.tradeEventType
       const symbolText = r.symbol ? displaySymbol(r.symbol, universe) : '—'
+      const disabled = r.symbol ? isSymbolDisabled(r.symbol, universe) : false
+      const symbolCellInner = r.symbol && disabled
+        ? `<span class="symbol-disabled" title="${esc(disabledTooltip(r.symbol, universe))}">${esc(symbolText)}</span>`
+        : esc(symbolText)
       return `<tr>
         <td>${r.id}</td>
         <td class="muted">${esc(fmtJst(r.timestamp))}</td>
         <td>${esc(r.tradeEventType)}</td>
-        <td><strong>${esc(symbolText)}</strong></td>
+        <td><strong>${symbolCellInner}</strong></td>
         <td>${esc(r.side ?? '—')}</td>
         <td>${r.quantity === null ? '—' : esc(r.quantity)}</td>
         <td>${r.limitPrice === null ? '—' : fmtNumber(r.limitPrice, 2)}</td>
@@ -839,16 +881,30 @@ function configBody(
       return `<tr><th>${esc(camelKey)}</th><td>${esc(formatConfigValue(v))}</td><td class="muted">${esc(label)}</td><td class="muted" style="font-size:11px">${esc(detail)}</td></tr>`
     })
     .join('')
-  const symRows = universe.allowedSymbols
-    .map(
-      (sym) =>
-        `<tr>
-          <td><strong>${esc(displaySymbol(sym, universe))}</strong></td>
+  // active + inactive 両方を 1 つの table で表示。inactive 行は grayed-out 化し、
+  // 「状態」「メモ (notes)」列で disable 経緯が読める。cron 評価対象は active=1 のみ
+  // (allowedSymbols)、表示のみ全件出すのが今 PR の趣旨。
+  const allConfigSymbols = [...universe.allowedSymbols, ...universe.inactiveSymbols]
+  const symRows = allConfigSymbols
+    .map((sym) => {
+      const disabled = isSymbolDisabled(sym, universe)
+      const rowClass = disabled ? ' class="symbol-disabled-row"' : ''
+      const symbolClass = disabled ? ' class="symbol-disabled"' : ''
+      const titleAttr = disabled ? ` title="${esc(disabledTooltip(sym, universe))}"` : ''
+      const stateCell = disabled
+        ? '<span class="muted">disabled</span>'
+        : '<span class="ok">active</span>'
+      const noteText = universe.symbolNotes[sym] ?? null
+      const noteCell = noteText ? esc(noteText) : '<span class="muted">—</span>'
+      return `<tr${rowClass}>
+          <td><strong><span${symbolClass}${titleAttr}>${esc(displaySymbol(sym, universe))}</span></strong></td>
+          <td>${stateCell}</td>
           <td>${esc(universe.symbolCurrency[sym] ?? '—')}</td>
           <td>${universe.symbolMaxNotional[sym] != null ? esc(universe.symbolMaxNotional[sym]) : '<span class="muted">—</span>'}</td>
           <td>${universe.inversePairs[sym] ? esc(universe.inversePairs[sym]) : '<span class="muted">—</span>'}</td>
-        </tr>`,
-    )
+          <td>${noteCell}</td>
+        </tr>`
+    })
     .join('')
   return `<details open>
     <summary>グローバル設定 (global_config)</summary>
@@ -858,9 +914,13 @@ function configBody(
     </table>
   </details>
   <details open>
-    <summary>銘柄別設定 (symbol_config、active=1) — ${universe.allowedSymbols.length} 銘柄</summary>
+    <summary>銘柄別設定 (symbol_config) — active ${universe.allowedSymbols.length} / disabled ${universe.inactiveSymbols.length} 銘柄</summary>
+    <p class="muted" style="font-size:12px">
+      disabled (active=0) 銘柄も表示しています。cron / risk gate の評価対象は active=1 のみで、
+      disabled 銘柄は灰色斜体・取消線で区別しています。再有効化は <code>UPDATE symbol_config SET active = 1 WHERE symbol = '...'</code>。
+    </p>
     <table>
-      <thead><tr><th>銘柄</th><th>通貨</th><th>1注文あたり上限 (max_notional)</th><th>インバース対 (inverse)</th></tr></thead>
+      <thead><tr><th>銘柄</th><th>状態</th><th>通貨</th><th>1注文あたり上限 (max_notional)</th><th>インバース対 (inverse)</th><th>メモ (notes)</th></tr></thead>
       <tbody>${symRows}</tbody>
     </table>
   </details>`
@@ -1274,8 +1334,9 @@ function alertsBody(args: AlertsBodyArgs): string {
           : r.severity === 'warning'
             ? 'warn'
             : 'muted'
+      const symbolDisabled = r.symbol ? isSymbolDisabled(r.symbol, universe) : false
       const symbolCell = r.symbol
-        ? `<a href="/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(r.symbol)}">${esc(displaySymbol(r.symbol, universe))}</a>`
+        ? `<a href="/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(r.symbol)}"${symbolDisabled ? ` title="${esc(disabledTooltip(r.symbol, universe))}"` : ''}><span${symbolDisabled ? ' class="symbol-disabled"' : ''}>${esc(displaySymbol(r.symbol, universe))}</span></a>`
         : '<span class="muted">-</span>'
       return `<tr>
         <td class="muted">${esc(fmtJst(r.timestamp))}</td>
@@ -1399,9 +1460,12 @@ function cronBody(
         r.filledPrice === null || r.filledPrice === undefined
           ? '-'
           : `${fmtNumber(r.filledPrice, 2)} × ${r.filledQty ?? '?'}`
+      const disabled = isSymbolDisabled(r.symbol, universe)
+      const symbolClass = disabled ? ' class="symbol-disabled"' : ''
+      const titleAttr = disabled ? ` title="${esc(disabledTooltip(r.symbol, universe))}"` : ''
       return `<tr>
         <td class="muted">${esc(fmtJst(r.timestamp))}</td>
-        <td><a href="/dashboard/cron?symbol=${encodeURIComponent(r.symbol)}"><strong>${esc(displaySymbol(r.symbol, universe))}</strong></a></td>
+        <td><a href="/dashboard/cron?symbol=${encodeURIComponent(r.symbol)}"${titleAttr}><strong><span${symbolClass}>${esc(displaySymbol(r.symbol, universe))}</span></strong></a></td>
         <td class="${cls}">${esc(r.decision)}</td>
         <td>${cronReasonCell(r)}</td>
         <td>${r.price === null ? '-' : fmtNumber(r.price, 2)}</td>
@@ -3639,24 +3703,35 @@ export function renderGridTab(args: ChartsBodyGrid): string {
   // 一目で識別できるようにする。
   const panelsHtml = args.charts
     .map((entry, idx) => {
+      const disabled = isSymbolDisabled(entry.symbol, args.universe)
+      const panelStyle = disabled
+        ? 'border:1px solid #d0d0d5;border-radius:6px;padding:8px;background:#fafafa;opacity:0.65'
+        : 'border:1px solid #d0d0d5;border-radius:6px;padding:8px;background:#fff'
       const symbolLink = `/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(entry.symbol)}`
       const headerText = displaySymbol(entry.symbol, args.universe)
-      const headerLink = `<a href="${symbolLink}" style="font-weight:600;font-size:14px;color:#06c;text-decoration:none">${esc(headerText)}</a>`
+      const linkClass = disabled ? ' class="symbol-disabled"' : ''
+      const titleAttr = disabled ? ` title="${esc(disabledTooltip(entry.symbol, args.universe))}"` : ''
+      const headerLink = `<a href="${symbolLink}"${linkClass}${titleAttr} style="font-weight:600;font-size:14px;color:#06c;text-decoration:none">${esc(headerText)}</a>`
+      const disabledBadge = disabled
+        ? `<span class="muted" style="font-size:11px">disabled</span>`
+        : ''
       if (entry.chart === null) {
         const errMsg = entry.error ?? 'チャートデータ取得失敗'
-        return `<div class="grid-panel" style="border:1px solid #d0d0d5;border-radius:6px;padding:8px;background:#fff">
-          <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:4px">
+        return `<div class="grid-panel" style="${panelStyle}">
+          <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:4px;gap:8px">
             ${headerLink}
             <span class="warn" style="font-size:11px">取得失敗</span>
+            ${disabledBadge}
           </div>
           <div class="muted" style="font-size:12px;padding:24px 8px;text-align:center">${esc(errMsg)}</div>
         </div>`
       }
       const badge = renderGridPanelBadge(entry.chart)
-      return `<div class="grid-panel" style="border:1px solid #d0d0d5;border-radius:6px;padding:8px;background:#fff">
+      return `<div class="grid-panel" style="${panelStyle}">
         <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:4px;gap:8px">
           ${headerLink}
           ${badge}
+          ${disabledBadge}
         </div>
         <div id="grid-chart-${idx}" style="width:100%;height:280px"></div>
       </div>`
@@ -4297,17 +4372,26 @@ function renderSymbolPickerForTab(args: ChartsBodySymbol): string {
     ? `&from=${encodeURIComponent(args.zoom.from.toISOString())}&to=${encodeURIComponent(args.zoom.to.toISOString())}`
     : ''
   const opts = args.availableSymbols
-    .map(
-      (s) =>
-        `<a href="/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(s)}${zoomQs}" style="margin-right:6px;${
-          s === args.focusSymbol ? 'font-weight:600;text-decoration:underline' : ''
-        }">${esc(displaySymbol(s, args.universe))}</a>`,
-    )
+    .map((s) => {
+      const disabled = isSymbolDisabled(s, args.universe)
+      const isFocus = s === args.focusSymbol
+      const linkClass = disabled ? ' class="symbol-disabled"' : ''
+      const titleAttr = disabled ? ` title="${esc(disabledTooltip(s, args.universe))}"` : ''
+      return `<a href="/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(s)}${zoomQs}"${linkClass}${titleAttr} style="margin-right:6px;${
+        isFocus ? 'font-weight:600;text-decoration:underline' : ''
+      }">${esc(displaySymbol(s, args.universe))}</a>`
+    })
     .join('')
   const focusLabel = args.focusSymbol
     ? displaySymbol(args.focusSymbol, args.universe)
     : '—'
+  const focusDisabled = args.focusSymbol
+    ? isSymbolDisabled(args.focusSymbol, args.universe)
+    : false
+  const focusBadge = focusDisabled
+    ? ` <span class="muted" style="font-size:11px">(disabled — ${esc(args.universe?.symbolNotes[args.focusSymbol!.toUpperCase()] ?? 'cron 評価対象外')})</span>`
+    : ''
   return `<p class="muted" style="font-size:12px">
-    銘柄: <strong>${esc(focusLabel)}</strong> | 切替: ${opts}
+    銘柄: <strong>${esc(focusLabel)}</strong>${focusBadge} | 切替: ${opts}
   </p>`
 }

--- a/test/helpers/configFixtures.ts
+++ b/test/helpers/configFixtures.ts
@@ -47,11 +47,13 @@ export function makeGlobalConfigSnapshot(
 export function makeSymbolUniverse(overrides: Partial<SymbolUniverse> = {}): SymbolUniverse {
   return {
     allowedSymbols: ['SOXL', 'SOXS'],
+    inactiveSymbols: [],
     symbolMaxNotional: {},
     symbolCurrency: { SOXL: 'USD', SOXS: 'USD' },
     symbolBucket: {},
     symbolMarket: { SOXL: 'US', SOXS: 'US' },
     symbolName: {},
+    symbolNotes: {},
     inversePairs: {},
     source: 'd1',
     ...overrides,

--- a/test/infrastructure/db/symbolConfigRepo.test.ts
+++ b/test/infrastructure/db/symbolConfigRepo.test.ts
@@ -5,14 +5,12 @@ import {
 } from '../../../src/infrastructure/db/symbolConfigRepo'
 
 function fakeDb(rows: unknown[]) {
+  // loadSymbolConfig は WHERE active=... を外したので、`from` 直後で resolve する
+  // (active=0 / 1 両方を読んで repo 側で振り分ける)。
   return {
     select() {
       return {
-        from() {
-          return {
-            where: vi.fn().mockResolvedValue(rows),
-          }
-        },
+        from: vi.fn().mockResolvedValue(rows),
       }
     },
   } as unknown as Parameters<typeof loadSymbolConfig>[0]
@@ -81,6 +79,39 @@ describe('loadSymbolConfig', () => {
     ]
     const result = await loadSymbolConfig(fakeDb(rows))
     expect(result.symbolMarket).toEqual({ X: 'US', Y: 'US' })
+  })
+
+  // dashboard が disabled (active=0) を grayed-out で表示するために、active=0 の
+  // symbol も読み込んで `inactiveSymbols` / `symbolNotes` に振り分ける。
+  // cron / risk gate は引き続き `allowedSymbols` のみを参照する (= 評価対象は変えない)。
+  it('partitions rows into allowedSymbols / inactiveSymbols by active flag', async () => {
+    const rows = [
+      { symbol: 'soxl', name: 'SOXL', market: 'US', active: true, maxNotional: 50000, notes: null },
+      { symbol: 'soxs', name: 'SOXS', market: 'US', active: false, maxNotional: null, notes: 'pair removed 2026-04-20' },
+      { symbol: '7203', name: 'トヨタ', market: 'JP', active: true, maxNotional: null, notes: null },
+      { symbol: '9697', name: 'カプコン', market: 'JP', active: false, maxNotional: null, notes: 'liquidity dropped' },
+    ]
+    const result = await loadSymbolConfig(fakeDb(rows))
+    expect(result.allowedSymbols).toEqual(['SOXL', '7203'])
+    expect(result.inactiveSymbols).toEqual(['SOXS', '9697'])
+    // notes は active=0 / 1 両方の銘柄分が含まれる (active=1 で notes 設定済の運用も想定)
+    expect(result.symbolNotes).toEqual({
+      SOXS: 'pair removed 2026-04-20',
+      '9697': 'liquidity dropped',
+    })
+    // currency / market map は active=0 含めて全銘柄分
+    expect(result.symbolMarket).toEqual({ SOXL: 'US', SOXS: 'US', '7203': 'JP', '9697': 'JP' })
+  })
+
+  it('skips empty / whitespace-only notes (defensive)', async () => {
+    const rows = [
+      { symbol: 'A', name: null, market: 'US', active: false, maxNotional: null, notes: '' },
+      { symbol: 'B', name: null, market: 'US', active: false, maxNotional: null, notes: '   ' },
+      { symbol: 'C', name: null, market: 'US', active: false, maxNotional: null, notes: '  reason  ' },
+    ]
+    const result = await loadSymbolConfig(fakeDb(rows))
+    expect(result.symbolNotes).toEqual({ C: 'reason' })
+    expect(result.inactiveSymbols).toEqual(['A', 'B', 'C'])
   })
 })
 

--- a/test/routes/admin.test.ts
+++ b/test/routes/admin.test.ts
@@ -1120,11 +1120,13 @@ describe('POST /admin/orders/sync-holdings', () => {
     const webullMod = await import('../../src/infrastructure/webull/WebullHttpClient')
     const universeSpy = vi.spyOn(universeMod, 'loadSymbolUniverse').mockResolvedValue({
       allowedSymbols: mocks.universe?.allowedSymbols ?? [],
+      inactiveSymbols: [],
       symbolMaxNotional: {},
       symbolCurrency: {},
       symbolBucket: {},
       symbolMarket: {},
       symbolName: {},
+      symbolNotes: {},
       inversePairs: {},
       source: 'd1',
     })

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -223,6 +223,35 @@ describe('dashboard', () => {
     expect(body).toContain('&lt;script&gt;')
   })
 
+  // disabled (active=0) 銘柄も config / picker / table に表示する (operator visibility)。
+  // cron / risk gate の評価対象は変えない (= allowedSymbols のみ)。
+  it('renders disabled symbols on config page with grayed-out style and notes tooltip', async () => {
+    vi.mocked(loadSymbolUniverse).mockResolvedValue(
+      makeSymbolUniverse({
+        allowedSymbols: ['SOXL'],
+        inactiveSymbols: ['9697'],
+        symbolCurrency: { SOXL: 'USD', '9697': 'JPY' },
+        symbolMarket: { SOXL: 'US', '9697': 'JP' },
+        symbolName: { '9697': 'カプコン' },
+        symbolNotes: { '9697': 'liquidity dropped' },
+      }),
+    )
+    const env = { ...baseEnv, DB: {} as D1Database }
+    const app = createApp()
+    const res = await app.request('/dashboard/config', { headers: authHeader }, env)
+    const body = await res.text()
+    // active 銘柄は通常表示、disabled 銘柄は symbol-disabled クラスで grayed-out
+    expect(body).toContain('SOXL')
+    expect(body).toContain('9697-カプコン')
+    expect(body).toContain('class="symbol-disabled"')
+    // tooltip に notes 表示
+    expect(body).toContain('DISABLED: liquidity dropped')
+    // 状態列に "disabled" が出る
+    expect(body).toContain('>disabled<')
+    // count 行に active / disabled 件数が出る
+    expect(body).toContain('active 1 / disabled 1')
+  })
+
   it('renders cron page with "unavailable" when DB is not bound', async () => {
     const app = createApp()
     const res = await app.request('/dashboard/cron', { headers: authHeader }, baseEnv)

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -223,9 +223,11 @@ describe('dashboard', () => {
     expect(body).toContain('&lt;script&gt;')
   })
 
-  // disabled (active=0) 銘柄も config / picker / table に表示する (operator visibility)。
+  // inactive (active=0) 銘柄も config / picker / table に表示する (operator visibility)。
   // cron / risk gate の評価対象は変えない (= allowedSymbols のみ)。
-  it('renders disabled symbols on config page with grayed-out style and notes tooltip', async () => {
+  // "INACTIVE" naming: `inactiveSymbols` は disable / pause 双方を含むため
+  // 中立的な "INACTIVE" を採用 (CodeRabbit #229)。
+  it('renders inactive symbols on config page with grayed-out style and notes tooltip', async () => {
     vi.mocked(loadSymbolUniverse).mockResolvedValue(
       makeSymbolUniverse({
         allowedSymbols: ['SOXL'],
@@ -240,16 +242,16 @@ describe('dashboard', () => {
     const app = createApp()
     const res = await app.request('/dashboard/config', { headers: authHeader }, env)
     const body = await res.text()
-    // active 銘柄は通常表示、disabled 銘柄は symbol-disabled クラスで grayed-out
+    // active 銘柄は通常表示、inactive 銘柄は symbol-disabled クラスで grayed-out
     expect(body).toContain('SOXL')
     expect(body).toContain('9697-カプコン')
     expect(body).toContain('class="symbol-disabled"')
-    // tooltip に notes 表示
-    expect(body).toContain('DISABLED: liquidity dropped')
-    // 状態列に "disabled" が出る
-    expect(body).toContain('>disabled<')
-    // count 行に active / disabled 件数が出る
-    expect(body).toContain('active 1 / disabled 1')
+    // tooltip に notes 表示 ("INACTIVE: <notes>" — pause も含むため中立 label)
+    expect(body).toContain('INACTIVE: liquidity dropped')
+    // 状態列に "inactive" が出る
+    expect(body).toContain('>inactive<')
+    // count 行に active / inactive 件数が出る
+    expect(body).toContain('active 1 / inactive 1')
   })
 
   it('renders cron page with "unavailable" when DB is not bound', async () => {
@@ -1692,6 +1694,52 @@ describe('renderGridTab', () => {
   it('charts 空 → ALLOWED_SYMBOLS が空である旨を案内', () => {
     const html = renderGridTab({ tab: 'grid', charts: [], zoom: null })
     expect(html).toContain('ALLOWED_SYMBOLS が空')
+  })
+
+  // inactive 銘柄は heavy chart load せずに placeholder panel のみ描画する
+  // (CodeRabbit #229: subrequest 浪費を避ける)。
+  it('inactivePlaceholders は INACTIVE バッジと個別タブ link 付きで grid に追加描画される', () => {
+    const html = renderGridTab({
+      tab: 'grid',
+      charts: [
+        { symbol: 'SOXL', chart: makeChart('SOXL', [
+          { timestamp: '2026-04-25T00:00:00.000Z', price: 120, sma50: 80, high20d: 130, low20d: 100 },
+        ]), error: null },
+      ],
+      inactivePlaceholders: [
+        { symbol: '9697', note: 'liquidity dropped' },
+      ],
+      zoom: null,
+    })
+    // active panel の chart container は引き続き出る
+    expect(html).toContain('id="grid-chart-0"')
+    // inactive panel: chart container は無い (= 軽量、subrequest 不要)
+    expect(html).not.toContain('id="grid-chart-1"')
+    // INACTIVE バッジ + tooltip
+    expect(html).toContain('>INACTIVE<')
+    expect(html).toContain('INACTIVE: liquidity dropped')
+    // 個別タブへの link (operator が深掘れる)
+    expect(html).toContain('?tab=symbol&symbol=9697')
+    // 説明文
+    expect(html).toContain('チャート未取得')
+  })
+
+  it('inactivePlaceholders だけ (active charts 空) でも案内ではなく placeholder grid を描画', () => {
+    const html = renderGridTab({
+      tab: 'grid',
+      charts: [],
+      inactivePlaceholders: [
+        { symbol: '9697', note: null },
+      ],
+      zoom: null,
+    })
+    // active 銘柄 0 でも、inactive がいれば「ALLOWED_SYMBOLS 空」案内では
+    // なく grid そのものを描画する (operator は inactive 銘柄を見える)
+    expect(html).not.toContain('ALLOWED_SYMBOLS が空')
+    expect(html).toContain('class="symbols-grid"')
+    expect(html).toContain('>INACTIVE<')
+    // notes が無い場合 tooltip は単に "INACTIVE"
+    expect(html).toContain('title="INACTIVE"')
   })
 })
 

--- a/test/trading/strategy/runStrategyCron.test.ts
+++ b/test/trading/strategy/runStrategyCron.test.ts
@@ -115,6 +115,30 @@ describe('runStrategyCron', () => {
     expect(result.analysis.universe.symbols).toEqual(['SOXL', 'SOXS'])
   })
 
+  // dashboard が disabled (active=0) を表示するために `inactiveSymbols` を
+  // SymbolUniverse に追加したが、cron / risk gate の評価対象は引き続き
+  // `allowedSymbols` のみであることを保証する regression test (= disabled 銘柄が
+  // 評価ループに混入しない)。
+  it('cron only evaluates allowedSymbols and ignores inactiveSymbols', async () => {
+    vi.mocked(loadSymbolUniverse).mockResolvedValue(
+      makeSymbolUniverse({
+        allowedSymbols: ['SOXL'],
+        inactiveSymbols: ['9697'],
+        symbolCurrency: { SOXL: 'USD', '9697': 'JPY' },
+        symbolMarket: { SOXL: 'US', '9697': 'JP' },
+        symbolNotes: { '9697': 'paused for review' },
+      }),
+    )
+    const envWithoutBridge = {
+      DB: {} as D1Database,
+    } as unknown as Parameters<typeof runStrategyCron>[0]
+    const result = await runStrategyCron(envWithoutBridge)
+    // analysis.universe.symbols は cron が評価しようとした symbol 集合。
+    // inactiveSymbols (9697) は混入しない。
+    expect(result.analysis.universe.symbols).toEqual(['SOXL'])
+    expect(result.analysis.universe.symbols).not.toContain('9697')
+  })
+
   it('fail-closes to portfolio_halted on invalid tradingDisabledUntil timestamp', async () => {
     const envBadTimestamp = {
       ...env,


### PR DESCRIPTION
## 動機

`active=0` (一時停止) にした銘柄が dashboard から完全に消えてしまうため、operator が

- なぜ disable されたか (経緯 / notes) を追跡できない
- 今 disabled なのが何銘柄あるか把握できない
- 再有効化すべきか chart で値動きを見る導線が無い

という visibility gap があった (例: 9697 を disable → picker / config / cron からも消える)。

## 設計

`SymbolUniverse` を拡張して `allowedSymbols` (active=1) と `inactiveSymbols` (active=0) を **別フィールドで返す**。

| 用途 | 参照するフィールド | 変更 |
|---|---|---|
| cron / risk gate / strategy 評価 | `allowedSymbols` のみ | 変更なし (= 評価対象は active=1 のみ) |
| dashboard 表示 (picker / table) | `[...allowedSymbols, ...inactiveSymbols]` | 全件表示、disabled は grayed-out |

`symbolNotes: Record<string, string>` も新設して、`symbol_config.notes` を tooltip / config table のメモ列に出す。

## 表示の差

- CSS: `.symbol-disabled { opacity:0.5; font-style:italic; text-decoration:line-through }`
- tooltip: `DISABLED: <notes>` (notes 無ければ単に `DISABLED`)
- 影響箇所:
  - `/dashboard/positions` 銘柄列
  - `/dashboard/trades` 銘柄列
  - `/dashboard/cron` 銘柄列
  - `/dashboard/alerts` 銘柄リンク
  - `/dashboard/charts?tab=symbol` の picker (focus に disabled badge も追加)
  - `/dashboard/charts?tab=grid` の各 panel header + panel 全体 opacity
  - `/dashboard/config` 銘柄テーブル ("状態" / "メモ" 列を新設、active / disabled 件数を summary に併記)

## cron 評価対象は変更なし

- `loadSymbolUniverse().allowedSymbols` 仕様は維持 (active=1 のみ)
- `runStrategyCron` / `RiskPolicy` / `TradingService` / `quoteScheduler` / `syncHoldings` は **`allowedSymbols` のみ参照**
- 新規 regression test (`runStrategyCron.test.ts`) で「`inactiveSymbols` が cron に混入しない」を保証

## 変更ファイル

- `src/infrastructure/db/symbolConfigRepo.ts` — WHERE active 削除、active=0/1 振り分け、`symbolNotes` 追加
- `src/infrastructure/db/symbolUniverse.ts` — `inactiveSymbols` / `symbolNotes` を `SymbolUniverse` に追加
- `src/routes/dashboard.ts` — `isSymbolDisabled` / `disabledTooltip` helper、CSS、各 body 更新
- test 5 ファイル: 新挙動の追加 + 既存 fixture の補完

## 検証

- `pnpm typecheck` clean
- `pnpm test --run` 全 927 件 pass

## 注意

- merge は CodeRabbit APPROVED を待ってから (auto-merge)
- 実 DB schema 変更なし (notes 列は既存の `symbol_config.notes` を読むだけ)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ダッシュボードで無効シンボルが表示され、無効は「無効」バッジと無効スタイルで区別されます
  * シンボルのメモがツールチップで確認可能になりました
  * グリッドでは無効シンボルは軽量プレースホルダで表示され、チャート読み込みを抑制します
  * 設定ページに「状態」と「メモ」列が追加され、アクティブ/非アクティブ数を表示

* **テスト**
  * 無効シンボル表示と、cron/リスク評価がアクティブのみを対象とする動作を検証するテストを追加しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->