### PR TITLE
fix(dashboard): preview stop/TP label が見切れる問題

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -3325,8 +3325,11 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
         if (Number.isFinite(pFromMs) && Number.isFinite(pToMs)) {
           previewStopLineXY = toCategoryXY(densifyHorizontalLine(pStopPrice, pFromMs, pToMs, ohlcTimestamps));
           previewTpLineXY = toCategoryXY(densifyHorizontalLine(pTpPrice, pFromMs, pToMs, ohlcTimestamps));
-          previewStopLabel = 'preview stop ' + pStopPrice.toFixed(2) + ' (' + (sc.rules.stopPct * 100).toFixed(0) + '%)';
-          previewTpLabel = 'preview TP ' + pTpPrice.toFixed(2) + ' (+' + (sc.rules.takeProfitPct * 100).toFixed(0) + '%)';
+          // label は actual stop/TP と長さを揃える (右端で見切れないよう
+          // "preview" prefix ではなく "(preview)" suffix にして、actual の
+          // "stop X (-Y%)" と同等の幅に収める)。
+          previewStopLabel = 'stop ' + pStopPrice.toFixed(2) + ' (preview)';
+          previewTpLabel = 'TP ' + pTpPrice.toFixed(2) + ' (preview)';
         }
       }
 
@@ -3458,7 +3461,9 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
         legend: { top: 22, type: 'scroll' },
         // plot 面積最大化: grid 余白を絞り、splitLine 淡く、axisLine 非表示で
         // candle が映える背景に (trader-strategist 助言)。bottom は slider 用 64px キープ。
-        grid: { left: 50, right: 20, top: 56, bottom: 64 },
+        // right は stop/TP の endLabel ("stop X (preview)" 等) が見切れないよう
+        // 80px 確保 (短い "stop X (-Y%)" でも余白として違和感ない範囲)。
+        grid: { left: 50, right: 80, top: 56, bottom: 64 },
         dataZoom: dataZoomCfg,
         // category mode: categories = intradayBars 各 bar の ISO timestamp。
         // overnight / 週末 / 米国祝日の空白を「詰めて」表示するため (TradingView


### PR DESCRIPTION
## 動機

dashboard chart で actual position の \`stop X (-Y%)\` / \`TP X (+Y%)\` は右端に収まっているが、preview 線の \`preview stop X (-Y%)\` / \`preview TP X (+Y%)\` は prefix 分長く chart 右端で truncate されて \`previe...\` と途中で切れていた。

原因は二つ:

1. label 自体が actual より長い (\`preview\` prefix 分)
2. \`grid.right: 20px\` だと endLabel の描画領域が不足

## 修正

`src/routes/dashboard.ts` (\`renderSymbolTab\`):

1. **label 短縮**: prefix を suffix 化して actual と同等長に
   - before: \`'preview stop ' + price + ' (' + stopPct + '%)'\`
   - after:  \`'stop ' + price + ' (preview)'\`
   - TP 側も同様に \`'TP ' + price + ' (preview)'\`
2. **grid.right 拡張**: \`20\` → \`80\` (endLabel 描画領域確保)

actual position の avg/stop/TP label は影響なし。grid view (\`buildPanel\`) は元から preview の endLabel を使っていないので変更不要。

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test --run\` 966 tests pass
- [ ] visual: 個別銘柄 chart の preview stop/TP label が右端で完全表示される
- [ ] visual: actual position 保有銘柄の stop/TP label に regression がない (右余白が増えるが文字は同じ)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * シンボルチャートのプレビュー停止/TP終了ラベルの表示形式を改善しました
  * パーセンテージ表示を削除し、価格と「preview」ラベルを表示するように変更されました
  * チャートレイアウトの右パディングを調整し、エッジのラベルのクリップ問題を解決しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->