### PR TITLE
fix(dashboard): grid view の cross-panel tooltip 同期を解除 (zoom 同期は維持)

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -4472,22 +4472,30 @@ export function renderGridTab(args: ChartsBodyGrid): string {
         var built = buildPanel('grid-chart-' + i, entry.chart);
         if (built) panels.push(built);
       }
-      // echarts.connect で全 panel の dataZoom / tooltip / legend を同期。
-      // Datadog dashboard と同様、1 panel で zoom/pan するだけで他 panel が
-      // 連動して同じ時間帯にスクロール。
+      // echarts.connect は dataZoom / tooltip / legend / axisPointer を一括で
+      // sync するため、16 panel で 1 つの panel を hover すると全 panel に同時
+      // tooltip が popup する (#240 後発見、ユーザ #43 報告)。よって
+      // **echarts.connect は使わず**、dataZoom だけを手動で broadcast する形に
+      // 切り替える。tooltip は各 panel ローカル — 自分の panel の hover 時だけ
+      // 自分の panel に表示。
+      //
+      // panel 間の dataZoom 同期方針:
+      //   1. 起点 panel の dataZoom event を listen
+      //   2. その startValue/endValue を ms 範囲に変換 (category mode は
+      //      categories[idx] の timestamp を採用)
+      //   3. 他 panel に dispatchAction({type:'dataZoom', startValue, endValue})
+      //      を **debounce 後 1 回だけ** 配信。各 panel は自分の category index
+      //      / time ms にあわせ変換 (panelMsToNative)。
+      //   4. dispatchAction の echarts 側 hook が再度 dataZoom event を発火
+      //      するので、suppressBroadcast フラグで無限ループ防止。
       var instances = panels.map(function (p) { return p.chart; });
-      if (instances.length > 0) echarts.connect(instances);
 
       // resize 時は全 panel を resize (responsive)
       window.addEventListener('resize', function () {
         for (var i = 0; i < instances.length; i += 1) instances[i].resize();
       });
 
-      // 1 panel の dataZoom event を listen して URL ?from / ?to を更新
-      // (個別銘柄タブと同方針)。connect 越しに他 panel の dataZoom も同期し
-      // 全 panel が同じイベントを発火しうるが、debounce 200ms でまとめる。
-      // 起点 panel は category mode / time mode のどちらでも構わない (同一
-      // ms 範囲を URL に書き戻す)。
+      // panel の現在 dataZoom 範囲を ms 範囲に変換 (category / time 両対応)。
       function panelDataZoomToMs(panel) {
         var opt = panel.chart.getOption();
         var dz = opt.dataZoom && opt.dataZoom[0];
@@ -4504,13 +4512,47 @@ export function renderGridTab(args: ChartsBodyGrid): string {
         }
         return { fromMs: sv, toMs: ev };
       }
+      // 受信 panel の native 軸単位 (category index or ms) に変換。
+      function panelMsToNative(panel, fromMs, toMs) {
+        if (panel.useCategoryAxis) {
+          if (panel.ohlcMs.length === 0) return null;
+          var sIdx = panel.nearestIndex(fromMs);
+          var eIdx = panel.nearestIndex(toMs);
+          if (sIdx < 0 || eIdx < 0) return null;
+          if (sIdx > eIdx) { var tmp = sIdx; sIdx = eIdx; eIdx = tmp; }
+          return { startValue: sIdx, endValue: eIdx };
+        }
+        return { startValue: fromMs, endValue: toMs };
+      }
       var dzTimer = null;
