### PR TITLE
fix(dashboard): broker probe — nav 初回訪問は auto-probe しない

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -850,11 +850,17 @@ function brokerProbeBody(args: {
     probe(sym, cat);
   });
 
-  // 起動時 auto-probe。URL に symbol+category があればそれ、なければ AAPL/US_STOCK。
+  // 起動時 auto-probe は **URL に symbol+category 両方** ある時だけ
+  // (= ボタンクリックで URL push された後の再読み込み / bookmark / 共有 link)。
+  // nav からのプレーン訪問 (?なし) で勝手に probe を投げない方針 (PR #250、
+  // ユーザ要望: 「Broker診断ボタンを押した直後は何も診断しないようにしてほし
+  // い」)。URL クエリ無し時は status を「click 待ち」で表示。
   var qs = new URLSearchParams(window.location.search);
-  var initialSymbol = qs.get('symbol') || 'AAPL';
-  var initialCategory = qs.get('category') || 'US_STOCK';
-  probe(initialSymbol, initialCategory);
+  if (qs.has('symbol') && qs.has('category')) {
+    probe(qs.get('symbol'), qs.get('category'));
+  } else {
+    statusEl.textContent = '銘柄ボタンをクリックして probe 開始';
+  }
 })();
 </script>`
 }


### PR DESCRIPTION
## Summary

ユーザ要望: 「Broker 診断ボタンを押した直後は何も診断しないようにしてほしい」。

PR #248 以降、ページ訪問時に default \`AAPL/US_STOCK\` で auto-probe してたが、nav から開いただけで Webull に通信が走るのは過剰。

## 修正

URL に \`symbol\` + \`category\` 両方ある時 (= ボタン click で URL push された後の reload / bookmark / 共有 link) **だけ** auto-probe を発火する。両方無い時は probe 不発で status を「銘柄ボタンをクリックして probe 開始」と表示。

\`\`\`js
if (qs.has('symbol') && qs.has('category')) {
  probe(qs.get('symbol'), qs.get('category'));
} else {
  statusEl.textContent = '銘柄ボタンをクリックして probe 開始';
}
\`\`\`

## Test plan

- [x] pnpm typecheck pass
- [x] pnpm test pass
- [ ] /dashboard/broker-probe (クエリなし) を直接開く → probe 発火しない、status に案内が出る
- [ ] /dashboard/broker-probe?symbol=AAPL&category=US_STOCK で開く → 自動 probe 発火 (= bookmark 動作維持)
- [ ] 銘柄ボタン click → probe 発火 (URL に push される)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ブローカープローブページの自動実行動作を改善しました。URLクエリに必要なパラメータが両方含まれている場合のみプローブが実行されるようになりました。パラメータが不足している場合は、ユーザーに記号ボタンをクリックするよう促すメッセージが表示されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->