### PR TITLE
feat(ops): wrangler env separation — env.dev / per-env triggers / docs (#277)

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -65,3 +65,14 @@ DASHBOARD_BASE_URL=
 # 「DB を間違って ON にしてもこの環境では絶対に発注しない」保険。
 # 受理値: unset / 'true' → DB 尊重、'false' → 強制 OFF、それ以外 → 強制 OFF。
 # TRADING_ENABLED=false
+
+# #277: per-env secrets. `.dev.vars` is local only. For deployed envs use
+# `wrangler secret put <KEY> --env=<dev|staging|production>`. Examples:
+#   wrangler secret put BASIC_AUTH_USER --env=dev
+#   wrangler secret put BASIC_AUTH_PASSWORD --env=dev
+#   wrangler secret put EVENT_INGEST_SECRET --env=dev
+#   wrangler secret put WEBULL_APP_KEY --env=dev
+#   wrangler secret put WEBULL_APP_SECRET --env=dev
+#   wrangler secret put WEBULL_ACCOUNT_ID --env=dev
+# Repeat for --env=staging (sandbox key) and --env=production (live key).
+# Production credentials MUST be distinct from staging/dev to avoid 誤爆.

--- a/docs/env-separation.md
+++ b/docs/env-separation.md
@@ -1,0 +1,108 @@
+# Env 分離運用 (#277)
+
+dev / staging / production を worker / D1 / DO namespace / secrets で物理的に分離する。本番口座接続前の prod 誤爆 (`webull-trading` 単一 worker に dev も staging も live key も同居) を防ぐ。
+
+## 4 つの実行プロファイル
+
+| Profile | 起動 | Worker name | D1 | cron | 用途 |
+|---|---|---|---|---|---|
+| local | `pnpm dev` (= `wrangler dev`) | top-level (`webull-trading`) | miniflare local SQLite | なし | 開発機での反復実行 |
+| dev | `pnpm deploy:dev` | `webull-trading-dev` | `webull-trading-dev` (要発行) | なし (manual) | remote dev / preview |
+| staging | `pnpm deploy:staging` | `webull-trading-staging` | `webull-trading-staging` | なし (manual) | sandbox key で integration 検証 |
+| production | `pnpm deploy:production` | `webull-trading-production` | `webull-trading-production` (要発行) | あり (5/15min/22:00 UTC) | 実マネー |
+
+`wrangler dev` (ローカル) はあえて env を切り替えずに top-level config を使う。cron / D1 ID 設定エラーの影響を受けず手元で立ち上がる事を優先するため。
+
+## env 切替
+
+```bash
+# remote dev へ deploy
+pnpm deploy:dev
+
+# staging
+pnpm deploy:staging
+
+# production
+pnpm deploy:production
+```
+
+scripts は `wrangler d1 migrations apply --env=<env> --remote` → `wrangler deploy --env=<env>` の 2 段。migration 失敗時は deploy 走らない。
+
+## ユーザー側の初期作業 (実マネー前)
+
+`wrangler.jsonc` 内の `REPLACE_WITH_DEV_ID` / `REPLACE_WITH_PRODUCTION_ID` は placeholder。実発行は手作業。
+
+### 1. D1 を env ごとに発行
+
+```bash
+pnpm wrangler d1 create webull-trading-dev
+# => 出力された database_id を wrangler.jsonc env.dev.d1_databases[0].database_id に貼る
+
+pnpm wrangler d1 create webull-trading-production
+# => 出力された database_id を wrangler.jsonc env.production.d1_databases[0].database_id に貼る
+```
+
+staging の D1 (`cbc199f0-…`) は既に発行済み。
+
+### 2. Migration を流す
+
+```bash
+pnpm wrangler d1 migrations apply webull-trading-dev --env=dev --remote
+pnpm wrangler d1 migrations apply webull-trading-production --env=production --remote
+```
+
+### 3. Secret を env ごとに投入
+
+`wrangler secret put <KEY> --env=<dev|staging|production>` で投入する。`.dev.vars.example` 末尾に key 一覧と例コマンドがある。
+
+最小必須:
+
+- `BASIC_AUTH_USER` / `BASIC_AUTH_PASSWORD`
+- `EVENT_INGEST_SECRET`
+- `WEBULL_APP_KEY` / `WEBULL_APP_SECRET` / `WEBULL_ACCOUNT_ID`
+
+**production の Webull credentials は staging/dev と別物にする**。staging は sandbox key (`api.sandbox.webull.hk`)、production は live key (`openapi.webull.com`)。`WEBULL_API_BASE` も env ごと別 secret として投入する事で混同を防ぐ。
+
+### 4. DO namespace
+
+`durable_objects.bindings` は `class_name` ベース。env ごとに worker name が違うので Cloudflare が自動的に別 namespace を割り当てる (`namespace_id` 手動指定不要)。データ移行 / 共有が必要になったら明示的に `script_name` を切る事を検討する (現状不要)。
+
+## Secret rotation
+
+```bash
+# 既存 secret を上書き
+pnpm wrangler secret put WEBULL_APP_SECRET --env=production
+
+# 削除
+pnpm wrangler secret delete WEBULL_APP_SECRET --env=production
+```
+
+rotation 後は対応する env を再 deploy せず即時反映される (Cloudflare 側で worker に re-bind される)。ただし production rotation 時は `pnpm deploy:production --dry-run` で binding 一覧が崩れていない事を確認する。
+
+## Cron triggers (重要な非自明仕様)
+
+wrangler 4 は `env.*` block が存在すると **top-level の `triggers` を継承しない**。`wrangler.jsonc` top-level の `triggers.crons` は `wrangler deploy` (`--env=""`) でしか発火しない。各 env に出したい場合はその env block 内に `triggers` を再宣言する。
+
+issue #277 の仕様 (cron は prod のみ) に従い、本リポジトリでは:
+
+- `env.production.triggers.crons` のみ宣言 (5min / 15min / 22:00 UTC)
+- `env.dev` / `env.staging` には `triggers` を置かない (= manual run)
+- top-level `triggers` は `wrangler dev` (ローカル) でのみ評価される
+
+staging で cron を試したい場合は `env.staging` に `triggers` を一時的に足してから revert する。
+
+## 確認コマンド
+
+```bash
+pnpm exec wrangler deploy --env=dev        --dry-run
+pnpm exec wrangler deploy --env=staging    --dry-run
+pnpm exec wrangler deploy --env=production --dry-run
+```
+
+dry-run 出力に出る binding 一覧 (D1 name / DO class) と cron 一覧を見て、env ごとに分離されている事を確認する。`REPLACE_WITH_*` のまま deploy しようとすると `wrangler d1 migrations apply` が先に失敗する設計。
+
+## 既知の制約 (Out of scope)
+
+- CI/CD auto deploy: #24 で扱う
+- Secret rotation 自動化 (1Password Connect / Vault 連携): out of scope
+- Per-env DRY_RUN / TRADING_ENABLED の デフォルト切替: `wrangler.jsonc` vars には現状未配置 (top-level `vars` 既定で fail-closed `DRY_RUN=true`)、必要時に `env.<env>.vars` に append する

--- a/docs/env-separation.md
+++ b/docs/env-separation.md
@@ -77,7 +77,7 @@ pnpm wrangler secret put WEBULL_APP_SECRET --env=production
 pnpm wrangler secret delete WEBULL_APP_SECRET --env=production
 ```
 
-rotation 後は対応する env を再 deploy せず即時反映される (Cloudflare 側で worker に re-bind される)。ただし production rotation 時は `pnpm deploy:production --dry-run` で binding 一覧が崩れていない事を確認する。
+rotation 後は対応する env を再 deploy せず即時反映される (Cloudflare 側で worker に re-bind される)。ただし production rotation 時は `pnpm wrangler deploy --env=production --dry-run` で binding 一覧が崩れていない事を確認する (`pnpm deploy:production` は先頭で `wrangler d1 migrations apply --remote` を実行するので dry-run 確認には使えない)。
 
 ## Cron triggers (重要な非自明仕様)
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
+    "deploy:dev": "wrangler d1 migrations apply webull-trading-dev --env=dev --remote && wrangler deploy --env=dev",
     "deploy:staging": "wrangler d1 migrations apply webull-trading-staging --env=staging --remote && wrangler deploy --env=staging",
     "deploy:production": "wrangler d1 migrations apply webull-trading-production --env=production --remote && wrangler deploy --env=production",
     "test": "vitest run",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -26,6 +26,25 @@
     ]
   },
   "env": {
+    // dev: separate worker + D1 for remote dev/preview. `wrangler dev` w/o
+    // --env still uses the top-level config (local miniflare + local SQLite).
+    "dev": {
+      "name": "webull-trading-dev",
+      "durable_objects": {
+        "bindings": [
+          { "name": "SYMBOL_STATE", "class_name": "SymbolStateDO" },
+          { "name": "PORTFOLIO_STATE", "class_name": "PortfolioStateDO" }
+        ]
+      },
+      "d1_databases": [
+        {
+          "binding": "DB",
+          "database_name": "webull-trading-dev",
+          "database_id": "REPLACE_WITH_DEV_ID",
+          "migrations_dir": "drizzle"
+        }
+      ]
+    },
     "staging": {
       "name": "webull-trading-staging",
       "durable_objects": {
@@ -42,6 +61,7 @@
           "migrations_dir": "drizzle"
         }
       ]
+      // No triggers: staging is manual run only (issue #277).
     },
     "production": {
       "name": "webull-trading-production",
@@ -58,7 +78,16 @@
           "database_id": "REPLACE_WITH_PRODUCTION_ID",
           "migrations_dir": "drizzle"
         }
-      ]
+      ],
+      // wrangler 4 does NOT inherit top-level `triggers` once env.* blocks
+      // exist, so cron must be re-declared explicitly here (issue #277).
+      "triggers": {
+        "crons": [
+          "*/5 * * * *",
+          "*/15 * * * *",
+          "0 22 * * *"
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
Closes #277
Refs #273

## Summary

本番口座接続前に dev / staging / production を物理的に分離する。worker 名 / D1 / DO / secrets を env ごとに別 binding にして prod 誤爆リスクを下げる。

## 変更点

### `wrangler.jsonc`
- `env.dev` block 新規追加 (`webull-trading-dev` worker + D1 binding placeholder `REPLACE_WITH_DEV_ID`)。
- `env.production.triggers.crons` を明示。
  - **重要**: wrangler 4 では `env.*` block を一度定義すると top-level `triggers.crons` が継承されない。`env.staging` を追加した時点で staging cron は既に黙って外れていた (dry-run で確認)。本 PR では「cron は prod のみ」の方針通り `env.production` のみに記述。

### `package.json`
- `deploy:dev` script を追加。

### `.dev.vars.example`
- per-env secret 投入例を append (`wrangler secret put <KEY> --env=<env>`)。
- prod credential は staging/dev とは別物にする旨を明記。

### `docs/env-separation.md` (新規)
- env 切替手順、secret rotation、D1 provisioning、cron 継承 gotcha、user-action vs code action を記載。

## Code-side ではない (user-action 残)

1. `wrangler d1 create webull-trading-dev` → id を `REPLACE_WITH_DEV_ID` に貼る
2. `wrangler d1 create webull-trading-production` → id を `REPLACE_WITH_PRODUCTION_ID` に貼る
3. `wrangler d1 migrations apply webull-trading-<env> --env=<env> --remote`
4. 各 env に `wrangler secret put` で credential 投入 (prod は live key)

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm exec wrangler deploy --env dev --dry-run` ok
- [x] `--env staging --dry-run` ok
- [x] `--env production --dry-run` ok (D1 id は placeholder のまま)
- [ ] (user-action) prod D1 / secrets 投入後の実 deploy

Refs: umbrella #273。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 開発・ステージング・本番環境を分離した運用手順、各環境の起動/デプロイ手順、cron/マイグレーション/シークレット運用や確認コマンドを整理して追加しました。

* **Chores**
  * 環境ごとのシークレット投入手順例と注意事項を追加しました。
  * 開発向けのリモートマイグレーション→デプロイを自動化するスクリプトを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/281)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->