### PR TITLE
feat(dashboard): 押し目 band visibility — markArea で半透明帯

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -3040,7 +3040,7 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
       var bandLowerY = latestHigh20d == null ? null : latestHigh20d * pullbackMinMul;
       var bandTopY = null;
       var bandBottomY = null;
-      if (bandUpperY != null && bandLowerY != null) {
+      if (Number.isFinite(bandUpperY) && Number.isFinite(bandLowerY)) {
         bandTopY = Math.max(bandUpperY, bandLowerY);
         bandBottomY = Math.min(bandUpperY, bandLowerY);
       }

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -3022,6 +3022,35 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
         var x = xForTimestamp(p.timestamp);
         return [x, p.high20d == null ? null : p.high20d * pullbackMinMul];
       });
+      // 押し目ゾーン fill 用の代表 y 値: 直近の有効な high20d を採用。
+      // 押し目ゾーン上下端は per-timestamp で変動するが、3% 幅の dashed line
+      // 2 本だけでは視認性が低いので、最新値で固定した横帯を markArea で重ねる
+      // (= 「現在の押し目ゾーンはこの価格帯」が一目で分かる)。
+      // high20d は 20 日移動高値で日次更新、chart 表示期間内では緩やかに動くため
+      // 視覚的近似として十分。
+      var latestHigh20d = null;
+      for (var lhi = sc.points.length - 1; lhi >= 0; lhi -= 1) {
+        var lhp = sc.points[lhi];
+        if (lhp && typeof lhp.high20d === 'number' && isFinite(lhp.high20d)) {
+          latestHigh20d = lhp.high20d;
+          break;
+        }
+      }
+      var bandUpperY = latestHigh20d == null ? null : latestHigh20d * pullbackMaxMul;
+      var bandLowerY = latestHigh20d == null ? null : latestHigh20d * pullbackMinMul;
+      var pullbackBandMarkArea = (bandUpperY != null && bandLowerY != null) ? {
+        silent: true,
+        itemStyle: {
+          color: 'rgba(255, 180, 50, 0.12)',
+          borderColor: 'rgba(255, 140, 0, 0.4)',
+          borderWidth: 1,
+          borderType: 'dashed',
+        },
+        data: [[
+          { yAxis: bandLowerY, name: '押し目ゾーン' },
+          { yAxis: bandUpperY },
+        ]],
+      } : null;
 
       // 価格トレンド線 (server-side で daily close の linear regression fit)。
       // 旧仕様の「上値抵抗線 / 下値支持線」上下 2 本は、ローソク足の上下を
@@ -3379,10 +3408,27 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
         },
         series: [
           // 保有時は押し目バンド非表示 (avg/stop/TP に集中)、非保有時は淡く表示
-          // (戦略 rule の参考、トレンドラインが主役なので opacity 0.4)。
+          // (戦略 rule の参考、トレンドラインが主役なので opacity 控えめ)。
+          //
+          // 視認性向上 (#231 follow-up): dashed line 2 本だけだと 3% 幅の帯は
+          // 細くて見落としやすかったため、最新 high20d を基準とした半透明の
+          // markArea fill を上端 line series に付与し「押し目ゾーンはここ」と
+          // 一目で分かる横帯にする。per-timestamp の動的な上端/下端 line は
+          // 日次の high20d 推移を表す参照線として残す (style もやや強化)。
           ...(sc.position ? [] : [
-            { name: '押し目ゾーン上端 (high20d × ' + (pullbackMaxMul).toFixed(2) + ')', type: 'line', data: bandUpperXY, lineStyle: { width: 0.6, color: '#057a55', type: 'dashed', opacity: 0.4 }, symbol: 'none', connectNulls: false, z: 1 },
-            { name: '押し目ゾーン下端 (high20d × ' + (pullbackMinMul).toFixed(2) + ')', type: 'line', data: bandLowerXY, lineStyle: { width: 0.6, color: '#b25000', type: 'dashed', opacity: 0.4 }, symbol: 'none', connectNulls: false, z: 1 },
+            {
+              name: '押し目ゾーン上端 (high20d × ' + (pullbackMaxMul).toFixed(2) + ')',
+              type: 'line', data: bandUpperXY,
+              lineStyle: { width: 1, color: '#057a55', type: 'dashed', opacity: 0.7 },
+              symbol: 'none', connectNulls: false, z: 1,
+              markArea: pullbackBandMarkArea || undefined,
+            },
+            {
+              name: '押し目ゾーン下端 (high20d × ' + (pullbackMinMul).toFixed(2) + ')',
+              type: 'line', data: bandLowerXY,
+              lineStyle: { width: 1, color: '#b25000', type: 'dashed', opacity: 0.7 },
+              symbol: 'none', connectNulls: false, z: 1,
+            },
           ]),
           // 価格トレンド (linear regression, 直近 30 日 daily close fit)。
           // 1 本だけ。中間色 (紫 #9333ea) で「上値 / 下値どちらでもない、価格

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -3038,7 +3038,13 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
       }
       var bandUpperY = latestHigh20d == null ? null : latestHigh20d * pullbackMaxMul;
       var bandLowerY = latestHigh20d == null ? null : latestHigh20d * pullbackMinMul;
