### PR TITLE
fix(bars): real_time_required を明示送信 (default true) (#255)

### DIFF
--- a/src/infrastructure/quotes/BarClient.ts
+++ b/src/infrastructure/quotes/BarClient.ts
@@ -91,11 +91,17 @@ export class WebullBarClient implements BarClient {
     // v2 stock/bars timespan enum (from probe 417 body):
     //   M1, M5, M15, M30, M60, M120, M240, D, W, M, Y
     // Daily = "D" (upper-case). Earlier `d1` yielded UNSUPPORTED_TIMESPAN.
+    //
+    // `real_time_required` は新 OpenAPI docs (#251) で required 扱い、default
+    // `true`。サーバ側既定と同じ値を明示送信して、将来 default 変更があっても
+    // 我々の挙動が動かないようにする (= 戦略 cron は real-time bar を期待する
+    // ので false に倒す動機はない)。issue #255。
     const query = {
       symbol,
       category,
       timespan: 'D',
       count: String(lookback),
+      real_time_required: 'true',
     }
 
     const url = new URL(this.barsPath, `${this.baseUrl}/`)

--- a/test/infrastructure/quotes/webullBarClient.test.ts
+++ b/test/infrastructure/quotes/webullBarClient.test.ts
@@ -77,6 +77,8 @@ describe('WebullBarClient.getDailyBars', () => {
     expect(capturedUrl?.searchParams.get('count')).toBe('30')
     expect(capturedUrl?.searchParams.get('period')).toBeNull()
     expect(capturedUrl?.searchParams.get('limit')).toBeNull()
+    // 新 OpenAPI docs (#251 / #255) で required 扱い、default 'true' を明示送信
+    expect(capturedUrl?.searchParams.get('real_time_required')).toBe('true')
     expect(capturedHeaders?.get('x-version')).toBe('v2')
   })
 


### PR DESCRIPTION
Closes #255

新 OpenAPI docs で `real_time_required` が required (default `true`)。サーバ既定と同じ値を明示送信して、将来の default 変更で挙動が動かないよう防御。

```ts
const query = {
  symbol, category, timespan: 'D', count: String(lookback),
  real_time_required: 'true',
}
```

参考: https://developer.webull.co.jp/apis/docs/reference/bars.md
親 issue: #251

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * Webull APIからの日次バーデータ取得において、リアルタイムデータの要件パラメータを明示的に指定するよう改善しました。これにより、APIからのデータ取得がより確実に動作するようになります。

* **ドキュメント**
  * リアルタイムデータ要件に関する説明コメントを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->