### PR TITLE
fix(webull): position DTO に新 field 名 (quantity / cost_price) を許容 (#252)

### DIFF
--- a/src/infrastructure/webull/dto.ts
+++ b/src/infrastructure/webull/dto.ts
@@ -42,23 +42,32 @@ export interface WebullPlaceOrderResponseDto {
 }
 
 /**
- * One row of the Webull `/openapi/account/positions` response. Field names
- * follow the official Webull OpenAPI reference
- * (https://developer.webull.com/apis/docs/reference/account-position/) —
- * canonical snake_case + numeric-as-string convention used throughout the
- * OpenAPI surface (mapper layer parses the strings to numbers before they
- * leave infrastructure).
+ * One row of the Webull positions response. Spec ambiguity #251: the older
+ * `/openapi/account/positions` SDK returned `quantity_total` / `avg_cost`,
+ * but the new docs (`/openapi/assets/positions` →
+ * https://developer.webull.co.jp/apis/docs/reference/account-position.md)
+ * use `quantity` / `cost_price`. JP UAT は実際の probe で **新名前** で返す。
+ *
+ * 旧 SDK 互換のため両方 optional として持ち、reader 側 (`parseBrokerAvg`,
+ * `parseBrokerQty` 等) は新→旧の順で読む defensive parsing にする。新規 reader
+ * を書くときも同じヘルパを通すこと。
+ *
+ * 全 field は string-encoded number / string (= OpenAPI 共通の数値文字列方針)。
+ * mapper 層で数値化してから infrastructure 層を出る。
  */
 export interface WebullPositionDto {
   /** Ticker. Webull returns it as the canonical form (e.g. `SOXL`, `1570`). */
   symbol?: string
-  /** Total holding (informational). */
+  /** 新 docs: total holding (informational). */
+  quantity?: string
+  /** 旧 SDK 互換: 新 docs では `quantity` に rename。 */
   quantity_total?: string
-  /** Available-to-sell holding. May be < `quantity_total` when shares are
-   *  reserved by an in-flight SELL. SELL fallback uses **this** value.
-   *  Webull canonical field name (per official reference docs). */
+  /** Available-to-sell holding. May be < total when shares are reserved by
+   *  an in-flight SELL. SELL fallback uses **this** value. 新旧 docs 共通。 */
   available_quantity?: string
-  /** Average cost basis (informational; not used by SELL fallback). */
+  /** 新 docs: average cost basis (informational; not used by SELL fallback). */
+  cost_price?: string
+  /** 旧 SDK 互換: 新 docs では `cost_price` に rename。 */
   avg_cost?: string
   /** Currency on the position. POC: USD/JPY only. */
   currency?: string

--- a/src/trading/reconciliation/syncHoldings.ts
+++ b/src/trading/reconciliation/syncHoldings.ts
@@ -395,6 +395,7 @@ function pickAvgPrice(brokerAvg: number | null, doAvg: number | null): number | 
 
 function parseBrokerQty(pos: WebullPositionDto | undefined): number | null {
   if (pos === undefined) return null
+  // available_quantity は新旧 docs 共通の名前 (#251 / #252)。
   const raw = pos.available_quantity
   if (raw === undefined || raw === null || raw === '') return null
   const parsed = Number(raw)
@@ -403,8 +404,16 @@ function parseBrokerQty(pos: WebullPositionDto | undefined): number | null {
 
 function parseBrokerAvg(pos: WebullPositionDto | undefined): number | null {
   if (pos === undefined) return null
-  const raw = pos.avg_cost
-  if (raw === undefined || raw === null || raw === '') return null
+  // 新 docs (#251) では `cost_price`、旧 SDK は `avg_cost`。新→旧の順で defensive
+  // parse (#252)。新 endpoint への切替前でも JP UAT は既に新名前で返してくる
+  // ケースがあり、旧名前だけ読んでると silently null = avg-price fallback を
+  // 強制発動してしまう。
+  // 新名前が undefined / null / 空文字 (== "未送信") なら旧名前にフォールバック。
+  // `??` だけでは空文字を「設定済」と扱ってしまうので、明示的に空かどうか判定。
+  const isEmpty = (v: unknown): boolean =>
+    v === undefined || v === null || v === ''
+  const raw = !isEmpty(pos.cost_price) ? pos.cost_price : pos.avg_cost
+  if (isEmpty(raw)) return null
   const parsed = Number(raw)
   return Number.isFinite(parsed) ? parsed : null
 }

--- a/test/trading/reconciliation/syncHoldings.test.ts
+++ b/test/trading/reconciliation/syncHoldings.test.ts
@@ -84,6 +84,21 @@ describe('syncHoldings internals', () => {
     expect(_internal.parseBrokerQty({ available_quantity: 'banana' })).toBeNull()
   })
 
+  // #251 / #252: 新 docs (account-position) は `cost_price`、旧 SDK は `avg_cost`。
+  // defensive parser は新→旧の順、両方無ければ null。
+  it('parseBrokerAvg prefers new cost_price over legacy avg_cost', () => {
+    expect(_internal.parseBrokerAvg(undefined)).toBeNull()
+    expect(_internal.parseBrokerAvg({ cost_price: '124.95' })).toBe(124.95)
+    expect(_internal.parseBrokerAvg({ avg_cost: '100.00' })).toBe(100)
+    // 両方ある場合は new (cost_price) 優先
+    expect(_internal.parseBrokerAvg({ cost_price: '124.95', avg_cost: '100.00' })).toBe(124.95)
+    // 新名前が空文字 / null の場合は旧名前にフォールバック
+    expect(_internal.parseBrokerAvg({ cost_price: '', avg_cost: '100.00' })).toBe(100)
+    // 数値化できない値は null
+    expect(_internal.parseBrokerAvg({ cost_price: 'banana' })).toBeNull()
+    expect(_internal.parseBrokerAvg({})).toBeNull()
+  })
+
   it('computePlannedAfter returns null when broker qty is zero', () => {
     expect(
       _internal.computePlannedAfter({ brokerQty: 0, brokerAvg: 100, before: null }),


### PR DESCRIPTION
Closes #252

#251 で発覚した OpenAPI ドキュメント drift の対応の 1 つ。

## 変更

- `WebullPositionDto` に新 docs の field 名を追加 (`quantity`、`cost_price`)、旧名前 (`quantity_total`、`avg_cost`) も両立
- `parseBrokerAvg` を new → legacy の順で defensive parse (空文字も fallback 対象)
- `parseBrokerQty` は `available_quantity` (新旧共通) で変更なし
- 単体テスト追加 (新優先 / 旧 fallback / 両方空 / 数値化失敗)

## 動機

probe で取得した JP UAT positions response は既に `cost_price` で返ってきていた。旧 `avg_cost` だけ読むと silently null → broker 側 avg を捨てて DO 側 avgPrice を保つ fallback が常時発動していた可能性。本 PR で broker truth が反映されるようになる。

## 親 issue

- #251 (drift parent)
- #252 (this issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * Webull APIの互換性を向上し、新旧のフィールド名形式に対応しました。平均価格の取得がより確実になります。

* **Tests**
  * ブローカー平均価格パーサーの新しい検証テストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->