### PR TITLE
fix(admin): broker probe — quote path を実 cron と一致させる

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -367,7 +367,8 @@ export const admin = new Hono<AppBindings>()
    * client-side handling.
    *
    * Probes (in parallel):
-   *   1. `GET /openapi/quotes/v2/market-data/stock/snapshot` for `?symbol=`
+   *   1. `GET /openapi/market-data/stock/snapshot` (with `x-version: v2`
+   *      header — same combo as `WebullQuoteClient`) for `?symbol=`
    *      (default SOXL) + `?category=` (default US_ETF).
    *   2. `GET /openapi/account/positions` for the configured JP cash account.
    *
@@ -503,9 +504,13 @@ export const admin = new Hono<AppBindings>()
     }
 
     const [quoteResult, positionsResult] = await Promise.all([
+      // path は WebullQuoteClient.DEFAULT_QUOTE_PATH と一致させる:
+      // /openapi/market-data/stock/snapshot (× /openapi/quotes/v2/...)。
+      // v2 は path ではなく x-version ヘッダ。最初に書いたとき paste ミスで
+      // /quotes/v2/ を path に入れてしまい、実 cron と違うパスを叩いてた。
       probeOnce({
         method: 'GET',
-        path: '/openapi/quotes/v2/market-data/stock/snapshot',
+        path: '/openapi/market-data/stock/snapshot',
         query: {
           symbols: symbol,
           category,


### PR DESCRIPTION
## Summary

PR #243 で書いた probe コードに paste ミス。実 cron (\`WebullQuoteClient.DEFAULT_QUOTE_PATH\`) は \`/openapi/market-data/stock/snapshot\` を叩くが、probe が \`/openapi/quotes/v2/market-data/stock/snapshot\` を叩いてた。\`v2\` は **\`x-version\` ヘッダ** であってパスじゃない。

このバグのせいで probe が 404 を返してて「JP UAT に endpoint 無い」と誤診断するところだった。

## 修正

- path: \`/openapi/quotes/v2/market-data/stock/snapshot\` → \`/openapi/market-data/stock/snapshot\`
- doc コメントも併せて修正

## Test plan

- [x] pnpm typecheck pass
- [x] pnpm test pass (966 tests)
- [ ] deploy 後 \`/admin/broker/probe?symbol=SOXL&category=US_ETF\` を再 probe → 404 ではなく cron と同じ broker 応答 (alert で見えてた 403 etc.) が来ることを確認