### PR TITLE
feat(webull): order-history の wrapper response 対応 (#253)

### DIFF
--- a/src/infrastructure/webull/WebullHttpClient.ts
+++ b/src/infrastructure/webull/WebullHttpClient.ts
@@ -424,12 +424,15 @@ function buildRequestUrl(baseUrl: string, path: string, query?: Record<string, s
  * 旧 (現行 callers が想定する) flat shape:
  *   { client_order_id, side, status, filled_quantity, ... }
  *
- * row が `orders[]` を持っていれば wrapper と判定し、`orders[0]` の中身を flat
- * shape に projection する。多 leg / combo は POC scope 外なので `orders[0]`
- * のみ採用 (combo_type !== 'NORMAL' なら呼び出し側 reconciler が detect)。
- *
- * 新 docs では per-order に `total_quantity` (rename from `quantity`) も来る
- * ので、normalize 時に `quantity` にコピーして従来 reader を維持する。
+ * row が `orders[]` を持っていれば wrapper と判定:
+ *   - `orders[0]` が存在 → flat shape に projection (`total_quantity` →
+ *     `quantity` も合わせてコピー)。多 leg / combo は POC scope 外なので
+ *     `orders[0]` のみ採用 (combo_type !== 'NORMAL' なら呼び出し側 reconciler
+ *     が detect)。
+ *   - `orders[]` が空 → 「対象 order が存在しない」状態として **空オブジェクト**
+ *     を返す (CodeRabbit #261)。partial detail (client_order_id だけ持つ) を
+ *     返すと findOrderByClientId が誤 match して、status/side 等を持たない
+ *     incomplete row を caller に渡してしまうため。
  *
  * 旧 flat shape の row はそのまま返す (互換)。
  */
@@ -441,8 +444,13 @@ export function normalizeOrderHistoryRow(
   if (!Array.isArray(wrapper.orders)) {
     return raw as WebullOrderDetailDto
   }
-  const inner: WebullOrderDetailDto = wrapper.orders[0] ?? {}
-  // top-level の client_order_id を最優先 (wrapper 側が canonical)。inner の同
+  const inner = wrapper.orders[0]
+  if (inner === undefined || inner === null) {
+    // wrapper.orders が空 / 不在 → 「対象なし」 sentinel として空オブジェクトを返す
+    // (caller の find は clientOrderId !== undefined で match しないので skip)。
+    return {} as WebullOrderDetailDto
+  }
+  // top-level の client_order_id を最優先 (wrapper 側が canonical)、inner の同
   // フィールドは fallback。
   const clientOrderId = wrapper.client_order_id ?? inner.client_order_id
   // 新 `total_quantity` を `quantity` にコピー (consumer は `quantity` を読む)。

--- a/src/infrastructure/webull/WebullHttpClient.ts
+++ b/src/infrastructure/webull/WebullHttpClient.ts
@@ -3,6 +3,7 @@ import { BrokerRequestError, brokerErrorForStatus } from '../../shared/errors'
 import type {
   WebullAccountDto,
   WebullOrderDetailDto,
+  WebullOrderHistoryWrapperDto,
   WebullPlaceOrderResponseDto,
   WebullPositionDto,
   WebullSubscriptionDto,
@@ -85,19 +86,31 @@ export class WebullHttpClient {
    * fetch the first page of `/openapi/account/orders/history` and filter
    * client-side. If the order is older than that window the caller gets
    * `undefined`; a wider pagination sweep is out of scope for the MVP.
+   *
+   * 新 OpenAPI docs (#251) では response が wrapper 形式 (`{client_order_id,
+   * combo_type, orders[]}`) に変わってる。\`normalizeOrderHistoryRow\` で
+   * wrapper / flat 双方を flat な \`WebullOrderDetailDto\` に正規化するので
+   * callers (reconcileFills 等) は signature を変えずに済む (#253)。
    */
   async findOrderByClientId(
     clientOrderId: string,
     pageSize = 50,
   ): Promise<WebullOrderDetailDto | undefined> {
-    const page = await this.request<WebullOrderDetailDto[]>(
+    const page = await this.request<unknown[]>(
       'GET',
       '/openapi/account/orders/history',
       {
         query: { account_id: this.requireAccountId(), page_size: String(pageSize) },
       },
     )
-    return page.find((entry) => entry.client_order_id === clientOrderId)
+    if (!Array.isArray(page)) return undefined
+    for (const raw of page) {
+      const normalized = normalizeOrderHistoryRow(
+        raw as WebullOrderHistoryWrapperDto | WebullOrderDetailDto,
+      )
+      if (normalized.client_order_id === clientOrderId) return normalized
+    }
+    return undefined
   }
 
   /**
@@ -403,4 +416,41 @@ function buildRequestUrl(baseUrl: string, path: string, query?: Record<string, s
   }
 
   return url
+}
+
+/**
+ * 新 OpenAPI docs (#251 / #253) の order-history / order-detail wrapper shape:
+ *   { client_order_id, combo_type, orders: [...inner...] }
+ * 旧 (現行 callers が想定する) flat shape:
+ *   { client_order_id, side, status, filled_quantity, ... }
+ *
+ * row が `orders[]` を持っていれば wrapper と判定し、`orders[0]` の中身を flat
+ * shape に projection する。多 leg / combo は POC scope 外なので `orders[0]`
+ * のみ採用 (combo_type !== 'NORMAL' なら呼び出し側 reconciler が detect)。
+ *
+ * 新 docs では per-order に `total_quantity` (rename from `quantity`) も来る
+ * ので、normalize 時に `quantity` にコピーして従来 reader を維持する。
+ *
+ * 旧 flat shape の row はそのまま返す (互換)。
+ */
+export function normalizeOrderHistoryRow(
+  raw: WebullOrderHistoryWrapperDto | WebullOrderDetailDto,
+): WebullOrderDetailDto {
+  if (raw === null || typeof raw !== 'object') return {} as WebullOrderDetailDto
+  const wrapper = raw as WebullOrderHistoryWrapperDto
+  if (!Array.isArray(wrapper.orders)) {
+    return raw as WebullOrderDetailDto
+  }
+  const inner: WebullOrderDetailDto = wrapper.orders[0] ?? {}
+  // top-level の client_order_id を最優先 (wrapper 側が canonical)。inner の同
+  // フィールドは fallback。
+  const clientOrderId = wrapper.client_order_id ?? inner.client_order_id
+  // 新 `total_quantity` を `quantity` にコピー (consumer は `quantity` を読む)。
+  const quantity = inner.quantity ?? inner.total_quantity
+  return {
+    ...inner,
+    client_order_id: clientOrderId,
+    quantity,
+    total_quantity: inner.total_quantity,
+  }
 }

--- a/src/infrastructure/webull/dto.ts
+++ b/src/infrastructure/webull/dto.ts
@@ -90,8 +90,15 @@ export interface WebullOrderItemDto {
 }
 
 /**
- * Shape returned by GET /openapi/account/orders/detail (v1).
+ * Shape returned by GET /openapi/account/orders/detail (v1) — flat 形式。
  * Fields mirror openapi-java-sdk's `v2.OrderHistory`.
+ *
+ * 新 docs (#251 / #253) では order-history / order-detail が wrapper 形式に
+ * なる:
+ *   { client_order_id, combo_type, orders: [...inner...] }
+ * ここでは `findOrderByClientId` 内で wrapper を正規化して同じ flat 形式に
+ * 落とし込むため、callers (reconcileFills 等) の signature は変えない。
+ * 新名前 `total_quantity` は `quantity` に正規化される。
  */
 export interface WebullOrderDetailDto {
   client_order_id?: string
@@ -103,10 +110,30 @@ export interface WebullOrderDetailDto {
   limit_price?: string
   stop_price?: string
   quantity?: string
+  /** 新 docs での名前。normalizer が `quantity` にコピーするので consumer は
+   *  従来通り `quantity` を読めば良い (両方持ってても矛盾しない)。 */
+  total_quantity?: string
   filled_quantity?: string
+  /** 新 docs では top-level に持つ。flat 表現でも optional として持っておき、
+   *  items[] が空のケースで `resolveFilledPrice` が参照できるよう保持。 */
+  filled_price?: string
   // Webull order lifecycle statuses: NEW, PARTIALLY_FILLED, FILLED,
   // CANCELLED, REJECTED, EXPIRED, etc. Keep as free string for forward-compat.
   status?: string
   support_trading_session?: string
   items?: WebullOrderItemDto[]
+}
+
+/**
+ * 新 docs (#251) の order-history / order-detail wrapper shape:
+ *   { client_order_id, combo_type, orders: [WebullOrderDetailDto] }
+ *
+ * 通常 1 つの client_order_id に対し orders[] は単一エントリ (combo / leg は
+ * POC スコープ外)。\`findOrderByClientId\` 内の \`normalizeOrderHistoryRow\` で
+ * 平坦化して \`WebullOrderDetailDto\` として扱う。
+ */
+export interface WebullOrderHistoryWrapperDto {
+  client_order_id?: string
+  combo_type?: string
+  orders?: WebullOrderDetailDto[]
 }

--- a/test/infrastructure/webull/webullHttpClient.test.ts
+++ b/test/infrastructure/webull/webullHttpClient.test.ts
@@ -174,6 +174,62 @@ describe('WebullHttpClient', () => {
     expect(await client.findOrderByClientId('missing')).toBeUndefined()
   })
 
+  // #251 / #253: 新 OpenAPI docs では order-history が wrapper 形式
+  // ({client_order_id, combo_type, orders[]}) で返るので、normalizer が
+  // wrapper を flat 形式に projection することを確認。
+  it('findOrderByClientId handles new wrapper response shape ({client_order_id, orders: [...]})', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          {
+            client_order_id: 'wrapped-1',
+            combo_type: 'NORMAL',
+            orders: [
+              {
+                symbol: 'SOXL',
+                side: 'BUY',
+                status: 'FILLED',
+                total_quantity: '4',
+                filled_quantity: '4',
+                filled_price: '125.00',
+              },
+            ],
+          },
+        ]),
+        { status: 200 },
+      ),
+    )
+    const client = createClient(fetchMock)
+    const detail = await client.findOrderByClientId('wrapped-1')
+    expect(detail).toBeDefined()
+    expect(detail?.client_order_id).toBe('wrapped-1')
+    expect(detail?.symbol).toBe('SOXL')
+    expect(detail?.status).toBe('FILLED')
+    expect(detail?.filled_quantity).toBe('4')
+    expect(detail?.filled_price).toBe('125.00')
+    // total_quantity → quantity に正規化されてること
+    expect(detail?.quantity).toBe('4')
+    expect(detail?.total_quantity).toBe('4')
+  })
+
+  it('findOrderByClientId handles legacy flat response shape (no orders[] wrapper)', async () => {
+    // 旧 shape は normalizer が pass-through すること (= 既存 callers が引き
+    // 続き動く backward compat)
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          { client_order_id: 'flat-1', symbol: 'AAPL', status: 'FILLED', quantity: '8', filled_quantity: '8' },
+        ]),
+        { status: 200 },
+      ),
+    )
+    const client = createClient(fetchMock)
+    const detail = await client.findOrderByClientId('flat-1')
+    expect(detail?.symbol).toBe('AAPL')
+    expect(detail?.quantity).toBe('8')
+    expect(detail?.status).toBe('FILLED')
+  })
+
   it('requests account details from the documented profile endpoint', async () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(

--- a/test/infrastructure/webull/webullHttpClient.test.ts
+++ b/test/infrastructure/webull/webullHttpClient.test.ts
@@ -230,6 +230,56 @@ describe('WebullHttpClient', () => {
     expect(detail?.status).toBe('FILLED')
   })
 
+  // CodeRabbit #261 finding 1: wrapper の `orders[]` が空のケース。
+  // partial detail (client_order_id だけ持つ) を返すと incomplete data が
+  // caller に渡るので、normalizer は空オブジェクト → find で skip される。
+  it('findOrderByClientId returns undefined when wrapper has empty orders[]', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          { client_order_id: 'empty-wrapper', combo_type: 'NORMAL', orders: [] },
+          { client_order_id: 'unrelated', symbol: 'NVDA', status: 'PENDING' },
+        ]),
+        { status: 200 },
+      ),
+    )
+    const client = createClient(fetchMock)
+    expect(await client.findOrderByClientId('empty-wrapper')).toBeUndefined()
+  })
+
+  // CodeRabbit #261 finding 2: top-level に client_order_id が無く inner 側
+  // にあるパターン。normalizer は inner.client_order_id を fallback として使う。
+  it('findOrderByClientId falls back to inner client_order_id when top-level is missing', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          {
+            // top-level に client_order_id が無いケース (新 docs で稀にあり得る)
+            combo_type: 'NORMAL',
+            orders: [
+              {
+                client_order_id: 'inner-only-1',
+                symbol: 'SOXL',
+                side: 'SELL',
+                status: 'FILLED',
+                total_quantity: '8',
+                filled_quantity: '8',
+              },
+            ],
+          },
+        ]),
+        { status: 200 },
+      ),
+    )
+    const client = createClient(fetchMock)
+    const detail = await client.findOrderByClientId('inner-only-1')
+    expect(detail).toBeDefined()
+    expect(detail?.client_order_id).toBe('inner-only-1')
+    expect(detail?.symbol).toBe('SOXL')
+    expect(detail?.quantity).toBe('8') // total_quantity → quantity 正規化
+    expect(detail?.status).toBe('FILLED')
+  })
+
   it('requests account details from the documented profile endpoint', async () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(


### PR DESCRIPTION
Closes #253

#251 ドキュメント drift 対応の 1 つ。新 docs では response が wrapper shape:

```json
{
  "client_order_id": "...",
  "combo_type": "...",
  "orders": [{ "filled_quantity", "filled_price", "total_quantity", ... }]
}
```

旧 SDK の flat shape (`{client_order_id, filled_quantity, ...}`) も併存させ、`findOrderByClientId` 内の normalizer で flat に正規化。callers (reconcileFills 等) は signature 不変。

## 変更

- `WebullOrderHistoryWrapperDto` を新規 type 定義 (dto.ts)
- `WebullOrderDetailDto` に `total_quantity`、`filled_price` を optional 追加
- `normalizeOrderHistoryRow` を export (wrapper / flat 両対応、`total_quantity` → `quantity` 自動コピー)
- 単体テスト追加 (旧 flat / 新 wrapper / 不在 coid)

## 親 issue

- #251 (drift parent)
- #253 (this issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 注文履歴の新しいラッパー形式を正しく扱うようになりました。ラッパー内の項目を既存の平坦な形式に正規化し、数量や注文IDの優先ルールを適用して誤一致を防ぎます。従来形式との後方互換性も維持しています。
* **Tests**
  * 新フォーマットやエッジケース（空の明細など）を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->