-      var pullbackBandMarkArea = (bandUpperY != null && bandLowerY != null) ? {
+      var bandTopY = null;
+      var bandBottomY = null;
+      if (bandUpperY != null && bandLowerY != null) {
+        bandTopY = Math.max(bandUpperY, bandLowerY);
+        bandBottomY = Math.min(bandUpperY, bandLowerY);
+      }
+      var pullbackBandMarkArea = (bandTopY != null && bandBottomY != null) ? {
         silent: true,
         itemStyle: {
           color: 'rgba(255, 180, 50, 0.12)',
@@ -3047,8 +3053,8 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
           borderType: 'dashed',
         },
         data: [[
-          { yAxis: bandLowerY, name: '押し目ゾーン' },
-          { yAxis: bandUpperY },
+          { yAxis: bandBottomY, name: '押し目ゾーン' },
+          { yAxis: bandTopY },
         ]],
       } : null;
 


### PR DESCRIPTION
## Motivation

個別銘柄 chart (`/dashboard/charts?symbol=...`) の押し目ゾーンは、`high20d × (1+pullbackMax)` (= e.g. -3%) と `high20d × (1+pullbackMin)` (= -6%) の dashed line 2 本だけで描画されていた。3% 幅は y 軸スケール次第で線同士がほぼ重なって見え、「押し目ゾーンがどこか」が一目で掴めない問題があった。

## Changes

`src/routes/dashboard.ts` `renderSymbolTab` の chart series に以下を追加:

1. 最新の有効な `high20d` を `sc.points` の末尾から線形探索 (`latestHigh20d`)。
2. その値で `bandUpperY = latestHigh20d * (1+pullbackMax)` / `bandLowerY = latestHigh20d * (1+pullbackMin)` を計算。
3. 押し目ゾーン上端 line series の `markArea` に `[bandLowerY, bandUpperY]` を渡し、半透明オレンジ (`rgba(255, 180, 50, 0.12)`) の横帯として fill。
4. 既存の per-timestamp の上下端 dashed line は **参照線として残す** (high20d の日次推移を見せる役割)。style はやや強化 (width 0.6→1、opacity 0.4→0.7)。

`high20d` は 20 日移動高値で日次更新、chart 表示期間 (~60 日) の中では緩やかにしか動かないため、最新値で固定した横帯は視覚的近似として十分。`sc.position` が存在する保有時は従来通り押し目バンド全体を非表示 (avg/stop/TP に集中するため)。

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test --run` — 961 / 961 passed
- [ ] visual: 個別銘柄 chart に薄いオレンジ帯が現れて押し目ゾーンが視認しやすくなる
- [ ] visual: 保有時は markArea も含めて非表示のまま (avg/stop/TP に集中)
- [ ] visual: tooltip / legend に余計な entry が出ない (markArea silent: true)

## Notes

- markArea は `silent: true` にして tooltip dedup (#231) と整合。
- z は line series が `z: 1` で markArea 自身は z 指定なし (= デフォルト 0、最も背後) → candle `z: 5` / SMA50 `z: 6` / trend line `z: 7` の下に隠れる正しい順序。
- POC scope: dashboard visualization-only。trading logic / data layer に変更なし。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * チャートの「押し目ゾーン」表示を改善しました。最新の有効データに基づく固定の水平バンドを半透明で塗りつぶし、境界線の太さと不透明度を強化して視認性を向上させました。
  * 従来の時刻ごとの動的な点線境界線は引き続き表示されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->