### PR TITLE
fix(dashboard): chart tooltip dedup — SMA50 / 価格トレンド等の重複行統合

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -3310,6 +3310,14 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
             if (!Array.isArray(params) || params.length === 0) return '';
             var ts = params[0].axisValue;
             var lines = ['<div style="font-weight:600;font-size:11px">' + jstLabelForX(ts) + '</div>'];
+            // densified path (intradayBars timestamp ごとに line series を埋める
+            // PR #190 / #192) により、同じ seriesName + 同じ y 値の data point が
+            // 同一 axis index 周辺に多数並ぶ。ECharts の trigger axis は該当
+            // params を全件渡してくるため、tooltip 上で SMA50 65.82 が 16 行
+            // 続くような重複表示が発生する。seriesName + 整形後 value を key に
+            // した Set で連続行を 1 行に dedup する (系列ごと 1 行)。candle は
+            // OHLC 4 値の array なので special-case のまま既存挙動を維持。
+            var seenLine = Object.create(null);
             for (var i = 0; i < params.length; i += 1) {
               var p = params[i];
               if (p.seriesType === 'candlestick' && Array.isArray(p.value)) {
@@ -3325,8 +3333,12 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
               } else {
                 var v = Array.isArray(p.value) ? p.value[1] : p.value;
                 if (v == null) continue;
+                var vText = Number(v).toFixed(2);
+                var key = String(p.seriesName) + '|' + vText;
+                if (seenLine[key]) continue;
+                seenLine[key] = true;
                 lines.push('<div style="font-size:11px">' + p.marker + ' ' + p.seriesName +
-                  ': ' + Number(v).toFixed(2) + '</div>');
+                  ': ' + vText + '</div>');
               }
             }
             return lines.join('');


### PR DESCRIPTION
## 動機

個別銘柄 chart の tooltip で、densified path 由来の **同 series + 同 value** の行が大量に並ぶ UX 問題を修正。

スクショ実例:
- `SMA50: 65.82` が 16 行 → 直後に `SMA50: 67.13` / `SMA50: 67.01` …
- `価格トレンド` (linear regression) や保有時の `avg / stop / TP` position lines も同様に同値が展開

### 原因

PR #190 / #192 等で、ECharts dataZoom + 2 点 line series が片端 zoom 範囲外で描画されない既知挙動 (#3637 系) への対処として、line series を **intradayBars timestamps で densify** している。これにより各 bar timestamp に同 y 値の data point が並ぶ → ECharts の `trigger: 'axis'` tooltip が hovered axis index 周辺の全 params を formatter に渡すため、同 series & 同 value の row が重複表示される。

## 変更

`src/routes/dashboard.ts` の symbol tab tooltip formatter (line series 行を組み立てる側) に `seriesName + 整形後 value` をキーにした dedup を追加。

- 同 series & 同値 (toFixed(2) 後の文字列で比較) は **最初の 1 件のみ** 表示
- candle (`price (1h OHLC)`) は OHLC 4 値の array なので **special-case 既存挙動を維持** (= dedup 対象外)
- 異なる series で偶然同値の場合は merge されない (key に seriesName を含むため)
- O(N) で大量 series でも性能影響なし

grid view の formatter (4015) は line series 行を出力していない (candlestick のみ render) ため変更不要。

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test --run` 全 pass (961 tests)
- [ ] visual: 個別銘柄 chart hover で SMA50 / 価格トレンド / position lines が **各 series 1 行ずつ** に dedup されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * ダッシュボードのチャートツールチップで、ラインシリーズデータ表示時の重複エントリを排除し、ツールチップの表示をより適切にしました。ろうそく足チャートのツールチップ機能は変更されていません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->