### PR TITLE
feat(dashboard): stop/TP preview lines (保有ナシでも可視化)

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1956,6 +1956,18 @@ export interface SymbolChartData {
   trendLine: TrendLineSegment | null
   /** Yahoo 日次 OHLC、candlestick 描画用 (空配列 = Yahoo fetch 失敗) */
   intradayBars: OhlcBar[]
+  /**
+   * 最新の cron-eval point (= strategy_decision_log 由来) の price。
+   * Yahoo daily filler を含めず、merge 前 cron-eval の末尾を採用する。
+   *
+   * preview stop/TP の virtualAvg はこの値を使う。`points` 末尾は
+   * Yahoo filler だと「古い日次 close」になる可能性があり、preview に使うと
+   * 「実 strategy 評価で参照していない過去価格」で線が引かれて誤解を招く。
+   * cron eval 履歴が無い (= strategy_decision_log が空) 場合は null。
+   */
+  latestCronPrice: number | null
+  /** `latestCronPrice` の timestamp (ISO Z)。preview line の to-end 用。null 時 preview 描画スキップ。 */
+  latestCronTimestamp: string | null
 }
 
 /**
@@ -2052,6 +2064,13 @@ export async function loadSymbolChart(
   const yahooBars =
     cronLastTs == null ? yahooBarsRaw : yahooBarsRaw.filter((b) => b.timestamp <= cronLastTs)
 
+  // 最新 cron-eval point (= 実 strategy 評価で使った値) を merge 前に snapshot。
+  // mergedPoints[末尾] は Yahoo daily filler の可能性があり (cron 停止中 / 古い銘柄)、
+  // preview stop/TP に使うと「strategy 上は触ってない過去 Yahoo 値」で線が引かれて
+  // 誤解を招く。preview は cron eval 履歴がある時だけ描く方針 → null フィールドで
+  // 「描画スキップ」シグナルにする。
+  const { latestCronPrice, latestCronTimestamp } = selectLatestCronSnapshot(points)
+
   // Yahoo bar を points にマージして全期間 price line を実現。同 timestamp で
   // 既に cron-eval point があればそちらを優先 (indicators が乗っているため)。
   // Yahoo bar 由来の point は indicators フィールド全 null。
@@ -2118,6 +2137,8 @@ export async function loadSymbolChart(
     rules,
     trendLine,
     intradayBars: intradayBars,
+    latestCronPrice,
+    latestCronTimestamp,
   }
 }
 
@@ -2159,6 +2180,35 @@ export async function loadAllSymbolCharts(
       }
     }),
   )
+}
+
+/**
+ * cron-eval points の末尾 (= 実 strategy 評価で参照した最新価格) を取り出して
+ * `{ latestCronPrice, latestCronTimestamp }` を返す。preview stop/TP は
+ * Yahoo filler を含む `mergedPoints[末尾]` ではなくこちらを使う方針。
+ *
+ * - cron 履歴空 / 末尾 price 非有限 / 末尾 timestamp 不正 → 全 null
+ *   (= preview 描画スキップのシグナル)。
+ * - 末尾の price は >= 0 で finite なものだけ採用 (株価の sanity check)。
+ *
+ * 入力は merge 前 (= strategy_decision_log 由来) の SymbolChartPoint[] を想定。
+ * 呼出側が誤って merged points を渡しても動くが、その場合は filler 末尾を
+ * 拾うので preview の意図と乖離する。設計上、`loadSymbolChart` 内で merge
+ * 前に呼ぶこと。
+ */
+export function selectLatestCronSnapshot(
+  cronPoints: SymbolChartPoint[],
+): { latestCronPrice: number | null; latestCronTimestamp: string | null } {
+  if (cronPoints.length === 0) {
+    return { latestCronPrice: null, latestCronTimestamp: null }
+  }
+  const last = cronPoints[cronPoints.length - 1]!
+  const tsValid = Number.isFinite(new Date(last.timestamp).getTime())
+  const priceValid = Number.isFinite(last.price)
+  if (!tsValid || !priceValid) {
+    return { latestCronPrice: null, latestCronTimestamp: null }
+  }
+  return { latestCronPrice: last.price, latestCronTimestamp: last.timestamp }
 }
 
 /**
@@ -3224,8 +3274,12 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
       var stopLabel = '';
       var tpLabel = '';
       // 保有ナシ時に「もし今 BUY したら」の損切り / 利食い水準を仮置きで描く
-      // preview lines。virtualAvg = 最新 cron eval price (sc.points 末尾) を
-      // 仮の avg と見立てる。BUY 検討時に水準が見えないと判断材料に欠けるため、
+      // preview lines。virtualAvg = sc.latestCronPrice (= 直近 cron eval で
+      // strategy 評価に使った価格) を仮の avg と見立てる。
+      // sc.points[末尾] を使うと Yahoo daily filler が末尾に来ているケース
+      // (cron 停止中 / 銘柄古い) で「過去 Yahoo close」を avg にしてしまい、
+      // user に「最新評価値」と誤解させる。latestCronPrice が null = 評価履歴
+      // 自体が無い → preview line そのものを描画スキップする。
       // dotted + opacity 0.5 で「actual position ではない」と区別する。
       var previewStopLineXY = null;
       var previewTpLineXY = null;
@@ -3253,14 +3307,22 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
         avgLabel = 'avg ' + avg.toFixed(2);
         stopLabel = 'stop ' + stopPrice.toFixed(2) + ' (' + (sc.rules.stopPct * 100).toFixed(0) + '%)';
         tpLabel = 'TP ' + tpPrice.toFixed(2) + ' (+' + (sc.rules.takeProfitPct * 100).toFixed(0) + '%)';
-      } else if (sc.points.length > 0) {
-        var virtualAvg = sc.points[sc.points.length - 1].price;
-        if (Number.isFinite(virtualAvg)) {
-          var pStopPrice = virtualAvg * (1 + sc.rules.stopPct);
-          var pTpPrice = virtualAvg * (1 + sc.rules.takeProfitPct);
-          extraYValues.push(pStopPrice, pTpPrice);
-          var pFromMs = new Date(sc.points[0].timestamp).getTime();
-          var pToMs = new Date(sc.points[sc.points.length - 1].timestamp).getTime();
+      } else if (
+        sc.points.length > 0 &&
+        sc.latestCronPrice != null &&
+        sc.latestCronPrice > 0 &&
+        sc.latestCronTimestamp != null
+      ) {
+        var virtualAvg = sc.latestCronPrice;
+        var pStopPrice = virtualAvg * (1 + sc.rules.stopPct);
+        var pTpPrice = virtualAvg * (1 + sc.rules.takeProfitPct);
+        extraYValues.push(pStopPrice, pTpPrice);
+        // preview line の x 範囲: chart 開始 → 最新 cron eval timestamp。
+        // 末尾を Yahoo filler 末尾まで伸ばすと「最新 cron 以降の Yahoo 区間」
+        // にも線が出てしまい virtualAvg と整合しないので latestCron まで。
+        var pFromMs = new Date(sc.points[0].timestamp).getTime();
+        var pToMs = new Date(sc.latestCronTimestamp).getTime();
+        if (Number.isFinite(pFromMs) && Number.isFinite(pToMs)) {
           previewStopLineXY = toCategoryXY(densifyHorizontalLine(pStopPrice, pFromMs, pToMs, ohlcTimestamps));
           previewTpLineXY = toCategoryXY(densifyHorizontalLine(pTpPrice, pFromMs, pToMs, ohlcTimestamps));
           previewStopLabel = 'preview stop ' + pStopPrice.toFixed(2) + ' (' + (sc.rules.stopPct * 100).toFixed(0) + '%)';
@@ -3674,15 +3736,15 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
             pushIfFinite(avg * (1 + sc.rules.stopPct));
             pushIfFinite(avg * (1 + sc.rules.takeProfitPct));
           }
-        } else if (sc.points.length > 0) {
-          // preview lines は chart 全幅 (sc.points 全期間) に展開しているため、
-          // visible 範囲とは常に交差する想定。virtualAvg = 末尾 price から
-          // stop/TP を算出して y range に含める。
-          var pVirtualAvg = sc.points[sc.points.length - 1].price;
-          if (Number.isFinite(pVirtualAvg)) {
-            pushIfFinite(pVirtualAvg * (1 + sc.rules.stopPct));
-            pushIfFinite(pVirtualAvg * (1 + sc.rules.takeProfitPct));
-          }
+        } else if (sc.latestCronPrice != null && sc.latestCronPrice > 0) {
+          // preview lines は描画範囲が chart 開始 → 最新 cron eval まで。
+          // visible 範囲とは常に交差する想定。virtualAvg = latestCronPrice
+          // (Yahoo filler ではなく実 strategy 評価値) から stop/TP を算出。
+          // latestCronPrice == null のときは preview 線そのものを描いていない
+          // ので y range にも含めない (= 軸が無駄に広がるのを防ぐ)。
+          var pVirtualAvg = sc.latestCronPrice;
+          pushIfFinite(pVirtualAvg * (1 + sc.rules.stopPct));
+          pushIfFinite(pVirtualAvg * (1 + sc.rules.takeProfitPct));
         }
         if (visibleY.length === 0) return;
         var rawMin = Math.min.apply(null, visibleY);
@@ -4046,8 +4108,9 @@ export function renderGridTab(args: ChartsBodyGrid): string {
           return out;
         }
         var avgLineXY = null, stopLineXY = null, tpLineXY = null;
-        // 保有ナシ時の preview stop/TP (current price ベースの仮置き)。
-        // 個別銘柄タブと同方針 (詳細コメントは上方参照)。
+        // 保有ナシ時の preview stop/TP (latestCronPrice ベースの仮置き)。
+        // 個別銘柄タブと同方針 (詳細コメントは上方参照)。Yahoo filler を
+        // 含めないために sc.latestCronPrice / sc.latestCronTimestamp を採用。
         var previewStopLineXY = null, previewTpLineXY = null;
         var extraYValues = [];
         if (sc.position) {
@@ -4063,14 +4126,19 @@ export function renderGridTab(args: ChartsBodyGrid): string {
           avgLineXY = toCategoryXY(densifyHorizontalLine(avg, fromMs, toMs, ohlcTimestamps));
           stopLineXY = toCategoryXY(densifyHorizontalLine(stopPrice, fromMs, toMs, ohlcTimestamps));
           tpLineXY = toCategoryXY(densifyHorizontalLine(tpPrice, fromMs, toMs, ohlcTimestamps));
-        } else if (sc.points.length > 0) {
-          var virtualAvg = sc.points[sc.points.length - 1].price;
-          if (Number.isFinite(virtualAvg)) {
-            var pStopPrice = virtualAvg * (1 + sc.rules.stopPct);
-            var pTpPrice = virtualAvg * (1 + sc.rules.takeProfitPct);
-            extraYValues.push(pStopPrice, pTpPrice);
-            var pFromMs = new Date(sc.points[0].timestamp).getTime();
-            var pToMs = new Date(sc.points[sc.points.length - 1].timestamp).getTime();
+        } else if (
+          sc.points.length > 0 &&
+          sc.latestCronPrice != null &&
+          sc.latestCronPrice > 0 &&
+          sc.latestCronTimestamp != null
+        ) {
+          var virtualAvg = sc.latestCronPrice;
+          var pStopPrice = virtualAvg * (1 + sc.rules.stopPct);
+          var pTpPrice = virtualAvg * (1 + sc.rules.takeProfitPct);
+          extraYValues.push(pStopPrice, pTpPrice);
+          var pFromMs = new Date(sc.points[0].timestamp).getTime();
+          var pToMs = new Date(sc.latestCronTimestamp).getTime();
+          if (Number.isFinite(pFromMs) && Number.isFinite(pToMs)) {
             previewStopLineXY = toCategoryXY(densifyHorizontalLine(pStopPrice, pFromMs, pToMs, ohlcTimestamps));
             previewTpLineXY = toCategoryXY(densifyHorizontalLine(pTpPrice, pFromMs, pToMs, ohlcTimestamps));
           }

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -3223,6 +3223,14 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
       var avgLabel = '';
       var stopLabel = '';
       var tpLabel = '';
+      // 保有ナシ時に「もし今 BUY したら」の損切り / 利食い水準を仮置きで描く
+      // preview lines。virtualAvg = 最新 cron eval price (sc.points 末尾) を
+      // 仮の avg と見立てる。BUY 検討時に水準が見えないと判断材料に欠けるため、
+      // dotted + opacity 0.5 で「actual position ではない」と区別する。
+      var previewStopLineXY = null;
+      var previewTpLineXY = null;
+      var previewStopLabel = '';
+      var previewTpLabel = '';
       var extraYValues = [];
       if (sc.position) {
         var avg = sc.position.avgPrice;
@@ -3245,6 +3253,19 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
         avgLabel = 'avg ' + avg.toFixed(2);
         stopLabel = 'stop ' + stopPrice.toFixed(2) + ' (' + (sc.rules.stopPct * 100).toFixed(0) + '%)';
         tpLabel = 'TP ' + tpPrice.toFixed(2) + ' (+' + (sc.rules.takeProfitPct * 100).toFixed(0) + '%)';
+      } else if (sc.points.length > 0) {
+        var virtualAvg = sc.points[sc.points.length - 1].price;
+        if (Number.isFinite(virtualAvg)) {
+          var pStopPrice = virtualAvg * (1 + sc.rules.stopPct);
+          var pTpPrice = virtualAvg * (1 + sc.rules.takeProfitPct);
+          extraYValues.push(pStopPrice, pTpPrice);
+          var pFromMs = new Date(sc.points[0].timestamp).getTime();
+          var pToMs = new Date(sc.points[sc.points.length - 1].timestamp).getTime();
+          previewStopLineXY = toCategoryXY(densifyHorizontalLine(pStopPrice, pFromMs, pToMs, ohlcTimestamps));
+          previewTpLineXY = toCategoryXY(densifyHorizontalLine(pTpPrice, pFromMs, pToMs, ohlcTimestamps));
+          previewStopLabel = 'preview stop ' + pStopPrice.toFixed(2) + ' (' + (sc.rules.stopPct * 100).toFixed(0) + '%)';
+          previewTpLabel = 'preview TP ' + pTpPrice.toFixed(2) + ' (+' + (sc.rules.takeProfitPct * 100).toFixed(0) + '%)';
+        }
       }
 
       // ECharts の scale:true は markLine を yAxis range に含めないため、
@@ -3525,6 +3546,28 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
             endLabel: { show: true, formatter: tpLabel, color: '#057a55', fontSize: 11 },
             silent: true, emphasis: { disabled: true }, z: 8,
           }] : []),
+          // 保有ナシ時の preview stop / TP (current price ベース)。dotted +
+          // opacity 0.5 で「actual position の線ではない、仮置き」と視覚区別。
+          // z:7 にして actual の z:8 より下に置く (混在することは無いが、
+          // 凡例での視覚上の優先度として明示)。
+          ...(previewStopLineXY ? [{
+            name: previewStopLabel, type: 'line', data: previewStopLineXY,
+            lineStyle: { width: 1, color: '#c22', type: 'dotted', opacity: 0.5 }, symbol: 'none',
+            itemStyle: { color: '#c22', opacity: 0.5 },
+            endLabel: {
+              show: true, formatter: previewStopLabel, color: '#c22', fontSize: 10, opacity: 0.7,
+            },
+            silent: true, emphasis: { disabled: true }, z: 7,
+          }] : []),
+          ...(previewTpLineXY ? [{
+            name: previewTpLabel, type: 'line', data: previewTpLineXY,
+            lineStyle: { width: 1, color: '#057a55', type: 'dotted', opacity: 0.5 }, symbol: 'none',
+            itemStyle: { color: '#057a55', opacity: 0.5 },
+            endLabel: {
+              show: true, formatter: previewTpLabel, color: '#057a55', fontSize: 10, opacity: 0.7,
+            },
+            silent: true, emphasis: { disabled: true }, z: 7,
+          }] : []),
         ],
       });
       window.addEventListener('resize', function () { symChart.resize(); });
@@ -3630,6 +3673,15 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
             pushIfFinite(avg);
             pushIfFinite(avg * (1 + sc.rules.stopPct));
             pushIfFinite(avg * (1 + sc.rules.takeProfitPct));
+          }
+        } else if (sc.points.length > 0) {
+          // preview lines は chart 全幅 (sc.points 全期間) に展開しているため、
+          // visible 範囲とは常に交差する想定。virtualAvg = 末尾 price から
+          // stop/TP を算出して y range に含める。
+          var pVirtualAvg = sc.points[sc.points.length - 1].price;
+          if (Number.isFinite(pVirtualAvg)) {
+            pushIfFinite(pVirtualAvg * (1 + sc.rules.stopPct));
+            pushIfFinite(pVirtualAvg * (1 + sc.rules.takeProfitPct));
           }
         }
         if (visibleY.length === 0) return;
@@ -3994,6 +4046,9 @@ export function renderGridTab(args: ChartsBodyGrid): string {
           return out;
         }
         var avgLineXY = null, stopLineXY = null, tpLineXY = null;
+        // 保有ナシ時の preview stop/TP (current price ベースの仮置き)。
+        // 個別銘柄タブと同方針 (詳細コメントは上方参照)。
+        var previewStopLineXY = null, previewTpLineXY = null;
         var extraYValues = [];
         if (sc.position) {
           var avg = sc.position.avgPrice;
@@ -4008,6 +4063,17 @@ export function renderGridTab(args: ChartsBodyGrid): string {
           avgLineXY = toCategoryXY(densifyHorizontalLine(avg, fromMs, toMs, ohlcTimestamps));
           stopLineXY = toCategoryXY(densifyHorizontalLine(stopPrice, fromMs, toMs, ohlcTimestamps));
           tpLineXY = toCategoryXY(densifyHorizontalLine(tpPrice, fromMs, toMs, ohlcTimestamps));
+        } else if (sc.points.length > 0) {
+          var virtualAvg = sc.points[sc.points.length - 1].price;
+          if (Number.isFinite(virtualAvg)) {
+            var pStopPrice = virtualAvg * (1 + sc.rules.stopPct);
+            var pTpPrice = virtualAvg * (1 + sc.rules.takeProfitPct);
+            extraYValues.push(pStopPrice, pTpPrice);
+            var pFromMs = new Date(sc.points[0].timestamp).getTime();
+            var pToMs = new Date(sc.points[sc.points.length - 1].timestamp).getTime();
+            previewStopLineXY = toCategoryXY(densifyHorizontalLine(pStopPrice, pFromMs, pToMs, ohlcTimestamps));
+            previewTpLineXY = toCategoryXY(densifyHorizontalLine(pTpPrice, pFromMs, pToMs, ohlcTimestamps));
+          }
         }
 
         // y 軸 range (candle + markers + position lines のみ。SMA50/band は除外)
@@ -4135,6 +4201,18 @@ export function renderGridTab(args: ChartsBodyGrid): string {
               name: 'tp', type: 'line', data: tpLineXY,
               lineStyle: { width: 1, color: '#057a55', type: 'dashed' }, symbol: 'none',
               silent: true, emphasis: { disabled: true }, z: 8,
+            }] : []),
+            // preview stop / TP (保有ナシで current price ベースの仮置き)。
+            // dotted + opacity 0.5 で actual position lines と区別。
+            ...(previewStopLineXY ? [{
+              name: 'preview stop', type: 'line', data: previewStopLineXY,
+              lineStyle: { width: 1, color: '#c22', type: 'dotted', opacity: 0.5 }, symbol: 'none',
+              silent: true, emphasis: { disabled: true }, z: 7,
+            }] : []),
+            ...(previewTpLineXY ? [{
+              name: 'preview tp', type: 'line', data: previewTpLineXY,
+              lineStyle: { width: 1, color: '#057a55', type: 'dotted', opacity: 0.5 }, symbol: 'none',
+              silent: true, emphasis: { disabled: true }, z: 7,
             }] : []),
           ],
         });

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -1213,6 +1213,56 @@ describe('densifyHorizontalLine', () => {
   })
 })
 
+import { selectLatestCronSnapshot } from '../../src/routes/dashboard'
+
+describe('selectLatestCronSnapshot', () => {
+  it('cron 履歴ありなら末尾 price/timestamp を返す (Yahoo filler を含めない)', () => {
+    const cron: SymbolChartPoint[] = [
+      { timestamp: '2026-04-23T05:00:00.000Z', price: 100, sma50: null, high20d: null, low20d: null },
+      { timestamp: '2026-04-25T05:00:00.000Z', price: 110, sma50: null, high20d: null, low20d: null },
+    ]
+    expect(selectLatestCronSnapshot(cron)).toEqual({
+      latestCronPrice: 110,
+      latestCronTimestamp: '2026-04-25T05:00:00.000Z',
+    })
+  })
+
+  it('空配列なら全 null (= preview 描画スキップ)', () => {
+    expect(selectLatestCronSnapshot([])).toEqual({
+      latestCronPrice: null,
+      latestCronTimestamp: null,
+    })
+  })
+
+  it('末尾 price が NaN なら全 null', () => {
+    const cron: SymbolChartPoint[] = [
+      { timestamp: '2026-04-25T05:00:00.000Z', price: Number.NaN, sma50: null, high20d: null, low20d: null },
+    ]
+    expect(selectLatestCronSnapshot(cron)).toEqual({
+      latestCronPrice: null,
+      latestCronTimestamp: null,
+    })
+  })
+
+  it('末尾 timestamp が不正 ISO なら全 null', () => {
+    const cron: SymbolChartPoint[] = [
+      { timestamp: 'not-an-iso', price: 110, sma50: null, high20d: null, low20d: null },
+    ]
+    expect(selectLatestCronSnapshot(cron)).toEqual({
+      latestCronPrice: null,
+      latestCronTimestamp: null,
+    })
+  })
+
+  it('複数 point の中間に 0 価格があっても末尾だけ判定する', () => {
+    const cron: SymbolChartPoint[] = [
+      { timestamp: '2026-04-23T05:00:00.000Z', price: 0, sma50: null, high20d: null, low20d: null },
+      { timestamp: '2026-04-25T05:00:00.000Z', price: 110, sma50: null, high20d: null, low20d: null },
+    ]
+    expect(selectLatestCronSnapshot(cron).latestCronPrice).toBe(110)
+  })
+})
+
 import { mergeYahooAndCronPoints } from '../../src/routes/dashboard'
 
 describe('mergeYahooAndCronPoints', () => {
@@ -1403,6 +1453,8 @@ describe('computeZoomRange', () => {
       rules: { pullbackMax: 0, pullbackMin: 0, stopPct: 0, takeProfitPct: 0, timeStopDays: 10 },
       trendLine: null,
       intradayBars: [],
+      latestCronPrice: null,
+      latestCronTimestamp: null,
     }
   }
 
@@ -1447,6 +1499,7 @@ describe('computeZoomRange', () => {
       symbol: 'X', points: [], markers: [], position: null,
       rules: { pullbackMax: 0, pullbackMin: 0, stopPct: 0, takeProfitPct: 0, timeStopDays: 10 },
       trendLine: null, intradayBars: [],
+      latestCronPrice: null, latestCronTimestamp: null,
     }
     expect(computeZoomRange(null, null, chart)).toBeNull()
   })
@@ -1491,6 +1544,7 @@ describe('renderCurrentIndicatorsBadge', () => {
       symbol: 'X', points, markers: [], position: null,
       rules: { pullbackMax: 0, pullbackMin: 0, stopPct: 0, takeProfitPct: 0, timeStopDays: 10 },
       trendLine: null, intradayBars: [],
+      latestCronPrice: null, latestCronTimestamp: null,
     }
   }
 
@@ -1546,6 +1600,7 @@ describe('renderZoomPresetButtons', () => {
       symbol: 'X', points, markers: [], position: null,
       rules: { pullbackMax: 0, pullbackMin: 0, stopPct: 0, takeProfitPct: 0, timeStopDays: 10 },
       trendLine: null, intradayBars: [],
+      latestCronPrice: null, latestCronTimestamp: null,
     }
   }
 
@@ -1643,6 +1698,7 @@ describe('renderGridTab', () => {
       symbol, points, markers: [], position: null,
       rules: { pullbackMax: -0.03, pullbackMin: -0.06, stopPct: -0.04, takeProfitPct: 0.07, timeStopDays: 10 },
       trendLine: null, intradayBars: [],
+      latestCronPrice: null, latestCronTimestamp: null,
     }
   }
 


### PR DESCRIPTION
## Summary

- 保有ナシの大半の銘柄では従来 avg/stop/TP が描画されず、BUY 検討時に「stop/TP の水準が見えない」状態だった。
- 最新 cron eval price (`sc.points` 末尾) を仮の avg と見立てて preview の stop/TP を描画し、「もし今 BUY したら」の損切り・利食い水準を可視化する。
- preview lines は **dotted + opacity 0.5** + label に `preview` prefix を付与し、保有中の actual position lines (solid avg / dashed stop / dashed TP) と視覚的に区別する。

## 実装

- `src/routes/dashboard.ts`
  - 個別銘柄チャートと grid panel チャートの両方に対応 (densifyHorizontalLine の dense path を `sc.points` 全幅に展開)
  - `sc.position` がある時は従来通りの actual lines、無い時は `virtualAvg = sc.points[last].price` から preview stop/TP を算出
  - `recomputeYAxis` も preview の y 値を含めて軸の自動 fit が崩れないよう更新
  - `stopPct` / `takeProfitPct` は既存の `sc.rules` を再利用

## UI 区別

| 状態 | avg | stop | TP |
|---|---|---|---|
| 保有中 (既存) | solid (`#444`) + endLabel `avg X` | red dashed + endLabel `stop X (-Y%)` | green dashed + endLabel `TP X (+Y%)` |
| **保有ナシ (新)** | (描かない) | red **dotted** opacity 0.5 + endLabel `preview stop X (-Y%)` | green **dotted** opacity 0.5 + endLabel `preview TP X (+Y%)` |

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test --run` 全 pass (961 tests)
- [ ] visual: 保有ナシ銘柄で薄い dotted の preview stop/TP が表示されることを `/dashboard` で確認
- [ ] visual: 保有中銘柄では従来通り solid avg + dashed stop/TP のままであることを確認
- [ ] visual: grid view の各 panel でも同じ挙動になることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ポジション無し時のストップロス/テイクプロフィットのプレビューをチャートとグリッドに点線で表示。ズーム操作時も表示範囲が自動調整されます。
* **テスト**
  * プレビュー表示の判定ロジックをカバーするテストを追加。表示の有無や無効データ時の挙動を検証するケースを含みます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->