### PR TITLE
feat(dashboard): grid view でも inactive 銘柄の chart 表示

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -140,16 +140,14 @@ export const dashboard = new Hono<AppBindings>()
           takeProfitPct: global.pullbackDefaultTakeProfitPct,
           timeStopDays: global.pullbackDefaultTimeStopDays,
         }
-        // 重い chart データ取得 (Yahoo daily + intraday + D1 + DO で銘柄あたり
-        // ~5 subrequest) は active 銘柄に限定する。inactive 銘柄が増えると
-        // Workers subrequest budget を逼迫させるため、grid では fetch なしの
-        // 静的 placeholder panel として表示する (operator は個別タブへ遷移して
-        // 必要に応じて深掘る)。
-        const charts = await loadAllSymbolCharts(c.env, universe.allowedSymbols, rules)
-        const inactivePlaceholders = universe.inactiveSymbols.map((symbol) => ({
-          symbol,
-          note: universe.symbolNotes[symbol] ?? null,
-        }))
+        // active + inactive 双方の chart を load する。inactive 銘柄もチャートで
+        // 動向確認したい (PR #229 で grid から外したが operator から復帰要望)。
+        // `loadAllSymbolCharts` は per-symbol catch (PR #197) で 1 銘柄が失敗
+        // しても他は OK。Workers subrequest budget を超えた場合も該当 panel が
+        // 個別 error 表示になるだけで grid 全体は描画される。視覚識別 (INACTIVE
+        // バッジ + grayed style) は `renderGridTab` 側で symbol 単位に付与する。
+        const allGridSymbols = [...universe.allowedSymbols, ...universe.inactiveSymbols]
+        const charts = await loadAllSymbolCharts(c.env, allGridSymbols, rules)
         // grid の zoom 基準: 全 panel 共通の dataZoom 同期があるため、最初に
         // load 成功した chart の lastTimestamp を基準に直近 7 日 (default) を
         // 採用する。URL ?from / ?to があればそれを優先 (既存と同挙動)。
@@ -161,7 +159,6 @@ export const dashboard = new Hono<AppBindings>()
             chartsBody({
               tab,
               charts,
-              inactivePlaceholders,
               zoom,
               universe,
             }),
