### PR TITLE
feat(security): rate-limit state-changing POST endpoints (#285)

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -389,3 +389,13 @@ export interface Env {
   CF_ACCESS_AUD?: string
   ACCESS_DEV_BYPASS_USER?: string
 }
+
+
+// #285: Cloudflare Workers `RateLimit` binding (state 変更 / 運用書込 / dashboard
+// soft cap)。`wrangler.jsonc` の `[[unsafe.bindings]]` で各 env に同名で宣言する。
+// local miniflare で binding が認識されないケースは middleware 側で warn → fail-open。
+export interface Env {
+  STATE_CHANGE_RATE_LIMIT?: RateLimit
+  ADMIN_WRITE_RATE_LIMIT?: RateLimit
+  DASHBOARD_RATE_LIMIT?: RateLimit
+}

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -1,0 +1,77 @@
+import type { MiddlewareHandler } from 'hono'
+import type { AppBindings } from '../app'
+import type { Env } from '../config/env'
+
+/**
+ * Rate-limit category。Cloudflare Workers `RateLimit` binding に対応する env
+ * 名と 1:1 対応 (env.STATE_CHANGE_RATE_LIMIT / env.ADMIN_WRITE_RATE_LIMIT /
+ * env.DASHBOARD_RATE_LIMIT)。
+ *
+ *   - STATE_CHANGE: kill-switch 等の致命的な state 変更。5 req / 60s。
+ *   - ADMIN_WRITE:  override / seed / clear-cooldown 等の運用書込。20 req / 60s。
+ *   - DASHBOARD:    read-only dashboard GET の soft cap。60 req / 60s。
+ */
+export type RateLimitCategory = 'STATE_CHANGE' | 'ADMIN_WRITE' | 'DASHBOARD'
+
+const BINDING_KEY: Record<RateLimitCategory, keyof Env> = {
+  STATE_CHANGE: 'STATE_CHANGE_RATE_LIMIT',
+  ADMIN_WRITE: 'ADMIN_WRITE_RATE_LIMIT',
+  DASHBOARD: 'DASHBOARD_RATE_LIMIT',
+}
+
+/**
+ * Returns a Hono middleware that rate-limits the request via the Cloudflare
+ * Workers `RateLimit` binding for `category`。
+ *
+ * Key 戦略: actor (Access middleware が `c.set('actor', ...)` で立てる場合)
+ * を優先し、無ければ `cf-connecting-ip`、それも無ければ 'unknown'。
+ *
+ * Binding が未設定 (local miniflare で `[[unsafe.bindings]]` が認識されない等)
+ * の場合は warn して fail-open: dev で middleware 全体が壊れる方が POC では
+ * リスクが大きいため。Production では wrangler.jsonc 側に binding が必ず
+ * 入っているのでこのケースは通常起きない。
+ *
+ * 429 時は `Retry-After: 60` ヘッダ + JSON body
+ * `{ error: 'rate_limited', retry_after: 60 }` を返す。
+ */
+export function rateLimit(category: RateLimitCategory): MiddlewareHandler<AppBindings> {
+  const envKey = BINDING_KEY[category]
+  return async (c, next) => {
+    const binding = c.env[envKey] as RateLimit | undefined
+    if (!binding || typeof binding.limit !== 'function') {
+      console.warn(
+        JSON.stringify({
+          event: 'rate_limit_binding_missing',
+          category,
+          envKey,
+          requestId: c.get('requestId') ?? null,
+        }),
+      )
+      await next()
+      return
+    }
+
+    const key = resolveRateLimitKey(c)
+    const outcome = await binding.limit({ key })
+    if (!outcome.success) {
+      c.header('Retry-After', '60')
+      return c.json({ error: 'rate_limited', retry_after: 60 }, 429)
+    }
+    await next()
+  }
+}
+
+/**
+ * actor (Access middleware の placeholder) → cf-connecting-ip → 'unknown' の
+ * 優先順で rate-limit key を解決する。Lane A (#29) が actor を立てるまでは
+ * IP fallback で十分機能する。
+ */
+function resolveRateLimitKey(
+  c: Parameters<MiddlewareHandler<AppBindings>>[0],
+): string {
+  const actor = c.get('actor' as never) as string | undefined
+  if (typeof actor === 'string' && actor.length > 0) return `actor:${actor}`
+  const ip = c.req.header('cf-connecting-ip')
+  if (typeof ip === 'string' && ip.length > 0) return `ip:${ip}`
+  return 'unknown'
+}

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -52,7 +52,24 @@ export function rateLimit(category: RateLimitCategory): MiddlewareHandler<AppBin
     }
 
     const key = resolveRateLimitKey(c)
