### PR TITLE
feat(ops): runtime kill-switch — DB-backed TRADING_ENABLED toggle (#276)

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -58,3 +58,10 @@ DASHBOARD_BASE_URL=
 # は limit_price 不要 / account_id を body)。受理値は 'v1' / 'v2' のみ、
 # それ以外 (空 / whitespace / 任意文字列) は 'v1' fallback。
 # WEBULL_PLACE_ORDER_SCHEMA=v2
+
+# #276: runtime kill-switch の deploy-gate override (optional、append 規約)。
+# prod は D1 `global_config.trading_enabled` が真値だが、env を 'false' に
+# すると DB が ON でも強制 OFF (= より制限的が勝つ)。preview / staging で
+# 「DB を間違って ON にしてもこの環境では絶対に発注しない」保険。
+# 受理値: unset / 'true' → DB 尊重、'false' → 強制 OFF、それ以外 → 強制 OFF。
+# TRADING_ENABLED=false

--- a/drizzle/0017_trading_toggle_history.sql
+++ b/drizzle/0017_trading_toggle_history.sql
@@ -1,0 +1,15 @@
+-- Runtime kill-switch toggle history (issue #276)。`global_config.trading_enabled`
+-- は singleton で「現在値」、こちらは append-only で「いつ誰が何故 ON/OFF にしたか」
+-- を残す。full audit log は #274 で別途扱う想定なので、ここでは kill-switch の
+-- before/after/reason に絞る最小スキーマ。0013/0014/0015 同様に新規 table の
+-- CREATE のみで global_config は触らない (drizzle-kit が `__new_global_config`
+-- 経由で全列リビルドを提案してくるが副作用が大きいので avoid)。
+CREATE TABLE `trading_toggle_history` (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `timestamp` text NOT NULL,
+  `actor` text,
+  `before` integer,
+  `after` integer NOT NULL,
+  `reason` text NOT NULL,
+  `request_id` text
+);

--- a/drizzle/meta/0017_snapshot.json
+++ b/drizzle/meta/0017_snapshot.json
@@ -1,0 +1,1213 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "d1b5a873-7bdd-4a2f-85d5-0f2f965606f7",
+  "prevId": "be86586d-e44f-4e40-aa21-6e9b160e64ac",
+  "tables": {
+    "config_audit_log": {
+      "name": "config_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before_json": {
+          "name": "before_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "after_json": {
+          "name": "after_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "config_audit_log_timestamp_id_idx": {
+          "name": "config_audit_log_timestamp_id_idx",
+          "columns": [
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "config_audit_log_actor_timestamp_id_idx": {
+          "name": "config_audit_log_actor_timestamp_id_idx",
+          "columns": [
+            "actor",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "config_audit_log_endpoint_timestamp_id_idx": {
+          "name": "config_audit_log_endpoint_timestamp_id_idx",
+          "columns": [
+            "endpoint",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "config_state_snapshot": {
+      "name": "config_state_snapshot",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "earnings_calendar": {
+      "name": "earnings_calendar",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "earnings_date": {
+          "name": "earnings_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "earnings_calendar_symbol_date_unique": {
+          "name": "earnings_calendar_symbol_date_unique",
+          "columns": [
+            "symbol",
+            "earnings_date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "global_config": {
+      "name": "global_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "trading_enabled": {
+          "name": "trading_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "market_hours_check": {
+          "name": "market_hours_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "max_order_notional": {
+          "name": "max_order_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "max_order_notional_usd": {
+          "name": "max_order_notional_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2000
+        },
+        "max_order_notional_jpy": {
+          "name": "max_order_notional_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100000
+        },
+        "total_capital_usd": {
+          "name": "total_capital_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_capital_jpy": {
+          "name": "total_capital_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_portfolio_exposure_pct": {
+          "name": "max_portfolio_exposure_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.6
+        },
+        "drawdown_kill_threshold": {
+          "name": "drawdown_kill_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.02
+        },
+        "stale_quote_ms": {
+          "name": "stale_quote_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 900000
+        },
+        "gap_reject_pct": {
+          "name": "gap_reject_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.03
+        },
+        "spread_limit_pct_us": {
+          "name": "spread_limit_pct_us",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.0025
+        },
+        "spread_limit_pct_jp": {
+          "name": "spread_limit_pct_jp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.006
+        },
+        "pullback_default_stop_pct": {
+          "name": "pullback_default_stop_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.04
+        },
+        "pullback_default_take_profit_pct": {
+          "name": "pullback_default_take_profit_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.07
+        },
+        "pullback_default_time_stop_days": {
+          "name": "pullback_default_time_stop_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "pullback_default_pullback_max": {
+          "name": "pullback_default_pullback_max",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.03
+        },
+        "pullback_default_pullback_min": {
+          "name": "pullback_default_pullback_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.06
+        },
+        "pullback_default_min_return_50d": {
+          "name": "pullback_default_min_return_50d",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.08
+        },
+        "pullback_default_require_above_sma50": {
+          "name": "pullback_default_require_above_sma50",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "pullback_default_k_atr": {
+          "name": "pullback_default_k_atr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "risk_base_per_trade_pct": {
+          "name": "risk_base_per_trade_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.004
+        },
+        "risk_dd_half_threshold": {
+          "name": "risk_dd_half_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.05
+        },
+        "risk_dd_halt_threshold": {
+          "name": "risk_dd_halt_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.1
+        },
+        "bucket_exposure_pct": {
+          "name": "bucket_exposure_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.3
+        },
+        "vix_warning_threshold": {
+          "name": "vix_warning_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 25
+        },
+        "vix_critical_threshold": {
+          "name": "vix_critical_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "vix_warning_size_scale": {
+          "name": "vix_warning_size_scale",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.5
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "global_config_max_order_notional_range": {
+          "name": "global_config_max_order_notional_range",
+          "value": "\"global_config\".\"max_order_notional\" > 0 AND \"global_config\".\"max_order_notional\" <= 10000000"
+        },
+        "global_config_max_order_notional_usd_range": {
+          "name": "global_config_max_order_notional_usd_range",
+          "value": "\"global_config\".\"max_order_notional_usd\" > 0 AND \"global_config\".\"max_order_notional_usd\" <= 1000000"
+        },
+        "global_config_max_order_notional_jpy_range": {
+          "name": "global_config_max_order_notional_jpy_range",
+          "value": "\"global_config\".\"max_order_notional_jpy\" > 0 AND \"global_config\".\"max_order_notional_jpy\" <= 100000000"
+        },
+        "global_config_total_capital_usd_range": {
+          "name": "global_config_total_capital_usd_range",
+          "value": "\"global_config\".\"total_capital_usd\" IS NULL OR \"global_config\".\"total_capital_usd\" > 0"
+        },
+        "global_config_total_capital_jpy_range": {
+          "name": "global_config_total_capital_jpy_range",
+          "value": "\"global_config\".\"total_capital_jpy\" IS NULL OR \"global_config\".\"total_capital_jpy\" > 0"
+        },
+        "global_config_max_portfolio_exposure_pct_range": {
+          "name": "global_config_max_portfolio_exposure_pct_range",
+          "value": "\"global_config\".\"max_portfolio_exposure_pct\" > 0 AND \"global_config\".\"max_portfolio_exposure_pct\" <= 1"
+        },
+        "global_config_drawdown_kill_threshold_range": {
+          "name": "global_config_drawdown_kill_threshold_range",
+          "value": "\"global_config\".\"drawdown_kill_threshold\" >= -1 AND \"global_config\".\"drawdown_kill_threshold\" <= 0"
+        },
+        "global_config_stale_quote_ms_range": {
+          "name": "global_config_stale_quote_ms_range",
+          "value": "\"global_config\".\"stale_quote_ms\" >= 0"
+        },
+        "global_config_gap_reject_pct_range": {
+          "name": "global_config_gap_reject_pct_range",
+          "value": "\"global_config\".\"gap_reject_pct\" >= 0 AND \"global_config\".\"gap_reject_pct\" <= 1"
+        },
+        "global_config_spread_limit_pct_us_range": {
+          "name": "global_config_spread_limit_pct_us_range",
+          "value": "\"global_config\".\"spread_limit_pct_us\" >= 0 AND \"global_config\".\"spread_limit_pct_us\" <= 1"
+        },
+        "global_config_spread_limit_pct_jp_range": {
+          "name": "global_config_spread_limit_pct_jp_range",
+          "value": "\"global_config\".\"spread_limit_pct_jp\" >= 0 AND \"global_config\".\"spread_limit_pct_jp\" <= 1"
+        },
+        "global_config_pullback_default_stop_pct_range": {
+          "name": "global_config_pullback_default_stop_pct_range",
+          "value": "\"global_config\".\"pullback_default_stop_pct\" < 0 AND \"global_config\".\"pullback_default_stop_pct\" >= -1"
+        },
+        "global_config_pullback_default_take_profit_pct_range": {
+          "name": "global_config_pullback_default_take_profit_pct_range",
+          "value": "\"global_config\".\"pullback_default_take_profit_pct\" > 0 AND \"global_config\".\"pullback_default_take_profit_pct\" <= 1"
+        },
+        "global_config_pullback_default_time_stop_days_range": {
+          "name": "global_config_pullback_default_time_stop_days_range",
+          "value": "\"global_config\".\"pullback_default_time_stop_days\" > 0 AND \"global_config\".\"pullback_default_time_stop_days\" <= ?"
+        },
+        "global_config_pullback_default_pullback_max_range": {
+          "name": "global_config_pullback_default_pullback_max_range",
+          "value": "\"global_config\".\"pullback_default_pullback_max\" <= 0 AND \"global_config\".\"pullback_default_pullback_max\" >= -1"
+        },
+        "global_config_pullback_default_pullback_min_range": {
+          "name": "global_config_pullback_default_pullback_min_range",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= 0 AND \"global_config\".\"pullback_default_pullback_min\" >= -1"
+        },
+        "global_config_pullback_default_min_return_50d_range": {
+          "name": "global_config_pullback_default_min_return_50d_range",
+          "value": "\"global_config\".\"pullback_default_min_return_50d\" >= -1 AND \"global_config\".\"pullback_default_min_return_50d\" <= 10"
+        },
+        "global_config_pullback_default_k_atr_range": {
+          "name": "global_config_pullback_default_k_atr_range",
+          "value": "\"global_config\".\"pullback_default_k_atr\" > 0 AND \"global_config\".\"pullback_default_k_atr\" <= 10"
+        },
+        "global_config_pullback_default_pullback_window_order": {
+          "name": "global_config_pullback_default_pullback_window_order",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= \"global_config\".\"pullback_default_pullback_max\""
+        },
+        "global_config_risk_base_per_trade_pct_range": {
+          "name": "global_config_risk_base_per_trade_pct_range",
+          "value": "\"global_config\".\"risk_base_per_trade_pct\" > 0 AND \"global_config\".\"risk_base_per_trade_pct\" <= 1"
+        },
+        "global_config_risk_dd_half_threshold_range": {
+          "name": "global_config_risk_dd_half_threshold_range",
+          "value": "\"global_config\".\"risk_dd_half_threshold\" < 0 AND \"global_config\".\"risk_dd_half_threshold\" >= -1"
+        },
+        "global_config_risk_dd_halt_threshold_range": {
+          "name": "global_config_risk_dd_halt_threshold_range",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" < 0 AND \"global_config\".\"risk_dd_halt_threshold\" >= -1"
+        },
+        "global_config_risk_dd_threshold_order": {
+          "name": "global_config_risk_dd_threshold_order",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" <= \"global_config\".\"risk_dd_half_threshold\""
+        },
+        "global_config_bucket_exposure_pct_range": {
+          "name": "global_config_bucket_exposure_pct_range",
+          "value": "\"global_config\".\"bucket_exposure_pct\" > 0 AND \"global_config\".\"bucket_exposure_pct\" <= 1"
+        },
+        "global_config_vix_warning_threshold_range": {
+          "name": "global_config_vix_warning_threshold_range",
+          "value": "\"global_config\".\"vix_warning_threshold\" > 0 AND \"global_config\".\"vix_warning_threshold\" <= 200"
+        },
+        "global_config_vix_critical_threshold_range": {
+          "name": "global_config_vix_critical_threshold_range",
+          "value": "\"global_config\".\"vix_critical_threshold\" > 0 AND \"global_config\".\"vix_critical_threshold\" <= 200"
+        },
+        "global_config_vix_threshold_order": {
+          "name": "global_config_vix_threshold_order",
+          "value": "\"global_config\".\"vix_warning_threshold\" <= \"global_config\".\"vix_critical_threshold\""
+        },
+        "global_config_vix_warning_size_scale_range": {
+          "name": "global_config_vix_warning_size_scale_range",
+          "value": "\"global_config\".\"vix_warning_size_scale\" >= 0 AND \"global_config\".\"vix_warning_size_scale\" <= 1"
+        }
+      }
+    },
+    "inverse_pairs": {
+      "name": "inverse_pairs",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inverse": {
+          "name": "inverse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "macro_event_calendar": {
+      "name": "macro_event_calendar",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_time": {
+          "name": "event_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "macro_event_calendar_type_date_unique": {
+          "name": "macro_event_calendar_type_date_unique",
+          "columns": [
+            "event_type",
+            "event_date"
+          ],
+          "isUnique": true
+        },
+        "macro_event_calendar_date_idx": {
+          "name": "macro_event_calendar_date_idx",
+          "columns": [
+            "event_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_emit_log": {
+      "name": "notification_emit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cause": {
+          "name": "cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notification_emit_log_timestamp_id_idx": {
+          "name": "notification_emit_log_timestamp_id_idx",
+          "columns": [
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "notification_emit_log_severity_timestamp_id_idx": {
+          "name": "notification_emit_log_severity_timestamp_id_idx",
+          "columns": [
+            "severity",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "notification_emit_log_event_type_timestamp_id_idx": {
+          "name": "notification_emit_log_event_type_timestamp_id_idx",
+          "columns": [
+            "event_type",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "strategy_decision_log": {
+      "name": "strategy_decision_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indicators_json": {
+          "name": "indicators_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "strategy_decision_log_symbol_id_idx": {
+          "name": "strategy_decision_log_symbol_id_idx",
+          "columns": [
+            "symbol",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "strategy_decision_log_coid_idx": {
+          "name": "strategy_decision_log_coid_idx",
+          "columns": [
+            "client_order_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "symbol_config": {
+      "name": "symbol_config",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "market": {
+          "name": "market",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_notional": {
+          "name": "max_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "symbol_config_currency_enum": {
+          "name": "symbol_config_currency_enum",
+          "value": "\"symbol_config\".\"currency\" IN ('USD', 'JPY')"
+        }
+      }
+    },
+    "trade_journal": {
+      "name": "trade_journal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trade_event_type": {
+          "name": "trade_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "strategy_name": {
+          "name": "strategy_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_action": {
+          "name": "signal_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_reason": {
+          "name": "signal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_allowed": {
+          "name": "risk_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_reasons": {
+          "name": "risk_reasons",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "limit_price": {
+          "name": "limit_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notional": {
+          "name": "notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "broker_status": {
+          "name": "broker_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "submitted": {
+          "name": "submitted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_qty": {
+          "name": "filled_qty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_price": {
+          "name": "filled_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "realized_pnl": {
+          "name": "realized_pnl",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hold_days": {
+          "name": "hold_days",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_reason": {
+          "name": "exit_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_applied_at": {
+          "name": "state_applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_error": {
+          "name": "state_apply_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_attempts": {
+          "name": "state_apply_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trading_toggle_history": {
+      "name": "trading_toggle_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before": {
+          "name": "before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "after": {
+          "name": "after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1778828808121,
       "tag": "0016_wakeful_xavin",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "6",
+      "when": 1778828802046,
+      "tag": "0017_trading_toggle_history",
+      "breakpoints": true
     }
   ]
 }

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -360,3 +360,16 @@ export interface Env {
 export interface Env {
   WEBULL_PLACE_ORDER_SCHEMA?: string
 }
+
+
+// #276: TRADING_ENABLED env var を deploy-gate (= non-prod / preview の強制 OFF
+// override) として残す。prod は D1 `global_config.trading_enabled` が真値だが、
+// 「env で OFF にしたら DB で ON にしても発注しない」=「より制限的な側が勝つ」
+// 仕様。`true` 明示 / unset は DB を尊重、その他は OFF override 扱い。
+//
+//   env unset / 'true'  → DB の trading_enabled を使う
+//   env が 'false'      → DB が true でも強制 OFF (fail-closed)
+//   env がそれ以外       → 安全側に倒し 強制 OFF (typo は cron 止める方が安全)
+export interface Env {
+  TRADING_ENABLED?: string
+}

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -599,3 +599,26 @@ export const configAuditLog = sqliteTable(
 
 export type ConfigAuditLogRow = typeof configAuditLog.$inferSelect
 export type ConfigAuditLogInsert = typeof configAuditLog.$inferInsert
+
+/**
+ * Runtime kill-switch toggle history (issue #276)。`global_config.trading_enabled`
+ * は単一行で「現在値」、こちらは append-only で「いつ誰が何故 ON/OFF にしたか」
+ * を残す。full audit log は #274 で別途扱う想定なので、ここでは kill-switch の
+ * before/after/reason に絞る最小スキーマ。
+ */
+export const tradingToggleHistory = sqliteTable('trading_toggle_history', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  timestamp: text('timestamp').notNull(),
+  /** basic-auth user (admin endpoint 経由は username, dashboard 経由も同様)。 */
+  actor: text('actor'),
+  /** 切替前の trading_enabled。NULL は初回 toggle (snapshot 不能) のみ想定。 */
+  before: integer('before', { mode: 'boolean' }),
+  /** 切替後の trading_enabled。 */
+  after: integer('after', { mode: 'boolean' }).notNull(),
+  /** operator から渡された自由記述の理由。必須 (audit context)。 */
+  reason: text('reason').notNull(),
+  requestId: text('request_id'),
+})
+
+export type TradingToggleHistoryRow = typeof tradingToggleHistory.$inferSelect
+export type TradingToggleHistoryInsert = typeof tradingToggleHistory.$inferInsert

--- a/src/infrastructure/db/tradingToggleRepo.ts
+++ b/src/infrastructure/db/tradingToggleRepo.ts
@@ -1,0 +1,88 @@
+import { eq } from 'drizzle-orm'
+import { drizzle, type DrizzleD1Database } from 'drizzle-orm/d1'
+import { globalConfig, tradingToggleHistory } from './schema'
+
+export interface TradingToggleResult {
+  before: boolean | null
+  after: boolean
+  historyId: number | null
+}
+
+/**
+ * Apply a kill-switch toggle (issue #276)。
+ *
+ * 1. `global_config.trading_enabled` の現在値を読む (before snapshot)
+ * 2. `enabled` で上書き UPDATE
+ * 3. `trading_toggle_history` に append (timestamp / actor / before / after /
+ *    reason / requestId)
+ *
+ * Returns the before/after snapshot for log emission. Throws if D1 binding is
+ * missing or the UPDATE fails — fail-closed (toggle が DB に書けなかったのに
+ * 200 返しちゃう sit を避ける)。
+ *
+ * No-op detection は呼出側に任せる: same-value toggle でも history は残す
+ * (operator が「無駄な ON ボタン押した」を audit で見たいケースもあるため)。
+ */
+export async function applyTradingToggle(
+  db: DrizzleD1Database,
+  args: {
+    enabled: boolean
+    actor: string | null
+    reason: string
+    requestId: string | null
+    now?: () => Date
+  },
+): Promise<TradingToggleResult> {
+  const now = (args.now ?? (() => new Date()))()
+  const nowIso = now.toISOString()
+
+  const rows = await db
+    .select({ tradingEnabled: globalConfig.tradingEnabled })
+    .from(globalConfig)
+    .where(eq(globalConfig.id, 'default'))
+    .limit(1)
+  const before: boolean | null = rows[0] ? rows[0].tradingEnabled : null
+
+  if (rows[0]) {
+    await db
+      .update(globalConfig)
+      .set({ tradingEnabled: args.enabled, updatedAt: nowIso })
+      .where(eq(globalConfig.id, 'default'))
+  } else {
+    // 初回 (= row 未 seed)。`/admin/trading/toggle` が seed も担当することで
+    // 「runtime に DB 未投入で toggle 不能」を回避。`updatedAt` 必須 / 他列は
+    // schema default (dry_run=true, trading_enabled は arg, など) に任せる。
+    await db.insert(globalConfig).values({
+      id: 'default',
+      tradingEnabled: args.enabled,
+      updatedAt: nowIso,
+    })
+  }
+
+  const inserted = await db
+    .insert(tradingToggleHistory)
+    .values({
+      timestamp: nowIso,
+      actor: args.actor,
+      before,
+      after: args.enabled,
+      reason: args.reason,
+      requestId: args.requestId,
+    })
+    .returning({ id: tradingToggleHistory.id })
+
+  return {
+    before,
+    after: args.enabled,
+    historyId: inserted[0]?.id ?? null,
+  }
+}
+
+/**
+ * Wraps a raw `D1Database` binding into a drizzle instance suitable for
+ * `applyTradingToggle`. Kept as a thin helper so callers don't need to import
+ * drizzle directly.
+ */
+export function createTradingToggleDb(d1: D1Database): DrizzleD1Database {
+  return drizzle(d1)
+}

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -17,6 +17,11 @@ import { createDb } from '../infrastructure/db/tradeJournalRepo'
 import { earningsCalendar, macroEventCalendar, tradeJournal } from '../infrastructure/db/schema'
 import { extractActor, recordChange } from '../infrastructure/db/configAuditLog'
 import {
+  applyTradingToggle,
+  createTradingToggleDb,
+} from '../infrastructure/db/tradingToggleRepo'
+import { resolveTradingEnabled } from '../trading/runtime/killSwitch'
+import {
   createEarningsCalendarDb,
   createEarningsCalendarRepo,
   type EarningsCalendarSeedInput,
@@ -151,6 +156,62 @@ export const admin = new Hono<AppBindings>()
   .post('/strategy/run', async (c) => {
     const result = await runStrategyCron(c.env)
     return c.json(result)
+  })
+  /**
+   * Runtime kill-switch toggle (issue #276)。`global_config.trading_enabled` を
+   * 切替えて `trading_toggle_history` に append。dashboard 経由は
+   * `application/x-www-form-urlencoded`、CLI 経由は JSON で受ける (Content-Type
+   * で分岐)。dashboard form 後の挙動を素直にするため、form post には HTML 302
+   * で `/dashboard` に戻す。
+   *
+   * Body (JSON or form): `{ enabled: boolean, reason: string }`
+   *
+   * `effective` フィールドで env override 適用後の値を返す: env=false なら DB
+   * を true に書いても `effective=false` で運用者に「env override 効いてる」
+   * を視認させる (saw-tooth な切替えで混乱する事故防止)。
+   */
+  .post('/trading/toggle', async (c) => {
+    if (!c.env.DB) {
+      throw new ValidationError('DB binding is not configured', { field: 'env' })
+    }
+    const contentType = c.req.header('content-type') ?? ''
+    const isForm =
+      contentType.includes('application/x-www-form-urlencoded') ||
+      contentType.includes('multipart/form-data')
+    const body = isForm
+      ? Object.fromEntries((await c.req.formData()).entries())
+      : ((await c.req.json().catch(() => null)) as unknown)
+    const { enabled, reason } = readToggleBody(body)
+
+    const db = createTradingToggleDb(c.env.DB)
+    const result = await applyTradingToggle(db, {
+      enabled,
+      actor: c.env.BASIC_AUTH_USER ?? null,
+      reason,
+      requestId: c.get('requestId') ?? null,
+    })
+    console.log(
+      JSON.stringify({
+        event: 'trading_toggle_applied',
+        requestId: c.get('requestId'),
+        actor: c.env.BASIC_AUTH_USER ?? null,
+        before: result.before,
+        after: result.after,
+        reason,
+      }),
+    )
+    if (isForm) {
+      // Form 経由は dashboard に戻して銀行のような one-click 操作にする。
+      return c.redirect('/dashboard', 303)
+    }
+    const effective = resolveTradingEnabled(result.after, c.env.TRADING_ENABLED)
+    return c.json({
+      before: result.before,
+      after: result.after,
+      effective,
+      envOverrideActive: effective !== result.after,
+      historyId: result.historyId,
+    })
   })
   /**
    * Offline backtest harness for PullbackUptrendStrategy (issue #198)。
@@ -1088,6 +1149,41 @@ function readOverridePositionBody(body: unknown): {
     throw new ValidationError('reason must be <= 256 chars', { field: 'reason' })
   }
   return { qty, avgPrice, openedAt, reason }
+}
+
+/**
+ * `/admin/trading/toggle` の body parser (issue #276)。JSON / form 双方を受け、
+ * `enabled` (boolean) と `reason` (1..256 chars) を strict に validate する。
+ * form value は string で渡るため "true"/"false"/"1"/"0"/"on" を許容。
+ */
+function readToggleBody(body: unknown): { enabled: boolean; reason: string } {
+  if (body === null || typeof body !== 'object' || Array.isArray(body)) {
+    throw new ValidationError('body must be a JSON object or form-encoded', { field: 'body' })
+  }
+  const raw = body as { enabled?: unknown; reason?: unknown }
+  const enabledRaw = raw.enabled
+  let enabled: boolean
+  if (typeof enabledRaw === 'boolean') {
+    enabled = enabledRaw
+  } else if (typeof enabledRaw === 'string') {
+    // form post は string で来る。dashboard form は 'true' / 'false' を送るので
+    // それを正規ケースに、CLI ミス防止に 'on' (HTML checkbox 流儀) も許容。
+    const norm = enabledRaw.trim().toLowerCase()
+    if (norm === 'true' || norm === '1' || norm === 'on') enabled = true
+    else if (norm === 'false' || norm === '0' || norm === 'off') enabled = false
+    else
+      throw new ValidationError("enabled must be boolean ('true'/'false')", { field: 'enabled' })
+  } else {
+    throw new ValidationError('enabled must be a boolean', { field: 'enabled' })
+  }
+  const reasonRaw = raw.reason
+  if (typeof reasonRaw !== 'string' || reasonRaw.trim().length === 0) {
+    throw new ValidationError('reason must be a non-empty string', { field: 'reason' })
+  }
+  if (reasonRaw.length > 256) {
+    throw new ValidationError('reason must be <= 256 chars', { field: 'reason' })
+  }
+  return { enabled, reason: reasonRaw }
 }
 
 function readAmount(body: unknown): number {

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1,7 +1,19 @@
 import { Hono } from 'hono'
 import type { AppBindings } from '../app'
 import type { Env } from '../config/env'
+
+/**
+ * Dashboard-local Hono context shape。`AppBindings.Variables` の `requestId` に
+ * 加え、kill-switch banner state を `use('*')` middleware で初頭 load して
+ * 全 route から参照可能にする (#276)。
+ */
+type DashboardBindings = AppBindings & {
+  Variables: AppBindings['Variables'] & {
+    killSwitchState: KillSwitchBannerState | null
+  }
+}
 import { loadGlobalConfigFrom } from '../infrastructure/db/globalConfigLoader'
+import { resolveTradingEnabled } from '../trading/runtime/killSwitch'
 import { loadSymbolUniverse, type SymbolUniverse } from '../infrastructure/db/symbolUniverse'
 import { formatSymbolDisplay } from '../shared/format'
 import { createDb } from '../infrastructure/db/tradeJournalRepo'
@@ -32,11 +44,37 @@ import { YahooBarClient } from '../infrastructure/quotes/YahooBarClient'
  * we surface "unavailable" rather than 500, so a partially-configured env
  * still yields a usable landing.
  */
-export const dashboard = new Hono<AppBindings>()
-  .get('/', (c) => c.html(layout('ダッシュボード', indexBody(), c.env)))
+interface KillSwitchBannerState {
+  dbEnabled: boolean
+  effective: boolean
+  envOverrideActive: boolean
+}
+
+async function loadKillSwitchState(env: Env): Promise<KillSwitchBannerState | null> {
+  if (!env.DB) return null
+  try {
+    const global = await loadGlobalConfigFrom(env)
+    const effective = resolveTradingEnabled(global.tradingEnabled, env.TRADING_ENABLED)
+    return {
+      dbEnabled: global.tradingEnabled,
+      effective,
+      envOverrideActive: effective !== global.tradingEnabled,
+    }
+  } catch {
+    return null
+  }
+}
+
+export const dashboard = new Hono<DashboardBindings>()
+  .use('*', async (c, next) => {
+    const state = await loadKillSwitchState(c.env)
+    c.set('killSwitchState', state)
+    await next()
+  })
+  .get('/', (c) => c.html(renderLayout(c, 'ダッシュボード', indexBody())))
   .get('/positions', async (c) => {
     if (!c.env.DB || !c.env.SYMBOL_STATE) {
-      return c.html(layout('保有状況', unavailable('DB or SYMBOL_STATE not bound'), c.env))
+      return c.html(renderLayout(c, '保有状況', unavailable('DB or SYMBOL_STATE not bound')))
     }
     const universe = await loadSymbolUniverse(c.env)
     const client = new SymbolStateClient(c.env.SYMBOL_STATE)
@@ -55,11 +93,11 @@ export const dashboard = new Hono<AppBindings>()
       ),
       loadLatestStrategyPrices(c.env.DB, allDisplaySymbols),
     ])
-    return c.html(layout('保有状況', positionsBody(rows, strategyPriceMap, universe), c.env))
+    return c.html(renderLayout(c, '保有状況', positionsBody(rows, strategyPriceMap, universe)))
   })
   .get('/portfolio', async (c) => {
     if (!c.env.PORTFOLIO_STATE) {
-      return c.html(layout('ポートフォリオ', unavailable('PORTFOLIO_STATE not bound'), c.env))
+      return c.html(renderLayout(c, 'ポートフォリオ', unavailable('PORTFOLIO_STATE not bound')))
     }
     try {
       const portfolio = await new PortfolioStateClient(c.env.PORTFOLIO_STATE).getPortfolio()
@@ -68,14 +106,14 @@ export const dashboard = new Hono<AppBindings>()
       const vixRegime = c.env.DB
         ? await loadVixRegimeSnapshot(c.env.DB, c.get('requestId'))
         : null
-      return c.html(layout('ポートフォリオ', portfolioBody(portfolio, vixRegime), c.env))
+      return c.html(renderLayout(c, 'ポートフォリオ', portfolioBody(portfolio, vixRegime)))
     } catch (err) {
-      return c.html(layout('ポートフォリオ', unavailable(messageOf(err)), c.env))
+      return c.html(renderLayout(c, 'ポートフォリオ', unavailable(messageOf(err))))
     }
   })
   .get('/trades', async (c) => {
     if (!c.env.DB) {
-      return c.html(layout('約定履歴', unavailable('DB not bound'), c.env))
+      return c.html(renderLayout(c, '約定履歴', unavailable('DB not bound')))
     }
     const limit = clampLimit(c.req.query('limit'))
     const db = createDb(c.env.DB)
@@ -85,21 +123,21 @@ export const dashboard = new Hono<AppBindings>()
       db.select().from(tradeJournal).orderBy(desc(tradeJournal.id)).limit(limit),
       loadSymbolUniverse(c.env).catch(() => null),
     ])
-    return c.html(layout('約定履歴', tradesBody(rows, limit, universe), c.env))
+    return c.html(renderLayout(c, '約定履歴', tradesBody(rows, limit, universe)))
   })
   .get('/config', async (c) => {
     if (!c.env.DB) {
-      return c.html(layout('設定', unavailable('DB not bound'), c.env))
+      return c.html(renderLayout(c, '設定', unavailable('DB not bound')))
     }
     const [global, universe] = await Promise.all([
       loadGlobalConfigFrom(c.env, c.get('requestId')),
       loadSymbolUniverse(c.env),
     ])
-    return c.html(layout('設定', configBody(global, universe), c.env))
+    return c.html(renderLayout(c, '設定', configBody(global, universe)))
   })
   .get('/charts', async (c) => {
     if (!c.env.DB) {
-      return c.html(layout('チャート', unavailable('DB not bound'), c.env))
+      return c.html(renderLayout(c, 'チャート', unavailable('DB not bound')))
     }
     try {
       const tab = parseChartsTab(c.req.query('tab'))
@@ -109,7 +147,7 @@ export const dashboard = new Hono<AppBindings>()
       // - symbol:   universe + symbolChart
       if (tab === 'overview') {
         const equity = await loadEquityCurve(c.env.DB)
-        return c.html(layout('チャート', chartsBody({ tab, equity }), c.env))
+        return c.html(renderLayout(c, 'チャート', chartsBody({ tab, equity })))
       }
       if (tab === 'quality') {
         const [decisions, pnls] = await Promise.all([
@@ -117,7 +155,8 @@ export const dashboard = new Hono<AppBindings>()
           loadTradePnls(c.env.DB),
         ])
         return c.html(
-          layout(
+          renderLayout(
+            c,
             'チャート',
             chartsBody({
               tab,
@@ -126,7 +165,6 @@ export const dashboard = new Hono<AppBindings>()
               stats: computeTradeStats(pnls),
               histogram: computePnlHistogram(pnls),
             }),
-            c.env,
           ),
         )
       }
@@ -160,7 +198,8 @@ export const dashboard = new Hono<AppBindings>()
         const referenceChart = charts.find((c) => c.chart !== null)?.chart ?? null
         const zoom = computeZoomRange(zoomFrom, zoomTo, referenceChart)
         return c.html(
-          layout(
+          renderLayout(
+            c,
             'チャート',
             chartsBody({
               tab,
@@ -168,7 +207,6 @@ export const dashboard = new Hono<AppBindings>()
               zoom,
               universe,
             }),
-            c.env,
           ),
         )
       }
@@ -222,7 +260,8 @@ export const dashboard = new Hono<AppBindings>()
       // - lastTimestamp 基準なので休場や POC 開始直後でも broken にならない
       const zoom = computeZoomRange(zoomFrom, zoomTo, symbolChart)
       return c.html(
-        layout(
+        renderLayout(
+          c,
           'チャート',
           chartsBody({
             tab,
@@ -233,11 +272,10 @@ export const dashboard = new Hono<AppBindings>()
             zoom,
             universe,
           }),
-          c.env,
         ),
       )
     } catch (err) {
-      return c.html(layout('チャート', unavailable(messageOf(err)), c.env))
+      return c.html(renderLayout(c, 'チャート', unavailable(messageOf(err))))
     }
   })
   .get('/cron/json', async (c) => {
@@ -316,7 +354,7 @@ export const dashboard = new Hono<AppBindings>()
   })
   .get('/cron', async (c) => {
     if (!c.env.DB) {
-      return c.html(layout('Cron 判定', unavailable('DB not bound'), c.env))
+      return c.html(renderLayout(c, 'Cron 判定', unavailable('DB not bound')))
     }
     const limit = clampLimit(c.req.query('limit'))
     const symbolFilter = c.req.query('symbol')?.toUpperCase().trim() || undefined
@@ -361,11 +399,11 @@ export const dashboard = new Hono<AppBindings>()
               .limit(limit),
         loadSymbolUniverse(c.env).catch(() => null),
       ])
-      return c.html(layout('Cron 判定', cronBody(rows, limit, symbolFilter, universe), c.env))
+      return c.html(renderLayout(c, 'Cron 判定', cronBody(rows, limit, symbolFilter, universe)))
     } catch (err) {
       // migration 未適用 / 一時的な D1 エラーで 500 にせず unavailable に落とす
       // (CodeRabbit #132)。段階的デプロイ時の自己保護。
-      return c.html(layout('Cron 判定', unavailable(messageOf(err)), c.env))
+      return c.html(renderLayout(c, 'Cron 判定', unavailable(messageOf(err))))
     }
   })
   /**
@@ -385,12 +423,12 @@ export const dashboard = new Hono<AppBindings>()
       ? await loadSymbolUniverse(c.env).catch(() => null)
       : null
     return c.html(
-      layout('Broker 診断', brokerProbeBody({ symbol, category, universe }), c.env),
+      renderLayout(c, 'Broker 診断', brokerProbeBody({ symbol, category, universe })),
     )
   })
   .get('/alerts', async (c) => {
     if (!c.env.DB) {
-      return c.html(layout('アラート', unavailable('DB not bound'), c.env))
+      return c.html(renderLayout(c, 'アラート', unavailable('DB not bound')))
     }
     const limit = clampAlertLimit(c.req.query('limit'))
     const severityFilter = parseSeverityFilter(c.req.query('severity'))
@@ -409,21 +447,21 @@ export const dashboard = new Hono<AppBindings>()
         loadSymbolUniverse(c.env).catch(() => null),
       ])
       return c.html(
-        layout(
+        renderLayout(
+          c,
           'アラート',
           alertsBody({ rows, limit, severityFilter, eventTypeFilter, currentQuery, universe }),
-          c.env,
         ),
       )
     } catch (err) {
       // 0012 migration 未適用 (= notification_emit_log テーブル無し) を
       // 500 にせず unavailable に落とす。段階的デプロイ時の自己保護。
-      return c.html(layout('アラート', unavailable(messageOf(err)), c.env))
+      return c.html(renderLayout(c, 'アラート', unavailable(messageOf(err))))
     }
   })
   .get('/audit', async (c) => {
     if (!c.env.DB) {
-      return c.html(layout('監査ログ', unavailable('DB not bound')))
+      return c.html(renderLayout(c, '監査ログ', unavailable('DB not bound')))
     }
     const limit = clampAuditLimit(c.req.query('limit'))
     const actorFilter = trimQuery(c.req.query('actor'))
@@ -438,7 +476,8 @@ export const dashboard = new Hono<AppBindings>()
     try {
       const rows = await loadRecentAudit(c.env.DB, options)
       return c.html(
-        layout(
+        renderLayout(
+          c,
           '監査ログ',
           auditBody({
             rows,
@@ -453,7 +492,7 @@ export const dashboard = new Hono<AppBindings>()
     } catch (err) {
       // 0016 migration 未適用 (= config_audit_log テーブル無し) を 500 にせず
       // unavailable に落とす。段階的デプロイ時の自己保護 (alerts と同パターン)。
-      return c.html(layout('監査ログ', unavailable(messageOf(err))))
+      return c.html(renderLayout(c, '監査ログ', unavailable(messageOf(err))))
     }
   })
 
@@ -614,6 +653,45 @@ function envBadgeTitlePrefix(mode: EnvBadgeMode): string {
 function renderEnvBadge(mode: EnvBadgeMode): string {
   const cls = mode === 'LIVE' ? 'live' : mode === 'DRY-RUN' ? 'dry' : 'unknown'
   return `<span class="env-badge ${cls}" title="DRY_RUN=${esc(mode)}">${esc(mode)}</span>`
+}
+
+function renderLayout(
+  c: {
+    env: unknown
+    var: { killSwitchState: KillSwitchBannerState | null }
+  },
+  title: string,
+  body: string,
+): string {
+  const banner = killSwitchBanner(c.var.killSwitchState)
+  return layout(title, banner + body, c.env)
+}
+
+function killSwitchBanner(state: KillSwitchBannerState | null): string {
+  if (state === null) {
+    return '<div class="kill-switch kill-switch-unknown">取引状態: <span class="muted">取得不能 (D1 未接続)</span></div>'
+  }
+  const statusLabel = state.effective
+    ? '<span class="ok">取引 ON (有効)</span>'
+    : '<span class="err">取引 OFF (停止中)</span>'
+  const envNote = state.envOverrideActive
+    ? `<span class="warn" style="margin-left:8px">⚠ env TRADING_ENABLED で deploy-gate ON: DB を ${state.dbEnabled ? 'ON' : 'OFF'} にしても effective は OFF</span>`
+    : ''
+  const disabled = state.envOverrideActive ? 'disabled' : ''
+  const buttonForm = state.effective
+    ? `<form method="post" action="/admin/trading/toggle" class="kill-switch-form" style="display:inline-flex;gap:6px;align-items:center;margin-left:12px">
+        <input type="hidden" name="enabled" value="false"/>
+        <input type="text" name="reason" placeholder="停止理由 (必須)" required maxlength="256" style="padding:3px 6px;font-size:12px;width:200px"/>
+        <button type="submit" ${disabled} style="padding:4px 10px;font-size:12px;background:#c22;color:#fff;border:none;border-radius:4px;cursor:pointer">取引停止</button>
+       </form>`
+    : `<form method="post" action="/admin/trading/toggle" class="kill-switch-form" onsubmit="return confirm('取引を再開します。本当によろしいですか？');" style="display:inline-flex;gap:6px;align-items:center;margin-left:12px">
+        <input type="hidden" name="enabled" value="true"/>
+        <input type="text" name="reason" placeholder="再開理由 (必須)" required maxlength="256" style="padding:3px 6px;font-size:12px;width:200px"/>
+        <button type="submit" ${disabled} style="padding:4px 10px;font-size:12px;background:#057a55;color:#fff;border:none;border-radius:4px;cursor:pointer">取引再開</button>
+       </form>`
+  return `<div class="kill-switch" style="padding:8px 12px;margin-bottom:12px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;font-size:13px;display:flex;align-items:center;flex-wrap:wrap">
+    <strong>取引状態:</strong>&nbsp;${statusLabel}${envNote}${buttonForm}
+  </div>`
 }
 
 function layout(title: string, body: string, env?: unknown): string {

--- a/src/routes/trade.ts
+++ b/src/routes/trade.ts
@@ -8,6 +8,7 @@ import { TradingService, type TradingConfig } from '../trading/application/Tradi
 import { MockExecution } from '../trading/execution/MockExecution'
 import { WebullExecution } from '../trading/execution/WebullExecution'
 import { DefaultRiskPolicy } from '../trading/risk/DefaultRiskPolicy'
+import { resolveTradingEnabled } from '../trading/runtime/killSwitch'
 import { PortfolioStateClient } from '../trading/state/PortfolioStateClient'
 import type { PortfolioStateDO } from '../trading/state/PortfolioStateDO'
 import { SymbolStateClient } from '../trading/state/SymbolStateClient'
@@ -32,7 +33,7 @@ export const trade = new Hono<AppBindings>()
     ])
     const service = createTradingService(request, c.env, universe, global)
     return c.json(
-      service.decide(request, toTradingConfig(request, universe, global), {
+      service.decide(request, toTradingConfig(request, universe, global, c.env.TRADING_ENABLED), {
         requestId,
       }),
     )
@@ -46,7 +47,7 @@ export const trade = new Hono<AppBindings>()
     ])
     const service = createTradingService(request, c.env, universe, global)
     return c.json(
-      await service.executeTrade(request, toTradingConfig(request, universe, global), {
+      await service.executeTrade(request, toTradingConfig(request, universe, global, c.env.TRADING_ENABLED), {
         requestId,
       }),
     )
@@ -111,6 +112,7 @@ function toTradingConfig(
   request: TradeRequest,
   universe: SymbolUniverse,
   global: LoadedGlobalConfig,
+  envTradingEnabled: string | undefined,
 ): TradingConfig {
   // 通貨別の max_order_notional を symbol の currency で選ぶ。universe に
   // 未登録の symbol は URL の 4 桁数字ヒューリスティックにフォールバックする
@@ -121,7 +123,9 @@ function toTradingConfig(
     currency === 'JPY' ? global.maxOrderNotionalJpy : global.maxOrderNotionalUsd
   return {
     dryRun: global.dryRun,
-    tradingEnabled: global.tradingEnabled,
+    // env=false が DB=true を上書きする (#276)。`/trade/execute` から発注
+    // しようとした operator も env override を尊重して reject される。
+    tradingEnabled: resolveTradingEnabled(global.tradingEnabled, envTradingEnabled),
     allowedSymbols: universe.allowedSymbols,
     maxOrderNotional,
     symbolMaxNotional: universe.symbolMaxNotional,

--- a/src/trading/runtime/killSwitch.ts
+++ b/src/trading/runtime/killSwitch.ts
@@ -1,0 +1,25 @@
+/**
+ * Runtime kill-switch resolver (issue #276)。
+ *
+ * 「DB が真値、env は deploy-gate の override」。両方を AND で結合して
+ * **より制限的な側が勝つ** (env=false なら DB=true でも OFF)。
+ *
+ * - DB (`global_config.trading_enabled`) は dashboard / admin から runtime
+ *   切替できる現在値。deploy 不要。
+ * - env (`TRADING_ENABLED`) は wrangler.jsonc / .dev.vars で固定する deploy-gate。
+ *   preview / staging で「DB を間違って ON にしてもこの環境では絶対に発注しない」
+ *   保険として効く。
+ *
+ * 受理値:
+ *   - env unset / 'true'           → DB を尊重
+ *   - env が 'false'               → 強制 OFF (override)
+ *   - env がそれ以外 (typo / 空白) → 安全側で強制 OFF
+ */
+export function resolveTradingEnabled(
+  dbFlag: boolean,
+  envOverrideRaw: string | undefined,
+): boolean {
+  if (envOverrideRaw === undefined) return dbFlag
+  if (envOverrideRaw === 'true') return dbFlag
+  return false
+}

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -34,6 +34,7 @@ import {
   type VixRegimeFilterDecision,
 } from '../risk/vixRegimeFilter'
 import { detectAndNotifyVixRegimeChange } from '../../infrastructure/notification/vixRegimeChange'
+import { resolveTradingEnabled } from '../runtime/killSwitch'
 import { runPullbackScheduler, type PullbackDecisionTrace, type PullbackRunSummary } from './pullbackScheduler'
 
 const DEFAULT_EQUITY_USD = 10_000
@@ -165,6 +166,10 @@ export async function runStrategyCron(
     loadSymbolUniverse(env),
   ])
 
+  // env=false は deploy-gate override (#276)。DB が true でも env=false なら
+  // 強制 OFF。より制限的な側が勝つ。
+  const effectiveTradingEnabled = resolveTradingEnabled(global.tradingEnabled, env.TRADING_ENABLED)
+
   // Notifier は cron tick の最序盤で組み立てる: 後続の skipReason 通知や
   // state change 検知が同じ instance を使う (#141)。requestId を伝搬させる
   // ことで `notification_emit_log.request_id` に紐付く。
@@ -176,7 +181,9 @@ export async function runStrategyCron(
   // 内部で握りつぶされる (caller は気にしなくて良い)。
   const watchedNow: WatchedConfig = {
     dryRun: global.dryRun,
-    tradingEnabled: global.tradingEnabled,
+    // env override 適用後の effective 値で遷移を観測する (env=false override が
+    // 効いた瞬間も STATE_CHANGE 通知できる、#276)。
+    tradingEnabled: effectiveTradingEnabled,
     marketHoursCheck: global.marketHoursCheck,
     drawdownKillThreshold: global.drawdownKillThreshold,
   }
@@ -235,7 +242,7 @@ export async function runStrategyCron(
     requestId: options.requestId,
     config: {
       dryRun: global.dryRun,
-      tradingEnabled: global.tradingEnabled,
+      tradingEnabled: effectiveTradingEnabled,
       pullbackRule: defaultRule,
       risk: {
         basePerTradePct: global.riskBasePerTradePct,
@@ -258,7 +265,8 @@ export async function runStrategyCron(
   // Critical な cron skip は #141 で push 通知化する。`trading_disabled` /
   // `no_tradable_symbols` は「設定通り」なので noisy にしないよう **通知しない**
   // (operator は意図的に切ってる場合が多い)。
-  if (!global.tradingEnabled) {
+  // DB と env override の AND 結果で判定 (#276: より制限的な側が勝つ)。
+  if (!effectiveTradingEnabled) {
     return { summary: emptySummary(), symbols: [], analysis: analysisBase(), skipReason: 'trading_disabled' }
   }
 

--- a/test/routes/adminTradingToggle.test.ts
+++ b/test/routes/adminTradingToggle.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp } from '../../src/app'
+import { applyTradingToggle } from '../../src/infrastructure/db/tradingToggleRepo'
+
+vi.mock('../../src/infrastructure/db/tradingToggleRepo', async () => {
+  const actual = await vi.importActual<typeof import('../../src/infrastructure/db/tradingToggleRepo')>(
+    '../../src/infrastructure/db/tradingToggleRepo',
+  )
+  return {
+    ...actual,
+    applyTradingToggle: vi.fn(),
+  }
+})
+
+const baseEnv = {
+  BASIC_AUTH_USER: 'admin',
+  BASIC_AUTH_PASSWORD: 'secret',
+}
+
+const authHeader = { Authorization: `Basic ${btoa('admin:secret')}` }
+
+describe('POST /admin/trading/toggle', () => {
+  beforeEach(() => {
+    vi.mocked(applyTradingToggle).mockResolvedValue({
+      before: false,
+      after: true,
+      historyId: 1,
+    })
+  })
+
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('401s without Basic Auth', async () => {
+    const app = createApp()
+    const res = await app.request(
+      '/admin/trading/toggle',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled: true, reason: 'manual unlock' }),
+      },
+      { ...baseEnv, DB: {} as unknown as D1Database },
+    )
+    expect(res.status).toBe(401)
+    expect(applyTradingToggle).not.toHaveBeenCalled()
+  })
+
+  it('400s when body is missing reason', async () => {
+    const app = createApp()
+    const res = await app.request(
+      '/admin/trading/toggle',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeader },
+        body: JSON.stringify({ enabled: true }),
+      },
+      { ...baseEnv, DB: {} as unknown as D1Database },
+    )
+    expect(res.status).toBe(400)
+    expect(applyTradingToggle).not.toHaveBeenCalled()
+  })
+
+  it('400s when enabled is missing or non-boolean', async () => {
+    const app = createApp()
+    const res = await app.request(
+      '/admin/trading/toggle',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeader },
+        body: JSON.stringify({ enabled: 'maybe', reason: 'r' }),
+      },
+      { ...baseEnv, DB: {} as unknown as D1Database },
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('400s when DB binding is missing', async () => {
+    const app = createApp()
+    const res = await app.request(
+      '/admin/trading/toggle',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeader },
+        body: JSON.stringify({ enabled: true, reason: 'r' }),
+      },
+      baseEnv,
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('200s and forwards JSON body to applyTradingToggle (CLI path)', async () => {
+    const app = createApp()
+    const res = await app.request(
+      '/admin/trading/toggle',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeader },
+        body: JSON.stringify({ enabled: true, reason: 'maintenance done' }),
+      },
+      { ...baseEnv, DB: {} as unknown as D1Database },
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      before: boolean | null
+      after: boolean
+      effective: boolean
+      envOverrideActive: boolean
+      historyId: number | null
+    }
+    expect(body).toEqual({
+      before: false,
+      after: true,
+      effective: true,
+      envOverrideActive: false,
+      historyId: 1,
+    })
+    expect(applyTradingToggle).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(applyTradingToggle).mock.calls[0]![1]).toMatchObject({
+      enabled: true,
+      actor: 'admin',
+      reason: 'maintenance done',
+    })
+  })
+
+  // #276 invariant: env=false が DB=true を上書きする (より制限的が勝つ)。
+  // toggle 自体は成功して DB が true になっても、レスポンスの `effective` は
+  // false で operator に「env override が効いてる」を視認させる。
+  it('reports effective=false and envOverrideActive=true when env TRADING_ENABLED=false', async () => {
+    const app = createApp()
+    const res = await app.request(
+      '/admin/trading/toggle',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeader },
+        body: JSON.stringify({ enabled: true, reason: 'try unlock' }),
+      },
+      { ...baseEnv, DB: {} as unknown as D1Database, TRADING_ENABLED: 'false' },
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      after: boolean
+      effective: boolean
+      envOverrideActive: boolean
+    }
+    expect(body.after).toBe(true) // DB は ON に書いた
+    expect(body.effective).toBe(false) // が effective は env で OFF
+    expect(body.envOverrideActive).toBe(true)
+  })
+
+  // dashboard 経由は application/x-www-form-urlencoded で来る。`enabled` は
+  // 'true' / 'false' 文字列。submit 後 303 redirect で /dashboard に戻す。
+  it('accepts form-encoded body and redirects to /dashboard (303)', async () => {
+    const app = createApp()
+    const form = new URLSearchParams({ enabled: 'false', reason: 'panic stop' })
+    const res = await app.request(
+      '/admin/trading/toggle',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          ...authHeader,
+        },
+        body: form.toString(),
+      },
+      { ...baseEnv, DB: {} as unknown as D1Database },
+    )
+    expect(res.status).toBe(303)
+    expect(res.headers.get('location')).toBe('/dashboard')
+    expect(applyTradingToggle).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(applyTradingToggle).mock.calls[0]![1]).toMatchObject({
+      enabled: false,
+      reason: 'panic stop',
+    })
+  })
+})

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -148,6 +148,58 @@ describe('dashboard', () => {
     })
   })
 
+  // #276: kill-switch banner は全 page 共通の header として layout 内に
+  // prepend される。DB binding がある時のみ表示、effective=true なら「停止」、
+  // false なら「再開」(confirm 付き) ボタンが出る。
+  it('renders kill-switch banner with 取引停止 button when tradingEnabled=true', async () => {
+    vi.mocked(loadGlobalConfigFrom).mockResolvedValue(
+      makeGlobalConfigSnapshot({ tradingEnabled: true }),
+    )
+    const env = { ...baseEnv, DB: {} as D1Database }
+    const app = createApp()
+    const res = await app.request('/dashboard', { headers: authHeader }, env)
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    expect(body).toContain('取引 ON (有効)')
+    expect(body).toContain('取引停止')
+    expect(body).toContain('action="/admin/trading/toggle"')
+    expect(body).toContain('name="enabled" value="false"')
+  })
+
+  it('renders kill-switch banner with 取引再開 + confirm() when tradingEnabled=false', async () => {
+    vi.mocked(loadGlobalConfigFrom).mockResolvedValue(
+      makeGlobalConfigSnapshot({ tradingEnabled: false }),
+    )
+    const env = { ...baseEnv, DB: {} as D1Database }
+    const app = createApp()
+    const res = await app.request('/dashboard', { headers: authHeader }, env)
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    expect(body).toContain('取引 OFF (停止中)')
+    expect(body).toContain('取引再開')
+    // 再開 は誤操作防止に HTML confirm()
+    expect(body).toContain('onsubmit="return confirm(')
+    expect(body).toContain('name="enabled" value="true"')
+  })
+
+  it('shows env override warning + disables buttons when env TRADING_ENABLED=false overrides DB=true', async () => {
+    vi.mocked(loadGlobalConfigFrom).mockResolvedValue(
+      makeGlobalConfigSnapshot({ tradingEnabled: true }),
+    )
+    const env = { ...baseEnv, DB: {} as D1Database, TRADING_ENABLED: 'false' }
+    const app = createApp()
+    const res = await app.request('/dashboard', { headers: authHeader }, env)
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    // env override 適用後の effective は OFF
+    expect(body).toContain('取引 OFF (停止中)')
+    // env override note が出る
+    expect(body).toContain('env TRADING_ENABLED で deploy-gate ON')
+    // button は disabled
+    expect(body).toMatch(/<button[^>]*disabled[^>]*>取引再開<\/button>/)
+  })
+
+
   it('renders positions page with DO state', async () => {
     const env = {
       ...baseEnv,

--- a/test/routes/trade.test.ts
+++ b/test/routes/trade.test.ts
@@ -261,6 +261,76 @@ describe('trade routes', () => {
     expect(body.riskDecision.reasons.some((r) => r.toLowerCase().includes('trading'))).toBe(true)
   })
 
+  // #276: env TRADING_ENABLED=false が DB=true を上書きする (より制限的が勝つ)。
+  // `/trade/decide` を通して RiskPolicy が tradingEnabled=false 扱いで reject
+  // することを確認する (= deploy-gate override が実際に発注 path で効く保証)。
+  it('env TRADING_ENABLED=false overrides DB tradingEnabled=true (#276 kill-switch)', async () => {
+    vi.mocked(loadGlobalConfigFrom).mockResolvedValue(
+      makeGlobalConfigSnapshot({ tradingEnabled: true }),
+    )
+    const app = createApp()
+
+    const response = await app.request(
+      '/trade/decide',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeader },
+        body: JSON.stringify({
+          symbol: 'SOXL',
+          price: 9,
+          quantity: 2,
+          buyBelow: 10,
+          sellAbove: 20,
+        }),
+      },
+      { ...env, TRADING_ENABLED: 'false' },
+    )
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as {
+      riskDecision: { allowed: boolean; reasons: string[] }
+    }
+    expect(body.riskDecision.allowed).toBe(false)
+    expect(body.riskDecision.reasons.some((r) => r.toLowerCase().includes('trading'))).toBe(true)
+  })
+
+  // #276 DoD invariant: DRY_RUN=true 時は kill-switch ON (tradingEnabled=true) でも
+  // **絶対に実発注しない**。execution mode が DRY_RUN になり Webull endpoint への
+  // fetch も 0 回であることを確認する。kill-switch ON / DRY_RUN ON の両立シナリオ。
+  it('DRY_RUN=true must NOT place real orders even when kill-switch is ON (#276 DoD)', async () => {
+    vi.mocked(loadGlobalConfigFrom).mockResolvedValue(
+      makeGlobalConfigSnapshot({ dryRun: true, tradingEnabled: true }),
+    )
+    const fetchMock = vi.fn<typeof fetch>()
+    vi.stubGlobal('fetch', fetchMock)
+    const app = createApp()
+
+    const response = await app.request(
+      '/trade/execute',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeader },
+        body: JSON.stringify({
+          symbol: 'SOXL',
+          price: 9,
+          quantity: 2,
+          buyBelow: 10,
+          sellAbove: 20,
+        }),
+      },
+      env,
+    )
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as {
+      executionResult?: { mode: string; submitted: boolean }
+    }
+    // kill-switch ON だが DRY_RUN は独立して効く: mode='DRY_RUN' で broker 発注なし。
+    expect(body.executionResult?.mode).toBe('DRY_RUN')
+    // Webull endpoint への HTTP は一切走らない。
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it('returns 400 for an empty symbol', async () => {
     const app = createApp()
 

--- a/test/trading/runtime/killSwitch.test.ts
+++ b/test/trading/runtime/killSwitch.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { resolveTradingEnabled } from '../../../src/trading/runtime/killSwitch'
+
+describe('resolveTradingEnabled', () => {
+  // env unset → DB を尊重 (両方の DB 値で確認)
+  it('returns DB value when env is undefined', () => {
+    expect(resolveTradingEnabled(true, undefined)).toBe(true)
+    expect(resolveTradingEnabled(false, undefined)).toBe(false)
+  })
+
+  it("respects DB when env is the string 'true'", () => {
+    expect(resolveTradingEnabled(true, 'true')).toBe(true)
+    expect(resolveTradingEnabled(false, 'true')).toBe(false)
+  })
+
+  // #276 core invariant: env=false が DB=true を上書きする
+  it("forces OFF when env is 'false' even if DB is true", () => {
+    expect(resolveTradingEnabled(true, 'false')).toBe(false)
+    expect(resolveTradingEnabled(false, 'false')).toBe(false)
+  })
+
+  // typo / empty / 任意文字列は安全側で OFF
+  it('fails closed (OFF) when env is a typo or empty string', () => {
+    expect(resolveTradingEnabled(true, '')).toBe(false)
+    expect(resolveTradingEnabled(true, 'TRUE')).toBe(false) // case-sensitive
+    expect(resolveTradingEnabled(true, 'yes')).toBe(false)
+    expect(resolveTradingEnabled(true, '1')).toBe(false)
+  })
+})

--- a/test/trading/strategy/runStrategyCron.test.ts
+++ b/test/trading/strategy/runStrategyCron.test.ts
@@ -47,6 +47,23 @@ describe('runStrategyCron', () => {
     expect(result.analysis.config.tradingEnabled).toBe(false)
   })
 
+  // #276: env=false が DB=true を上書きする。「より制限的な側が勝つ」 invariant の
+  // cron 経路での確認。DB が true でも env override が効いていれば cron は
+  // trading_disabled で即 skip し、PORTFOLIO_STATE などへ進まない (fail-closed)。
+  it('env TRADING_ENABLED=false overrides DB tradingEnabled=true (#276 kill-switch)', async () => {
+    vi.mocked(loadGlobalConfigFrom).mockResolvedValue(
+      makeGlobalConfigSnapshot({ tradingEnabled: true }),
+    )
+    const envWithEnvOverride = {
+      ...env,
+      TRADING_ENABLED: 'false',
+    } as unknown as Parameters<typeof runStrategyCron>[0]
+    const result = await runStrategyCron(envWithEnvOverride)
+    expect(result.skipReason).toBe('trading_disabled')
+    // analysis.config.tradingEnabled は effective 値 (env override 適用後) を反映する。
+    expect(result.analysis.config.tradingEnabled).toBe(false)
+  })
+
   it('skips with no_tradable_symbols when universe is empty', async () => {
     vi.mocked(loadSymbolUniverse).mockResolvedValue(
       makeSymbolUniverse({


### PR DESCRIPTION
Closes #276
Refs #273

## Summary

本番口座接続前に必須となる「異常検知 → 即停止」を deploy 待ちにしないための runtime kill-switch。`global_config.trading_enabled` を DB の真値とし、env var `TRADING_ENABLED` は non-prod の追加 OFF override としてのみ機能 (より制約の強い方が勝つ)。

## 変更点

### DB
- `drizzle/0017_trading_toggle_history.sql` (新規): kill-switch 切替履歴 (id / timestamp / actor / before / after / reason / request_id)。
- `global_config.trading_enabled` は既存列を再利用 (default `false` = fail-closed)。

### Runtime
- `src/trading/runtime/killSwitch.ts` (新規): `resolveTradingEnabled(dbValue, envOverride)` — env override `'false'` は DB を上書きして OFF、それ以外は DB 尊重。
- `src/trading/strategy/runStrategyCron.ts`: gate / analysis / watched config の各点で `resolveTradingEnabled` を適用。
- `src/routes/trade.ts`: `toTradingConfig` に env override を thread。

### Admin / UI
- `POST /admin/trading/toggle` (form-encoded): `{ enabled, reason }`、`applyTradingToggle` で UPDATE + INSERT-history。
- `src/routes/dashboard.ts`: `renderLayout(c, title, body)` ヘルパー導入 + kill-switch banner (全画面 header)。`use('*')` middleware で 1 リクエスト 1 回だけ state を load。
  - 有効時は緑、停止時は赤、env override 中は warning + ボタン disabled。
  - OFF ボタンは即実行 (confirm 無し — fast kill)、ON は `onsubmit confirm()`。

### Env
- `src/config/env.ts`: `TRADING_ENABLED?: string` を append。
- `.dev.vars.example`: override section を append。

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` **1019/1019 pass** (+17 over post-#274/#275 baseline)
- [x] DRY_RUN=true 時に kill-switch ON でも実発注しないことを test で保証
- [x] env override (`TRADING_ENABLED=false`) が DB true を上書きすることを test で確認

## Rebase 注記

- migration を `0016_*` → `0017_*` に renumber (#274 の `0016_wakeful_xavin` が先行 merge されたため)。
- `drizzle/meta/0017_snapshot.json` の `prevId` を 0016 の id に更新、`config_audit_log` table block を含める。
- `dashboard.ts` の `renderLayout` を #275 の env badge layout シグネチャと統合。

## Refs

- umbrella #273 (本番口座接続準備)
- toggle history (本 PR 内) は最小の audit。汎用 config audit log は #274 で実装済み。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 取引の有効/無効を一元管理するキルスイッチ機能を追加しました。管理者は `/trading/toggle` エンドポイントまたはダッシュボード上から取引を即座に停止・再開できます。
  * 環境変数による安全装置を導入し、DB設定が有効でも環境側で強制的に取引を停止できるようになりました。
  * ダッシュボードに取引状態バナーを常時表示し、ユーザーが現在の取引ステータスを一目で確認できるようにしました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/280)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->