@@ -520,6 +517,7 @@ const STYLE = `
   .symbol-disabled{opacity:0.5;font-style:italic;text-decoration:line-through}
   tr.symbol-disabled-row{background:#fafafa}
   tr.symbol-disabled-row td{color:#86868b}
+  .grid-panel.symbol-inactive{background:#fafafa;opacity:0.65}
 `
 
 function layout(title: string, body: string): string {
@@ -2730,19 +2728,15 @@ interface ChartsBodySymbol {
 interface ChartsBodyGrid {
   tab: 'grid'
   /**
-   * Active (cron 評価対象) 銘柄の SymbolChartData (load 失敗銘柄は値 null。
-   * 1 銘柄失敗で全 grid を 500 にしない)。
+   * Grid に表示する全銘柄 (active + inactive) の SymbolChartData。load 失敗時は
+   * `chart === null`。inactive 銘柄も同じ Map から render し、panel header に
+   * INACTIVE バッジ + grayed style を付与して識別する (`isSymbolInactive` で判定)。
+   *
+   * PR #229 で inactive を grid から外したが、operator から「inactive 銘柄も
+   * 動向確認したい」要望があったため復活。subrequest budget は per-symbol catch
+   * で graceful degrade (個別 panel が空になるだけ、grid 全体は描画される)。
    */
   charts: Array<{ symbol: string; chart: SymbolChartData | null; error: string | null }>
-  /**
-   * Inactive (active=0) 銘柄の static placeholder。chart データは fetch せず、
-   * grid 上では灰色の panel + INACTIVE バッジ + notes tooltip だけを描画する。
-   * 個別タブ (?tab=symbol&symbol=...) へ link して operator が深掘りできる。
-   *
-   * 旧実装は inactive も `loadAllSymbolCharts` に投げていたが、銘柄あたり
-   * ~5 subrequest かかるため Workers の budget を圧迫する (CodeRabbit #229)。
-   */
-  inactivePlaceholders?: Array<{ symbol: string; note: string | null }>
   /** dataZoom 初期範囲。null なら全期間 */
   zoom: { from: Date; to: Date } | null
   /** panel header の銘柄表示を JP 銘柄向け 番号-会社名 形式にするための universe。 */
@@ -3711,8 +3705,7 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
  * - SMA50 / band / 詳細パネルは省略 (panel size に合わせて視認性を優先)
  */
 export function renderGridTab(args: ChartsBodyGrid): string {
-  const inactivePlaceholders = args.inactivePlaceholders ?? []
-  if (args.charts.length === 0 && inactivePlaceholders.length === 0) {
+  if (args.charts.length === 0) {
     return `<p class="muted">ALLOWED_SYMBOLS が空です。<code>symbol_config</code> に少なくとも 1 銘柄登録してください。</p>`
   }
   // grid 共通 toolbar の preset zoom buttons。reference chart (最初に load 成功)
@@ -3721,66 +3714,48 @@ export function renderGridTab(args: ChartsBodyGrid): string {
   const referenceChart = args.charts.find((c) => c.chart !== null)?.chart ?? null
   const presetButtonsHtml = renderZoomPresetButtons(referenceChart)
 
-  // Active panel: chart 本体は client side で echarts.init される。
-  // panel header に symbol 名 (詳細タブへの link) と最新 indicators (price /
-  // SMA50 / high20d / low20d) を出して「市場全体ビュー」で trader が銘柄を
-  // 一目で識別できるようにする。
-  // Note: args.charts は active 銘柄だけで構成される (inactive は別経路)。
-  const activePanelsHtml = args.charts
+  // 各 panel: chart 本体は client side で echarts.init される。panel header に
+  // symbol 名 (詳細タブへの link) と最新 indicators (price / SMA50) を出して
+  // 「市場全体ビュー」で trader が銘柄を一目で識別できるようにする。
+  // inactive 銘柄は data 取得は通常通り行うが、panel header に INACTIVE バッジと
+  // grayed-out style (`symbol-inactive`) を付けて視覚識別する。
+  const panelsHtml = args.charts
     .map((entry, idx) => {
-      const panelStyle = 'border:1px solid #d0d0d5;border-radius:6px;padding:8px;background:#fff'
+      const inactive = isSymbolInactive(entry.symbol, args.universe)
+      const baseStyle = 'border:1px solid #d0d0d5;border-radius:6px;padding:8px;background:#fff'
+      const panelClass = inactive ? 'grid-panel symbol-inactive' : 'grid-panel'
       const symbolLink = `/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(entry.symbol)}`
       const headerText = displaySymbol(entry.symbol, args.universe)
-      const headerLink = `<a href="${symbolLink}" style="font-weight:600;font-size:14px;color:#06c;text-decoration:none">${esc(headerText)}</a>`
+      const tooltipText = inactiveTooltip(entry.symbol, args.universe)
+      const linkClass = inactive ? ' class="symbol-disabled"' : ''
+      const titleAttr = inactive ? ` title="${esc(tooltipText)}"` : ''
+      const headerLink = `<a href="${symbolLink}"${linkClass}${titleAttr} style="font-weight:600;font-size:14px;color:#06c;text-decoration:none">${esc(headerText)}</a>`
+      const inactiveBadge = inactive
+        ? `<span class="muted" style="font-size:11px"${titleAttr}>INACTIVE</span>`
+        : ''
       if (entry.chart === null) {
         const errMsg = entry.error ?? 'チャートデータ取得失敗'
-        return `<div class="grid-panel" style="${panelStyle}">
+        const errBadge = `<span class="warn" style="font-size:11px">取得失敗</span>`
+        const rightSide = inactive ? inactiveBadge + errBadge : errBadge
+        return `<div class="${panelClass}" style="${baseStyle}">
           <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:4px;gap:8px">
             ${headerLink}
-            <span class="warn" style="font-size:11px">取得失敗</span>
+            <div style="display:flex;gap:6px;align-items:center">${rightSide}</div>
           </div>
           <div class="muted" style="font-size:12px;padding:24px 8px;text-align:center">${esc(errMsg)}</div>
         </div>`
       }
       const badge = renderGridPanelBadge(entry.chart)
-      return `<div class="grid-panel" style="${panelStyle}">
+      const rightSide = inactive ? inactiveBadge + badge : badge
+      return `<div class="${panelClass}" style="${baseStyle}">
         <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:4px;gap:8px">
           ${headerLink}
-          ${badge}
+          <div style="display:flex;gap:6px;align-items:center">${rightSide}</div>
         </div>
         <div id="grid-chart-${idx}" style="width:100%;height:280px"></div>
       </div>`
     })
     .join('')
-
-  // Inactive placeholder panel: chart データを fetch せず、symbol header と
-  // INACTIVE バッジ + notes tooltip だけ描画する。個別タブへ link することで
-  // operator が必要な時だけ chart を fetch できる (subrequest 軽量化)。
-  const inactivePanelsHtml = inactivePlaceholders
-    .map((entry) => {
-      const panelStyle = 'border:1px solid #d0d0d5;border-radius:6px;padding:8px;background:#fafafa;opacity:0.65'
-      const symbolLink = `/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(entry.symbol)}`
-      const headerText = displaySymbol(entry.symbol, args.universe)
-      const tooltipText = entry.note ? `INACTIVE: ${entry.note}` : 'INACTIVE'
-      const titleAttr = ` title="${esc(tooltipText)}"`
-      const headerLink = `<a href="${symbolLink}" class="symbol-disabled"${titleAttr} style="font-weight:600;font-size:14px;color:#06c;text-decoration:none">${esc(headerText)}</a>`
-      const noteHtml = entry.note
-        ? `<div class="muted" style="font-size:11px;padding:4px 0 0">${esc(entry.note)}</div>`
-        : ''
-      return `<div class="grid-panel" style="${panelStyle}">
-        <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:4px;gap:8px">
-          ${headerLink}
-          <span class="muted" style="font-size:11px">INACTIVE</span>
-        </div>
-        <div class="muted" style="font-size:12px;padding:24px 8px;text-align:center">
-          チャート未取得 (cron 評価対象外) — <a href="${symbolLink}">個別タブで表示</a>
-        </div>
-        ${noteHtml}
-      </div>`
-    })
-    .join('')
-
-  const panelsHtml = activePanelsHtml + inactivePanelsHtml
 
   // client 側に渡す全銘柄分の chart payload。各 panel が個別 echarts.init で
   // 消費する。__chartData.charts は array of { symbol, chart, displayName }

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -3722,14 +3722,22 @@ export function renderGridTab(args: ChartsBodyGrid): string {
   const panelsHtml = args.charts
     .map((entry, idx) => {
       const inactive = isSymbolInactive(entry.symbol, args.universe)
-      const baseStyle = 'border:1px solid #d0d0d5;border-radius:6px;padding:8px;background:#fff'
+      // inactive は background / text-decoration の inline 上書きを避け、
+      // CSS class 側 (.grid-panel.symbol-inactive と .symbol-disabled) に任せる。
+      // inline style は CSS class より優先されてしまうため (CodeRabbit #230)。
+      const baseStyle = inactive
+        ? 'border:1px solid #d0d0d5;border-radius:6px;padding:8px'
+        : 'border:1px solid #d0d0d5;border-radius:6px;padding:8px;background:#fff'
       const panelClass = inactive ? 'grid-panel symbol-inactive' : 'grid-panel'
       const symbolLink = `/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(entry.symbol)}`
       const headerText = displaySymbol(entry.symbol, args.universe)
       const tooltipText = inactiveTooltip(entry.symbol, args.universe)
       const linkClass = inactive ? ' class="symbol-disabled"' : ''
       const titleAttr = inactive ? ` title="${esc(tooltipText)}"` : ''
-      const headerLink = `<a href="${symbolLink}"${linkClass}${titleAttr} style="font-weight:600;font-size:14px;color:#06c;text-decoration:none">${esc(headerText)}</a>`
+      const linkStyle = inactive
+        ? 'font-weight:600;font-size:14px;color:#06c'
+        : 'font-weight:600;font-size:14px;color:#06c;text-decoration:none'
+      const headerLink = `<a href="${symbolLink}"${linkClass}${titleAttr} style="${linkStyle}">${esc(headerText)}</a>`
       const inactiveBadge = inactive
         ? `<span class="muted" style="font-size:11px"${titleAttr}>INACTIVE</span>`
         : ''

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -1735,6 +1735,63 @@ describe('renderGridTab', () => {
     expect(html).toContain('class="symbol-disabled"')
   })
 
+  // CodeRabbit #230: inline style は CSS class より優先されるため、inactive panel
+  // では `background:#fff` / `text-decoration:none` の inline 上書きを抑制する。
+  // これで `.grid-panel.symbol-inactive { background:#fafafa; opacity:0.65 }` と
+  // `.symbol-disabled { text-decoration:line-through }` が effective になる。
+  it('inactive panel は inline background:#fff を出力せず、CSS class (symbol-inactive) に任せる', () => {
+    const universe = makeSymbolUniverse({
+      allowedSymbols: ['SOXL'],
+      inactiveSymbols: ['9697'],
+      symbolCurrency: { SOXL: 'USD', '9697': 'JPY' },
+    })
+    const html = renderGridTab({
+      tab: 'grid',
+      charts: [
+        { symbol: '9697', chart: makeChart('9697', [
+          { timestamp: '2026-04-25T00:00:00.000Z', price: 4500, sma50: 4400, high20d: 4600, low20d: 4300 },
+        ]), error: null },
+      ],
+      zoom: null,
+      universe,
+    })
+    // inactive panel の wrapper には background:#fff が inline で入らない
+    // (= class 側の background:#fafafa が effective)
+    const panelOpenIdx = html.indexOf('class="grid-panel symbol-inactive"')
+    expect(panelOpenIdx).toBeGreaterThanOrEqual(0)
+    const panelOpenEnd = html.indexOf('>', panelOpenIdx)
+    const panelOpenTag = html.slice(panelOpenIdx, panelOpenEnd)
+    expect(panelOpenTag).not.toContain('background:#fff')
+    // inactive header link には text-decoration:none が inline で入らない
+    // (= symbol-disabled の line-through が effective)
+    const linkIdx = html.indexOf('class="symbol-disabled"')
+    expect(linkIdx).toBeGreaterThanOrEqual(0)
+    const linkEnd = html.indexOf('>', linkIdx)
+    const linkOpenTag = html.slice(linkIdx, linkEnd)
+    expect(linkOpenTag).not.toContain('text-decoration:none')
+  })
+
+  // active panel の inline style は従来どおり残す (regression guard)。
+  it('active panel は従来どおり inline background:#fff と link の text-decoration:none を持つ', () => {
+    const universe = makeSymbolUniverse({
+      allowedSymbols: ['SOXL'],
+      inactiveSymbols: [],
+      symbolCurrency: { SOXL: 'USD' },
+    })
+    const html = renderGridTab({
+      tab: 'grid',
+      charts: [
+        { symbol: 'SOXL', chart: makeChart('SOXL', [
+          { timestamp: '2026-04-25T00:00:00.000Z', price: 120, sma50: 80, high20d: 130, low20d: 100 },
+        ]), error: null },
+      ],
+      zoom: null,
+      universe,
+    })
+    expect(html).toContain('background:#fff')
+    expect(html).toContain('text-decoration:none')
+  })
+
   it('inactive 銘柄で chart load に失敗した場合は active と同じ error 表示 + INACTIVE バッジを併記', () => {
     const universe = makeSymbolUniverse({
       allowedSymbols: ['SOXL'],

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -1696,9 +1696,72 @@ describe('renderGridTab', () => {
     expect(html).toContain('ALLOWED_SYMBOLS が空')
   })
 
-  // inactive 銘柄は heavy chart load せずに placeholder panel のみ描画する
-  // (CodeRabbit #229: subrequest 浪費を避ける)。
-  it('inactivePlaceholders は INACTIVE バッジと個別タブ link 付きで grid に追加描画される', () => {
+  // inactive 銘柄も active と同じく chart データを load して描画する。
+  // ただし `symbol-inactive` クラス + INACTIVE バッジ + symbol-disabled tooltip
+  // で視覚識別する (PR #229 で外したが operator から復活要望)。
+  it('inactive 銘柄も grid-chart container を持ち、INACTIVE バッジと grayed style で識別される', () => {
+    const universe = makeSymbolUniverse({
+      allowedSymbols: ['SOXL'],
+      inactiveSymbols: ['9697'],
+      symbolNotes: { '9697': 'liquidity dropped' },
+      symbolCurrency: { SOXL: 'USD', '9697': 'JPY' },
+    })
+    const html = renderGridTab({
+      tab: 'grid',
+      charts: [
+        { symbol: 'SOXL', chart: makeChart('SOXL', [
+          { timestamp: '2026-04-25T00:00:00.000Z', price: 120, sma50: 80, high20d: 130, low20d: 100 },
+        ]), error: null },
+        { symbol: '9697', chart: makeChart('9697', [
+          { timestamp: '2026-04-25T00:00:00.000Z', price: 4500, sma50: 4400, high20d: 4600, low20d: 4300 },
+        ]), error: null },
+      ],
+      zoom: null,
+      universe,
+    })
+    // active / inactive 双方の chart container が出る (= operator が動向確認できる)
+    expect(html).toContain('id="grid-chart-0"')
+    expect(html).toContain('id="grid-chart-1"')
+    // inactive panel に grayed style class が付与される
+    expect(html).toContain('class="grid-panel symbol-inactive"')
+    // active panel は通常 class
+    expect(html).toContain('class="grid-panel"')
+    // INACTIVE バッジ + tooltip (notes 入り)
+    expect(html).toContain('>INACTIVE<')
+    expect(html).toContain('INACTIVE: liquidity dropped')
+    // 個別タブへの link
+    expect(html).toContain('?tab=symbol&symbol=9697')
+    // header link が symbol-disabled (= 取消線で識別)
+    expect(html).toContain('class="symbol-disabled"')
+  })
+
+  it('inactive 銘柄で chart load に失敗した場合は active と同じ error 表示 + INACTIVE バッジを併記', () => {
+    const universe = makeSymbolUniverse({
+      allowedSymbols: ['SOXL'],
+      inactiveSymbols: ['9697'],
+      symbolCurrency: { SOXL: 'USD', '9697': 'JPY' },
+    })
+    const html = renderGridTab({
+      tab: 'grid',
+      charts: [
+        { symbol: 'SOXL', chart: makeChart('SOXL', [
+          { timestamp: '2026-04-25T00:00:00.000Z', price: 120, sma50: 80, high20d: 130, low20d: 100 },
+        ]), error: null },
+        { symbol: '9697', chart: null, error: 'subrequest budget exhausted' },
+      ],
+      zoom: null,
+      universe,
+    })
+    // 失敗 panel でも INACTIVE バッジと取得失敗バッジが両方出る
+    expect(html).toContain('symbol-inactive')
+    expect(html).toContain('>INACTIVE<')
+    expect(html).toContain('取得失敗')
+    expect(html).toContain('subrequest budget exhausted')
+    // 失敗 panel に chart container は出ない (active と同挙動)
+    expect(html).not.toContain('id="grid-chart-1"')
+  })
+
+  it('universe が無ければ inactive 識別なし (= 全 panel が active 扱い)', () => {
     const html = renderGridTab({
       tab: 'grid',
       charts: [
@@ -1706,40 +1769,10 @@ describe('renderGridTab', () => {
           { timestamp: '2026-04-25T00:00:00.000Z', price: 120, sma50: 80, high20d: 130, low20d: 100 },
         ]), error: null },
       ],
-      inactivePlaceholders: [
-        { symbol: '9697', note: 'liquidity dropped' },
-      ],
       zoom: null,
     })
-    // active panel の chart container は引き続き出る
-    expect(html).toContain('id="grid-chart-0"')
-    // inactive panel: chart container は無い (= 軽量、subrequest 不要)
-    expect(html).not.toContain('id="grid-chart-1"')
-    // INACTIVE バッジ + tooltip
-    expect(html).toContain('>INACTIVE<')
-    expect(html).toContain('INACTIVE: liquidity dropped')
-    // 個別タブへの link (operator が深掘れる)
-    expect(html).toContain('?tab=symbol&symbol=9697')
-    // 説明文
-    expect(html).toContain('チャート未取得')
-  })
-
-  it('inactivePlaceholders だけ (active charts 空) でも案内ではなく placeholder grid を描画', () => {
-    const html = renderGridTab({
-      tab: 'grid',
-      charts: [],
-      inactivePlaceholders: [
-        { symbol: '9697', note: null },
-      ],
-      zoom: null,
-    })
-    // active 銘柄 0 でも、inactive がいれば「ALLOWED_SYMBOLS 空」案内では
-    // なく grid そのものを描画する (operator は inactive 銘柄を見える)
-    expect(html).not.toContain('ALLOWED_SYMBOLS が空')
-    expect(html).toContain('class="symbols-grid"')
-    expect(html).toContain('>INACTIVE<')
-    // notes が無い場合 tooltip は単に "INACTIVE"
-    expect(html).toContain('title="INACTIVE"')
+    expect(html).not.toContain('symbol-inactive')
+    expect(html).not.toContain('>INACTIVE<')
   })
 })
 


### PR DESCRIPTION
## 動機

PR #229 で subrequest budget 配慮のため inactive (active=0) 銘柄を grid から外し、軽量 placeholder のみ描画していた。しかし operator から「inactive 銘柄も chart で動向確認したい (再有効化判断、停止後の値動き把握)」要望があり、grid でも chart データを load する方針に戻す。

視覚識別 (INACTIVE バッジ + grayed-out) は維持して、active と区別できる状態を保つ。

## 実装

- `dashboard.ts` (grid handler):
  - `[...universe.allowedSymbols, ...universe.inactiveSymbols]` を `loadAllSymbolCharts` に渡す
  - `inactivePlaceholders` を `chartsBody` に渡さない
- `ChartsBodyGrid` 型から `inactivePlaceholders` field を削除 (charts Map で全銘柄を cover)
- `renderGridTab` を統一: 全 panel を `args.charts` から render、各 panel で `isSymbolInactive` チェックして
  - `symbol-inactive` class を panel に付与 (grayed style)
  - INACTIVE バッジを panel header に併記
  - header link に `symbol-disabled` (取消線 + tooltip "INACTIVE: <notes>")
- 新 CSS class `.grid-panel.symbol-inactive { background:#fafafa; opacity:0.65 }`

## subrequest budget の trade-off

`loadAllSymbolCharts` は per-symbol catch (PR #197) を持つので:

- 全銘柄が成功 → 全 panel に chart 描画 (理想ケース)
- 一部が subrequest budget 超過で失敗 → 該当 panel だけ「取得失敗」表示。他 panel は正常描画
- inactive 銘柄が増えて grid 全体が重くなった場合は、後日 paging or 段階表示で対応 (POC scope では現状の per-symbol catch で十分 graceful)

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test --run` 全 pass (959 tests)
- [x] 新規テスト: inactive 銘柄も `grid-chart-N` container を持つ
- [x] 新規テスト: inactive panel に `symbol-inactive` class + `INACTIVE` バッジ + `symbol-disabled` tooltip
- [x] 新規テスト: inactive load 失敗時も INACTIVE バッジと取得失敗バッジを併記
- [x] 新規テスト: universe 未指定時は inactive 識別なし (全 active 扱い)
- [ ] 手動: dashboard で active + inactive 混在の grid を見て、視覚的に区別できる
- [ ] 手動: `?tab=grid` で subrequest budget の余裕がある状態で全銘柄描画される

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * グリッドチャート: 非アクティブシンボルは静的プレースホルダーではなく実際のチャート読み込み経路で表示されます
  * 非アクティブには「INACTIVE」バッジ、無効化スタイルでグレーアウト表示され、ヘッダーリンクが無効化されます
  * 読み込み失敗時はエラーメッセージを表示し、チャートコンテナは表示されません
* **テスト**
  * 非アクティブ表示挙動と読み込み失敗時の表示を検証するテストを追加/更新しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->