### PR TITLE
fix(admin): broker probe order history の page_size を 5 → 10

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -548,18 +548,20 @@ export const admin = new Hono<AppBindings>()
         query: { account_id: accountId },
         version: 'v2',
       }),
-      // OLD: 現行 findOrderByClientId が叩く path + v1
+      // OLD: 現行 findOrderByClientId が叩く path + v1。
+      // page_size は broker 側の制約で 10-100 のみ受理 (`5` だと 417
+      // OAUTH_OPENAPI_PARAM_ERR、see #251 follow-up)。
       probeOnce({
         method: 'GET',
         path: '/openapi/account/orders/history',
-        query: { account_id: accountId, page_size: '5' },
+        query: { account_id: accountId, page_size: '10' },
         version: 'v1',
       }),
       // NEW: 新 OpenAPI docs の trade/order/history + v2
       probeOnce({
         method: 'GET',
         path: '/openapi/trade/order/history',
-        query: { account_id: accountId, page_size: '5' },
+        query: { account_id: accountId, page_size: '10' },
         version: 'v2',
       }),
     ])


### PR DESCRIPTION
Webull broker の order history endpoint は `page_size` 範囲制約 (10-100) を持ち、5 だと 417 `OAUTH_OPENAPI_PARAM_ERR` で reject される。probe 設定ミス。

実 probe で確認した body:
```json
{"message":"Parameter error, invalid page_size, value: 5, value should be between 10 and 100","error_code":"OAUTH_OPENAPI_PARAM_ERR"}
```

5 → 10 に変更で旧/新両 endpoint が 200 で返ることを期待。drift 比較として有用なのは positions だけ既に確認済 (両方 200、新 path は 7 倍速い)。

親 issue: #251

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ブローカー統合のプローブエンドポイント設定を調整し、システムの安定性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->