-      function onDz() {
+      var suppressBroadcast = false;
+      function onDz(srcPanel) {
+        if (suppressBroadcast) return;
         if (dzTimer) clearTimeout(dzTimer);
         dzTimer = setTimeout(function () {
-          if (panels.length === 0) return;
-          var range = panelDataZoomToMs(panels[0]);
+          var range = panelDataZoomToMs(srcPanel);
           if (!range) return;
+          // 1. 他 panel に broadcast (suppressBroadcast 中は再 emit を捨てる)
+          suppressBroadcast = true;
+          try {
+            for (var i = 0; i < panels.length; i += 1) {
+              var p = panels[i];
+              if (p === srcPanel) continue;
+              var native = panelMsToNative(p, range.fromMs, range.toMs);
+              if (!native) continue;
+              p.chart.dispatchAction({
+                type: 'dataZoom',
+                startValue: native.startValue,
+                endValue: native.endValue,
+              });
+            }
+          } finally {
+            // dispatchAction が同期発火する dataZoom event を捌き終えたら解除。
+            // setTimeout 0 で micro-task 単位の遅延を入れる (echarts の listener
+            // は同期的に呼ばれるが念のため遅延)。
+            setTimeout(function () { suppressBroadcast = false; }, 0);
+          }
+          // 2. URL ?from / ?to を更新
           try {
             var fromIso = new Date(range.fromMs).toISOString();
             var toIso = new Date(range.toMs).toISOString();
@@ -4521,9 +4563,9 @@ export function renderGridTab(args: ChartsBodyGrid): string {
           } catch (e) { /* noop */ }
         }, 200);
       }
-      for (var pi2 = 0; pi2 < panels.length; pi2 += 1) {
-        panels[pi2].chart.on('dataZoom', onDz);
-      }
+      panels.forEach(function (panel) {
+        panel.chart.on('dataZoom', function () { onDz(panel); });
+      });
 
       // preset zoom buttons (1D/5D/1M/All): 全 panel に dispatchAction で
       // 共通 ms 範囲を broadcast。category mode panel では nearestIndex で

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -2771,9 +2771,12 @@ interface ChartsBodySymbol {
 
 /**
  * 銘柄グリッドビュー: ALLOWED_SYMBOLS を 4 列 (responsive) grid で並列表示。
- * 各 panel は個別 mini chart で、Datadog dashboard 風に dataZoom と tooltip が
- * `echarts.connect` 経由で全 panel 間で同期する。preset zoom (1D/5D/1M/All)
- * は grid 全体共通の toolbar から発火し、全 chart へ dispatchAction される。
+ * 各 panel は個別 mini chart で、dataZoom (zoom/pan) のみ全 panel 間で同期。
+ * tooltip / axisPointer は **panel ローカル** — hover 中の panel だけに表示
+ * (16 panel で全 popup する問題を避けるため `echarts.connect` は使わず、
+ * 起点 panel の dataZoom を `dispatchAction` で他 panel に broadcast する手動
+ * 同期に切替えた、PR #241)。preset zoom (1D/5D/1M/All) も同様に dispatchAction
+ * で全 chart に配信。
  */
 interface ChartsBodyGrid {
   tab: 'grid'
@@ -3903,17 +3906,20 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
 
 /**
  * 銘柄グリッドビュー (Datadog dashboard 風)。ALLOWED_SYMBOLS を 4 列 grid で
- * 並列表示し、`echarts.connect('symbols-grid')` で全 panel の dataZoom と
- * tooltip を同期させる。preset zoom (1D/5D/1M/All) は grid 共通 toolbar から
- * 全 chart へ dispatchAction で broadcast。
+ * 並列表示。dataZoom (zoom/pan) のみ全 panel 間で同期、tooltip は panel ローカル
+ * (PR #241 で `echarts.connect` を撤去、起点 panel → 他 panel へ手動
+ * `dispatchAction({type:'dataZoom'})` で broadcast)。preset zoom (1D/5D/1M/All)
+ * も grid 共通 toolbar から dispatchAction で全 chart に配信。
  *
- * mini chart の構成 (個別銘柄タブの簡素版):
+ * mini chart の構成 (PR #239 で個別銘柄タブと表示要素パリティ):
  * - candle (1h OHLC)
  * - 価格トレンド (linear regression)
- * - 保有時の avg / stop / TP 水平線
- * - BUY/SELL pin (markPoint)
+ * - SMA50
+ * - 押し目ゾーン markArea + sloped 上下端線 (未保有時のみ)
+ * - 保有時の avg / stop / TP 水平線 + endLabel
+ * - 未保有時の preview stop / TP 点線 + endLabel
+ * - BUY/SELL pin (markPoint, hover で qty / PnL / fill 時刻 tooltip)
  * - session divider (vertical lines)
- * - SMA50 / band / 詳細パネルは省略 (panel size に合わせて視認性を優先)
  */
 export function renderGridTab(args: ChartsBodyGrid): string {
   if (args.charts.length === 0) {
@@ -4272,9 +4278,9 @@ export function renderGridTab(args: ChartsBodyGrid): string {
           }
         }
 
-        // dataZoom 初期範囲。connect 経由で他 panel と同期するため、最初の
-        // setOption 直後に echarts.connect('symbols-grid') を呼ぶ (panel 構築
-        // ループの末尾)。filterMode は trend / position line の dropping 防止
+        // dataZoom 初期範囲。panel 構築ループ末尾の onDz / preset button が
+        // dispatchAction で他 panel に broadcast する手動同期 (PR #241、connect
+        // は使わない)。filterMode は trend / position line の dropping 防止
         // 目的で 'weakFilter' (個別銘柄タブと同方針)。
         var dzInitial = (function () {
           if (data.zoomFromMs == null || data.zoomToMs == null) return {};
@@ -4598,8 +4604,8 @@ export function renderGridTab(args: ChartsBodyGrid): string {
 
   return `<p class="muted" style="font-size:12px">
     ALLOWED_SYMBOLS の全銘柄を 4 列 grid で並列表示 (Datadog dashboard 風)。
-    ズーム / パン (slider drag, wheel) と tooltip は全 panel 間で同期します。
-    panel 左上の銘柄名をクリックすると個別銘柄タブの詳細表示に遷移。
+    ズーム / パン (slider drag, wheel) は全 panel 間で同期、tooltip は hover した
+    panel ローカル。panel 左上の銘柄名をクリックすると個別銘柄タブの詳細表示に遷移。
   </p>
   ${presetButtonsHtml}
   <div class="grid-filter-bar" style="display:flex;gap:14px;align-items:center;margin-top:8px;font-size:12px;flex-wrap:wrap">


### PR DESCRIPTION
## Summary

PR #239 でパリティ追加した結果、16 panel あると 1 panel hover で **全 panel に同時 tooltip が popup** してダッシュボードが埋め尽くされる ([ユーザ #43 報告](https://github.com/ochanuco/webull-trading/issues/43))。

## 原因

\`echarts.connect(instances)\` は dataZoom / **tooltip / axisPointer** / legend を一括で sync する。grid を Datadog 風に「zoom 一括連動」させる目的だったが、tooltip まで sync されるのが副作用。

## 修正

\`echarts.connect\` を外し、**dataZoom のみ手動 broadcast** に切り替える:

1. 起点 panel の \`dataZoom\` event → \`panelDataZoomToMs\` で ms 範囲に変換
2. 他 panel に \`dispatchAction({type:'dataZoom', startValue, endValue})\` を debounce 200ms で配信
3. 各受信 panel は category mode なら \`nearestIndex\` で自分の index に変換 (\`panelMsToNative\`)
4. \`suppressBroadcast\` フラグで dispatchAction 由来の再帰発火を抑制 (無限ループ防止)

これで:
- ✅ zoom / pan は全 panel 同期 (元の挙動維持)
- ✅ preset zoom buttons (1D/5D/1M/All) も全 panel 同期 (既存の dispatchAction ループ)
- ✅ tooltip / axisPointer は **panel ローカル** → hover 中の panel だけに表示

## Test plan

- [x] pnpm typecheck pass
- [x] pnpm test pass (966 tests)
- [ ] /dashboard/charts?tab=grid で 1 panel hover 時に他 panel に tooltip が出ないこと
- [ ] zoom drag が全 panel に連動すること
- [ ] 1D/5D/1M/All ボタンで全 panel が同期すること
- [ ] URL ?from/?to が更新されること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * グリッドビューのパネル間でのズーム/パン同期を改善し、操作の反映がより安定・迅速になりました。URLの表示期間（from/to）が開始パネルの範囲で更新されます。

* **変更点**
  * パネル間のツールチップ（ホバー表示）同期を廃止し、各パネルでローカルに表示されるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->