### PR TITLE
fix(reconcile): repair cohort で lookback を外す (#268)

### DIFF
--- a/src/trading/reconciliation/reconcileFills.ts
+++ b/src/trading/reconciliation/reconcileFills.ts
@@ -229,14 +229,23 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
       and(
         eq(tradeJournal.tradeEventType, 'post_submit'),
         eq(tradeJournal.submitted, true),
-        // Always require the lookback window for the "fresh poll" cohort.
-        // Repair-mode (retryStateApply=true) drops it for cohort (b) only,
-        // applied via the OR below.
+        // Lookback の適用は cohort 別に分かれる (#268):
+        //   - fresh poll cohort (broker_status NULL): broker への問合せが必要
+        //     なので、古い行を毎 tick 引っ張ると broker pressure になる
+        //     (default 48h cap)。
+        //   - repair cohort (broker_status='FILLED' AND state_applied_at NULL):
+        //     broker poll 不要 (broker_status 確認済)、DO RPC のみで軽量。
+        //     **lookback 無視で常に sweep** する。これにより長期保有 fill が
+        //     48h 経過後 aged-out で permanent split-brain になる事故を防ぐ。
+        //     行数爆発は SELECT LIMIT 50 で bounded、永続 fail 行は #228 の
+        //     auto-abandon (MAX_REPAIR_ATTEMPTS=5) で cohort から自動的に外れる。
+        //
+        // `retryStateApply` フラグは残してあるが #268 以降は no-op
+        // (互換性のため signature 維持、将来 admin 側で別 sweep モードに
+        // 再定義する余地)。
         or(
           and(isNull(tradeJournal.brokerStatus), gte(tradeJournal.timestamp, since)),
-          options.retryStateApply
-            ? repairFilter
-            : and(repairFilter, gte(tradeJournal.timestamp, since)),
+          repairFilter,
         ),
       ),
     )


### PR DESCRIPTION
Closes #268

`broker_status='FILLED' AND state_applied_at IS NULL` の repair cohort は cron 経路では現在 `lookbackMs` (default 48h) でフィルタされ、長期保有 fill が 48h 経過後 aged-out で **permanent split-brain** になる事故があった。

## 実例 (今回発見)

```
trade_journal id=32:
  symbol: AAPL
  timestamp: 2026-04-21T15:37Z (8 days ago)
  broker_status: FILLED
  filled_qty: 1, filled_price: 269.48
  state_applied_at: NULL
  state_apply_attempts: 0  ← cron で 1 度も処理されてない
```

dashboard /positions で qty="—" 表示 (= 持ってないように見える誤認)。

## 修正

SELECT の WHERE 1 行修正のみ:

```diff
-options.retryStateApply
-  ? repairFilter
-  : and(repairFilter, gte(tradeJournal.timestamp, since)),
+repairFilter,
```

- fresh poll cohort (broker_status NULL) は lookback 維持 (broker pressure 抑制)
- repair cohort は broker poll 不要 (DO RPC のみ) なので lookback 不要

## 安全網 (既存)

- `SELECT ... LIMIT 50` で 1 tick あたり処理行数 bounded
- PR #228 の auto-abandon (`MAX_REPAIR_ATTEMPTS=5`) で永続 fail 行は cohort から自動的に外れる

## API 互換

`retryStateApply` フラグは signature 維持、本 PR で no-op 化 (admin endpoint 経路でも同じ挙動)。

## Test plan

- [x] pnpm typecheck pass
- [x] pnpm test pass (986 tests)
- [ ] deploy 後、AAPL 行 (id=32) が次の 5 分 cron で `state_applied_at` 自動 stamp される
- [ ] /dashboard/positions で AAPL が qty=1 / avgPrice=269.48 表示

## 親 issue

- #268 (this issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **バグ修正**
  * 約定の調整ロジックを改善し、修復対象の候補選択基準を変更しました。修復が必要な約定がより確実に処理されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->