### PR TITLE
fix(reconcile): chain 依存 fill を 1 tick で解決するため ASC 順処理に (#270)

### DIFF
--- a/src/trading/reconciliation/reconcileFills.ts
+++ b/src/trading/reconciliation/reconcileFills.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gte, isNull, or, sql } from 'drizzle-orm'
+import { and, asc, eq, gte, isNull, or, sql } from 'drizzle-orm'
 import { alias } from 'drizzle-orm/sqlite-core'
 import type { Env } from '../../config/env'
 import { createDb } from '../../infrastructure/db/tradeJournalRepo'
@@ -250,7 +250,14 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
       ),
     )
     .groupBy(tradeJournal.id)
-    .orderBy(desc(tradeJournal.id))
+    // ASC = 古い順 = chain 依存 (BUY → SELL) が natural 順で 1 tick 内解決
+    // (#270)。DESC だと SELL を先に処理して DO 上ポジ無し→ "Cannot SELL
+    // without an open position" の false-positive alert が出る。
+    // 古い行を全部捌いてから新しい行に進むので、long-term 蓄積した repair
+    // cohort も時系列どおり apply される。LIMIT 50 + 5min cron で「古い行
+    // 優先で詰まって新しい行が遅延」状況は long-term 蓄積でしか起きない
+    // (= 別問題、#228 auto-abandon と組み合わせれば自然に収束)。
+    .orderBy(asc(tradeJournal.id))
     .limit(limit)
 
   const uniqueCandidates = dedupeCandidatesByRowId(candidates)


### PR DESCRIPTION
Closes #270

PR #269 で repair cohort の lookback を外した結果、長期蓄積した fill が一気に sweep 対象になり、BUY/SELL chain で SELL が先に処理されて DO 上ポジ無し → `Cannot SELL without an open position` の false-positive alert 発火。次の cron tick で自己修復はするが `reconcile_fills_partial` alert が無駄に鳴る (割れ窓)。

## 修正

```diff
-.orderBy(desc(tradeJournal.id))
+.orderBy(asc(tradeJournal.id))
```

ASC = 古い順 = chain 依存 (BUY 先 → SELL 後) が natural 順で 1 tick 内解決。

## 副次影響

- LIMIT 50 で「古い行優先で詰まって新しい行が遅延」状況は long-term 蓄積でのみ発生 (= 別問題)、#228 auto-abandon と組み合わせれば自然収束
- 既存テストすべて pass (986 件)

## 親

- #268/#269 の副次 bug
- #270 (this issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正

* トレード照合における処理順序を最適化しました。売却注文の前に対応する買付注文が確実に処理されるようになり、誤った「ポジションなし売却」アラートの発生を防止しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->