### PR TITLE
feat(security): escape DB-derived strings in dashboard (#284)

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -15,7 +15,7 @@ type DashboardBindings = AppBindings & {
 import { loadGlobalConfigFrom } from '../infrastructure/db/globalConfigLoader'
 import { resolveTradingEnabled } from '../trading/runtime/killSwitch'
 import { loadSymbolUniverse, type SymbolUniverse } from '../infrastructure/db/symbolUniverse'
-import { formatSymbolDisplay } from '../shared/format'
+import { escapeHtml, formatSymbolDisplay } from '../shared/format'
 import { createDb } from '../infrastructure/db/tradeJournalRepo'
 import { MAX_TIME_STOP_DAYS, strategyDecisionLog, tradeJournal } from '../infrastructure/db/schema'
 import {
@@ -548,19 +548,14 @@ function clampLimit(raw: string | undefined): number {
 }
 
 /**
- * HTML entity escaper. Used on every string derived from D1 / DO payloads
- * (symbol names, error messages, etc.) before interpolating into HTML to
- * defend against injection via crafted config rows.
+ * HTML entity escaper. Thin alias over shared `escapeHtml` (#284) — every
+ * D1 / DO-derived string (symbol names, error messages, audit JSON, alerts
+ * cause / message, …) passes through this before interpolation. Without it
+ * an attacker who can write `notes` / `reason` / `before_json` could inject
+ * a <script> that submits the kill-switch / seed-cash form on the
+ * operator's session.
  */
-function esc(value: unknown): string {
-  if (value === null || value === undefined) return ''
-  return String(value)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;')
-}
+const esc = escapeHtml
 
 function fmtNumber(n: number | null | undefined, digits = 2): string {
   if (n === null || n === undefined || !Number.isFinite(n)) return '-'

--- a/src/shared/format.ts
+++ b/src/shared/format.ts
@@ -27,3 +27,21 @@ export function formatSymbolDisplay(input: SymbolDisplayInput): string {
   }
   return input.symbol
 }
+
+/**
+ * HTML entity escaper for DB-derived / user-controllable strings interpolated
+ * into server-rendered HTML. Defends against XSS that would otherwise pivot
+ * into kill-switch / seed-cash CSRF (#284).
+ *
+ * - null / undefined → "" (so `${escapeHtml(x ?? null)}` is safe)
+ * - escapes `& < > " '` (`'` for single-quoted attribute safety)
+ */
+export function escapeHtml(value: unknown): string {
+  if (value === null || value === undefined) return ''
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}

--- a/test/routes/dashboardXss.test.ts
+++ b/test/routes/dashboardXss.test.ts
@@ -32,10 +32,9 @@ vi.mock('../../src/infrastructure/db/configAuditLog', () => ({
 }))
 
 const baseEnv = {
-  BASIC_AUTH_USER: 'admin',
-  BASIC_AUTH_PASSWORD: 'secret',
+  ACCESS_DEV_BYPASS_USER: 'admin',
 }
-const authHeader = { Authorization: `Basic ${btoa('admin:secret')}` }
+const authHeader = {}
 
 describe('dashboard XSS (#284)', () => {
   beforeEach(() => {

--- a/test/routes/dashboardXss.test.ts
+++ b/test/routes/dashboardXss.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp } from '../../src/app'
+import { loadGlobalConfigFrom } from '../../src/infrastructure/db/globalConfigLoader'
+import { loadSymbolUniverse } from '../../src/infrastructure/db/symbolUniverse'
+import { loadRecentAlerts } from '../../src/infrastructure/notification/notificationEmitLog'
+import { loadRecentAudit } from '../../src/infrastructure/db/configAuditLog'
+import { makeGlobalConfigSnapshot, makeSymbolUniverse } from '../helpers/configFixtures'
+
+/**
+ * #284 — XSS audit for dashboard. Every DB-derived string interpolated into
+ * server-rendered HTML must pass through `escapeHtml`. Otherwise a malicious
+ * row (planted by an upstream bug, or a compromised JP/US broker payload that
+ * lands in `cause` / `message` / `notes` / `before_json`) can submit the
+ * kill-switch / seed-cash POST forms on the operator's authenticated session.
+ *
+ * Each test seeds a different XSS payload into a different field and asserts
+ * the literal payload (raw `<script>` / `<img onerror=…>` / `"><svg …>`) is
+ * NOT present in the rendered HTML — only its escaped form.
+ */
+
+vi.mock('../../src/infrastructure/db/globalConfigLoader', () => ({
+  loadGlobalConfigFrom: vi.fn(),
+}))
+vi.mock('../../src/infrastructure/db/symbolUniverse', () => ({
+  loadSymbolUniverse: vi.fn(),
+}))
+vi.mock('../../src/infrastructure/notification/notificationEmitLog', () => ({
+  loadRecentAlerts: vi.fn(),
+}))
+vi.mock('../../src/infrastructure/db/configAuditLog', () => ({
+  loadRecentAudit: vi.fn(),
+}))
+
+const baseEnv = {
+  BASIC_AUTH_USER: 'admin',
+  BASIC_AUTH_PASSWORD: 'secret',
+}
+const authHeader = { Authorization: `Basic ${btoa('admin:secret')}` }
+
+describe('dashboard XSS (#284)', () => {
+  beforeEach(() => {
+    vi.mocked(loadGlobalConfigFrom).mockResolvedValue(makeGlobalConfigSnapshot())
+    vi.mocked(loadSymbolUniverse).mockResolvedValue(
+      makeSymbolUniverse({ allowedSymbols: ['SOXL'], symbolCurrency: { SOXL: 'USD' } }),
+    )
+  })
+  afterEach(() => vi.resetAllMocks())
+
+  it('escapes <script> payload in alerts message / cause / symbol', async () => {
+    const scriptPayload = '<script>alert(1)</script>'
+    const imgPayload = '<img src=x onerror=alert(2)>'
+    const symbolPayload = '"><svg onload=alert(3)>'
+    vi.mocked(loadRecentAlerts).mockResolvedValue([
+      {
+        id: 1,
+        timestamp: '2026-04-23T00:00:00.000Z',
+        requestId: 'req-1',
+        eventType: 'ERROR',
+        severity: 'critical',
+        symbol: symbolPayload,
+        cause: imgPayload,
+        message: scriptPayload,
+      },
+    ])
+    const app = createApp()
+    const res = await app.request(
+      '/dashboard/alerts',
+      { headers: authHeader },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    // 生の <script> / <img onerror=…> / "><svg…> はどれも HTML に直で出てはいけない。
+    expect(body).not.toContain(scriptPayload)
+    expect(body).not.toContain(imgPayload)
+    expect(body).not.toContain(symbolPayload)
+    // 代わりに escape 済みの形が含まれること (= payload が table 行として
+    // 表示されているが inert になっている、を確認)。
+    expect(body).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+    expect(body).toContain('&lt;img src=x onerror=alert(2)&gt;')
+  })
+
+  it('escapes <img onerror> payload inside audit before_json / after_json', async () => {
+    const beforePayload = '<img onerror=alert(1)>'
+    const afterPayload = '</script><script>alert(2)</script>'
+    const actorPayload = '"><script>alert(3)</script>'
+    vi.mocked(loadRecentAudit).mockResolvedValue([
+      {
+        id: 1,
+        timestamp: '2026-04-23T00:00:00.000Z',
+        actor: actorPayload,
+        endpoint: '/admin/symbols/SOXL/seed-cash',
+        targetKey: 'symbol=SOXL',
+        // before/after は JSON 文字列で DB に入る (admin route 側で stringify)。
+        // formatAuditJson は parse→re-stringify するが、parse 失敗時は raw を返す。
+        // どちらの分岐でも payload 文字列は最終的に escapeHtml で中和される必要がある。
+        beforeJson: JSON.stringify({ notes: beforePayload }),
+        afterJson: JSON.stringify({ notes: afterPayload }),
+        requestId: 'req-1',
+      },
+    ])
+    const app = createApp()
+    const res = await app.request(
+      '/dashboard/audit',
+      { headers: authHeader },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    expect(body).not.toContain(beforePayload)
+    expect(body).not.toContain('<script>alert(2)</script>')
+    expect(body).not.toContain('<script>alert(3)</script>')
+    // formatAuditJson が壊れて parse failure に倒れた場合の raw fallback も
+    // escape されることを確認するため、エスケープ済みの形が body に居ること
+    // (parse 成功でも失敗でも esc は通る)。
+    expect(body).toContain('&lt;img onerror=alert(1)&gt;')
+  })
+
+  it('escapes free-text payload in symbol_config notes (config page)', async () => {
+    const notesPayload = '<svg onload=alert(1)>'
+    const bucketPayload = '"><iframe src=javascript:alert(2)>'
+    vi.mocked(loadSymbolUniverse).mockResolvedValue(
+      makeSymbolUniverse({
+        allowedSymbols: ['SOXL'],
+        symbolCurrency: { SOXL: 'USD' },
+        symbolNotes: { SOXL: notesPayload },
+        // inversePairs 値は esc() で出力される自由テキスト相当 (DB 列値)。
+        inversePairs: { SOXL: bucketPayload },
+      }),
+    )
+    const app = createApp()
+    const res = await app.request(
+      '/dashboard/config',
+      { headers: authHeader },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    expect(body).not.toContain(notesPayload)
+    expect(body).not.toContain(bucketPayload)
+    expect(body).toContain('&lt;svg onload=alert(1)&gt;')
+    expect(body).toContain('&quot;&gt;&lt;iframe src=javascript:alert(2)&gt;')
+  })
+
+  it('escapes attribute-break payload in audit filter form (echoed query)', async () => {
+    // actor / endpoint filter は query string をそのまま <input value="..."> に
+    // echo するので attribute-context XSS の最たる surface。`" ` で attribute を
+    // 早期 close されると onfocus= が混入できる。
+    vi.mocked(loadRecentAudit).mockResolvedValue([])
+    const app = createApp()
+    const attackerActor = '" autofocus onfocus="alert(1)'
+    const url = `/dashboard/audit?actor=${encodeURIComponent(attackerActor)}`
+    const res = await app.request(url, { headers: authHeader }, { ...baseEnv, DB: {} as D1Database })
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    // 生の `" autofocus onfocus="alert(1)` (= attribute break + 新 attribute) が
+    // value="..." の **内側** に出てはいけない。`&quot;` でクオートが中和される。
+    expect(body).not.toMatch(/value="" autofocus onfocus="alert\(1\)"/)
+    expect(body).toContain('&quot; autofocus onfocus=&quot;alert(1)')
+  })
+})

--- a/test/shared/format.test.ts
+++ b/test/shared/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { formatSymbolDisplay } from '../../src/shared/format'
+import { escapeHtml, formatSymbolDisplay } from '../../src/shared/format'
 
 describe('formatSymbolDisplay', () => {
   it('returns `${symbol}-${name}` for JP symbols with a non-empty name', () => {
@@ -28,5 +28,39 @@ describe('formatSymbolDisplay', () => {
     expect(formatSymbolDisplay({ symbol: '7974', name: '   ' })).toBe('7974')
     expect(formatSymbolDisplay({ symbol: 'AAPL', name: null })).toBe('AAPL')
     expect(formatSymbolDisplay({ symbol: 'AAPL' })).toBe('AAPL')
+  })
+})
+
+describe('escapeHtml (#284)', () => {
+  it('returns empty string for null / undefined', () => {
+    expect(escapeHtml(null)).toBe('')
+    expect(escapeHtml(undefined)).toBe('')
+  })
+
+  it('escapes the 5 baseline metacharacters', () => {
+    expect(escapeHtml('& < > " \'')).toBe('&amp; &lt; &gt; &quot; &#39;')
+  })
+
+  it('escapes a <script> payload so the tag is inert', () => {
+    expect(escapeHtml('<script>alert(1)</script>')).toBe(
+      '&lt;script&gt;alert(1)&lt;/script&gt;',
+    )
+  })
+
+  it('escapes an attribute-break payload (`" onerror=…`)', () => {
+    expect(escapeHtml('" onerror="alert(1)')).toBe('&quot; onerror=&quot;alert(1)')
+  })
+
+  it('coerces numbers / booleans to strings without throwing', () => {
+    expect(escapeHtml(0)).toBe('0')
+    expect(escapeHtml(false)).toBe('false')
+    expect(escapeHtml(42)).toBe('42')
+  })
+
+  it('escapes ampersand FIRST so existing entities are not double-broken into literals', () => {
+    // 入力 `&lt;` は文字列 4 文字。出力では `&` だけが先頭 escape され
+    // 残りは literal で保つ (`&amp;lt;`)。これにより `&lt;` の literal 表示
+    // と「あとから `<` が湧いて出る」誤解釈を区別できる。
+    expect(escapeHtml('&lt;')).toBe('&amp;lt;')
   })
 })


### PR DESCRIPTION
Closes #284
Refs #283

## Summary

dashboard が DB / DO 由来文字列を HTML 直埋めしている箇所の escape audit。**監査結果: 既に完全に escape 済み** (local \`esc()\` helper が全 ~80 call-site に適用済) だったため、本 PR は共通化と regression test fence の追加にとどまる。これで #29 (Access) で auth が強化されても、XSS → CSRF → kill-switch ON の連鎖を防ぐ test fence が repo に常駐。

## 変更点

- \`src/shared/format.ts\` (新規 export): \`escapeHtml(value: unknown): string\`
  - 5 metachars (\`& < > \" '\`) を escape、null/undef → \`''\`、ampersand-first ordering
- \`src/routes/dashboard.ts\`:
  - 既存 inline \`esc()\` body を \`const esc = escapeHtml\` の 1 行 alias に置換
  - 既存 ~80 call-site の挙動は変更無し
- \`test/shared/format.test.ts\` (新規 6 件): null/undef、5 metachars、属性 break、type coercion、ordering
- \`test/routes/dashboardXss.test.ts\` (新規 4 件):
  1. Alerts page (\`message\` / \`cause\` / \`symbol\` の 3 field × XSS payload)
  2. Audit page (\`before_json\` / \`after_json\` / \`actor\` の 3 field × payload)
  3. Config page (\`symbolNotes.SOXL\` / \`inversePairs.SOXL\`)
  4. Audit filter form の属性 context (\`?actor=\` query)

計 **10 種類の XSS payload × 9 種類の DB / query field** で regression test。

## 意図的に escape していない箇所 (justify)

- 数値 (TS で型保証)
- 固定 enum (\`'LIVE'\` / \`'OFF'\` / \`'US_STOCK'\` 等)
- 既に内部で esc() 済みの pre-rendered HTML fragment
- \`encodeURIComponent\` 通した URL
- \`safeJsonScript\` (\`\\u003c\` 置換で \`</script>\` 対策別途済)

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` 75 files / 1029 tests pass (+10)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * ダッシュボードのHTML埋め込み時のエスケープ処理を共通化し、複数ページで一貫したXSS対策を適用

* **Tests**
  * ダッシュボードの複数画面（アラート／監査ログ／設定）向けXSS防止の統合テストを追加
  * HTMLエスケープの単体テストを追加・強化

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/287)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->