### PR TITLE
feat(admin): broker probe で旧/新 path 並列比較 (#254)

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -366,11 +366,13 @@ export const admin = new Hono<AppBindings>()
    * status 403 across US_STOCK / US_ETF) come from the broker side or our
    * client-side handling.
    *
-   * Probes (in parallel):
-   *   1. `GET /openapi/market-data/stock/snapshot` (with `x-version: v2`
-   *      header — same combo as `WebullQuoteClient`) for `?symbol=`
-   *      (default SOXL) + `?category=` (default US_ETF).
-   *   2. `GET /openapi/account/positions` for the configured JP cash account.
+   * Probes (in parallel, #251 / #254 で旧/新 path 比較):
+   *   1. `GET /openapi/market-data/stock/snapshot` (`x-version: v2`)
+   *      for `?symbol=` (default SOXL) + `?category=` (default US_ETF).
+   *   2. positions (旧): `GET /openapi/account/positions` (`x-version: v1`)
+   *   3. positions (新): `GET /openapi/assets/positions` (`x-version: v2`)
+   *   4. order history (旧): `GET /openapi/account/orders/history` (`v1`)
+   *   5. order history (新): `GET /openapi/trade/order/history` (`v2`)
    *
    * Each probe returns the same uniform shape regardless of phase:
    * `{ phase: 'response' | 'auth' | 'fetch', status, ok, bodyTruncated,
@@ -503,11 +505,23 @@ export const admin = new Hono<AppBindings>()
       }
     }
 
-    const [quoteResult, positionsResult] = await Promise.all([
-      // path は WebullQuoteClient.DEFAULT_QUOTE_PATH と一致させる:
+    // #251 / #254: drift 検証のため旧 path (v1) と 新 path (v2) を **並列** で
+    // 叩いて比較する。各セクションを result 配列の object として返却:
+    //   - quote (path 共通、v2 ヘッダ): 既存
+    //   - positions: old=/openapi/account/positions+v1 vs new=/openapi/assets/positions+v2
+    //   - orderHistory: old=/openapi/account/orders/history+v1 vs new=/openapi/trade/order/history+v2
+    // dashboard UI は 旧 (= positions) を保有銘柄リスト描画に使うので shape は
+    // 後方互換維持 (`positions` field 名据え置き)、新 path 結果は追加 field。
+    const [
+      quoteResult,
+      positionsOld,
+      positionsNew,
+      orderHistoryOld,
+      orderHistoryNew,
+    ] = await Promise.all([
+      // path は WebullQuoteClient.DEFAULT_QUOTE_PATH と一致:
       // /openapi/market-data/stock/snapshot (× /openapi/quotes/v2/...)。
-      // v2 は path ではなく x-version ヘッダ。最初に書いたとき paste ミスで
-      // /quotes/v2/ を path に入れてしまい、実 cron と違うパスを叩いてた。
+      // v2 は path ではなく x-version ヘッダ。
       probeOnce({
         method: 'GET',
         path: '/openapi/market-data/stock/snapshot',
@@ -519,14 +533,34 @@ export const admin = new Hono<AppBindings>()
         },
         version: 'v2',
       }),
-      // version='v1' は WebullHttpClient.request が account ルートで送ってる
-      // 固定値 (line 180)。accountId は probe 入口の missingEnv チェックで
-      // 既に空文字 reject 済 → ここに到達した時点で必ず非空。
+      // OLD: WebullHttpClient.getPositions (現行 cron が叩く path + v1)
       probeOnce({
         method: 'GET',
         path: '/openapi/account/positions',
         query: { account_id: accountId },
         version: 'v1',
+      }),
+      // NEW: 新 OpenAPI docs の path + v2 (x-access-token 必須化の可能性は
+      // 別 issue #258 で評価、本 probe は signing 周りは現行と同じ buildSignedHeaders)
+      probeOnce({
+        method: 'GET',
+        path: '/openapi/assets/positions',
+        query: { account_id: accountId },
+        version: 'v2',
+      }),
+      // OLD: 現行 findOrderByClientId が叩く path + v1
+      probeOnce({
+        method: 'GET',
+        path: '/openapi/account/orders/history',
+        query: { account_id: accountId, page_size: '5' },
+        version: 'v1',
+      }),
+      // NEW: 新 OpenAPI docs の trade/order/history + v2
+      probeOnce({
+        method: 'GET',
+        path: '/openapi/trade/order/history',
+        query: { account_id: accountId, page_size: '5' },
+        version: 'v2',
       }),
     ])
 
@@ -538,7 +572,13 @@ export const admin = new Hono<AppBindings>()
       sandbox: baseUrl,
       input: { symbol, category, accountIdConfigured: accountId.length > 0 },
       quote: quoteResult,
-      positions: positionsResult,
+      // 後方互換: dashboard UI が `positions` を保有銘柄リスト描画に使うので
+      // 旧 path 結果を従来通り返す。
+      positions: positionsOld,
+      // 新 OpenAPI docs ベースの結果。drift 比較に使う。
+      positionsNew,
+      orderHistoryOld,
+      orderHistoryNew,
     })
   })
   .get('/orders/:clientOrderId', async (c) => {

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -835,10 +835,12 @@ function brokerProbeBody(args: {
       .then(function (res) {
         var body = res.body;
         statusEl.textContent = res.status === 200 ? '完了' : ('admin endpoint status=' + res.status);
-        if (body.quote) quoteEl.textContent = prettify(body.quote);
-        if (body.positions) renderPositionsList(body.positions);
-        // #254: drift 比較用に新 path 結果も raw + table へ。raw 側は positions
-        // (旧) を従来通り、新フィールドは新規 pre 要素に。
+        // CodeRabbit #262: body fields が欠けてても UI を必ず更新して stale を
+        // 残さない。quote / positions / 各 raw を **常に** 上書き。
+        quoteEl.textContent = body.quote ? prettify(body.quote) : '(no data)';
+        renderPositionsList(body.positions || null);
+        // drift 比較: 新 path 結果も raw + table へ。値が無くても "(no data)"
+        // を入れて stale 表示にしない。
         var positionsNewRaw = document.getElementById('probe-positions-new-raw');
         var orderOldRaw = document.getElementById('probe-order-old-raw');
         var orderNewRaw = document.getElementById('probe-order-new-raw');

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -709,9 +709,31 @@ function brokerProbeBody(args: {
 <h2 style="font-size:14px;margin:16px 0 4px 0">meta</h2>
 <pre id="probe-meta" style="background:#f6f6f6;border:1px solid #ddd;border-radius:4px;padding:8px;font-size:12px">(まだ probe 未実行)</pre>
 
+<h2 style="font-size:14px;margin:16px 0 4px 0">drift 比較 (旧 path vs 新 path)</h2>
+<p class="muted" style="font-size:11px;margin:0 0 8px 0">
+  #251 で発覚した OpenAPI ドキュメント drift の検証。旧 (\`/openapi/account/*\` + v1) と新 (\`/openapi/assets/*\` or \`/openapi/trade/order/*\` + v2) を並列で叩いた結果。両方 200 なら alias、片方 404 なら drift 確定、shape 違いなら schema migration が必要。
+</p>
+<table style="width:100%;border-collapse:collapse;font-size:12px;margin-bottom:16px">
+  <thead><tr style="border-bottom:1px solid #ddd">
+    <th style="text-align:left;padding:4px 8px">endpoint</th>
+    <th style="text-align:left;padding:4px 8px">old</th>
+    <th style="text-align:left;padding:4px 8px">new</th>
+  </tr></thead>
+  <tbody id="probe-drift-table">
+    <tr><td colspan="3" class="muted" style="padding:8px;text-align:center">(probe 未実行)</td></tr>
+  </tbody>
+</table>
+
 <details style="margin-top:16px">
-  <summary class="muted" style="font-size:12px;cursor:pointer">positions raw response</summary>
-  <pre id="probe-positions-raw" style="background:#f6f6f6;border:1px solid #ddd;border-radius:4px;padding:8px;font-size:11px;overflow:auto;max-height:300px;white-space:pre-wrap;word-break:break-all;margin-top:8px"></pre>
+  <summary class="muted" style="font-size:12px;cursor:pointer">positions / orderHistory raw responses (旧/新)</summary>
+  <h3 style="font-size:12px;margin:8px 0 4px 0">positions (旧 /openapi/account/positions, v1)</h3>
+  <pre id="probe-positions-raw" style="background:#f6f6f6;border:1px solid #ddd;border-radius:4px;padding:8px;font-size:11px;overflow:auto;max-height:300px;white-space:pre-wrap;word-break:break-all"></pre>
+  <h3 style="font-size:12px;margin:8px 0 4px 0">positionsNew (新 /openapi/assets/positions, v2)</h3>
+  <pre id="probe-positions-new-raw" style="background:#f6f6f6;border:1px solid #ddd;border-radius:4px;padding:8px;font-size:11px;overflow:auto;max-height:300px;white-space:pre-wrap;word-break:break-all"></pre>
+  <h3 style="font-size:12px;margin:8px 0 4px 0">orderHistoryOld (旧 /openapi/account/orders/history, v1)</h3>
+  <pre id="probe-order-old-raw" style="background:#f6f6f6;border:1px solid #ddd;border-radius:4px;padding:8px;font-size:11px;overflow:auto;max-height:300px;white-space:pre-wrap;word-break:break-all"></pre>
+  <h3 style="font-size:12px;margin:8px 0 4px 0">orderHistoryNew (新 /openapi/trade/order/history, v2)</h3>
+  <pre id="probe-order-new-raw" style="background:#f6f6f6;border:1px solid #ddd;border-radius:4px;padding:8px;font-size:11px;overflow:auto;max-height:300px;white-space:pre-wrap;word-break:break-all"></pre>
 </details>
 
 <script>
@@ -815,6 +837,15 @@ function brokerProbeBody(args: {
         statusEl.textContent = res.status === 200 ? '完了' : ('admin endpoint status=' + res.status);
         if (body.quote) quoteEl.textContent = prettify(body.quote);
         if (body.positions) renderPositionsList(body.positions);
+        // #254: drift 比較用に新 path 結果も raw + table へ。raw 側は positions
+        // (旧) を従来通り、新フィールドは新規 pre 要素に。
+        var positionsNewRaw = document.getElementById('probe-positions-new-raw');
+        var orderOldRaw = document.getElementById('probe-order-old-raw');
+        var orderNewRaw = document.getElementById('probe-order-new-raw');
+        if (positionsNewRaw) positionsNewRaw.textContent = prettify(body.positionsNew);
+        if (orderOldRaw) orderOldRaw.textContent = prettify(body.orderHistoryOld);
+        if (orderNewRaw) orderNewRaw.textContent = prettify(body.orderHistoryNew);
+        renderDriftTable(body);
         metaEl.textContent = JSON.stringify({
           timestamp: body.timestamp,
           sandbox: body.sandbox,
@@ -828,6 +859,27 @@ function brokerProbeBody(args: {
       .finally(function () {
         refreshBtn.disabled = false;
       });
+  }
+
+  // drift 比較テーブルを描画。各行は status / msTaken を旧/新 並列表示。
+  function renderDriftTable(body) {
+    var tableBody = document.getElementById('probe-drift-table');
+    if (!tableBody) return;
+    function cell(section) {
+      if (!section) return '<td class="muted" style="padding:4px 8px">(no data)</td>';
+      var status = section.status == null ? section.phase : 'status=' + section.status;
+      var ok = section.ok ? '✅' : (section.ok === false ? '❌' : '');
+      var ms = section.msTaken == null ? '' : ' (' + section.msTaken + 'ms)';
+      var color = section.ok ? '#0a8a0a' : (section.ok === false ? '#c22' : '#666');
+      return '<td style="padding:4px 8px;color:' + color + '">' + ok + ' ' + status + ms + '</td>';
+    }
+    function row(label, oldSection, newSection) {
+      return '<tr><td style="padding:4px 8px"><code>' + label + '</code></td>' +
+        cell(oldSection) + cell(newSection) + '</tr>';
+    }
+    tableBody.innerHTML =
+      row('positions', body.positions, body.positionsNew) +
+      row('order history', body.orderHistoryOld, body.orderHistoryNew);
   }
 
   function onPickClick(ev) {


### PR DESCRIPTION
Closes #254

#251 ドキュメント drift 対応の 1 つ。1 回の probe で 4 endpoint を並列実行して比較する。

## 並列 probe 対象

| section | path | x-version |
|---|---|---|
| positions (旧) | `/openapi/account/positions` | v1 |
| positions (新) | `/openapi/assets/positions` | v2 |
| order history (旧) | `/openapi/account/orders/history` | v1 |
| order history (新) | `/openapi/trade/order/history` | v2 |

## response shape

`positions` field は旧結果を据置 (dashboard 既存ロジック互換)、追加 field:
- `positionsNew`
- `orderHistoryOld`
- `orderHistoryNew`

## dashboard

`/dashboard/broker-probe` に **drift 比較テーブル** + 各 raw response の expand 表示を追加。1 画面で:
- 両方 200 → alias 期間
- 片方 404 → drift 確定
- shape 違い → schema 移行必要

の 3 状態が判定可能。

## 親 issue

- #251 (drift parent)
- #254 (this issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ブローカープローブページにドリフト検証機能を拡張しました
  * ポジションと注文履歴の並列比較と、旧/新応答の生データパネルを追加しました
  * ドリフト比較テーブルを追加し、差分の可視化を強化しました
* **改善**
  * プローブ完了時にUIを常に更新して古い表示を防止するようにしました (空データ時のフォールバック表示を含む)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->