### PR TITLE
fix(dashboard): preview label の見切れ + 押し目ゾーン文字削除

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -3096,7 +3096,7 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
           borderType: 'dashed',
         },
         data: [[
-          { yAxis: bandBottomY, name: '押し目ゾーン' },
+          { yAxis: bandBottomY },
           { yAxis: bandTopY },
         ]],
       } : null;
@@ -3463,7 +3463,7 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
         // candle が映える背景に (trader-strategist 助言)。bottom は slider 用 64px キープ。
         // right は stop/TP の endLabel ("stop X (preview)" 等) が見切れないよう
         // 80px 確保 (短い "stop X (-Y%)" でも余白として違和感ない範囲)。
-        grid: { left: 50, right: 80, top: 56, bottom: 64 },
+        grid: { left: 50, right: 120, top: 56, bottom: 64 },
         dataZoom: dataZoomCfg,
         // category mode: categories = intradayBars 各 bar の ISO timestamp。
         // overnight / 週末 / 米国祝日の空白を「詰めて」表示するため (TradingView


### PR DESCRIPTION
## 動機

dashboard chart の price + トレンドラインビューに残っていた 2 点の見栄え問題を修正。

1. **preview stop/TP label の見切れ**: PR #235 で `grid.right` を 80 に拡大したが、依然として "(preview)" の末尾が `previe` / `prev` で切れていた。
2. **押し目ゾーン文字 label の chart 内描画**: PR #232 で `markArea` の `data[0]` に `name: '押し目ゾーン'` を設定したが、これが chart 内に文字 label として描画され見栄えが悪い。凡例には line series host 側で表示されているので冗長。

## 修正

`src/routes/dashboard.ts` (`renderSymbolTab`):

- `grid.right`: 80 → **120** へ拡大して preview stop/TP label を完全表示。
- `pullbackBandMarkArea.data[0]` の `name: '押し目ゾーン'` を **削除**。chart 内 text 描画を消す。
- 凡例用の line series host (`name: '押し目ゾーン'`, type: 'line', markArea: pullbackBandMarkArea) は **維持** → legend には引き続き "押し目ゾーン" エントリが表示。

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test --run` 全 pass (966 tests)
- [ ] visual: preview stop/TP label 完全表示 + chart 内 "押し目ゾーン" text なし、凡例には "押し目ゾーン" が引き続き表示

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * チャートの右側のラベル表示を改善し、ストップロスやテイクプロフィットなどの表示が切れなくなりました。
  * チャートの水平レイアウトスペースを調整し、より良い表示体験を実現しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->