### PR TITLE
feat(dashboard): LIVE/DRY-RUN env badge in header (#275)

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -33,10 +33,10 @@ import { YahooBarClient } from '../infrastructure/quotes/YahooBarClient'
  * still yields a usable landing.
  */
 export const dashboard = new Hono<AppBindings>()
-  .get('/', (c) => c.html(layout('ダッシュボード', indexBody())))
+  .get('/', (c) => c.html(layout('ダッシュボード', indexBody(), c.env)))
   .get('/positions', async (c) => {
     if (!c.env.DB || !c.env.SYMBOL_STATE) {
-      return c.html(layout('保有状況', unavailable('DB or SYMBOL_STATE not bound')))
+      return c.html(layout('保有状況', unavailable('DB or SYMBOL_STATE not bound'), c.env))
     }
     const universe = await loadSymbolUniverse(c.env)
     const client = new SymbolStateClient(c.env.SYMBOL_STATE)
@@ -55,11 +55,11 @@ export const dashboard = new Hono<AppBindings>()
       ),
       loadLatestStrategyPrices(c.env.DB, allDisplaySymbols),
     ])
-    return c.html(layout('保有状況', positionsBody(rows, strategyPriceMap, universe)))
+    return c.html(layout('保有状況', positionsBody(rows, strategyPriceMap, universe), c.env))
   })
   .get('/portfolio', async (c) => {
     if (!c.env.PORTFOLIO_STATE) {
-      return c.html(layout('ポートフォリオ', unavailable('PORTFOLIO_STATE not bound')))
+      return c.html(layout('ポートフォリオ', unavailable('PORTFOLIO_STATE not bound'), c.env))
     }
     try {
       const portfolio = await new PortfolioStateClient(c.env.PORTFOLIO_STATE).getPortfolio()
@@ -68,14 +68,14 @@ export const dashboard = new Hono<AppBindings>()
       const vixRegime = c.env.DB
         ? await loadVixRegimeSnapshot(c.env.DB, c.get('requestId'))
         : null
-      return c.html(layout('ポートフォリオ', portfolioBody(portfolio, vixRegime)))
+      return c.html(layout('ポートフォリオ', portfolioBody(portfolio, vixRegime), c.env))
     } catch (err) {
-      return c.html(layout('ポートフォリオ', unavailable(messageOf(err))))
+      return c.html(layout('ポートフォリオ', unavailable(messageOf(err)), c.env))
     }
   })
   .get('/trades', async (c) => {
     if (!c.env.DB) {
-      return c.html(layout('約定履歴', unavailable('DB not bound')))
+      return c.html(layout('約定履歴', unavailable('DB not bound'), c.env))
     }
     const limit = clampLimit(c.req.query('limit'))
     const db = createDb(c.env.DB)
@@ -85,21 +85,21 @@ export const dashboard = new Hono<AppBindings>()
       db.select().from(tradeJournal).orderBy(desc(tradeJournal.id)).limit(limit),
       loadSymbolUniverse(c.env).catch(() => null),
     ])
-    return c.html(layout('約定履歴', tradesBody(rows, limit, universe)))
+    return c.html(layout('約定履歴', tradesBody(rows, limit, universe), c.env))
   })
   .get('/config', async (c) => {
     if (!c.env.DB) {
-      return c.html(layout('設定', unavailable('DB not bound')))
+      return c.html(layout('設定', unavailable('DB not bound'), c.env))
     }
     const [global, universe] = await Promise.all([
       loadGlobalConfigFrom(c.env, c.get('requestId')),
       loadSymbolUniverse(c.env),
     ])
-    return c.html(layout('設定', configBody(global, universe)))
+    return c.html(layout('設定', configBody(global, universe), c.env))
   })
   .get('/charts', async (c) => {
     if (!c.env.DB) {
-      return c.html(layout('チャート', unavailable('DB not bound')))
+      return c.html(layout('チャート', unavailable('DB not bound'), c.env))
     }
     try {
       const tab = parseChartsTab(c.req.query('tab'))
@@ -109,7 +109,7 @@ export const dashboard = new Hono<AppBindings>()
       // - symbol:   universe + symbolChart
       if (tab === 'overview') {
         const equity = await loadEquityCurve(c.env.DB)
-        return c.html(layout('チャート', chartsBody({ tab, equity })))
+        return c.html(layout('チャート', chartsBody({ tab, equity }), c.env))
       }
       if (tab === 'quality') {
         const [decisions, pnls] = await Promise.all([
@@ -126,6 +126,7 @@ export const dashboard = new Hono<AppBindings>()
               stats: computeTradeStats(pnls),
               histogram: computePnlHistogram(pnls),
             }),
+            c.env,
           ),
         )
       }
@@ -167,6 +168,7 @@ export const dashboard = new Hono<AppBindings>()
               zoom,
               universe,
             }),
+            c.env,
           ),
         )
       }
@@ -231,10 +233,11 @@ export const dashboard = new Hono<AppBindings>()
             zoom,
             universe,
           }),
