### PR TITLE
feat(ops): config change audit log (#274)

### DIFF
--- a/drizzle/0016_wakeful_xavin.sql
+++ b/drizzle/0016_wakeful_xavin.sql
@@ -1,0 +1,14 @@
+CREATE TABLE `config_audit_log` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`timestamp` text NOT NULL,
+	`actor` text NOT NULL,
+	`endpoint` text NOT NULL,
+	`target_key` text,
+	`before_json` text NOT NULL,
+	`after_json` text NOT NULL,
+	`request_id` text
+);
+--> statement-breakpoint
+CREATE INDEX `config_audit_log_timestamp_id_idx` ON `config_audit_log` (`timestamp`,`id`);--> statement-breakpoint
+CREATE INDEX `config_audit_log_actor_timestamp_id_idx` ON `config_audit_log` (`actor`,`timestamp`,`id`);--> statement-breakpoint
+CREATE INDEX `config_audit_log_endpoint_timestamp_id_idx` ON `config_audit_log` (`endpoint`,`timestamp`,`id`);

--- a/drizzle/meta/0016_snapshot.json
+++ b/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,1154 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "be86586d-e44f-4e40-aa21-6e9b160e64ac",
+  "prevId": "b427c35a-42b5-4397-9912-90ab6f1414d4",
+  "tables": {
+    "config_audit_log": {
+      "name": "config_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before_json": {
+          "name": "before_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "after_json": {
+          "name": "after_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "config_audit_log_timestamp_id_idx": {
+          "name": "config_audit_log_timestamp_id_idx",
+          "columns": [
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "config_audit_log_actor_timestamp_id_idx": {
+          "name": "config_audit_log_actor_timestamp_id_idx",
+          "columns": [
+            "actor",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "config_audit_log_endpoint_timestamp_id_idx": {
+          "name": "config_audit_log_endpoint_timestamp_id_idx",
+          "columns": [
+            "endpoint",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "config_state_snapshot": {
+      "name": "config_state_snapshot",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "earnings_calendar": {
+      "name": "earnings_calendar",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "earnings_date": {
+          "name": "earnings_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "earnings_calendar_symbol_date_unique": {
+          "name": "earnings_calendar_symbol_date_unique",
+          "columns": [
+            "symbol",
+            "earnings_date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "global_config": {
+      "name": "global_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "trading_enabled": {
+          "name": "trading_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "market_hours_check": {
+          "name": "market_hours_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "max_order_notional": {
+          "name": "max_order_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "max_order_notional_usd": {
+          "name": "max_order_notional_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2000
+        },
+        "max_order_notional_jpy": {
+          "name": "max_order_notional_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100000
+        },
+        "total_capital_usd": {
+          "name": "total_capital_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_capital_jpy": {
+          "name": "total_capital_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_portfolio_exposure_pct": {
+          "name": "max_portfolio_exposure_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.6
+        },
+        "drawdown_kill_threshold": {
+          "name": "drawdown_kill_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.02
+        },
+        "stale_quote_ms": {
+          "name": "stale_quote_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 900000
+        },
+        "gap_reject_pct": {
+          "name": "gap_reject_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.03
+        },
+        "spread_limit_pct_us": {
+          "name": "spread_limit_pct_us",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.0025
+        },
+        "spread_limit_pct_jp": {
+          "name": "spread_limit_pct_jp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.006
+        },
+        "pullback_default_stop_pct": {
+          "name": "pullback_default_stop_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.04
+        },
+        "pullback_default_take_profit_pct": {
+          "name": "pullback_default_take_profit_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.07
+        },
+        "pullback_default_time_stop_days": {
+          "name": "pullback_default_time_stop_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "pullback_default_pullback_max": {
+          "name": "pullback_default_pullback_max",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.03
+        },
+        "pullback_default_pullback_min": {
+          "name": "pullback_default_pullback_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.06
+        },
+        "pullback_default_min_return_50d": {
+          "name": "pullback_default_min_return_50d",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.08
+        },
+        "pullback_default_require_above_sma50": {
+          "name": "pullback_default_require_above_sma50",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "pullback_default_k_atr": {
+          "name": "pullback_default_k_atr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "risk_base_per_trade_pct": {
+          "name": "risk_base_per_trade_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.004
+        },
+        "risk_dd_half_threshold": {
+          "name": "risk_dd_half_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.05
+        },
+        "risk_dd_halt_threshold": {
+          "name": "risk_dd_halt_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.1
+        },
+        "bucket_exposure_pct": {
+          "name": "bucket_exposure_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.3
+        },
+        "vix_warning_threshold": {
+          "name": "vix_warning_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 25
+        },
+        "vix_critical_threshold": {
+          "name": "vix_critical_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "vix_warning_size_scale": {
+          "name": "vix_warning_size_scale",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.5
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "global_config_max_order_notional_range": {
+          "name": "global_config_max_order_notional_range",
+          "value": "\"global_config\".\"max_order_notional\" > 0 AND \"global_config\".\"max_order_notional\" <= 10000000"
+        },
+        "global_config_max_order_notional_usd_range": {
+          "name": "global_config_max_order_notional_usd_range",
+          "value": "\"global_config\".\"max_order_notional_usd\" > 0 AND \"global_config\".\"max_order_notional_usd\" <= 1000000"
+        },
+        "global_config_max_order_notional_jpy_range": {
+          "name": "global_config_max_order_notional_jpy_range",
+          "value": "\"global_config\".\"max_order_notional_jpy\" > 0 AND \"global_config\".\"max_order_notional_jpy\" <= 100000000"
+        },
+        "global_config_total_capital_usd_range": {
+          "name": "global_config_total_capital_usd_range",
+          "value": "\"global_config\".\"total_capital_usd\" IS NULL OR \"global_config\".\"total_capital_usd\" > 0"
+        },
+        "global_config_total_capital_jpy_range": {
+          "name": "global_config_total_capital_jpy_range",
+          "value": "\"global_config\".\"total_capital_jpy\" IS NULL OR \"global_config\".\"total_capital_jpy\" > 0"
+        },
+        "global_config_max_portfolio_exposure_pct_range": {
+          "name": "global_config_max_portfolio_exposure_pct_range",
+          "value": "\"global_config\".\"max_portfolio_exposure_pct\" > 0 AND \"global_config\".\"max_portfolio_exposure_pct\" <= 1"
+        },
+        "global_config_drawdown_kill_threshold_range": {
+          "name": "global_config_drawdown_kill_threshold_range",
+          "value": "\"global_config\".\"drawdown_kill_threshold\" >= -1 AND \"global_config\".\"drawdown_kill_threshold\" <= 0"
+        },
+        "global_config_stale_quote_ms_range": {
+          "name": "global_config_stale_quote_ms_range",
+          "value": "\"global_config\".\"stale_quote_ms\" >= 0"
+        },
+        "global_config_gap_reject_pct_range": {
+          "name": "global_config_gap_reject_pct_range",
+          "value": "\"global_config\".\"gap_reject_pct\" >= 0 AND \"global_config\".\"gap_reject_pct\" <= 1"
+        },
+        "global_config_spread_limit_pct_us_range": {
+          "name": "global_config_spread_limit_pct_us_range",
+          "value": "\"global_config\".\"spread_limit_pct_us\" >= 0 AND \"global_config\".\"spread_limit_pct_us\" <= 1"
+        },
+        "global_config_spread_limit_pct_jp_range": {
+          "name": "global_config_spread_limit_pct_jp_range",
+          "value": "\"global_config\".\"spread_limit_pct_jp\" >= 0 AND \"global_config\".\"spread_limit_pct_jp\" <= 1"
+        },
+        "global_config_pullback_default_stop_pct_range": {
+          "name": "global_config_pullback_default_stop_pct_range",
+          "value": "\"global_config\".\"pullback_default_stop_pct\" < 0 AND \"global_config\".\"pullback_default_stop_pct\" >= -1"
+        },
+        "global_config_pullback_default_take_profit_pct_range": {
+          "name": "global_config_pullback_default_take_profit_pct_range",
+          "value": "\"global_config\".\"pullback_default_take_profit_pct\" > 0 AND \"global_config\".\"pullback_default_take_profit_pct\" <= 1"
+        },
+        "global_config_pullback_default_time_stop_days_range": {
+          "name": "global_config_pullback_default_time_stop_days_range",
+          "value": "\"global_config\".\"pullback_default_time_stop_days\" > 0 AND \"global_config\".\"pullback_default_time_stop_days\" <= ?"
+        },
+        "global_config_pullback_default_pullback_max_range": {
+          "name": "global_config_pullback_default_pullback_max_range",
+          "value": "\"global_config\".\"pullback_default_pullback_max\" <= 0 AND \"global_config\".\"pullback_default_pullback_max\" >= -1"
+        },
+        "global_config_pullback_default_pullback_min_range": {
+          "name": "global_config_pullback_default_pullback_min_range",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= 0 AND \"global_config\".\"pullback_default_pullback_min\" >= -1"
+        },
+        "global_config_pullback_default_min_return_50d_range": {
+          "name": "global_config_pullback_default_min_return_50d_range",
+          "value": "\"global_config\".\"pullback_default_min_return_50d\" >= -1 AND \"global_config\".\"pullback_default_min_return_50d\" <= 10"
+        },
+        "global_config_pullback_default_k_atr_range": {
+          "name": "global_config_pullback_default_k_atr_range",
+          "value": "\"global_config\".\"pullback_default_k_atr\" > 0 AND \"global_config\".\"pullback_default_k_atr\" <= 10"
+        },
+        "global_config_pullback_default_pullback_window_order": {
+          "name": "global_config_pullback_default_pullback_window_order",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= \"global_config\".\"pullback_default_pullback_max\""
+        },
+        "global_config_risk_base_per_trade_pct_range": {
+          "name": "global_config_risk_base_per_trade_pct_range",
+          "value": "\"global_config\".\"risk_base_per_trade_pct\" > 0 AND \"global_config\".\"risk_base_per_trade_pct\" <= 1"
+        },
+        "global_config_risk_dd_half_threshold_range": {
+          "name": "global_config_risk_dd_half_threshold_range",
+          "value": "\"global_config\".\"risk_dd_half_threshold\" < 0 AND \"global_config\".\"risk_dd_half_threshold\" >= -1"
+        },
+        "global_config_risk_dd_halt_threshold_range": {
+          "name": "global_config_risk_dd_halt_threshold_range",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" < 0 AND \"global_config\".\"risk_dd_halt_threshold\" >= -1"
+        },
+        "global_config_risk_dd_threshold_order": {
+          "name": "global_config_risk_dd_threshold_order",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" <= \"global_config\".\"risk_dd_half_threshold\""
+        },
+        "global_config_bucket_exposure_pct_range": {
+          "name": "global_config_bucket_exposure_pct_range",
+          "value": "\"global_config\".\"bucket_exposure_pct\" > 0 AND \"global_config\".\"bucket_exposure_pct\" <= 1"
+        },
+        "global_config_vix_warning_threshold_range": {
+          "name": "global_config_vix_warning_threshold_range",
+          "value": "\"global_config\".\"vix_warning_threshold\" > 0 AND \"global_config\".\"vix_warning_threshold\" <= 200"
+        },
+        "global_config_vix_critical_threshold_range": {
+          "name": "global_config_vix_critical_threshold_range",
+          "value": "\"global_config\".\"vix_critical_threshold\" > 0 AND \"global_config\".\"vix_critical_threshold\" <= 200"
+        },
+        "global_config_vix_threshold_order": {
+          "name": "global_config_vix_threshold_order",
+          "value": "\"global_config\".\"vix_warning_threshold\" <= \"global_config\".\"vix_critical_threshold\""
+        },
+        "global_config_vix_warning_size_scale_range": {
+          "name": "global_config_vix_warning_size_scale_range",
+          "value": "\"global_config\".\"vix_warning_size_scale\" >= 0 AND \"global_config\".\"vix_warning_size_scale\" <= 1"
+        }
+      }
+    },
+    "inverse_pairs": {
+      "name": "inverse_pairs",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inverse": {
+          "name": "inverse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "macro_event_calendar": {
+      "name": "macro_event_calendar",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_time": {
+          "name": "event_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "macro_event_calendar_type_date_unique": {
+          "name": "macro_event_calendar_type_date_unique",
+          "columns": [
+            "event_type",
+            "event_date"
+          ],
+          "isUnique": true
+        },
+        "macro_event_calendar_date_idx": {
+          "name": "macro_event_calendar_date_idx",
+          "columns": [
+            "event_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_emit_log": {
+      "name": "notification_emit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cause": {
+          "name": "cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notification_emit_log_timestamp_id_idx": {
+          "name": "notification_emit_log_timestamp_id_idx",
+          "columns": [
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "notification_emit_log_severity_timestamp_id_idx": {
+          "name": "notification_emit_log_severity_timestamp_id_idx",
+          "columns": [
+            "severity",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "notification_emit_log_event_type_timestamp_id_idx": {
+          "name": "notification_emit_log_event_type_timestamp_id_idx",
+          "columns": [
+            "event_type",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "strategy_decision_log": {
+      "name": "strategy_decision_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indicators_json": {
+          "name": "indicators_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "strategy_decision_log_symbol_id_idx": {
+          "name": "strategy_decision_log_symbol_id_idx",
+          "columns": [
+            "symbol",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "strategy_decision_log_coid_idx": {
+          "name": "strategy_decision_log_coid_idx",
+          "columns": [
+            "client_order_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "symbol_config": {
+      "name": "symbol_config",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "market": {
+          "name": "market",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_notional": {
+          "name": "max_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "symbol_config_currency_enum": {
+          "name": "symbol_config_currency_enum",
+          "value": "\"symbol_config\".\"currency\" IN ('USD', 'JPY')"
+        }
+      }
+    },
+    "trade_journal": {
+      "name": "trade_journal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trade_event_type": {
+          "name": "trade_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "strategy_name": {
+          "name": "strategy_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_action": {
+          "name": "signal_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_reason": {
+          "name": "signal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_allowed": {
+          "name": "risk_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_reasons": {
+          "name": "risk_reasons",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "limit_price": {
+          "name": "limit_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notional": {
+          "name": "notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "broker_status": {
+          "name": "broker_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "submitted": {
+          "name": "submitted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_qty": {
+          "name": "filled_qty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_price": {
+          "name": "filled_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "realized_pnl": {
+          "name": "realized_pnl",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hold_days": {
+          "name": "hold_days",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_reason": {
+          "name": "exit_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_applied_at": {
+          "name": "state_applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_error": {
+          "name": "state_apply_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_attempts": {
+          "name": "state_apply_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1778204800000,
       "tag": "0015_vix_regime_thresholds",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "6",
+      "when": 1778828808121,
+      "tag": "0016_wakeful_xavin",
+      "breakpoints": true
     }
   ]
 }

--- a/src/infrastructure/db/configAuditLog.ts
+++ b/src/infrastructure/db/configAuditLog.ts
@@ -1,0 +1,128 @@
+import { and, desc, eq, gte, lte, type SQL } from 'drizzle-orm'
+import { configAuditLog, type ConfigAuditLogRow } from './schema'
+import { createDb } from './tradeJournalRepo'
+
+/**
+ * Append-only audit trail for state-changing admin POST handlers (#274). Each
+ * mutation captures a JSON snapshot of the affected resource `before` and
+ * `after`. The pair is `JSON.stringify`'d at write-time so dashboard views can
+ * render a diff without re-fetching state.
+ *
+ * `recordChange` returns early when the stringified before/after match — a
+ * pure no-op (e.g. `seed-cash` with the same amount) shouldn't show up in the
+ * audit table. D1 write failures are propagated; callers wrap the entire admin
+ * handler so a logging failure surfaces rather than silently dropping the row.
+ */
+
+export interface RecordChangeParams {
+  /** basic-auth username, or `'ai-agent'` when the header is absent / unparseable. */
+  actor: string
+  /** logical endpoint id (e.g. `/admin/symbols/:symbol/seed-cash`). */
+  endpoint: string
+  /** Short tag identifying the affected resource (e.g. `symbol=SOXL`). */
+  targetKey: string | null
+  /** Pre-mutation snapshot. Any JSON-serializable value. */
+  before: unknown
+  /** Post-mutation snapshot. Any JSON-serializable value. */
+  after: unknown
+  requestId?: string | null
+  /** Test seam for deterministic timestamps. */
+  now?: () => Date
+}
+
+export interface RecordChangeResult {
+  /** `true` when a row was inserted. `false` when before==after (no-op skip). */
+  recorded: boolean
+}
+
+export async function recordChange(
+  db: D1Database,
+  params: RecordChangeParams,
+): Promise<RecordChangeResult> {
+  const beforeJson = JSON.stringify(params.before ?? null)
+  const afterJson = JSON.stringify(params.after ?? null)
+  if (beforeJson === afterJson) {
+    return { recorded: false }
+  }
+  const timestamp = (params.now ?? (() => new Date()))().toISOString()
+  await createDb(db).insert(configAuditLog).values({
+    timestamp,
+    actor: params.actor,
+    endpoint: params.endpoint,
+    targetKey: params.targetKey,
+    beforeJson,
+    afterJson,
+    requestId: params.requestId ?? null,
+  })
+  return { recorded: true }
+}
+
+/**
+ * Extract basic-auth username from an incoming `Authorization` header. Mirrors
+ * the parse that Hono's `basicAuth` middleware already accepted upstream — we
+ * just decode again here because Hono does not surface the username in context.
+ *
+ * Fallback `'ai-agent'` when the header is missing / malformed: every audit row
+ * still has an actor, and the bot-vs-human distinction is preserved on the
+ * dashboard.
+ */
+export function extractActor(authorizationHeader: string | null | undefined): string {
+  if (!authorizationHeader) return 'ai-agent'
+  const match = /^basic\s+(.+)$/i.exec(authorizationHeader.trim())
+  if (!match) return 'ai-agent'
+  const token = match[1]?.trim()
+  if (!token) return 'ai-agent'
+  let decoded: string
+  try {
+    decoded = atob(token)
+  } catch {
+    return 'ai-agent'
+  }
+  const idx = decoded.indexOf(':')
+  const user = (idx >= 0 ? decoded.slice(0, idx) : decoded).trim()
+  return user.length > 0 ? user : 'ai-agent'
+}
+
+export type ConfigAuditRow = ConfigAuditLogRow
+
+export interface LoadAuditOptions {
+  /** Latest N rows. Default 100, capped at 500. */
+  limit?: number
+  /** Exact actor match. */
+  actor?: string
+  /** Exact endpoint match. */
+  endpoint?: string
+  /** ISO timestamp inclusive lower bound. */
+  fromIso?: string
+  /** ISO timestamp inclusive upper bound. */
+  toIso?: string
+}
+
+/**
+ * dashboard `/dashboard/audit` 用 SELECT。timestamp DESC で最新から limit 件返す。
+ * actor / endpoint / date range は AND で組み合わせる。
+ */
+export async function loadRecentAudit(
+  db: D1Database,
+  options: LoadAuditOptions = {},
+): Promise<ConfigAuditRow[]> {
+  const limit = clampLimit(options.limit)
+  const drizzle = createDb(db)
+  let query = drizzle.select().from(configAuditLog).$dynamic()
+  const conditions: SQL[] = []
+  if (options.actor) conditions.push(eq(configAuditLog.actor, options.actor))
+  if (options.endpoint) conditions.push(eq(configAuditLog.endpoint, options.endpoint))
+  if (options.fromIso) conditions.push(gte(configAuditLog.timestamp, options.fromIso))
+  if (options.toIso) conditions.push(lte(configAuditLog.timestamp, options.toIso))
+  if (conditions.length > 0) {
+    query = query.where(conditions.length === 1 ? conditions[0] : and(...conditions))
+  }
+  return await query
+    .orderBy(desc(configAuditLog.timestamp), desc(configAuditLog.id))
+    .limit(limit)
+}
+
+function clampLimit(raw: number | undefined): number {
+  if (raw === undefined || !Number.isFinite(raw) || raw <= 0) return 100
+  return Math.min(Math.floor(raw), 500)
+}

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -553,3 +553,49 @@ export const macroEventCalendar = sqliteTable(
 
 export type MacroEventCalendarRow = typeof macroEventCalendar.$inferSelect
 export type MacroEventCalendarInsert = typeof macroEventCalendar.$inferInsert
+
+/**
+ * Append-only audit trail of state-changing admin POST calls (#274). One row per
+ * mutation: `before_json` / `after_json` are `JSON.stringify`'d snapshots of the
+ * affected resource so dashboard can render diffs without re-fetching state.
+ *
+ * Rows are written by `recordChange()` only when before != after — pure no-op
+ * calls (e.g. seed-cash with the same amount) are skipped to keep the table
+ * focused on actual changes.
+ *
+ * `actor` is the basic-auth username, falling back to `'ai-agent'` when the
+ * header is missing or unparseable. `target_key` is a free-form short string
+ * (e.g. `symbol=SOXL` / `portfolio=daily`) so a single endpoint with multiple
+ * resources (`/earnings/seed`) can still group rows.
+ */
+export const configAuditLog = sqliteTable(
+  'config_audit_log',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    timestamp: text('timestamp').notNull(),
+    actor: text('actor').notNull(),
+    endpoint: text('endpoint').notNull(),
+    targetKey: text('target_key'),
+    beforeJson: text('before_json').notNull(),
+    afterJson: text('after_json').notNull(),
+    requestId: text('request_id'),
+  },
+  (t) => ({
+    // dashboard `/dashboard/audit` は timestamp DESC で読む。id を tiebreak に
+    // 含めて同 timestamp の順序を安定化 (notification_emit_log 相当の対応)。
+    timestampIdIdx: index('config_audit_log_timestamp_id_idx').on(t.timestamp, t.id),
+    actorTimestampIdIdx: index('config_audit_log_actor_timestamp_id_idx').on(
+      t.actor,
+      t.timestamp,
+      t.id,
+    ),
+    endpointTimestampIdIdx: index('config_audit_log_endpoint_timestamp_id_idx').on(
+      t.endpoint,
+      t.timestamp,
+      t.id,
+    ),
+  }),
+)
+
+export type ConfigAuditLogRow = typeof configAuditLog.$inferSelect
+export type ConfigAuditLogInsert = typeof configAuditLog.$inferInsert

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,5 +1,6 @@
 import { and, eq, isNull, sql } from 'drizzle-orm'
 import { Hono } from 'hono'
+import type { Context } from 'hono'
 import type { AppBindings } from '../app'
 import { ValidationError } from '../shared/errors'
 import { createWebullHttpClient } from '../infrastructure/webull/WebullHttpClient'
@@ -13,7 +14,8 @@ import { loadSymbolUniverse } from '../infrastructure/db/symbolUniverse'
 import { YahooBarClient } from '../infrastructure/quotes/YahooBarClient'
 import { loadGlobalConfigFrom } from '../infrastructure/db/globalConfigLoader'
 import { createDb } from '../infrastructure/db/tradeJournalRepo'
-import { tradeJournal } from '../infrastructure/db/schema'
+import { earningsCalendar, macroEventCalendar, tradeJournal } from '../infrastructure/db/schema'
+import { extractActor, recordChange } from '../infrastructure/db/configAuditLog'
 import {
   createEarningsCalendarDb,
   createEarningsCalendarRepo,
@@ -61,6 +63,7 @@ export const admin = new Hono<AppBindings>()
     const args = readOverridePositionBody(body)
 
     const client = new SymbolStateClient(c.env.SYMBOL_STATE)
+    const before = await safeGetSymbolState(client, symbol)
     const state = await client.overridePosition(symbol, {
       qty: args.qty,
       avgPrice: args.avgPrice,
@@ -68,6 +71,13 @@ export const admin = new Hono<AppBindings>()
       reason: args.reason,
       requestId: c.get('requestId'),
     })
+    await writeAuditLog(
+      c,
+      '/admin/symbol-state/:symbol/override-position',
+      `symbol=${symbol}`,
+      { position: before?.position ?? null },
+      { position: state.position, reason: args.reason },
+    )
     return c.json({
       symbol,
       position: state.position,
@@ -87,7 +97,15 @@ export const admin = new Hono<AppBindings>()
     const amount = readAmount(body)
 
     const client = new SymbolStateClient(c.env.SYMBOL_STATE)
+    const before = await safeGetSymbolState(client, symbol)
     const state = await client.seedSettledCash(symbol, amount)
+    await writeAuditLog(
+      c,
+      '/admin/symbols/:symbol/seed-cash',
+      `symbol=${symbol}`,
+      { settledCash: before?.settledCash ?? null },
+      { settledCash: state.settledCash },
+    )
     return c.json({ symbol, settledCash: state.settledCash, updatedAt: state.updatedAt })
   })
   /**
@@ -106,7 +124,15 @@ export const admin = new Hono<AppBindings>()
     }
     const pastIso = new Date(0).toISOString()
     const client = new SymbolStateClient(c.env.SYMBOL_STATE)
+    const before = await safeGetSymbolState(client, symbol)
     const state = await client.setCooldown(symbol, pastIso)
+    await writeAuditLog(
+      c,
+      '/admin/symbols/:symbol/clear-cooldown',
+      `symbol=${symbol}`,
+      { cooldownUntil: before?.cooldownUntil ?? null },
+      { cooldownUntil: state.cooldownUntil },
+    )
     return c.json({
       symbol,
       cooldownUntil: state.cooldownUntil,
@@ -610,6 +636,19 @@ export const admin = new Hono<AppBindings>()
     }
     const client = new PortfolioStateClient(c.env.PORTFOLIO_STATE)
     const { before, after } = await client.rollDaily()
+    await writeAuditLog(
+      c,
+      '/admin/portfolio/roll-daily',
+      'portfolio=daily',
+      {
+        dailyStartEquity: before.dailyStartEquity,
+        dailyRealizedPnl: before.dailyRealizedPnl,
+      },
+      {
+        dailyStartEquity: after.dailyStartEquity,
+        dailyRealizedPnl: after.dailyRealizedPnl,
+      },
+    )
     return c.json({
       rolledAt: after.updatedAt,
       rolledDelta: before.dailyRealizedPnl,
@@ -633,7 +672,15 @@ export const admin = new Hono<AppBindings>()
     const amount = readAmount(body)
 
     const client = new PortfolioStateClient(c.env.PORTFOLIO_STATE)
+    const before = await safeGetPortfolioState(client)
     const state = await client.seedDailyStartEquity(amount)
+    await writeAuditLog(
+      c,
+      '/admin/portfolio/seed-equity',
+      'portfolio=daily',
+      { dailyStartEquity: before?.dailyStartEquity ?? null },
+      { dailyStartEquity: state.dailyStartEquity },
+    )
     return c.json({
       dailyStartEquity: state.dailyStartEquity,
       dailyRealizedPnl: state.dailyRealizedPnl,
@@ -671,6 +718,15 @@ export const admin = new Hono<AppBindings>()
     })
     const repo = createEarningsCalendarRepo(createEarningsCalendarDb(c.env.DB))
     const result = await repo.bulkUpsert(records)
+    if (result.inserted > 0) {
+      await writeAuditLog(
+        c,
+        '/admin/earnings/seed',
+        `inserted=${result.inserted}`,
+        null,
+        { inserted: result.inserted, skipped: result.skipped, records },
+      )
+    }
     return c.json({ inserted: result.inserted, skipped: result.skipped, total: records.length })
   })
   /**
@@ -699,10 +755,17 @@ export const admin = new Hono<AppBindings>()
       throw new ValidationError("'id' must be a positive integer path param", { field: 'id' })
     }
     const repo = createEarningsCalendarRepo(createEarningsCalendarDb(c.env.DB))
+    const beforeRow = await createDb(c.env.DB)
+      .select()
+      .from(earningsCalendar)
+      .where(eq(earningsCalendar.id, id))
+      .then((rows) => rows[0] ?? null)
+      .catch(() => null)
     const ok = await repo.deleteById(id)
     if (!ok) {
       return c.json({ error: 'earnings_row_not_found', id }, 404)
     }
+    await writeAuditLog(c, '/admin/earnings/:id', `earnings_id=${id}`, beforeRow, null)
     return c.json({ deleted: true, id })
   })
   /**
@@ -738,6 +801,15 @@ export const admin = new Hono<AppBindings>()
     })
     const repo = createMacroEventCalendarRepo(createMacroEventCalendarDb(c.env.DB))
     const result = await repo.bulkUpsert(records)
+    if (result.inserted > 0) {
+      await writeAuditLog(
+        c,
+        '/admin/macro-events/seed',
+        `inserted=${result.inserted}`,
+        null,
+        { inserted: result.inserted, skipped: result.skipped, records },
+      )
+    }
     return c.json({ inserted: result.inserted, skipped: result.skipped, total: records.length })
   })
   /**
@@ -799,10 +871,17 @@ export const admin = new Hono<AppBindings>()
       throw new ValidationError("'id' must be a positive integer path param", { field: 'id' })
     }
     const repo = createMacroEventCalendarRepo(createMacroEventCalendarDb(c.env.DB))
+    const beforeRow = await createDb(c.env.DB)
+      .select()
+      .from(macroEventCalendar)
+      .where(eq(macroEventCalendar.id, id))
+      .then((rows) => rows[0] ?? null)
+      .catch(() => null)
     const ok = await repo.deleteById(id)
     if (!ok) {
       return c.json({ error: 'macro_event_row_not_found', id }, 404)
     }
+    await writeAuditLog(c, '/admin/macro-events/:id', `macro_event_id=${id}`, beforeRow, null)
     return c.json({ deleted: true, id })
   })
 
@@ -1055,6 +1134,69 @@ function parseTruthyQuery(value: string | undefined): boolean {
   if (value === undefined) return false
   const normalized = value.trim().toLowerCase()
   return normalized === '1' || normalized === 'true' || normalized === 'yes'
+}
+
+/**
+ * 状態変更系 admin POST 用の audit log writer (#274)。基本認証 user を header
+ * から抽出し `recordChange` で diff 1 行を書く。`env.DB` が無い / D1 が落ちて
+ * いるケースは log を skip (handler 本体の状態変更は既に成立しているため、
+ * audit の欠落で 500 を返したくない)。before == after は recordChange 側で
+ * no-op skip される。
+ */
+async function writeAuditLog(
+  c: Context<AppBindings>,
+  endpoint: string,
+  targetKey: string | null,
+  before: unknown,
+  after: unknown,
+): Promise<void> {
+  if (!c.env.DB) return
+  const actor = extractActor(c.req.header('Authorization'))
+  try {
+    await recordChange(c.env.DB, {
+      actor,
+      endpoint,
+      targetKey,
+      before,
+      after,
+      requestId: c.get('requestId') ?? null,
+    })
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        event: 'config_audit_log_write_failed',
+        endpoint,
+        targetKey,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    )
+  }
+}
+
+/**
+ * `client.getState(symbol)` を safe wrap。stub に getState が無い (legacy fake)
+ * / DO 呼び出しが throw した場合は `null` を返す — audit ログの before snapshot
+ * が取れないだけで、handler 本体の状態変更は止めない。
+ */
+async function safeGetSymbolState(
+  client: SymbolStateClient,
+  symbol: string,
+): Promise<Awaited<ReturnType<SymbolStateClient['getState']>> | null> {
+  try {
+    return await client.getState(symbol)
+  } catch {
+    return null
+  }
+}
+
+async function safeGetPortfolioState(
+  client: PortfolioStateClient,
+): Promise<Awaited<ReturnType<PortfolioStateClient['getPortfolio']>> | null> {
+  try {
+    return await client.getPortfolio()
+  } catch {
+    return null
+  }
 }
 
 /**

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -7,6 +7,11 @@ import { formatSymbolDisplay } from '../shared/format'
 import { createDb } from '../infrastructure/db/tradeJournalRepo'
 import { MAX_TIME_STOP_DAYS, strategyDecisionLog, tradeJournal } from '../infrastructure/db/schema'
 import {
+  loadRecentAudit,
+  type ConfigAuditRow,
+  type LoadAuditOptions,
+} from '../infrastructure/db/configAuditLog'
+import {
   loadRecentAlerts,
   type AlertRow,
   type LoadAlertOptions,
@@ -412,6 +417,41 @@ export const dashboard = new Hono<AppBindings>()
       return c.html(layout('アラート', unavailable(messageOf(err))))
     }
   })
+  .get('/audit', async (c) => {
+    if (!c.env.DB) {
+      return c.html(layout('監査ログ', unavailable('DB not bound')))
+    }
+    const limit = clampAuditLimit(c.req.query('limit'))
+    const actorFilter = trimQuery(c.req.query('actor'))
+    const endpointFilter = trimQuery(c.req.query('endpoint'))
+    const fromFilter = parseAuditDateFilter(c.req.query('from'), false)
+    const toFilter = parseAuditDateFilter(c.req.query('to'), true)
+    const options: LoadAuditOptions = { limit }
+    if (actorFilter) options.actor = actorFilter
+    if (endpointFilter) options.endpoint = endpointFilter
+    if (fromFilter) options.fromIso = fromFilter
+    if (toFilter) options.toIso = toFilter
+    try {
+      const rows = await loadRecentAudit(c.env.DB, options)
+      return c.html(
+        layout(
+          '監査ログ',
+          auditBody({
+            rows,
+            limit,
+            actorFilter,
+            endpointFilter,
+            fromFilter: c.req.query('from') ?? '',
+            toFilter: c.req.query('to') ?? '',
+          }),
+        ),
+      )
+    } catch (err) {
+      // 0016 migration 未適用 (= config_audit_log テーブル無し) を 500 にせず
+      // unavailable に落とす。段階的デプロイ時の自己保護 (alerts と同パターン)。
+      return c.html(layout('監査ログ', unavailable(messageOf(err))))
+    }
+  })
 
 function messageOf(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
@@ -560,6 +600,7 @@ function layout(title: string, body: string): string {
   <a href="/dashboard/cron">Cron</a>
   <a href="/dashboard/charts">チャート</a>
   <a href="/dashboard/alerts">アラート</a>
+  <a href="/dashboard/audit">監査ログ</a>
   <a href="/dashboard/broker-probe" title="Webull broker に直接 quote/positions を投げて raw レスポンスを表示する診断ページ">broker 診断</a>
 </nav>
 ${body}
@@ -945,6 +986,7 @@ function indexBody(): string {
   <li><a href="/dashboard/cron">Cron 判定</a> — <code>strategy_decision_log</code> 直近 (<code>?symbol=SOXL</code> で絞り込み可)</li>
   <li><a href="/dashboard/charts">チャート</a> — 概要 (エクイティカーブ + ドローダウン) / 取引品質 (PnL 分布 + 統計 + Decision breakdown) / 個別銘柄 (price + SMA50 + entry/exit) を tab 切替</li>
   <li><a href="/dashboard/alerts">アラート</a> — Slack/Discord に push 通知した critical / warning / info の直近 (#141)。webhook 未設定でも D1 に記録される。</li>
+  <li><a href="/dashboard/audit">監査ログ</a> — 状態変更系 admin POST の before/after 差分 (#274)。actor / endpoint / 日付で絞り込み可。</li>
 </ul>`
 }
 
@@ -1787,6 +1829,100 @@ export function renderAlertFilterPills(
     ),
   ].join('')
   return `<nav style="margin-bottom:12px">${sev}<span class="muted" style="margin:0 8px">|</span>${ev}</nav>`
+}
+
+interface AuditBodyArgs {
+  rows: ConfigAuditRow[]
+  limit: number
+  actorFilter: string | undefined
+  endpointFilter: string | undefined
+  /** Raw query string values for the form inputs (passthrough so a typo round-trips). */
+  fromFilter: string
+  toFilter: string
+}
+
+/**
+ * `/dashboard/audit` の HTML 本文 (#274)。
+ *
+ *   - 直近 100 件 (`?limit=N` で 1〜500)
+ *   - actor / endpoint / from / to で絞り込み (GET form)
+ *   - before_json / after_json は `<details>` で展開表示
+ */
+function auditBody(args: AuditBodyArgs): string {
+  const { rows, limit, actorFilter, endpointFilter, fromFilter, toFilter } = args
+  const form = `<form method="get" action="/dashboard/audit" style="margin-bottom:12px;display:flex;gap:8px;flex-wrap:wrap;align-items:flex-end">
+  <label>actor<br><input name="actor" value="${esc(actorFilter ?? '')}" placeholder="ai-agent" style="padding:4px 8px"></label>
+  <label>endpoint<br><input name="endpoint" value="${esc(endpointFilter ?? '')}" placeholder="/admin/symbols/:symbol/seed-cash" style="padding:4px 8px;min-width:280px"></label>
+  <label>from<br><input name="from" type="date" value="${esc(fromFilter)}" style="padding:4px 8px"></label>
+  <label>to<br><input name="to" type="date" value="${esc(toFilter)}" style="padding:4px 8px"></label>
+  <label>limit<br><input name="limit" type="number" min="1" max="500" value="${limit}" style="padding:4px 8px;width:90px"></label>
+  <button type="submit" style="padding:6px 14px">絞り込み</button>
+  <a href="/dashboard/audit" style="padding:6px 14px;text-decoration:none">リセット</a>
+</form>`
+  const header = `<p class="muted">直近 ${rows.length} 件 (limit=${limit}, max 500)。状態変更系 admin POST の before/after diff。before == after の no-op 呼び出しは記録されません。</p>`
+  if (rows.length === 0) {
+    return `${header}${form}<p class="muted">該当する監査ログは見つかりませんでした。</p>`
+  }
+  const tbody = rows
+    .map((r) => {
+      return `<tr>
+        <td class="muted">${esc(fmtJst(r.timestamp))}</td>
+        <td><strong>${esc(r.actor)}</strong></td>
+        <td><code>${esc(r.endpoint)}</code></td>
+        <td>${esc(r.targetKey ?? '-')}</td>
+        <td><details><summary class="muted">before</summary><pre style="margin:4px 0 0;white-space:pre-wrap;word-break:break-word;font-size:12px;background:#fafafa;padding:6px;border-radius:4px">${esc(formatAuditJson(r.beforeJson))}</pre></details></td>
+        <td><details><summary class="muted">after</summary><pre style="margin:4px 0 0;white-space:pre-wrap;word-break:break-word;font-size:12px;background:#fafafa;padding:6px;border-radius:4px">${esc(formatAuditJson(r.afterJson))}</pre></details></td>
+        <td class="muted"><code>${esc(r.requestId ?? '-')}</code></td>
+      </tr>`
+    })
+    .join('')
+  return `${header}${form}
+  <table>
+    <thead><tr>
+      <th>timestamp (JST)</th><th>actor</th><th>endpoint</th><th>target</th><th>before</th><th>after</th><th>requestId</th>
+    </tr></thead>
+    <tbody>${tbody}</tbody>
+  </table>`
+}
+
+/**
+ * `?limit=N` を 1〜500 に丸める。`/dashboard/audit` 既定 100。
+ */
+function clampAuditLimit(raw: string | undefined): number {
+  const n = raw === undefined ? 100 : Number.parseInt(raw, 10)
+  if (!Number.isFinite(n) || n <= 0) return 100
+  return Math.min(n, 500)
+}
+
+function trimQuery(raw: string | undefined): string | undefined {
+  if (raw === undefined) return undefined
+  const trimmed = raw.trim()
+  return trimmed.length === 0 ? undefined : trimmed
+}
+
+/**
+ * `YYYY-MM-DD` 日付フィルタを ISO timestamp に展開。`isEnd=true` は `T23:59:59.999Z`、
+ * false は `T00:00:00.000Z` を付ける (UTC base — 監査ログの timestamp は
+ * ISO UTC で書かれる)。文法が合わない値は undefined を返す (フィルタ skip)。
+ */
+function parseAuditDateFilter(raw: string | undefined, isEnd: boolean): string | undefined {
+  if (raw === undefined) return undefined
+  const trimmed = raw.trim()
+  if (trimmed === '') return undefined
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) return undefined
+  return isEnd ? `${trimmed}T23:59:59.999Z` : `${trimmed}T00:00:00.000Z`
+}
+
+/**
+ * `before_json` / `after_json` を整形して表示。JSON parse が成功すれば 2-space
+ * indent、失敗 (= マイグレ前の raw 文字列など) は原文をそのまま返す。
+ */
+function formatAuditJson(raw: string): string {
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2)
+  } catch {
+    return raw
+  }
 }
 
 function cronBody(

--- a/test/infrastructure/db/configAuditLog.test.ts
+++ b/test/infrastructure/db/configAuditLog.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  extractActor,
+  recordChange,
+  loadRecentAudit,
+} from '../../../src/infrastructure/db/configAuditLog'
+import { createDb } from '../../../src/infrastructure/db/tradeJournalRepo'
+
+vi.mock('../../../src/infrastructure/db/tradeJournalRepo', () => ({
+  createDb: vi.fn(),
+}))
+
+function fakeInsertChain() {
+  const chain = {
+    values: vi.fn(async (_v: unknown) => undefined),
+  }
+  return {
+    chain,
+    db: {
+      insert: vi.fn(() => chain),
+    },
+  }
+}
+
+function fakeSelectChain(rows: unknown[]) {
+  const query = {
+    from: vi.fn(() => query),
+    $dynamic: vi.fn(() => query),
+    where: vi.fn((_arg: unknown) => query),
+    orderBy: vi.fn((..._args: unknown[]) => query),
+    limit: vi.fn(async (_n: number) => rows),
+  }
+  return {
+    query,
+    db: {
+      select: vi.fn(() => query),
+    },
+  }
+}
+
+const fakeD1 = {} as D1Database
+
+describe('recordChange', () => {
+  it('skips the row when before == after (no-op)', async () => {
+    const { db, chain } = fakeInsertChain()
+    vi.mocked(createDb).mockReturnValue(db as unknown as ReturnType<typeof createDb>)
+
+    const result = await recordChange(fakeD1, {
+      actor: 'ai-agent',
+      endpoint: '/admin/symbols/:symbol/seed-cash',
+      targetKey: 'symbol=SOXL',
+      before: { settledCash: 1000 },
+      after: { settledCash: 1000 },
+    })
+
+    expect(result).toEqual({ recorded: false })
+    expect(db.insert).not.toHaveBeenCalled()
+    expect(chain.values).not.toHaveBeenCalled()
+  })
+
+  it('inserts a stringified diff row when before != after', async () => {
+    const { db, chain } = fakeInsertChain()
+    vi.mocked(createDb).mockReturnValue(db as unknown as ReturnType<typeof createDb>)
+
+    const result = await recordChange(fakeD1, {
+      actor: 'alice',
+      endpoint: '/admin/symbols/:symbol/seed-cash',
+      targetKey: 'symbol=SOXL',
+      before: { settledCash: 1000 },
+      after: { settledCash: 2000 },
+      requestId: 'req-1',
+      now: () => new Date('2026-05-15T12:00:00.000Z'),
+    })
+
+    expect(result).toEqual({ recorded: true })
+    expect(chain.values).toHaveBeenCalledTimes(1)
+    expect(chain.values.mock.calls[0]![0]).toEqual({
+      timestamp: '2026-05-15T12:00:00.000Z',
+      actor: 'alice',
+      endpoint: '/admin/symbols/:symbol/seed-cash',
+      targetKey: 'symbol=SOXL',
+      beforeJson: JSON.stringify({ settledCash: 1000 }),
+      afterJson: JSON.stringify({ settledCash: 2000 }),
+      requestId: 'req-1',
+    })
+  })
+
+  it('treats null and undefined before/after as JSON null (still skips when both are null)', async () => {
+    const { db } = fakeInsertChain()
+    vi.mocked(createDb).mockReturnValue(db as unknown as ReturnType<typeof createDb>)
+
+    const result = await recordChange(fakeD1, {
+      actor: 'ai-agent',
+      endpoint: '/admin/earnings/:id',
+      targetKey: 'earnings_id=7',
+      before: undefined,
+      after: null,
+    })
+
+    expect(result).toEqual({ recorded: false })
+    expect(db.insert).not.toHaveBeenCalled()
+  })
+})
+
+describe('extractActor', () => {
+  it('returns ai-agent when the Authorization header is absent', () => {
+    expect(extractActor(undefined)).toBe('ai-agent')
+    expect(extractActor(null)).toBe('ai-agent')
+    expect(extractActor('')).toBe('ai-agent')
+  })
+
+  it('decodes basic-auth username (drops password)', () => {
+    const header = `Basic ${btoa('alice:secret')}`
+    expect(extractActor(header)).toBe('alice')
+  })
+
+  it('handles lowercase scheme and surrounding whitespace', () => {
+    const header = `  basic ${btoa('bob:pw')}  `
+    expect(extractActor(header)).toBe('bob')
+  })
+
+  it('falls back to ai-agent on malformed token', () => {
+    expect(extractActor('Bearer abc')).toBe('ai-agent')
+    expect(extractActor('Basic !!!not-base64!!!')).toBe('ai-agent')
+  })
+
+  it('falls back to ai-agent when the decoded username is empty', () => {
+    const header = `Basic ${btoa(':only-password')}`
+    expect(extractActor(header)).toBe('ai-agent')
+  })
+})
+
+describe('loadRecentAudit', () => {
+  it('applies actor + endpoint + date range together via AND', async () => {
+    const { db, query } = fakeSelectChain([])
+    vi.mocked(createDb).mockReturnValue(db as unknown as ReturnType<typeof createDb>)
+
+    await loadRecentAudit(fakeD1, {
+      actor: 'alice',
+      endpoint: '/admin/symbols/:symbol/seed-cash',
+      fromIso: '2026-05-01T00:00:00.000Z',
+      toIso: '2026-05-15T23:59:59.999Z',
+    })
+
+    expect(query.where).toHaveBeenCalledTimes(1)
+    const condition = query.where.mock.calls[0]![0] as { queryChunks?: unknown[] } | undefined
+    expect(condition).toBeDefined()
+    expect(condition && 'queryChunks' in condition).toBe(true)
+  })
+
+  it('omits where() when no filter is given and clamps limit to 500', async () => {
+    const { db, query } = fakeSelectChain([])
+    vi.mocked(createDb).mockReturnValue(db as unknown as ReturnType<typeof createDb>)
+
+    await loadRecentAudit(fakeD1, { limit: 9999 })
+
+    expect(query.where).not.toHaveBeenCalled()
+    expect(query.limit).toHaveBeenCalledWith(500)
+  })
+
+  it('defaults limit to 100 when omitted', async () => {
+    const { db, query } = fakeSelectChain([])
+    vi.mocked(createDb).mockReturnValue(db as unknown as ReturnType<typeof createDb>)
+
+    await loadRecentAudit(fakeD1, {})
+
+    expect(query.limit).toHaveBeenCalledWith(100)
+  })
+})

--- a/test/routes/adminAuditLog.test.ts
+++ b/test/routes/adminAuditLog.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createApp } from '../../src/app'
+
+/**
+ * Integration test for issue #274: state-changing admin POST handlers must
+ * write a `config_audit_log` row via `recordChange`. Uses the seed-cash
+ * endpoint because it is the smallest path that goes through the wrapper.
+ *
+ * `createDb` is spied so we can capture the drizzle `insert().values()` call
+ * without spinning up a real D1.
+ */
+
+const baseEnv = {
+  BASIC_AUTH_USER: 'admin',
+  BASIC_AUTH_PASSWORD: 'secret',
+  DRY_RUN: 'true',
+  TRADING_ENABLED: 'false',
+  ALLOWED_SYMBOLS: 'SOXL',
+  MAX_ORDER_NOTIONAL: '100',
+}
+
+const authHeader = { Authorization: `Basic ${btoa('admin:secret')}` }
+
+interface SeedCashCall {
+  symbol: string
+  amount: number
+}
+
+function fakeSymbolState(captured: { calls: SeedCashCall[] }, beforeCash: number) {
+  const stub = {
+    async getState(symbol: string) {
+      return {
+        symbol,
+        position: null,
+        pendingOrder: null,
+        lastSignalAt: null,
+        cooldownUntil: null,
+        settledCash: beforeCash,
+        pendingSettlement: [],
+        lastExecutedPrice: null,
+        lastQuote: null,
+        updatedAt: '2026-04-21T10:00:00.000Z',
+      }
+    },
+    async seedSettledCash(symbol: string, amount: number) {
+      captured.calls.push({ symbol, amount })
+      return {
+        symbol,
+        position: null,
+        pendingOrder: null,
+        lastSignalAt: null,
+        cooldownUntil: null,
+        settledCash: amount,
+        pendingSettlement: [],
+        lastExecutedPrice: null,
+        lastQuote: null,
+        updatedAt: '2026-04-21T10:00:00.000Z',
+      }
+    },
+  }
+  return {
+    idFromName: (_name: string) => 'id',
+    get: (_id: string) => stub,
+  } as unknown
+}
+
+interface InsertCapture {
+  table?: unknown
+  values: unknown[]
+}
+
+function fakeDbCapturingInserts(captured: InsertCapture) {
+  return {
+    insert: (table: unknown) => {
+      captured.table = table
+      return {
+        values: async (v: unknown) => {
+          captured.values.push(v)
+        },
+      }
+    },
+  }
+}
+
+describe('admin audit log integration (#274)', () => {
+  it('writes a config_audit_log row when seed-cash mutates settledCash', async () => {
+    const dbModule = await import('../../src/infrastructure/db/tradeJournalRepo')
+    const insertCapture: InsertCapture = { values: [] }
+    const spy = vi
+      .spyOn(dbModule, 'createDb')
+      .mockReturnValue(fakeDbCapturingInserts(insertCapture) as never)
+
+    try {
+      const app = createApp()
+      const symbolStateCalls = { calls: [] as SeedCashCall[] }
+      const res = await app.request(
+        '/admin/symbols/SOXL/seed-cash',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', ...authHeader },
+          body: JSON.stringify({ amount: 5_000 }),
+        },
+        {
+          ...baseEnv,
+          DB: {} as unknown as D1Database,
+          SYMBOL_STATE: fakeSymbolState(symbolStateCalls, 1_000),
+        },
+      )
+      expect(res.status).toBe(200)
+      expect(symbolStateCalls.calls).toEqual([{ symbol: 'SOXL', amount: 5_000 }])
+
+      expect(insertCapture.values).toHaveLength(1)
+      const row = insertCapture.values[0] as {
+        actor: string
+        endpoint: string
+        targetKey: string | null
+        beforeJson: string
+        afterJson: string
+        requestId: string | null
+        timestamp: string
+      }
+      expect(row.actor).toBe('admin')
+      expect(row.endpoint).toBe('/admin/symbols/:symbol/seed-cash')
+      expect(row.targetKey).toBe('symbol=SOXL')
+      expect(JSON.parse(row.beforeJson)).toEqual({ settledCash: 1_000 })
+      expect(JSON.parse(row.afterJson)).toEqual({ settledCash: 5_000 })
+      expect(typeof row.requestId).toBe('string')
+      expect(row.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  it('skips the audit row when seed-cash is a no-op (before == after)', async () => {
+    const dbModule = await import('../../src/infrastructure/db/tradeJournalRepo')
+    const insertCapture: InsertCapture = { values: [] }
+    const spy = vi
+      .spyOn(dbModule, 'createDb')
+      .mockReturnValue(fakeDbCapturingInserts(insertCapture) as never)
+
+    try {
+      const app = createApp()
+      const symbolStateCalls = { calls: [] as SeedCashCall[] }
+      const res = await app.request(
+        '/admin/symbols/SOXL/seed-cash',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', ...authHeader },
+          body: JSON.stringify({ amount: 1_000 }),
+        },
+        {
+          ...baseEnv,
+          DB: {} as unknown as D1Database,
+          SYMBOL_STATE: fakeSymbolState(symbolStateCalls, 1_000),
+        },
+      )
+      expect(res.status).toBe(200)
+      expect(symbolStateCalls.calls).toEqual([{ symbol: 'SOXL', amount: 1_000 }])
+      expect(insertCapture.values).toHaveLength(0)
+    } finally {
+      spy.mockRestore()
+    }
+  })
+})


### PR DESCRIPTION
Closes #274
Refs #273

## Summary

`/admin` POST 経由の DB 書込を who/when/diff で記録する config audit log を追加。本番口座接続前に「誰がいつ何を変えたか」を追跡可能にする。

## 変更点

- `drizzle/0016_wakeful_xavin.sql`: `config_audit_log` table (id / timestamp / actor / endpoint / target_key / before_json / after_json / request_id)
- `src/infrastructure/db/configAuditLog.ts` (新規):
  - `recordChange()` — before==after の no-op は skip
  - `extractActor()` — basic-auth Authorization header から user 抽出、無ければ `'ai-agent'`
  - `loadRecentAudit()` — actor / endpoint / 日付 range filter
- `src/routes/admin.ts`: 状態変更系 9 endpoint を wrap
  - `symbol-state override-position` / `seed-cash` / `clear-cooldown`
  - `earnings seed` / `earnings DELETE`
  - `macro-events seed` / `macro-events DELETE`
  - `portfolio roll-daily` / `portfolio seed-equity`
- `src/routes/dashboard.ts`: `/dashboard/audit` page (filter 付き最新 N=100)

## Out of scope

- audit log の retention / export → R2 logpush (#207) と合流
- kill-switch (#276) の toggle 履歴は #276 側で独自実装、本 PR の汎用 audit とは別表

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` 999/999 pass (+13: 11 unit / 2 integration)
- [x] `seed-cash` POST が audit log row を書くことを integration test で確認
- [x] before==after の no-op skip を unit test で確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 管理者による設定変更がシステムに自動記録されるようになりました。
  * ダッシュボードで監査ログを検索・フィルタリング表示できるようになりました。実行者、エンドポイント、日付範囲で絞り込み可能です。

* **Tests**
  * 監査ログ機能の自動テストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/278)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->