-    const outcome = await binding.limit({ key })
+    let outcome: { success: boolean }
+    try {
+      outcome = await binding.limit({ key })
+    } catch (err) {
+      // RateLimit binding の一時障害で admin/dashboard を 500 で巻き添えにしない (fail-open)。
+      console.warn(
+        JSON.stringify({
+          event: 'rate_limit_check_failed',
+          category,
+          envKey,
+          key,
+          error: err instanceof Error ? err.message : String(err),
+          requestId: c.get('requestId') ?? null,
+        }),
+      )
+      await next()
+      return
+    }
     if (!outcome.success) {
       c.header('Retry-After', '60')
       return c.json({ error: 'rate_limited', retry_after: 60 }, 429)

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -2,6 +2,7 @@ import { and, eq, isNull, sql } from 'drizzle-orm'
 import { Hono } from 'hono'
 import type { Context } from 'hono'
 import type { AppBindings } from '../app'
+import { rateLimit } from '../middleware/rateLimit'
 import { ValidationError } from '../shared/errors'
 import { createWebullHttpClient } from '../infrastructure/webull/WebullHttpClient'
 import { buildSignedHeaders } from '../infrastructure/webull/WebullAuth'
@@ -55,7 +56,7 @@ export const admin = new Hono<AppBindings>()
    * audit log with before/after/reason/requestId. Does NOT touch
    * `pendingOrder` / `cooldownUntil` / `settledCash`.
    */
-  .post('/symbol-state/:symbol/override-position', async (c) => {
+  .post('/symbol-state/:symbol/override-position', rateLimit('ADMIN_WRITE'), async (c) => {
     const symbol = c.req.param('symbol').trim().toUpperCase()
     if (symbol.length === 0) {
       throw new ValidationError('symbol must be a non-empty path param', { field: 'symbol' })
@@ -89,7 +90,7 @@ export const admin = new Hono<AppBindings>()
       updatedAt: state.updatedAt,
     })
   })
-  .post('/symbols/:symbol/seed-cash', async (c) => {
+  .post('/symbols/:symbol/seed-cash', rateLimit('ADMIN_WRITE'), async (c) => {
     const symbol = c.req.param('symbol').trim().toUpperCase()
     if (symbol.length === 0) {
       throw new ValidationError('symbol must be a non-empty path param', { field: 'symbol' })
@@ -119,7 +120,7 @@ export const admin = new Hono<AppBindings>()
    * 使う。PositionStore.setCooldown は string 必須なので `new Date(0).toISOString()`
    * を渡すことで「過去」扱いにして実質クリア。
    */
-  .post('/symbols/:symbol/clear-cooldown', async (c) => {
+  .post('/symbols/:symbol/clear-cooldown', rateLimit('ADMIN_WRITE'), async (c) => {
     const symbol = c.req.param('symbol').trim().toUpperCase()
     if (symbol.length === 0) {
       throw new ValidationError('symbol must be a non-empty path param', { field: 'symbol' })
@@ -170,7 +171,7 @@ export const admin = new Hono<AppBindings>()
    * を true に書いても `effective=false` で運用者に「env override 効いてる」
    * を視認させる (saw-tooth な切替えで混乱する事故防止)。
    */
-  .post('/trading/toggle', async (c) => {
+  .post('/trading/toggle', rateLimit('STATE_CHANGE'), async (c) => {
     if (!c.env.DB) {
       throw new ValidationError('DB binding is not configured', { field: 'env' })
     }
@@ -692,7 +693,7 @@ export const admin = new Hono<AppBindings>()
    * Returns both the before / after snapshot so an operator (or the eventual
    * EOD cron) can log the exact dollar delta that was rolled.
    */
-  .post('/portfolio/roll-daily', async (c) => {
+  .post('/portfolio/roll-daily', rateLimit('ADMIN_WRITE'), async (c) => {
     if (!c.env.PORTFOLIO_STATE) {
       throw new ValidationError('PORTFOLIO_STATE binding is not configured', { field: 'env' })
     }
@@ -725,7 +726,7 @@ export const admin = new Hono<AppBindings>()
       },
     })
   })
-  .post('/portfolio/seed-equity', async (c) => {
+  .post('/portfolio/seed-equity', rateLimit('ADMIN_WRITE'), async (c) => {
     if (!c.env.PORTFOLIO_STATE) {
       throw new ValidationError('PORTFOLIO_STATE binding is not configured', { field: 'env' })
     }
@@ -758,7 +759,7 @@ export const admin = new Hono<AppBindings>()
    *
    * Body: `[{ symbol: "AAPL", earnings_date: "2026-04-30", notes?: "Q2" }, ...]`
    */
-  .post('/earnings/seed', async (c) => {
+  .post('/earnings/seed', rateLimit('ADMIN_WRITE'), async (c) => {
     if (!c.env.DB) {
       throw new ValidationError('DB binding is not configured', { field: 'env' })
     }
@@ -807,7 +808,7 @@ export const admin = new Hono<AppBindings>()
   /**
    * Delete a single earnings row by `id`。誤 seed の取り消し用。404 if not found。
    */
-  .delete('/earnings/:id', async (c) => {
+  .delete('/earnings/:id', rateLimit('ADMIN_WRITE'), async (c) => {
     if (!c.env.DB) {
       throw new ValidationError('DB binding is not configured', { field: 'env' })
     }
@@ -838,7 +839,7 @@ export const admin = new Hono<AppBindings>()
    * Body: `[{ event_type: "FOMC", event_date: "2026-06-17",
    *           event_time?: "14:00", notes?: "June FOMC" }, ...]`
    */
-  .post('/macro-events/seed', async (c) => {
+  .post('/macro-events/seed', rateLimit('ADMIN_WRITE'), async (c) => {
     if (!c.env.DB) {
       throw new ValidationError('DB binding is not configured', { field: 'env' })
     }
@@ -923,7 +924,7 @@ export const admin = new Hono<AppBindings>()
   /**
    * Delete a single macro event row by `id`。誤 seed の取り消し用。
    */
-  .delete('/macro-events/:id', async (c) => {
+  .delete('/macro-events/:id', rateLimit('ADMIN_WRITE'), async (c) => {
     if (!c.env.DB) {
       throw new ValidationError('DB binding is not configured', { field: 'env' })
     }

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -154,7 +154,7 @@ export const admin = new Hono<AppBindings>()
    * Honours `global_config.dry_run` via runStrategyCron itself — does NOT
    * bypass. Protected by the same basic-auth as the rest of /admin/*.
    */
-  .post('/strategy/run', async (c) => {
+  .post('/strategy/run', rateLimit('ADMIN_WRITE'), async (c) => {
     const result = await runStrategyCron(c.env)
     return c.json(result)
   })
@@ -342,7 +342,7 @@ export const admin = new Hono<AppBindings>()
    * aged out of the cron lookback window. Use to manually unstick legacy
    * split-brain rows after deploying the marker columns.
    */
-  .post('/orders/reconcile', async (c) => {
+  .post('/orders/reconcile', rateLimit('ADMIN_WRITE'), async (c) => {
     const retryStateApply = parseTruthyQuery(c.req.query('retryStateApply'))
     const summary = await reconcileFills({
       env: c.env,
@@ -405,7 +405,7 @@ export const admin = new Hono<AppBindings>()
    * Body: ignored (POST kept for "this mutates state" intent — `dryRun`
    *   path obviously doesn't, but the verb stays consistent).
    */
-  .post('/orders/sync-holdings', async (c) => {
+  .post('/orders/sync-holdings', rateLimit('ADMIN_WRITE'), async (c) => {
     if (!c.env.SYMBOL_STATE) {
       throw new ValidationError('SYMBOL_STATE binding is not configured', { field: 'env' })
     }

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import type { AppBindings } from '../app'
 import type { Env } from '../config/env'
+import { rateLimit } from '../middleware/rateLimit'
 
 /**
  * Dashboard-local Hono context shape。`AppBindings.Variables` の `requestId` に
@@ -66,6 +67,7 @@ async function loadKillSwitchState(env: Env): Promise<KillSwitchBannerState | nu
 }
 
 export const dashboard = new Hono<DashboardBindings>()
+  .use('*', rateLimit('DASHBOARD'))
   .use('*', async (c, next) => {
     const state = await loadKillSwitchState(c.env)
     c.set('killSwitchState', state)

--- a/test/middleware/rateLimit.test.ts
+++ b/test/middleware/rateLimit.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Hono } from 'hono'
+import { createApp } from '../../src/app'
+import { applyTradingToggle } from '../../src/infrastructure/db/tradingToggleRepo'
+
+vi.mock('../../src/infrastructure/db/tradingToggleRepo', async () => {
+  const actual = await vi.importActual<typeof import('../../src/infrastructure/db/tradingToggleRepo')>(
+    '../../src/infrastructure/db/tradingToggleRepo',
+  )
+  return {
+    ...actual,
+    applyTradingToggle: vi.fn(),
+  }
+})
+
+const baseEnv = {
+  ACCESS_DEV_BYPASS_USER: 'admin',
+}
+
+const authHeader = {}
+
+/**
+ * Fake `RateLimit` binding that returns canned outcomes from a list and
+ * records all calls. Lets a test simulate "5 allowed then 1 throttled" without
+ * touching the real Cloudflare binding.
+ */
+function makeFakeRateLimit(outcomes: boolean[]) {
+  const calls: Array<{ key: string }> = []
+  let idx = 0
+  return {
+    binding: {
+      async limit(opts: { key: string }) {
+        calls.push(opts)
+        const next = idx < outcomes.length ? outcomes[idx] : outcomes[outcomes.length - 1] ?? true
+        idx += 1
+        return { success: next ?? true }
+      },
+    },
+    calls,
+  }
+}
+
+describe('rateLimit() middleware on /admin/trading/toggle (STATE_CHANGE)', () => {
+  beforeEach(() => {
+    vi.mocked(applyTradingToggle).mockResolvedValue({
+      before: false,
+      after: true,
+      historyId: 1,
+    })
+  })
+
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('returns 429 with Retry-After: 60 on the 6th request within window', async () => {
+    const app = createApp()
+    const { binding, calls } = makeFakeRateLimit([true, true, true, true, true, false])
+    const env = {
+      ...baseEnv,
+      DB: {} as unknown as D1Database,
+      STATE_CHANGE_RATE_LIMIT: binding,
+    }
+    const body = JSON.stringify({ enabled: true, reason: 'rl-test' })
+    const headers = { 'Content-Type': 'application/json', ...authHeader }
+
+    for (let i = 0; i < 5; i++) {
+      const res = await app.request(
+        '/admin/trading/toggle',
+        { method: 'POST', headers, body },
+        env,
+      )
+      expect(res.status).toBe(200)
+    }
+
+    const throttled = await app.request(
+      '/admin/trading/toggle',
+      { method: 'POST', headers, body },
+      env,
+    )
+    expect(throttled.status).toBe(429)
+    expect(throttled.headers.get('Retry-After')).toBe('60')
+    const json = (await throttled.json()) as { error: string; retry_after: number }
+    expect(json).toEqual({ error: 'rate_limited', retry_after: 60 })
+    expect(calls.length).toBe(6)
+    // The throttled request must NOT have invoked the underlying toggle.
+    expect(applyTradingToggle).toHaveBeenCalledTimes(5)
+  })
+
+  it('falls back to cf-connecting-ip key when actor is not set', async () => {
+    // #29 merge 後は Access が必ず actor を set するので createApp 経由ではこのケース不到達。
+    // middleware の defensive IP fallback path を直接 unit test する。
+    const { rateLimit } = await import('../../src/middleware/rateLimit')
+    const { binding, calls } = makeFakeRateLimit([true])
+    const minimal = new Hono<{ Bindings: { STATE_CHANGE_RATE_LIMIT?: RateLimit } }>()
+      .use('*', rateLimit('STATE_CHANGE'))
+      .get('/', (c) => c.text('ok'))
+    const res = await minimal.request(
+      '/',
+      { headers: { 'cf-connecting-ip': '203.0.113.7' } },
+      { STATE_CHANGE_RATE_LIMIT: binding },
+    )
+    expect(res.status).toBe(200)
+    expect(calls[0]?.key).toBe('ip:203.0.113.7')
+  })
+
+  it('fail-opens (allows request) when binding is missing', async () => {
+    const app = createApp()
+    const env = {
+      ...baseEnv,
+      DB: {} as unknown as D1Database,
+      // STATE_CHANGE_RATE_LIMIT intentionally omitted.
+    }
+    const res = await app.request(
+      '/admin/trading/toggle',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeader },
+        body: JSON.stringify({ enabled: true, reason: 'rl-test' }),
+      },
+      env,
+    )
+    // No binding => warn-and-proceed; downstream handler still runs.
+    expect(res.status).toBe(200)
+    expect(applyTradingToggle).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/middleware/rateLimit.test.ts
+++ b/test/middleware/rateLimit.test.ts
@@ -124,4 +124,30 @@ describe('rateLimit() middleware on /admin/trading/toggle (STATE_CHANGE)', () =>
     expect(res.status).toBe(200)
     expect(applyTradingToggle).toHaveBeenCalledTimes(1)
   })
+
+  it('fail-opens (allows request) when binding.limit throws', async () => {
+    // RateLimit 側の一時障害で admin/dashboard を 500 で巻き添えにしないことを保証 (CodeRabbit #288)。
+    const app = createApp()
+    const throwingBinding: RateLimit = {
+      async limit() {
+        throw new Error('rate limit upstream down')
+      },
+    }
+    const env = {
+      ...baseEnv,
+      DB: {} as unknown as D1Database,
+      STATE_CHANGE_RATE_LIMIT: throwingBinding,
+    }
+    const res = await app.request(
+      '/admin/trading/toggle',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeader },
+        body: JSON.stringify({ enabled: true, reason: 'rl-throw' }),
+      },
+      env,
+    )
+    expect(res.status).toBe(200)
+    expect(applyTradingToggle).toHaveBeenCalledTimes(1)
+  })
 })

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -12,6 +12,34 @@
       { "name": "PORTFOLIO_STATE", "class_name": "PortfolioStateDO" }
     ]
   },
+  // #285: Cloudflare Workers RateLimit bindings. State-changing POST endpoints
+  // get a tight cap, other admin writes a looser cap, dashboard GETs a soft
+  // cap. `/events/trade` (bridge ingest) is intentionally NOT rate-limited —
+  // it is high-volume bar/tick fan-in and any cap would drop legitimate market
+  // data. Categories are applied per-route in src/routes/admin.ts and
+  // src/routes/dashboard.ts via the rateLimit() middleware factory.
+  "unsafe": {
+    "bindings": [
+      {
+        "name": "STATE_CHANGE_RATE_LIMIT",
+        "type": "ratelimit",
+        "namespace_id": "1001",
+        "simple": { "limit": 5, "period": 60 }
+      },
+      {
+        "name": "ADMIN_WRITE_RATE_LIMIT",
+        "type": "ratelimit",
+        "namespace_id": "1002",
+        "simple": { "limit": 20, "period": 60 }
+      },
+      {
+        "name": "DASHBOARD_RATE_LIMIT",
+        "type": "ratelimit",
+        "namespace_id": "1003",
+        "simple": { "limit": 60, "period": 60 }
+      }
+    ]
+  },
   "migrations": [
     { "tag": "v1", "new_sqlite_classes": ["SymbolStateDO"] },
     { "tag": "v2", "new_sqlite_classes": ["PortfolioStateDO"] },
@@ -43,7 +71,31 @@
           "database_id": "REPLACE_WITH_DEV_ID",
           "migrations_dir": "drizzle"
         }
-      ]
+      ],
+      // #285: per-env RateLimit binding duplicate (wrangler 4 does NOT inherit
+      // top-level `unsafe.bindings` into env.* blocks). See top-level comment.
+      "unsafe": {
+        "bindings": [
+          {
+            "name": "STATE_CHANGE_RATE_LIMIT",
+            "type": "ratelimit",
+            "namespace_id": "1001",
+            "simple": { "limit": 5, "period": 60 }
+          },
+          {
+            "name": "ADMIN_WRITE_RATE_LIMIT",
+            "type": "ratelimit",
+            "namespace_id": "1002",
+            "simple": { "limit": 20, "period": 60 }
+          },
+          {
+            "name": "DASHBOARD_RATE_LIMIT",
+            "type": "ratelimit",
+            "namespace_id": "1003",
+            "simple": { "limit": 60, "period": 60 }
+          }
+        ]
+      }
     },
     "staging": {
       "name": "webull-trading-staging",
@@ -60,7 +112,30 @@
           "database_id": "cbc199f0-5ed8-40b0-b619-6bdb43a400e3",
           "migrations_dir": "drizzle"
         }
-      ]
+      ],
+      // #285: per-env RateLimit binding duplicate.
+      "unsafe": {
+        "bindings": [
+          {
+            "name": "STATE_CHANGE_RATE_LIMIT",
+            "type": "ratelimit",
+            "namespace_id": "1001",
+            "simple": { "limit": 5, "period": 60 }
+          },
+          {
+            "name": "ADMIN_WRITE_RATE_LIMIT",
+            "type": "ratelimit",
+            "namespace_id": "1002",
+            "simple": { "limit": 20, "period": 60 }
+          },
+          {
+            "name": "DASHBOARD_RATE_LIMIT",
+            "type": "ratelimit",
+            "namespace_id": "1003",
+            "simple": { "limit": 60, "period": 60 }
+          }
+        ]
+      }
       // No triggers: staging is manual run only (issue #277).
     },
     "production": {
@@ -79,6 +154,29 @@
           "migrations_dir": "drizzle"
         }
       ],
+      // #285: per-env RateLimit binding duplicate.
+      "unsafe": {
+        "bindings": [
+          {
+            "name": "STATE_CHANGE_RATE_LIMIT",
+            "type": "ratelimit",
+            "namespace_id": "1001",
+            "simple": { "limit": 5, "period": 60 }
+          },
+          {
+            "name": "ADMIN_WRITE_RATE_LIMIT",
+            "type": "ratelimit",
+            "namespace_id": "1002",
+            "simple": { "limit": 20, "period": 60 }
+          },
+          {
+            "name": "DASHBOARD_RATE_LIMIT",
+            "type": "ratelimit",
+            "namespace_id": "1003",
+            "simple": { "limit": 60, "period": 60 }
+          }
+        ]
+      },
       // wrangler 4 does NOT inherit top-level `triggers` once env.* blocks
       // exist, so cron must be re-declared explicitly here (issue #277).
       "triggers": {


### PR DESCRIPTION
Closes #285
Refs #283

## Summary

state 変更 POST に Cloudflare Workers \`RateLimit\` binding を適用。Access (#29) 通過後の連打 / リプレイ / 認証突破後の thrash を抑える。

## 変更点

### 新規 \`src/middleware/rateLimit.ts\`
- factory \`rateLimit(category)\` で \`STATE_CHANGE\` / \`ADMIN_WRITE\` / \`DASHBOARD\` の 3 種類
- key: \`actor:<email>\` (Access middleware が \`c.get('actor')\` を set) → IP fallback (\`cf-connecting-ip\`) → \`'unknown'\`
- 超過: 429 + \`Retry-After: 60\` header + JSON \`{ error: 'rate_limited', retry_after: 60 }\`
- binding 不在環境 (vitest / 旧 wrangler version) では \`rate_limit_binding_missing\` を log → fail-open

### \`wrangler.jsonc\`
- top-level + \`env.dev\` / \`env.staging\` / \`env.production\` 各 block に \`[[unsafe.bindings]]\` を追加
- 3 binding × 4 env = 12 entries

### Route 適用
| Route | Binding |
|---|---|
| \`POST /admin/trading/toggle\` | STATE_CHANGE (5/60s) |
| \`POST /admin/symbol-state/:symbol/override-position\` | ADMIN_WRITE (20/60s) |
| \`POST /admin/symbols/:symbol/seed-cash\` | ADMIN_WRITE |
| \`POST /admin/symbols/:symbol/clear-cooldown\` | ADMIN_WRITE |
| \`POST /admin/earnings/seed\` / \`DELETE /admin/earnings/:id\` | ADMIN_WRITE |
| \`POST /admin/macro-events/seed\` / \`DELETE /admin/macro-events/:id\` | ADMIN_WRITE |
| \`POST /admin/portfolio/roll-daily\` / \`POST /admin/portfolio/seed-equity\` | ADMIN_WRITE |
| \`/dashboard/*\` (GET) | DASHBOARD (60/60s) |
| \`/events/trade\` (bridge ingest) | **EXEMPT** (wrangler コメントで明記) |

### \`src/config/env.ts\`
- 末尾に新規 \`Env\` block 追加: \`STATE_CHANGE_RATE_LIMIT?\` / \`ADMIN_WRITE_RATE_LIMIT?\` / \`DASHBOARD_RATE_LIMIT?\` (\`RateLimit\` type、optional で fail-open)

## Rebase 注記

- \`src/config/env.ts\` で #29 (CF_ACCESS_*) の追加 block と衝突 → 両 block を sequential append として merge
- test/middleware/rateLimit.test.ts の "IP fallback" test は #29 merge 後 createApp 経由では不到達 (Access が必ず actor を set) のため、middleware を minimal Hono app で単体テストに書き換え
- test の auth fixture を \`ACCESS_DEV_BYPASS_USER\` に統一

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` **77 files / 1041 tests pass** (+3 rateLimit tests over post-#287 baseline)
- [x] \`pnpm exec wrangler deploy --env <dev/staging/production> --dry-run\` 全 env 通過
- [ ] (post-deploy) prod で 6 連打 toggle が 5 成功 / 1 件 429

## 注意

- \`wrangler.jsonc\` の \`unsafe.bindings\` namespace_id は placeholder (1001/1002/1003)。Cloudflare が account 単位で割り当てる本物の値に置き換えが必要 (実 deploy 前)

Refs umbrella #283 で security 3 件揃い踏み完了。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 管理系とダッシュボード系の複数エンドポイントにカテゴリ別レート制限を適用しました（STATE_CHANGE/ADMIN_WRITE/DASHBOARD）。制限超過時は429とリトライ情報が返ります。

* **Behavior**
  * レート制限バインディングが未設定／不正／例外となった場合は fail-open で処理を継続します。

* **Chores**
  * 各環境の設定にレート制限バインディングを追加しました。

* **Tests**
  * 許可・抑止・フォールオープン動作を検証するテストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/288)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->