+          c.env,
         ),
       )
     } catch (err) {
-      return c.html(layout('チャート', unavailable(messageOf(err))))
+      return c.html(layout('チャート', unavailable(messageOf(err)), c.env))
     }
   })
   .get('/cron/json', async (c) => {
@@ -313,7 +316,7 @@ export const dashboard = new Hono<AppBindings>()
   })
   .get('/cron', async (c) => {
     if (!c.env.DB) {
-      return c.html(layout('Cron 判定', unavailable('DB not bound')))
+      return c.html(layout('Cron 判定', unavailable('DB not bound'), c.env))
     }
     const limit = clampLimit(c.req.query('limit'))
     const symbolFilter = c.req.query('symbol')?.toUpperCase().trim() || undefined
@@ -358,11 +361,11 @@ export const dashboard = new Hono<AppBindings>()
               .limit(limit),
         loadSymbolUniverse(c.env).catch(() => null),
       ])
-      return c.html(layout('Cron 判定', cronBody(rows, limit, symbolFilter, universe)))
+      return c.html(layout('Cron 判定', cronBody(rows, limit, symbolFilter, universe), c.env))
     } catch (err) {
       // migration 未適用 / 一時的な D1 エラーで 500 にせず unavailable に落とす
       // (CodeRabbit #132)。段階的デプロイ時の自己保護。
-      return c.html(layout('Cron 判定', unavailable(messageOf(err))))
+      return c.html(layout('Cron 判定', unavailable(messageOf(err)), c.env))
     }
   })
   /**
@@ -382,12 +385,12 @@ export const dashboard = new Hono<AppBindings>()
       ? await loadSymbolUniverse(c.env).catch(() => null)
       : null
     return c.html(
-      layout('Broker 診断', brokerProbeBody({ symbol, category, universe })),
+      layout('Broker 診断', brokerProbeBody({ symbol, category, universe }), c.env),
     )
   })
   .get('/alerts', async (c) => {
     if (!c.env.DB) {
-      return c.html(layout('アラート', unavailable('DB not bound')))
+      return c.html(layout('アラート', unavailable('DB not bound'), c.env))
     }
     const limit = clampAlertLimit(c.req.query('limit'))
     const severityFilter = parseSeverityFilter(c.req.query('severity'))
@@ -409,12 +412,13 @@ export const dashboard = new Hono<AppBindings>()
         layout(
           'アラート',
           alertsBody({ rows, limit, severityFilter, eventTypeFilter, currentQuery, universe }),
+          c.env,
         ),
       )
     } catch (err) {
       // 0012 migration 未適用 (= notification_emit_log テーブル無し) を
       // 500 にせず unavailable に落とす。段階的デプロイ時の自己保護。
-      return c.html(layout('アラート', unavailable(messageOf(err))))
+      return c.html(layout('アラート', unavailable(messageOf(err)), c.env))
     }
   })
   .get('/audit', async (c) => {
@@ -578,19 +582,54 @@ const STYLE = `
   tr.symbol-disabled-row{background:#fafafa}
   tr.symbol-disabled-row td{color:#86868b}
   .grid-panel.symbol-inactive{background:#fafafa;opacity:0.65}
+  .env-badge{display:inline-block;margin-left:10px;padding:2px 10px;font-size:11px;font-weight:700;letter-spacing:0.5px;border-radius:10px;vertical-align:middle}
+  .env-badge.live{background:#c22;color:#fff}
+  .env-badge.dry{background:#057a55;color:#fff}
+  .env-badge.unknown{background:#f5c518;color:#3a2a00}
 `
 
-function layout(title: string, body: string): string {
+/**
+ * Env badge (#275): operator が画面で live / dry-run を即判別できるよう、
+ * 全 dashboard page の header に常時表示するための env state derivation。
+ * `c.env` 未配線 / `DRY_RUN` 未設定でも 500 を起こさないよう defensive に default。
+ */
+export type EnvBadgeMode = 'LIVE' | 'DRY-RUN' | 'UNKNOWN'
+
+export function resolveEnvBadgeMode(env: unknown): EnvBadgeMode {
+  const raw =
+    env && typeof env === 'object' && 'DRY_RUN' in env
+      ? (env as { DRY_RUN?: unknown }).DRY_RUN
+      : undefined
+  if (raw === 'true') return 'DRY-RUN'
+  if (raw === 'false') return 'LIVE'
+  return 'UNKNOWN'
+}
+
+function envBadgeTitlePrefix(mode: EnvBadgeMode): string {
+  if (mode === 'LIVE') return '[LIVE]'
+  if (mode === 'DRY-RUN') return '[DRY]'
+  return '[?]'
+}
+
+function renderEnvBadge(mode: EnvBadgeMode): string {
+  const cls = mode === 'LIVE' ? 'live' : mode === 'DRY-RUN' ? 'dry' : 'unknown'
+  return `<span class="env-badge ${cls}" title="DRY_RUN=${esc(mode)}">${esc(mode)}</span>`
+}
+
+function layout(title: string, body: string, env?: unknown): string {
+  const mode = resolveEnvBadgeMode(env)
+  const titlePrefix = envBadgeTitlePrefix(mode)
+  const badge = renderEnvBadge(mode)
   return `<!doctype html>
 <html lang="ja">
 <head>
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width,initial-scale=1"/>
-<title>${esc(title)} — Webull Trading</title>
+<title>${titlePrefix} ${esc(title)} — Webull Trading</title>
 <style>${STYLE}</style>
 </head>
 <body>
-<h1>Webull Trading — ${esc(title)}</h1>
+<h1>Webull Trading — ${esc(title)}${badge}</h1>
 <nav>
   <a href="/dashboard">ホーム</a>
   <a href="/dashboard/positions">保有状況</a>

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -99,8 +99,53 @@ describe('dashboard', () => {
     const res = await app.request('/dashboard', { headers: authHeader }, baseEnv)
     expect(res.status).toBe(200)
     const body = await res.text()
-    expect(body).toContain('<title>ダッシュボード')
+    // #275: env badge prefix ([?] = UNKNOWN since DRY_RUN unset in baseEnv) goes
+    // before the page title.
+    expect(body).toContain('<title>[?] ダッシュボード')
     expect(body).toContain('/dashboard/positions')
+  })
+
+  // #275: header env badge — operator が live / dry-run を画面で即判別できるよう
+  // 全 dashboard page に常時表示する。DRY_RUN env から派生、未設定 / 不正値は
+  // UNKNOWN に倒れて 500 にしない。
+  describe('env badge (#275)', () => {
+    it('renders green DRY-RUN badge when DRY_RUN=true', async () => {
+      const app = createApp()
+      const res = await app.request(
+        '/dashboard',
+        { headers: authHeader },
+        { ...baseEnv, DRY_RUN: 'true' },
+      )
+      expect(res.status).toBe(200)
+      const body = await res.text()
+      expect(body).toContain('<title>[DRY] ダッシュボード')
+      expect(body).toContain('class="env-badge dry"')
+      expect(body).toContain('>DRY-RUN<')
+    })
+
+    it('renders red LIVE badge when DRY_RUN=false', async () => {
+      const app = createApp()
+      const res = await app.request(
+        '/dashboard',
+        { headers: authHeader },
+        { ...baseEnv, DRY_RUN: 'false' },
+      )
+      expect(res.status).toBe(200)
+      const body = await res.text()
+      expect(body).toContain('<title>[LIVE] ダッシュボード')
+      expect(body).toContain('class="env-badge live"')
+      expect(body).toContain('>LIVE<')
+    })
+
+    it('renders yellow UNKNOWN badge when DRY_RUN is unset (defensive default)', async () => {
+      const app = createApp()
+      const res = await app.request('/dashboard', { headers: authHeader }, baseEnv)
+      expect(res.status).toBe(200)
+      const body = await res.text()
+      expect(body).toContain('<title>[?] ダッシュボード')
+      expect(body).toContain('class="env-badge unknown"')
+      expect(body).toContain('>UNKNOWN<')
+    })
   })
 
   it('renders positions page with DO state', async () => {


### PR DESCRIPTION
Closes #275
Refs #273

## Summary

dashboard 全画面 header に LIVE / DRY-RUN / UNKNOWN バッジを常時表示。本番接続後の誤操作防止。

## 変更点

- `src/routes/dashboard.ts`
  - `resolveEnvBadgeMode()` / `envBadgeTitlePrefix()` / `renderEnvBadge()` 追加
  - `layout(title, body)` → `layout(title, body, env?)` に拡張、23 call site 更新
  - `<h1>` に badge span、`<title>` に `[LIVE]` / `[DRY]` / `[?]` prefix
  - 既存 STYLE block に `.env-badge` / `.live` / `.dry` / `.unknown` を追記
- `test/routes/dashboard.test.ts`
  - 既存 title assertion 更新 + 新規 3 アサーション (DRY-RUN / LIVE / UNKNOWN)

## Badge

- `DRY_RUN === 'true'` → 緑 `DRY-RUN` (#057a55)
- `DRY_RUN === 'false'` → 赤 `LIVE` (#c22, 白文字)
- undefined / 他 → 黄 `UNKNOWN` (#f5c518, dark text for AA contrast)

`/admin` は JSON のみで HTML layout 無し → 対象外。

## Out of scope

- 環境名 (dev/staging/prod) 表示 → #277 に合流
- kill-switch (#276)

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` 989/989 (+3 badge tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ダッシュボードのページタイトルに環境バッジ（[LIVE]、[DRY]、[?]）が表示されるようになりました。取引モードの状態が一目で確認できます。
  * 全ダッシュボードページで環境バッジの表示が統一されました。

* **テスト**
  * 環境バッジの表示動作に関するテストケースを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/279)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->