### PR TITLE
feat(observability): quote_feed partial failure を /dashboard/alerts に昇格

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -116,6 +116,29 @@ export default {
               errors: summary.errors,
             }),
           )
+          // Partial failure: getSnapshots() がカテゴリ単位で throw しても全体の
+          // promise は resolve するため、summary.errors にだけ積まれて silent に
+          // なってた (SOXL が 5 日 stale だったケース)。errors 件数 > 0 のときは
+          // /dashboard/alerts に warning として昇格させ、operator が cron 沈黙を
+          // 検知できるようにする。global throw の cause='quote_feed' とは区別する
+          // ため cause='quote_feed_partial'。
+          if (summary.errors.length > 0) {
+            const summaryMsg = summary.errors
+              .slice(0, 3)
+              .map((e) => `[${e.category}] ${e.message}`)
+              .join(' | ')
+            const tail = summary.errors.length > 3 ? ` (+${summary.errors.length - 3} more)` : ''
+            ctx.waitUntil(
+              createNotifier(env, { requestId })
+                .notify({
+                  type: 'ERROR',
+                  message: `quote_feed partial failure (${summary.errors.length} error(s)): ${summaryMsg}${tail}`,
+                  cause: 'quote_feed_partial',
+                  severity: 'warning',
+                })
+                .catch(() => undefined),
+            )
+          }
         },
         (error) => {
           const message = error instanceof Error ? error.message : String(error)


### PR DESCRIPTION
## Summary

SOXL の \`SymbolStateDO.lastQuote\` が 5 日固定 (2026-04-23 02:50Z 以降) で BUY が risk gate #4 (halt or stale quote) に永久 reject される件の **根因可視化**。

\`runQuoteFeed\` の per-category catch (\`quoteScheduler.ts:55-60\`) は entire batch を silent に \`continue\` するだけで、partial failure は console log にしか出ず \`/dashboard/alerts\` にも通知されない。operator が「cron は走ってるけど特定 category だけ stale」状態に気付けない。

## 変更

\`src/index.ts\` の \`runQuoteFeed\` success branch に追加:

\`\`\`ts
if (summary.errors.length > 0) {
  // 先頭 3 件を [category] message 形式で連結 + 超過分は '+N more'
  notify({
    type: 'ERROR',
    message: \`quote_feed partial failure (\${n} error(s)): ...\`,
    cause: 'quote_feed_partial',
    severity: 'warning',
  })
}
\`\`\`

- global throw 経路 (\`cause='quote_feed'\`) とは別 cause で区別 → alerts dashboard で「全体 fail」と「部分 fail」を分けて見れる
- severity 'warning' に統一 (POC fail-closed 設計上、quote stale → BUY 自動 reject なので critical ではない)

## なぜ今これだけ

- 本 PR は **可視化のみ** (broker 側 root cause の修正 / fallback retry / 自動回復は含まない)
- まず alerts に出ることを確認してから、(B) probe endpoint や (D) manual refresh の必要性を判断

## Test plan

- [x] pnpm typecheck pass
- [x] pnpm test pass (966 tests)
- [ ] deploy 後、次の 5 分 cron で /dashboard/alerts に \`quote_feed_partial\` warning が出ること (現状 SOXL stale なので 100% 出るはず)
- [ ] 表示された message から実際の broker error 本文を読み取れること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* クォートフィード処理が部分的に失敗した場合、警告通知が表示されるようになりました。処理全体は成功しても、カテゴリレベルでのデータ取得失敗を検出し、オペレータに可視化します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->