### PR TITLE
feat(webull): trade/account endpoint path の env override (#257)

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -18,13 +18,6 @@ WEBULL_APP_SECRET=
 WEBULL_ACCOUNT_ID=
 # Sandbox default. Use https://openapi.webull.com for production.
 WEBULL_API_BASE=https://api.sandbox.webull.hk
-
-# #257: trade/account endpoint path 上書き (optional)。default は旧 path
-# (/openapi/account/*)。staging で新 path に切替えるとき設定。空 / whitespace
-# のみは未設定扱い (= default fallback)。
-# WEBULL_PATH_POSITIONS=/openapi/assets/positions
-# WEBULL_PATH_ORDERS_HISTORY=/openapi/trade/order/history
-# WEBULL_PATH_ORDERS_PLACE=/openapi/trade/order/place
 ALLOWED_SYMBOLS=SOXL,SOXS
 MAX_ORDER_NOTIONAL=100
 SYMBOL_MAX_NOTIONAL={"SOXL":200,"SOXS":150}
@@ -44,3 +37,11 @@ SLACK_WEBHOOK_URL=
 DISCORD_WEBHOOK_URL=
 # dashboard 通知 link の base URL (例: https://webull-trading.example.workers.dev)。
 DASHBOARD_BASE_URL=
+
+# #257: trade/account endpoint path 上書き (optional、append at end 規約)。
+# default は旧 path (/openapi/account/*)。staging で新 path に切替えるとき
+# 設定する。値は `/` で始まる絶対パスのみ受理、空 / whitespace / 相対 URL
+# は default fallback (broken request 投げない / WEBULL_API_BASE bypass 防止)。
+# WEBULL_PATH_POSITIONS=/openapi/assets/positions
+# WEBULL_PATH_ORDERS_HISTORY=/openapi/trade/order/history
+# WEBULL_PATH_ORDERS_PLACE=/openapi/trade/order/place

--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -18,6 +18,13 @@ WEBULL_APP_SECRET=
 WEBULL_ACCOUNT_ID=
 # Sandbox default. Use https://openapi.webull.com for production.
 WEBULL_API_BASE=https://api.sandbox.webull.hk
+
+# #257: trade/account endpoint path 上書き (optional)。default は旧 path
+# (/openapi/account/*)。staging で新 path に切替えるとき設定。空 / whitespace
+# のみは未設定扱い (= default fallback)。
+# WEBULL_PATH_POSITIONS=/openapi/assets/positions
+# WEBULL_PATH_ORDERS_HISTORY=/openapi/trade/order/history
+# WEBULL_PATH_ORDERS_PLACE=/openapi/trade/order/place
 ALLOWED_SYMBOLS=SOXL,SOXS
 MAX_ORDER_NOTIONAL=100
 SYMBOL_MAX_NOTIONAL={"SOXL":200,"SOXS":150}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -51,6 +51,22 @@ export interface Env {
   WEBULL_API_BASE?: string
   /** Override the snapshot endpoint path (POC: UAT 未確定なので env で差し替え). */
   WEBULL_QUOTE_PATH?: string
+  /**
+   * #257: trade/account endpoint path overrides。新 OpenAPI docs (#251) で
+   * `/openapi/account/*` → `/openapi/assets/*` / `/openapi/trade/order/*`
+   * への drift があり、staging で env を切替えて段階移行できる。default は
+   * 旧 path (= 現行挙動)、未設定 / 空 / whitespace のみ なら fallback。
+   *
+   *   旧                                  →  新
+   *   /openapi/account/positions          →  /openapi/assets/positions
+   *   /openapi/account/orders/history     →  /openapi/trade/order/history
+   *   /openapi/account/orders/place       →  /openapi/trade/order/place
+   *
+   * 旧/新 alias で両 200 確認済 (PR #262 probe / 2026-04-29 検証)。
+   */
+  WEBULL_PATH_POSITIONS?: string
+  WEBULL_PATH_ORDERS_HISTORY?: string
+  WEBULL_PATH_ORDERS_PLACE?: string
 }
 
 

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -51,22 +51,6 @@ export interface Env {
   WEBULL_API_BASE?: string
   /** Override the snapshot endpoint path (POC: UAT 未確定なので env で差し替え). */
   WEBULL_QUOTE_PATH?: string
-  /**
-   * #257: trade/account endpoint path overrides。新 OpenAPI docs (#251) で
-   * `/openapi/account/*` → `/openapi/assets/*` / `/openapi/trade/order/*`
-   * への drift があり、staging で env を切替えて段階移行できる。default は
-   * 旧 path (= 現行挙動)、未設定 / 空 / whitespace のみ なら fallback。
-   *
-   *   旧                                  →  新
-   *   /openapi/account/positions          →  /openapi/assets/positions
-   *   /openapi/account/orders/history     →  /openapi/trade/order/history
-   *   /openapi/account/orders/place       →  /openapi/trade/order/place
-   *
-   * 旧/新 alias で両 200 確認済 (PR #262 probe / 2026-04-29 検証)。
-   */
-  WEBULL_PATH_POSITIONS?: string
-  WEBULL_PATH_ORDERS_HISTORY?: string
-  WEBULL_PATH_ORDERS_PLACE?: string
 }
 
 
@@ -331,4 +315,22 @@ export interface Env {
    * (例: `https://webull-trading.example.workers.dev`)。未設定なら link 省略。
    */
   DASHBOARD_BASE_URL?: string
+}
+
+
+// #257: trade/account endpoint path overrides (append at end / 共有ファイル
+// は末尾 append 規約)。新 OpenAPI docs (#251) で `/openapi/account/*` →
+// `/openapi/assets/positions` / `/openapi/trade/order/*` への drift。env を
+// 切替えるだけで段階移行できる。default は旧 path、未設定 / 空 / whitespace
+// のみ / `/` で始まらない値は fallback (絶対 URL 注入で WEBULL_API_BASE を
+// bypass する事故防止、CodeRabbit #264)。
+//
+//   旧                                  →  新
+//   /openapi/account/positions          →  /openapi/assets/positions
+//   /openapi/account/orders/history     →  /openapi/trade/order/history
+//   /openapi/account/orders/place       →  /openapi/trade/order/place
+export interface Env {
+  WEBULL_PATH_POSITIONS?: string
+  WEBULL_PATH_ORDERS_HISTORY?: string
+  WEBULL_PATH_ORDERS_PLACE?: string
 }

--- a/src/infrastructure/webull/WebullHttpClient.ts
+++ b/src/infrastructure/webull/WebullHttpClient.ts
@@ -369,13 +369,18 @@ export function createWebullHttpClient(
   env: WebullClientEnv,
   options?: { fetchFn?: typeof fetch; timeoutMs?: number; retry?: WebullRetryOptions },
 ): WebullHttpClient {
-  // #257: env で trade/account path を上書き可能。trim 済みかつ非空なら採用、
-  // 未設定 / 空文字 / whitespace-only は default にフォールバック (空文字を
-  // "設定済" とみなして broken request を投げないため)。
+  // #257: env で trade/account path を上書き可能。受理条件:
+  //   - 文字列であること
+  //   - trim 後が非空
+  //   - `/` で始まる絶対パス (= WEBULL_API_BASE を bypass する絶対 URL を弾く、
+  //     CodeRabbit #264 finding)
+  // 上記を満たさない場合は undefined を返して default path にフォールバック。
   const trim = (v: string | undefined): string | undefined => {
     if (typeof v !== 'string') return undefined
     const t = v.trim()
-    return t.length === 0 ? undefined : t
+    if (t.length === 0) return undefined
+    if (!t.startsWith('/')) return undefined
+    return t
   }
   return new WebullHttpClient({
     auth: new WebullAuth({

--- a/src/infrastructure/webull/WebullHttpClient.ts
+++ b/src/infrastructure/webull/WebullHttpClient.ts
@@ -25,6 +25,22 @@ export interface WebullClientEnv {
    * have no intent to run margin-leveraged trades from this POC.
    */
   WEBULL_ACCOUNT_ID_JP_CASH?: string
+  /**
+   * #257: trade/account endpoint path の env override。新 OpenAPI docs
+   * (#251) で `/openapi/account/*` → `/openapi/assets/*` /
+   * `/openapi/trade/order/*` への drift があり、staging で env を切替えて
+   * 段階移行できるようにする。default は現行 path、未設定なら従来挙動。
+   *
+   * 旧 → 新の対応:
+   *   /openapi/account/positions       → /openapi/assets/positions
+   *   /openapi/account/orders/history  → /openapi/trade/order/history
+   *   /openapi/account/orders/place    → /openapi/trade/order/place
+   *
+   * 旧/新ともに alias で 200 が返ることは probe で確認済 (PR #262)。
+   */
+  WEBULL_PATH_POSITIONS?: string
+  WEBULL_PATH_ORDERS_HISTORY?: string
+  WEBULL_PATH_ORDERS_PLACE?: string
 }
 
 interface WebullRetryOptions {
@@ -42,7 +58,15 @@ interface WebullHttpClientOptions {
   timeoutMs?: number
   retry?: WebullRetryOptions
   fetchFn?: typeof fetch
+  /** #257: trade/account endpoint path overrides。default は旧 path。 */
+  positionsPath?: string
+  ordersHistoryPath?: string
+  ordersPlacePath?: string
 }
+
+const DEFAULT_POSITIONS_PATH = '/openapi/account/positions'
+const DEFAULT_ORDERS_HISTORY_PATH = '/openapi/account/orders/history'
+const DEFAULT_ORDERS_PLACE_PATH = '/openapi/account/orders/place'
 
 export class WebullHttpClient {
   private readonly baseUrl: string
@@ -51,6 +75,9 @@ export class WebullHttpClient {
   private readonly fetchFn: typeof fetch
   private readonly retry: Required<WebullRetryOptions>
   private readonly accountId: string | undefined
+  private readonly positionsPath: string
+  private readonly ordersHistoryPath: string
+  private readonly ordersPlacePath: string
 
   constructor(private readonly options: WebullHttpClientOptions) {
     this.baseUrl = (options.baseUrl ?? 'https://api.sandbox.webull.hk').replace(/\/+$/, '')
@@ -66,6 +93,9 @@ export class WebullHttpClient {
       jitter: options.retry?.jitter ?? 0.25,
     }
     this.accountId = options.accountId
+    this.positionsPath = options.positionsPath ?? DEFAULT_POSITIONS_PATH
+    this.ordersHistoryPath = options.ordersHistoryPath ?? DEFAULT_ORDERS_HISTORY_PATH
+    this.ordersPlacePath = options.ordersPlacePath ?? DEFAULT_ORDERS_PLACE_PATH
   }
 
   async listSubscriptions(): Promise<WebullSubscriptionDto[]> {
@@ -98,7 +128,7 @@ export class WebullHttpClient {
   ): Promise<WebullOrderDetailDto | undefined> {
     const page = await this.request<unknown[]>(
       'GET',
-      '/openapi/account/orders/history',
+      this.ordersHistoryPath,
       {
         query: { account_id: this.requireAccountId(), page_size: String(pageSize) },
       },
@@ -124,7 +154,7 @@ export class WebullHttpClient {
    * https://developer.webull.com/apis/docs/reference/account-position/
    */
   async getPositions(): Promise<WebullPositionDto[]> {
-    return this.request<WebullPositionDto[]>('GET', '/openapi/account/positions', {
+    return this.request<WebullPositionDto[]>('GET', this.positionsPath, {
       query: { account_id: this.requireAccountId() },
     })
   }
@@ -158,7 +188,7 @@ export class WebullHttpClient {
     // Single CASH account handles both US and JP (multi-currency cash
     // account). v2 endpoint — JP UAT rejects the v1 `/trade/order/place`
     // body shape with ILLEGAL_PARAMETER.
-    return this.request<WebullPlaceOrderResponseDto>('POST', '/openapi/account/orders/place', {
+    return this.request<WebullPlaceOrderResponseDto>('POST', this.ordersPlacePath, {
       query: { account_id: this.requireAccountId() },
       body: toWebullPlaceOrderRequest(intent),
     })
@@ -339,6 +369,14 @@ export function createWebullHttpClient(
   env: WebullClientEnv,
   options?: { fetchFn?: typeof fetch; timeoutMs?: number; retry?: WebullRetryOptions },
 ): WebullHttpClient {
+  // #257: env で trade/account path を上書き可能。trim 済みかつ非空なら採用、
+  // 未設定 / 空文字 / whitespace-only は default にフォールバック (空文字を
+  // "設定済" とみなして broken request を投げないため)。
+  const trim = (v: string | undefined): string | undefined => {
+    if (typeof v !== 'string') return undefined
+    const t = v.trim()
+    return t.length === 0 ? undefined : t
+  }
   return new WebullHttpClient({
     auth: new WebullAuth({
       appKey: env.WEBULL_APP_KEY,
@@ -349,6 +387,9 @@ export function createWebullHttpClient(
     timeoutMs: options?.timeoutMs,
     retry: options?.retry,
     fetchFn: options?.fetchFn,
+    positionsPath: trim(env.WEBULL_PATH_POSITIONS),
+    ordersHistoryPath: trim(env.WEBULL_PATH_ORDERS_HISTORY),
+    ordersPlacePath: trim(env.WEBULL_PATH_ORDERS_PLACE),
   })
 }
 

--- a/test/infrastructure/webull/webullHttpClient.test.ts
+++ b/test/infrastructure/webull/webullHttpClient.test.ts
@@ -6,7 +6,7 @@ import {
   BrokerServerError,
 } from '../../../src/shared/errors'
 import { WebullAuth } from '../../../src/infrastructure/webull/WebullAuth'
-import { WebullHttpClient } from '../../../src/infrastructure/webull/WebullHttpClient'
+import { WebullHttpClient, createWebullHttpClient } from '../../../src/infrastructure/webull/WebullHttpClient'
 import type { OrderIntent } from '../../../src/trading/domain/OrderIntent'
 
 const intent: OrderIntent = {
@@ -609,5 +609,70 @@ describe('WebullHttpClient', () => {
     expect(String(url)).toContain('/app/subscriptions/list')
     expect(init?.method).toBe('GET')
     expect(init?.body).toBeUndefined()
+  })
+
+  // #257: trade/account endpoint path の env override 経路。default は旧 path、
+  // env で新 path を指定すると getPositions / findOrderByClientId / placeOrder
+  // 全部が新 path に切替わる。
+  describe('path env override (#257)', () => {
+    it('uses default /openapi/account/* paths when no override is provided', async () => {
+      const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(JSON.stringify([]), { status: 200 }),
+      )
+      const client = createWebullHttpClient(
+        {
+          WEBULL_APP_KEY: 'k',
+          WEBULL_APP_SECRET: 's',
+          WEBULL_ACCOUNT_ID_JP_CASH: 'acct',
+          WEBULL_API_BASE: 'https://broker.example.test',
+        },
+        { fetchFn: fetchMock, retry: { maxAttempts: 1, baseDelayMs: 0, multiplier: 1, jitter: 0 } },
+      )
+      await client.getPositions()
+      const u = new URL(fetchMock.mock.calls[0]![0] as string)
+      expect(u.pathname).toBe('/openapi/account/positions')
+    })
+
+    it('honours WEBULL_PATH_POSITIONS / WEBULL_PATH_ORDERS_HISTORY env overrides', async () => {
+      // mockImplementation で毎回新しい Response を返す (body を二度読みしないため)
+      const fetchMock = vi.fn<typeof fetch>().mockImplementation(async () =>
+        new Response(JSON.stringify([]), { status: 200 }),
+      )
+      const client = createWebullHttpClient(
+        {
+          WEBULL_APP_KEY: 'k',
+          WEBULL_APP_SECRET: 's',
+          WEBULL_ACCOUNT_ID_JP_CASH: 'acct',
+          WEBULL_API_BASE: 'https://broker.example.test',
+          WEBULL_PATH_POSITIONS: '/openapi/assets/positions',
+          WEBULL_PATH_ORDERS_HISTORY: '/openapi/trade/order/history',
+        },
+        { fetchFn: fetchMock, retry: { maxAttempts: 1, baseDelayMs: 0, multiplier: 1, jitter: 0 } },
+      )
+      await client.getPositions()
+      expect(new URL(fetchMock.mock.calls[0]![0] as string).pathname).toBe('/openapi/assets/positions')
+      await client.findOrderByClientId('coid')
+      expect(new URL(fetchMock.mock.calls[1]![0] as string).pathname).toBe('/openapi/trade/order/history')
+    })
+
+    it('treats whitespace-only env override as unset (falls back to default)', async () => {
+      const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(JSON.stringify([]), { status: 200 }),
+      )
+      const client = createWebullHttpClient(
+        {
+          WEBULL_APP_KEY: 'k',
+          WEBULL_APP_SECRET: 's',
+          WEBULL_ACCOUNT_ID_JP_CASH: 'acct',
+          WEBULL_API_BASE: 'https://broker.example.test',
+          // 空文字 / whitespace-only は "未設定" 扱い (broken request 回避)
+          WEBULL_PATH_POSITIONS: '   ',
+          WEBULL_PATH_ORDERS_HISTORY: '',
+        },
+        { fetchFn: fetchMock, retry: { maxAttempts: 1, baseDelayMs: 0, multiplier: 1, jitter: 0 } },
+      )
+      await client.getPositions()
+      expect(new URL(fetchMock.mock.calls[0]![0] as string).pathname).toBe('/openapi/account/positions')
+    })
   })
 })

--- a/test/infrastructure/webull/webullHttpClient.test.ts
+++ b/test/infrastructure/webull/webullHttpClient.test.ts
@@ -633,10 +633,10 @@ describe('WebullHttpClient', () => {
       expect(u.pathname).toBe('/openapi/account/positions')
     })
 
-    it('honours WEBULL_PATH_POSITIONS / WEBULL_PATH_ORDERS_HISTORY env overrides', async () => {
+    it('honours WEBULL_PATH_POSITIONS / WEBULL_PATH_ORDERS_HISTORY / WEBULL_PATH_ORDERS_PLACE env overrides', async () => {
       // mockImplementation で毎回新しい Response を返す (body を二度読みしないため)
       const fetchMock = vi.fn<typeof fetch>().mockImplementation(async () =>
-        new Response(JSON.stringify([]), { status: 200 }),
+        new Response(JSON.stringify({ client_order_id: 'test-coid', order_id: 'oid-1' }), { status: 200 }),
       )
       const client = createWebullHttpClient(
         {
@@ -646,6 +646,7 @@ describe('WebullHttpClient', () => {
           WEBULL_API_BASE: 'https://broker.example.test',
           WEBULL_PATH_POSITIONS: '/openapi/assets/positions',
           WEBULL_PATH_ORDERS_HISTORY: '/openapi/trade/order/history',
+          WEBULL_PATH_ORDERS_PLACE: '/openapi/trade/order/place',
         },
         { fetchFn: fetchMock, retry: { maxAttempts: 1, baseDelayMs: 0, multiplier: 1, jitter: 0 } },
       )
@@ -653,6 +654,32 @@ describe('WebullHttpClient', () => {
       expect(new URL(fetchMock.mock.calls[0]![0] as string).pathname).toBe('/openapi/assets/positions')
       await client.findOrderByClientId('coid')
       expect(new URL(fetchMock.mock.calls[1]![0] as string).pathname).toBe('/openapi/trade/order/history')
+      await client.placeOrder(intent)
+      expect(new URL(fetchMock.mock.calls[2]![0] as string).pathname).toBe('/openapi/trade/order/place')
+    })
+
+    it('rejects override values that are not absolute paths (security: prevent base URL bypass)', async () => {
+      // 絶対 URL や相対値だと WEBULL_API_BASE を bypass されるリスクがあるので、
+      // `/` で始まらない値は default fallback (CodeRabbit #264)。
+      const fetchMock = vi.fn<typeof fetch>().mockImplementation(async () =>
+        new Response(JSON.stringify([]), { status: 200 }),
+      )
+      const client = createWebullHttpClient(
+        {
+          WEBULL_APP_KEY: 'k',
+          WEBULL_APP_SECRET: 's',
+          WEBULL_ACCOUNT_ID_JP_CASH: 'acct',
+          WEBULL_API_BASE: 'https://broker.example.test',
+          // 絶対 URL や 相対 path は reject されて default fallback
+          WEBULL_PATH_POSITIONS: 'https://attacker.example.com/positions',
+          WEBULL_PATH_ORDERS_HISTORY: 'orders/history',
+        },
+        { fetchFn: fetchMock, retry: { maxAttempts: 1, baseDelayMs: 0, multiplier: 1, jitter: 0 } },
+      )
+      await client.getPositions()
+      const url = new URL(fetchMock.mock.calls[0]![0] as string)
+      expect(url.host).toBe('broker.example.test')
+      expect(url.pathname).toBe('/openapi/account/positions')
     })
 
     it('treats whitespace-only env override as unset (falls back to default)', async () => {


### PR DESCRIPTION
Closes #257

#251 で発覚した OpenAPI ドキュメント drift の対応。新 docs では `/openapi/account/*` が `/openapi/assets/positions` / `/openapi/trade/order/*` に移動。probe で旧/新ともに **alias で 200** で動くことは確認済 (PR #262 + 2026-04-29 追試)。

## 変更

env を切替えるだけで段階移行できるよう、3 つの env var を追加:

| env var | 旧 path (default) | 新 path |
|---|---|---|
| `WEBULL_PATH_POSITIONS` | /openapi/account/positions | /openapi/assets/positions |
| `WEBULL_PATH_ORDERS_HISTORY` | /openapi/account/orders/history | /openapi/trade/order/history |
| `WEBULL_PATH_ORDERS_PLACE` | /openapi/account/orders/place | /openapi/trade/order/place |

未設定 / 空 / whitespace のみ → default fallback (broken request 投げない)。

## 設計

- `WebullHttpClient` コンストラクタに `positionsPath` / `ordersHistoryPath` / `ordersPlacePath` を追加
- `createWebullHttpClient(env)` で env から **trim 経由で** plumb
- callers (`getPositions` / `findOrderByClientId` / `placeOrder`) は `this.<path>` 参照に書き換え (hardcode 解消)
- staging で `wrangler secret put WEBULL_PATH_POSITIONS=/openapi/assets/positions` 等で切替え試験 → 動作 OK なら default 化を別 PR で

## Test plan

- [x] pnpm typecheck pass
- [x] pnpm test pass (974 tests, +3)
- [ ] 既存挙動維持 (env 未設定なら旧 path) を確認
- [ ] env override 設定で新 path にリクエストが行くこと
- [ ] 空 / whitespace は default fallback
- [ ] (staging deploy 後) wrangler secret で env を 1 つずつ切替え、broker 応答を /admin/broker/probe で確認

## 親 issue

- #251 (drift parent)
- #257 (this issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Webull APIのエンドポイントパスを環境変数で個別カスタマイズ可能に。ポジション取得、注文履歴取得、新規注文の各パスを上書きでき、未設定や無効値は既定値にフォールバックします。

* **テスト**
  * 環境変数によるパス上書きの動作と、不正／空白値時のフォールバックを検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->