### PR TITLE
feat(webull): Place Order body schema env-gated v1/v2 切替え (#256)

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -52,3 +52,9 @@ DASHBOARD_BASE_URL=
 # 受理値は 'v1' / 'v2' のみ、それ以外 (空 / whitespace / 任意文字列) は 'v1'
 # fallback (auth signing が壊れるのを防ぐ strict 受理)。
 # WEBULL_TRADE_VERSION=v2
+
+# #256: Place Order body schema version (optional、append 規約)。default 'v1'
+# (現挙動)、'v2' で新 docs 形式 (combo_type=NORMAL / session=CORE / MARKET
+# は limit_price 不要 / account_id を body)。受理値は 'v1' / 'v2' のみ、
+# それ以外 (空 / whitespace / 任意文字列) は 'v1' fallback。
+# WEBULL_PLACE_ORDER_SCHEMA=v2

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -345,3 +345,18 @@ export interface Env {
 export interface Env {
   WEBULL_TRADE_VERSION?: string
 }
+
+
+// #256: Place Order body schema version の env override (append at end)。
+// 'v1' (default / 現挙動) と 'v2' (新 OpenAPI docs) を切替え可能。受理値は
+// 'v1' / 'v2' のみ allow-list、それ以外 (空 / whitespace / 任意文字列) は
+// 'v1' fallback (任意文字列で broken body を broker に送らないため strict)。
+//
+// v2 にすると mapper は以下に変更:
+//   - combo_type: 'NORMAL' を必ず付ける
+//   - support_trading_session: 'N' → 'CORE' (新 enum、'N' は廃止)
+//   - MARKET 注文では limit_price を送らない (LIMIT のときのみ required)
+//   - account_id を query → body に移動
+export interface Env {
+  WEBULL_PLACE_ORDER_SCHEMA?: string
+}

--- a/src/infrastructure/webull/WebullHttpClient.ts
+++ b/src/infrastructure/webull/WebullHttpClient.ts
@@ -8,7 +8,7 @@ import type {
   WebullPositionDto,
   WebullSubscriptionDto,
 } from './dto'
-import { toWebullPlaceOrderRequest } from './mapper'
+import { toWebullPlaceOrderRequest, type PlaceOrderSchemaVersion } from './mapper'
 import { WebullAuth } from './WebullAuth'
 
 export interface WebullClientEnv {
@@ -48,6 +48,12 @@ export interface WebullClientEnv {
    * 未設定 / 空 / whitespace のみ / 'v1'/'v2' 以外 → 'v1' fallback。
    */
   WEBULL_TRADE_VERSION?: string
+  /**
+   * #256: Place Order body schema version。'v1' (default / 現挙動) か 'v2'
+   * (新 OpenAPI docs)。受理値は 'v1' / 'v2' のみ allow-list、それ以外は
+   * 'v1' fallback。
+   */
+  WEBULL_PLACE_ORDER_SCHEMA?: string
 }
 
 interface WebullRetryOptions {
@@ -75,12 +81,19 @@ interface WebullHttpClientOptions {
    * v1 でも alias 受理されてるので staging で env 切替えて検証する。
    */
   tradeVersion?: string
+  /**
+   * #256: Place Order body schema version。'v1' (default / 現挙動) か 'v2'
+   * (新 OpenAPI docs)。v2 だと combo_type=NORMAL、session=CORE、
+   * limit_price (MARKET) 省略、account_id を body 側へ移動する。
+   */
+  placeOrderSchema?: PlaceOrderSchemaVersion
 }
 
 const DEFAULT_POSITIONS_PATH = '/openapi/account/positions'
 const DEFAULT_ORDERS_HISTORY_PATH = '/openapi/account/orders/history'
 const DEFAULT_ORDERS_PLACE_PATH = '/openapi/account/orders/place'
 const DEFAULT_TRADE_VERSION = 'v1'
+const DEFAULT_PLACE_ORDER_SCHEMA: PlaceOrderSchemaVersion = 'v1'
 
 export class WebullHttpClient {
   private readonly baseUrl: string
@@ -93,6 +106,7 @@ export class WebullHttpClient {
   private readonly ordersHistoryPath: string
   private readonly ordersPlacePath: string
   private readonly tradeVersion: string
+  private readonly placeOrderSchema: PlaceOrderSchemaVersion
 
   constructor(private readonly options: WebullHttpClientOptions) {
     this.baseUrl = (options.baseUrl ?? 'https://api.sandbox.webull.hk').replace(/\/+$/, '')
@@ -112,6 +126,7 @@ export class WebullHttpClient {
     this.ordersHistoryPath = options.ordersHistoryPath ?? DEFAULT_ORDERS_HISTORY_PATH
     this.ordersPlacePath = options.ordersPlacePath ?? DEFAULT_ORDERS_PLACE_PATH
     this.tradeVersion = options.tradeVersion ?? DEFAULT_TRADE_VERSION
+    this.placeOrderSchema = options.placeOrderSchema ?? DEFAULT_PLACE_ORDER_SCHEMA
   }
 
   async listSubscriptions(): Promise<WebullSubscriptionDto[]> {
@@ -204,9 +219,16 @@ export class WebullHttpClient {
     // Single CASH account handles both US and JP (multi-currency cash
     // account). v2 endpoint — JP UAT rejects the v1 `/trade/order/place`
     // body shape with ILLEGAL_PARAMETER.
+    //
+    // #256: schema が v2 のときは account_id を body 側に移動 (新 docs)、
+    //   query には付けない。v1 (default) は従来どおり query。
+    const accountId = this.requireAccountId()
+    const body = toWebullPlaceOrderRequest(intent, this.placeOrderSchema, accountId)
+    const query: Record<string, string> =
+      this.placeOrderSchema === 'v2' ? {} : { account_id: accountId }
     return this.request<WebullPlaceOrderResponseDto>('POST', this.ordersPlacePath, {
-      query: { account_id: this.requireAccountId() },
-      body: toWebullPlaceOrderRequest(intent),
+      query,
+      body,
     })
   }
 
@@ -409,6 +431,15 @@ export function createWebullHttpClient(
     if (t === 'v1' || t === 'v2') return t
     return undefined
   }
+  // #256: Place Order body schema version の strict allow-list 受理。
+  // 'v1' / 'v2' 以外 (空 / whitespace / 任意文字列) は undefined → default 'v1'。
+  // 任意文字列を通すと broken body schema を broker に送って order が壊れる。
+  const validateOrderSchema = (v: string | undefined): PlaceOrderSchemaVersion | undefined => {
+    if (typeof v !== 'string') return undefined
+    const t = v.trim()
+    if (t === 'v1' || t === 'v2') return t
+    return undefined
+  }
   return new WebullHttpClient({
     auth: new WebullAuth({
       appKey: env.WEBULL_APP_KEY,
@@ -423,6 +454,7 @@ export function createWebullHttpClient(
     ordersHistoryPath: trim(env.WEBULL_PATH_ORDERS_HISTORY),
     ordersPlacePath: trim(env.WEBULL_PATH_ORDERS_PLACE),
     tradeVersion: validateVersion(env.WEBULL_TRADE_VERSION),
+    placeOrderSchema: validateOrderSchema(env.WEBULL_PLACE_ORDER_SCHEMA),
   })
 }
 

--- a/src/infrastructure/webull/dto.ts
+++ b/src/infrastructure/webull/dto.ts
@@ -18,7 +18,7 @@ export type WebullMarket = 'US' | 'JP'
 /**
  * Place Order body schema。#251 / #256 で v1 (旧 SDK) と v2 (新 OpenAPI docs)
  * の差分対応のため、両方を許容する shape を持つ。version の選択は env
- * (\`WEBULL_PLACE_ORDER_VERSION\`) で行い、mapper が schema 別の body を構築する。
+ * (\`WEBULL_PLACE_ORDER_SCHEMA\`) で行い、mapper が schema 別の body を構築する。
  *
  * v1 (default / 現挙動):
  *   - limit_price 必須 (MARKET orders にも safety cap として送る)

--- a/src/infrastructure/webull/dto.ts
+++ b/src/infrastructure/webull/dto.ts
@@ -15,23 +15,45 @@ export interface WebullSubscriptionDto {
 
 export type WebullMarket = 'US' | 'JP'
 
+/**
+ * Place Order body schema。#251 / #256 で v1 (旧 SDK) と v2 (新 OpenAPI docs)
+ * の差分対応のため、両方を許容する shape を持つ。version の選択は env
+ * (\`WEBULL_PLACE_ORDER_VERSION\`) で行い、mapper が schema 別の body を構築する。
+ *
+ * v1 (default / 現挙動):
+ *   - limit_price 必須 (MARKET orders にも safety cap として送る)
+ *   - support_trading_session: 'N'
+ *   - combo_type は無し
+ *   - account_id は query param 側
+ *
+ * v2 (新 docs / opt-in):
+ *   - limit_price は LIMIT/STOP_LOSS_LIMIT のときのみ required
+ *   - support_trading_session enum は \`NIGHT/ALL/CORE/ALL_DAY\` (旧 'N' は廃止)
+ *   - combo_type 必須 (\`'NORMAL'\` for non-combo single-leg)
+ *   - account_id は body へ
+ */
 export interface WebullV2OrderEntry {
   client_order_id: string
   symbol: string
   instrument_type: 'EQUITY'
   market: WebullMarket
   order_type: 'LIMIT' | 'MARKET'
-  /** MARKET orders still carry limit_price as a safety cap (Webull schema). */
-  limit_price: string
+  /** v1 必須 (MARKET でも safety cap)、v2 で MARKET は省略可。 */
+  limit_price?: string
   quantity: string
-  support_trading_session: 'N'
+  /** v1: 'N'、v2: 'CORE' (新 enum)。 */
+  support_trading_session: string
   side: 'BUY' | 'SELL'
   time_in_force: 'DAY'
   entrust_type: 'QTY'
   account_tax_type: 'GENERAL'
+  /** v2 のみ。combo / multi-leg 未対応 POC では常に 'NORMAL'。 */
+  combo_type?: 'NORMAL'
 }
 
 export interface WebullPlaceOrderRequestDto {
+  /** v2 で account_id を body 側に持つ場合に使用。v1 では未送信。 */
+  account_id?: string
   new_orders: [WebullV2OrderEntry]
 }
 

--- a/src/infrastructure/webull/mapper.ts
+++ b/src/infrastructure/webull/mapper.ts
@@ -2,26 +2,63 @@ import type { ExecutionResult } from '../../trading/domain/ExecutionResult'
 import type { OrderIntent } from '../../trading/domain/OrderIntent'
 import type { WebullMarket, WebullPlaceOrderRequestDto, WebullPlaceOrderResponseDto } from './dto'
 
-export function toWebullPlaceOrderRequest(intent: OrderIntent): WebullPlaceOrderRequestDto {
+/**
+ * Place Order body schema version (#251 / #256)。
+ *
+ * - 'v1' (default / 現挙動): 旧 SDK shape。\`support_trading_session='N'\`、
+ *   \`limit_price\` は MARKET にも送る、\`account_id\` は query param 側、
+ *   \`combo_type\` 無し。
+ * - 'v2' (新 OpenAPI docs / opt-in): \`combo_type='NORMAL'\` 必須、
+ *   \`support_trading_session='CORE'\` (旧 'N' は新 enum に無い)、MARKET 注文では
+ *   \`limit_price\` を送らない、\`account_id\` を body へ。
+ */
+export type PlaceOrderSchemaVersion = 'v1' | 'v2'
+
+export function toWebullPlaceOrderRequest(
+  intent: OrderIntent,
+  schema: PlaceOrderSchemaVersion = 'v1',
+  accountId?: string,
+): WebullPlaceOrderRequestDto {
   const symbol = intent.symbol.toUpperCase()
+  const isMarket = true // 現状 strategy は MARKET 注文のみ
+  const baseEntry = {
+    client_order_id: intent.clientOrderId,
+    symbol,
+    instrument_type: 'EQUITY' as const,
+    market: inferWebullMarket(symbol),
+    order_type: 'MARKET' as const,
+    quantity: String(intent.quantity),
+    side: intent.side,
+    time_in_force: 'DAY' as const,
+    entrust_type: 'QTY' as const,
+    account_tax_type: 'GENERAL' as const,
+  }
+  if (schema === 'v2') {
+    return {
+      // v2: account_id は body 側
+      ...(accountId !== undefined ? { account_id: accountId } : {}),
+      new_orders: [
+        {
+          ...baseEntry,
+          combo_type: 'NORMAL',
+          // v2 enum: NIGHT/ALL/CORE/ALL_DAY ('N' は廃止)。POC は通常時間帯のみ → CORE。
+          support_trading_session: 'CORE',
+          // v2 + MARKET: limit_price 不要 (LIMIT/STOP_LOSS_LIMIT のみ required)。
+          // 安全 cap が欲しい場合は order_type を LIMIT に変える別 PR 案件。
+          ...(isMarket ? {} : { limit_price: intent.price.toFixed(3) }),
+        },
+      ],
+    }
+  }
+  // v1: 現行挙動。MARKET でも safety cap として limit_price を必ず送る。
   return {
     new_orders: [
       {
-        client_order_id: intent.clientOrderId,
-        symbol,
-        instrument_type: 'EQUITY',
-        market: inferWebullMarket(symbol),
-        // MARKET: sandbox の fill simulator は limit 注文を通さないので、
-        // POC 検証用に成行で発注する。Webull schema は MARKET でも
-        // limit_price を safety cap として必須にしている。
-        order_type: 'MARKET',
+        ...baseEntry,
+        // sandbox の fill simulator が limit 注文を通さないので POC は MARKET。
+        // v1 schema は MARKET でも limit_price 必須 (safety cap)。
         limit_price: intent.price.toFixed(3),
-        quantity: String(intent.quantity),
         support_trading_session: 'N',
-        side: intent.side,
-        time_in_force: 'DAY',
-        entrust_type: 'QTY',
-        account_tax_type: 'GENERAL',
       },
     ],
   }

--- a/test/infrastructure/webull/mapper.test.ts
+++ b/test/infrastructure/webull/mapper.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import {
+  toWebullPlaceOrderRequest,
+  type PlaceOrderSchemaVersion,
+} from '../../../src/infrastructure/webull/mapper'
+import type { OrderIntent } from '../../../src/trading/domain/OrderIntent'
+
+const intent: OrderIntent = {
+  symbol: 'SOXL',
+  side: 'BUY',
+  quantity: 4,
+  price: 12.5,
+  notional: 50,
+  clientOrderId: 'coid-test',
+}
+
+// #251 / #256: Place Order body schema version の差分テスト。
+// v1 (default / 現挙動) と v2 (新 OpenAPI docs) の body shape を検証。
+describe('toWebullPlaceOrderRequest', () => {
+  describe('v1 (default / 現挙動)', () => {
+    it('produces the legacy shape with limit_price + support_trading_session=N + no combo_type', () => {
+      const body = toWebullPlaceOrderRequest(intent, 'v1', 'acct-1')
+      expect(body.account_id).toBeUndefined() // v1 は body に account_id 載せない
+      expect(body.new_orders).toHaveLength(1)
+      const order = body.new_orders[0]
+      expect(order.client_order_id).toBe('coid-test')
+      expect(order.symbol).toBe('SOXL')
+      expect(order.market).toBe('US')
+      expect(order.order_type).toBe('MARKET')
+      expect(order.limit_price).toBe('12.500') // safety cap として送る
+      expect(order.support_trading_session).toBe('N')
+      expect(order.combo_type).toBeUndefined()
+      expect(order.side).toBe('BUY')
+      expect(order.quantity).toBe('4')
+    })
+
+    it('default schema=v1 (引数省略) でも v1 shape', () => {
+      const body = toWebullPlaceOrderRequest(intent)
+      expect(body.account_id).toBeUndefined()
+      expect(body.new_orders[0].support_trading_session).toBe('N')
+      expect(body.new_orders[0].limit_price).toBe('12.500')
+      expect(body.new_orders[0].combo_type).toBeUndefined()
+    })
+  })
+
+  describe('v2 (新 OpenAPI docs / opt-in)', () => {
+    it('moves account_id to body, sets combo_type=NORMAL + session=CORE, omits limit_price for MARKET', () => {
+      const body = toWebullPlaceOrderRequest(intent, 'v2', 'acct-1')
+      expect(body.account_id).toBe('acct-1') // v2 は body 側
+      expect(body.new_orders).toHaveLength(1)
+      const order = body.new_orders[0]
+      expect(order.combo_type).toBe('NORMAL')
+      expect(order.support_trading_session).toBe('CORE')
+      expect(order.limit_price).toBeUndefined() // MARKET では送らない
+      expect(order.client_order_id).toBe('coid-test')
+      expect(order.symbol).toBe('SOXL')
+    })
+
+    it('omits account_id from body if not provided', () => {
+      const body = toWebullPlaceOrderRequest(intent, 'v2')
+      expect(body.account_id).toBeUndefined()
+      expect(body.new_orders[0].combo_type).toBe('NORMAL')
+    })
+  })
+
+  describe('JP symbol', () => {
+    it('infers market=JP for 4-digit TSE codes (both v1 and v2)', () => {
+      const jpIntent: OrderIntent = { ...intent, symbol: '7203' }
+      const v1 = toWebullPlaceOrderRequest(jpIntent, 'v1' as PlaceOrderSchemaVersion)
+      const v2 = toWebullPlaceOrderRequest(jpIntent, 'v2' as PlaceOrderSchemaVersion)
+      expect(v1.new_orders[0].market).toBe('JP')
+      expect(v2.new_orders[0].market).toBe('JP')
+    })
+  })
+})

--- a/test/infrastructure/webull/webullHttpClient.test.ts
+++ b/test/infrastructure/webull/webullHttpClient.test.ts
@@ -766,4 +766,86 @@ describe('WebullHttpClient', () => {
       expect(captured?.get('x-version')).toBe('v1')
     })
   })
+
+  // #256: Place Order body schema version の env override
+  describe('place order schema env override (#256)', () => {
+    it('defaults to v1 schema (account_id in query, support_trading_session=N, limit_price sent)', async () => {
+      let capturedUrl: URL | undefined
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let capturedBody: any
+      const fetchMock = vi.fn<typeof fetch>().mockImplementation(async (input, init) => {
+        capturedUrl = new URL(typeof input === 'string' ? input : input instanceof URL ? input.href : input.url)
+        capturedBody = init?.body ? JSON.parse(init.body as string) : undefined
+        return new Response(JSON.stringify({ client_order_id: 'coid', order_id: 'oid' }), { status: 200 })
+      })
+      const client = createWebullHttpClient(
+        {
+          WEBULL_APP_KEY: 'k',
+          WEBULL_APP_SECRET: 's',
+          WEBULL_ACCOUNT_ID_JP_CASH: 'acct-1',
+          WEBULL_API_BASE: 'https://broker.example.test',
+        },
+        { fetchFn: fetchMock, retry: { maxAttempts: 1, baseDelayMs: 0, multiplier: 1, jitter: 0 } },
+      )
+      await client.placeOrder(intent)
+      expect(capturedUrl?.searchParams.get('account_id')).toBe('acct-1')
+      expect(capturedBody.account_id).toBeUndefined()
+      const order = capturedBody.new_orders[0]
+      expect(order.support_trading_session).toBe('N')
+      expect(order.limit_price).toBeDefined()
+      expect(order.combo_type).toBeUndefined()
+    })
+
+    it('honours WEBULL_PLACE_ORDER_SCHEMA=v2 (account_id in body, combo_type=NORMAL, session=CORE, no limit_price)', async () => {
+      let capturedUrl: URL | undefined
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let capturedBody: any
+      const fetchMock = vi.fn<typeof fetch>().mockImplementation(async (input, init) => {
+        capturedUrl = new URL(typeof input === 'string' ? input : input instanceof URL ? input.href : input.url)
+        capturedBody = init?.body ? JSON.parse(init.body as string) : undefined
+        return new Response(JSON.stringify({ client_order_id: 'coid', order_id: 'oid' }), { status: 200 })
+      })
+      const client = createWebullHttpClient(
+        {
+          WEBULL_APP_KEY: 'k',
+          WEBULL_APP_SECRET: 's',
+          WEBULL_ACCOUNT_ID_JP_CASH: 'acct-1',
+          WEBULL_API_BASE: 'https://broker.example.test',
+          WEBULL_PLACE_ORDER_SCHEMA: 'v2',
+        },
+        { fetchFn: fetchMock, retry: { maxAttempts: 1, baseDelayMs: 0, multiplier: 1, jitter: 0 } },
+      )
+      await client.placeOrder(intent)
+      expect(capturedUrl?.searchParams.get('account_id')).toBeNull() // v2 は query に無い
+      expect(capturedBody.account_id).toBe('acct-1') // v2 は body 側
+      const order = capturedBody.new_orders[0]
+      expect(order.combo_type).toBe('NORMAL')
+      expect(order.support_trading_session).toBe('CORE')
+      expect(order.limit_price).toBeUndefined() // MARKET では送らない
+    })
+
+    it('rejects invalid schema values and falls back to v1', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let capturedBody: any
+      const fetchMock = vi.fn<typeof fetch>().mockImplementation(async (input, init) => {
+        capturedBody = init?.body ? JSON.parse(init.body as string) : undefined
+        return new Response(JSON.stringify({ client_order_id: 'coid', order_id: 'oid' }), { status: 200 })
+      })
+      const client = createWebullHttpClient(
+        {
+          WEBULL_APP_KEY: 'k',
+          WEBULL_APP_SECRET: 's',
+          WEBULL_ACCOUNT_ID_JP_CASH: 'acct-1',
+          WEBULL_API_BASE: 'https://broker.example.test',
+          // 任意文字列 / 空 は v1 fallback (broken body 防止)
+          WEBULL_PLACE_ORDER_SCHEMA: 'v3',
+        },
+        { fetchFn: fetchMock, retry: { maxAttempts: 1, baseDelayMs: 0, multiplier: 1, jitter: 0 } },
+      )
+      await client.placeOrder(intent)
+      // v1 fallback の挙動を確認
+      expect(capturedBody.new_orders[0].support_trading_session).toBe('N')
+      expect(capturedBody.account_id).toBeUndefined()
+    })
+  })
 })


### PR DESCRIPTION
Closes #256

#251 ドキュメント drift 対応の **最後の deferred 件**。新 docs では Place Order body shape が大きく変わってる。env-gated で **default v1 (現挙動)** のまま、staging で v2 を opt-in 試験できるようにする。実発注ロジックの直接書換えは default では発生しない (= 安全)。

## v2 で何が変わる

| 項目 | v1 (現挙動) | v2 (新 docs) |
|---|---|---|
| `combo_type` | 無し | `'NORMAL'` 必須 |
| `support_trading_session` | `'N'` | `'CORE'` ('N' は新 enum に無し) |
| `limit_price` (MARKET) | safety cap として送る | LIMIT のみ required (省略) |
| `account_id` の位置 | query param | body の top-level |

## 実装

- `mapper.toWebullPlaceOrderRequest` に `schema: PlaceOrderSchemaVersion` + `accountId?: string` 引数追加
- `WebullHttpClient.placeOrder` が `this.placeOrderSchema` に応じて query/body を切替え
- `WEBULL_PLACE_ORDER_SCHEMA` env override (`'v1'`/`'v2'` の allow-list、それ以外は v1 fallback / broken body 防止 strict)
- `env.ts` / `.dev.vars.example` 末尾 append (共有ファイル規約 / CodeRabbit #264 で指摘されたパターン)
- `WebullV2OrderEntry` の type を緩和 (limit_price / combo_type / session を optional / 値文字列を string に)

## staging 切替え手順

```bash
wrangler secret put WEBULL_PLACE_ORDER_SCHEMA --env staging
# 値: v2
```

その後 dry_run=true 環境で 1 件発注 → `/admin/broker/probe` の orderHistoryNew で broker 受理を確認。OK なら default 化を follow-up PR で。

## Test plan

- [x] pnpm typecheck pass
- [x] pnpm test pass (983 tests, +5)
- [ ] (staging dry-run) v2 で order 発注 → broker accept 確認
- [ ] live 発注前は **必ず manual review** (取引ロジック直接影響、CR auto-approve は不可)

## 親 issue

- #251 (drift parent)
- #256 (this issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 注文APIのリクエストスキーマを環境設定で切替可能に（v1/v2、デフォルトv1）。v2は一部フィールド配置と値が変わります。

* **動作変更（影響点）**
  * v2では注文のaccount_idをリクエストボディへ移動、MARKET注文でlimit_priceを省略可能、取引セッションやコンボ属性の扱いが変化。

* **ドキュメント**
  * 環境変数説明とv1/v2差分をサンプルコメントに追記。

* **テスト**
  * v1/v2のリクエスト形状差異を検証するテストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->