### PR TITLE
feat(webull): trade/account x-version の env override (#258)

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -45,3 +45,10 @@ DASHBOARD_BASE_URL=
 # WEBULL_PATH_POSITIONS=/openapi/assets/positions
 # WEBULL_PATH_ORDERS_HISTORY=/openapi/trade/order/history
 # WEBULL_PATH_ORDERS_PLACE=/openapi/trade/order/place
+
+# #258: trade/account routes の x-version ヘッダ override (optional、append
+# 規約)。default 'v1' (= 現行)。新 docs では v2 推奨だが旧 path でも v1 alias
+# で受理されるので staging で 'v2' 切替え検証してから default 化する。
+# 受理値は 'v1' / 'v2' のみ、それ以外 (空 / whitespace / 任意文字列) は 'v1'
+# fallback (auth signing が壊れるのを防ぐ strict 受理)。
+# WEBULL_TRADE_VERSION=v2

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -334,3 +334,14 @@ export interface Env {
   WEBULL_PATH_ORDERS_HISTORY?: string
   WEBULL_PATH_ORDERS_PLACE?: string
 }
+
+
+// #258: trade/account routes に送る x-version ヘッダ値の env override
+// (append at end)。default 'v1' (= 現行挙動)。新 OpenAPI docs では v2 必須化
+// の方向だが、旧 path も v1 alias で受理されてるので staging で env 切替えて
+// 検証してから default 化する。
+// 受理値は 'v1' / 'v2' のみ allow-list。それ以外 (空 / whitespace / 不正値)
+// は 'v1' fallback (任意文字列を渡すと auth signing が壊れるため strict)。
+export interface Env {
+  WEBULL_TRADE_VERSION?: string
+}

--- a/src/infrastructure/webull/WebullHttpClient.ts
+++ b/src/infrastructure/webull/WebullHttpClient.ts
@@ -41,6 +41,13 @@ export interface WebullClientEnv {
   WEBULL_PATH_POSITIONS?: string
   WEBULL_PATH_ORDERS_HISTORY?: string
   WEBULL_PATH_ORDERS_PLACE?: string
+  /**
+   * #258: trade/account routes に送る x-version ヘッダ値。default 'v1'
+   * (= 現行挙動)、'v2' に opt-in 可能。新 docs では v2 推奨だが旧/新 path
+   * とも v1 alias が動いてるので staging で切替え試験できる。
+   * 未設定 / 空 / whitespace のみ / 'v1'/'v2' 以外 → 'v1' fallback。
+   */
+  WEBULL_TRADE_VERSION?: string
 }
 
 interface WebullRetryOptions {
@@ -62,11 +69,18 @@ interface WebullHttpClientOptions {
   positionsPath?: string
   ordersHistoryPath?: string
   ordersPlacePath?: string
+  /**
+   * #258: trade/account routes に送る x-version ヘッダ値。default 'v1' (= 現行
+   * 挙動)、env で 'v2' に opt-in 可能。新 OpenAPI docs では v2 必須化の方向だが
+   * v1 でも alias 受理されてるので staging で env 切替えて検証する。
+   */
+  tradeVersion?: string
 }
 
 const DEFAULT_POSITIONS_PATH = '/openapi/account/positions'
 const DEFAULT_ORDERS_HISTORY_PATH = '/openapi/account/orders/history'
 const DEFAULT_ORDERS_PLACE_PATH = '/openapi/account/orders/place'
+const DEFAULT_TRADE_VERSION = 'v1'
 
 export class WebullHttpClient {
   private readonly baseUrl: string
@@ -78,6 +92,7 @@ export class WebullHttpClient {
   private readonly positionsPath: string
   private readonly ordersHistoryPath: string
   private readonly ordersPlacePath: string
+  private readonly tradeVersion: string
 
   constructor(private readonly options: WebullHttpClientOptions) {
     this.baseUrl = (options.baseUrl ?? 'https://api.sandbox.webull.hk').replace(/\/+$/, '')
@@ -96,6 +111,7 @@ export class WebullHttpClient {
     this.positionsPath = options.positionsPath ?? DEFAULT_POSITIONS_PATH
     this.ordersHistoryPath = options.ordersHistoryPath ?? DEFAULT_ORDERS_HISTORY_PATH
     this.ordersPlacePath = options.ordersPlacePath ?? DEFAULT_ORDERS_PLACE_PATH
+    this.tradeVersion = options.tradeVersion ?? DEFAULT_TRADE_VERSION
   }
 
   async listSubscriptions(): Promise<WebullSubscriptionDto[]> {
@@ -220,7 +236,9 @@ export class WebullHttpClient {
         body: payload,
         host: resolvedUrl.host,
         // Webull SDK sets x-version=v1 for the documented trade/account routes.
-        version: 'v1',
+        // 新 OpenAPI docs (#251 / #258) では v2 必須化の方向。env override
+        // (`WEBULL_TRADE_VERSION`) で staging 切替え可能、default は v1。
+        version: this.tradeVersion,
       })
     } catch (error) {
       throw new BrokerRequestError(
@@ -382,6 +400,15 @@ export function createWebullHttpClient(
     if (!t.startsWith('/')) return undefined
     return t
   }
+  // #258: x-version は 'v1' / 'v2' のみ allow-list 受理。それ以外 (空 /
+  // whitespace / 不正値) は undefined を返して default ('v1') に fallback。
+  // 任意文字列を通すと broker auth signing が壊れるため strict validation。
+  const validateVersion = (v: string | undefined): string | undefined => {
+    if (typeof v !== 'string') return undefined
+    const t = v.trim()
+    if (t === 'v1' || t === 'v2') return t
+    return undefined
+  }
   return new WebullHttpClient({
     auth: new WebullAuth({
       appKey: env.WEBULL_APP_KEY,
@@ -395,6 +422,7 @@ export function createWebullHttpClient(
     positionsPath: trim(env.WEBULL_PATH_POSITIONS),
     ordersHistoryPath: trim(env.WEBULL_PATH_ORDERS_HISTORY),
     ordersPlacePath: trim(env.WEBULL_PATH_ORDERS_PLACE),
+    tradeVersion: validateVersion(env.WEBULL_TRADE_VERSION),
   })
 }
 

--- a/test/infrastructure/webull/webullHttpClient.test.ts
+++ b/test/infrastructure/webull/webullHttpClient.test.ts
@@ -702,4 +702,68 @@ describe('WebullHttpClient', () => {
       expect(new URL(fetchMock.mock.calls[0]![0] as string).pathname).toBe('/openapi/account/positions')
     })
   })
+
+  // #258: trade/account routes の x-version env override
+  describe('trade x-version env override (#258)', () => {
+    it('defaults to x-version: v1 when WEBULL_TRADE_VERSION is unset', async () => {
+      let captured: Headers | undefined
+      const fetchMock = vi.fn<typeof fetch>().mockImplementation(async (input, init) => {
+        captured = new Headers(init?.headers)
+        return new Response(JSON.stringify([]), { status: 200 })
+      })
+      const client = createWebullHttpClient(
+        {
+          WEBULL_APP_KEY: 'k',
+          WEBULL_APP_SECRET: 's',
+          WEBULL_ACCOUNT_ID_JP_CASH: 'acct',
+          WEBULL_API_BASE: 'https://broker.example.test',
+        },
+        { fetchFn: fetchMock, retry: { maxAttempts: 1, baseDelayMs: 0, multiplier: 1, jitter: 0 } },
+      )
+      await client.getPositions()
+      expect(captured?.get('x-version')).toBe('v1')
+    })
+
+    it('honours WEBULL_TRADE_VERSION=v2 override', async () => {
+      let captured: Headers | undefined
+      const fetchMock = vi.fn<typeof fetch>().mockImplementation(async (input, init) => {
+        captured = new Headers(init?.headers)
+        return new Response(JSON.stringify([]), { status: 200 })
+      })
+      const client = createWebullHttpClient(
+        {
+          WEBULL_APP_KEY: 'k',
+          WEBULL_APP_SECRET: 's',
+          WEBULL_ACCOUNT_ID_JP_CASH: 'acct',
+          WEBULL_API_BASE: 'https://broker.example.test',
+          WEBULL_TRADE_VERSION: 'v2',
+        },
+        { fetchFn: fetchMock, retry: { maxAttempts: 1, baseDelayMs: 0, multiplier: 1, jitter: 0 } },
+      )
+      await client.getPositions()
+      expect(captured?.get('x-version')).toBe('v2')
+    })
+
+    it('rejects invalid version values (anything not v1/v2) and falls back to v1', async () => {
+      let captured: Headers | undefined
+      const fetchMock = vi.fn<typeof fetch>().mockImplementation(async (input, init) => {
+        captured = new Headers(init?.headers)
+        return new Response(JSON.stringify([]), { status: 200 })
+      })
+      const client = createWebullHttpClient(
+        {
+          WEBULL_APP_KEY: 'k',
+          WEBULL_APP_SECRET: 's',
+          WEBULL_ACCOUNT_ID_JP_CASH: 'acct',
+          WEBULL_API_BASE: 'https://broker.example.test',
+          // 任意文字列 / 空 / whitespace は v1 fallback (auth signing が壊れる
+          // のを防ぐ strict allow-list)
+          WEBULL_TRADE_VERSION: 'v3',
+        },
+        { fetchFn: fetchMock, retry: { maxAttempts: 1, baseDelayMs: 0, multiplier: 1, jitter: 0 } },
+      )
+      await client.getPositions()
+      expect(captured?.get('x-version')).toBe('v1')
+    })
+  })
 })


### PR DESCRIPTION
Closes #258

#251 ドキュメント drift 対応。新 docs では `x-version: v2` 必須化の方向だが、旧 path も v1 alias で受理されている (probe で確認済)。env で切替えて検証 → default 化、の段階移行を可能にする。

## 変更

- `WEBULL_TRADE_VERSION` env 追加 (default `v1` = 現行挙動)
- 受理値は `v1` / `v2` のみ **allow-list** (任意文字列で auth signing が壊れるのを防ぐ strict 受理)、それ以外は `v1` fallback
- `WebullHttpClient.request()` の hardcoded `'v1'` を `this.tradeVersion` 参照に
- `createWebullHttpClient` で env から `validateVersion` 経由で plumb
- `env.ts` / `.dev.vars.example` は **末尾 append** (共有ファイル規約 / CodeRabbit #264 で指摘されたパターン)
- 単体テスト追加: default v1 / v2 override / 不正値で v1 fallback

## staging 切替手順

```bash
wrangler secret put WEBULL_TRADE_VERSION --env staging
# 値: v2
```

その後 `/admin/broker/probe` で broker 応答を確認、問題なければ default 化の follow-up PR。

## Test plan

- [x] pnpm typecheck pass
- [x] pnpm test pass (978 tests)
- [ ] (staging deploy 後) `WEBULL_TRADE_VERSION=v2` で probe → broker 応答確認

## 親 issue

- #251 (drift parent)
- #258 (this issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * トレード・アカウント機能で使用するAPIバージョンを設定できるようになりました。環境変数で `v1` または `v2` を指定可能です。デフォルトは `v1` で、無効な値は自動的に `v1` にフォールバックします。

* **テスト**
  * APIバージョン設定機能の動作検証テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->