### PR TITLE
feat(ops): custom domain routes — trading.chanu.co (prod) / trading-staging.chanu.co (staging)

### DIFF
--- a/docs/env-separation.md
+++ b/docs/env-separation.md
@@ -4,12 +4,12 @@ dev / staging / production を worker / D1 / DO namespace / secrets で物理的
 
 ## 4 つの実行プロファイル
 
-| Profile | 起動 | Worker name | D1 | cron | 用途 |
-|---|---|---|---|---|---|
-| local | `pnpm dev` (= `wrangler dev`) | top-level (`webull-trading`) | miniflare local SQLite | なし | 開発機での反復実行 |
-| dev | `pnpm deploy:dev` | `webull-trading-dev` | `webull-trading-dev` (要発行) | なし (manual) | remote dev / preview |
-| staging | `pnpm deploy:staging` | `webull-trading-staging` | `webull-trading-staging` | なし (manual) | sandbox key で integration 検証 |
-| production | `pnpm deploy:production` | `webull-trading-production` | `webull-trading-production` (要発行) | あり (5/15min/22:00 UTC) | 実マネー |
+| Profile | 起動 | Worker name | URL | D1 | cron | 用途 |
+|---|---|---|---|---|---|---|
+| local | `pnpm dev` (= `wrangler dev`) | top-level (`webull-trading`) | `localhost:8787` | miniflare local SQLite | なし | 開発機での反復実行 |
+| dev | `pnpm deploy:dev` | `webull-trading-dev` | `webull-trading-dev.*.workers.dev` | `webull-trading-dev` (要発行) | なし (manual) | remote dev / preview |
+| staging | `pnpm deploy:staging` | `webull-trading-staging` | `trading-staging.chanu.co` | `webull-trading-staging` | なし (manual) | sandbox key で integration 検証 |
+| production | `pnpm deploy:production` | `webull-trading-production` | `trading.chanu.co` | `webull-trading-production` (要発行) | あり (5/15min/22:00 UTC) | 実マネー |
 
 `wrangler dev` (ローカル) はあえて env を切り替えずに top-level config を使う。cron / D1 ID 設定エラーの影響を受けず手元で立ち上がる事を優先するため。
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -99,6 +99,9 @@
     },
     "staging": {
       "name": "webull-trading-staging",
+      "routes": [
+        { "pattern": "trading-staging.chanu.co", "custom_domain": true }
+      ],
       "durable_objects": {
         "bindings": [
           { "name": "SYMBOL_STATE", "class_name": "SymbolStateDO" },
@@ -140,6 +143,9 @@
     },
     "production": {
       "name": "webull-trading-production",
+      "routes": [
+        { "pattern": "trading.chanu.co", "custom_domain": true }
+      ],
       "durable_objects": {
         "bindings": [
           { "name": "SYMBOL_STATE", "class_name": "SymbolStateDO" },


### PR DESCRIPTION
Refs #283

## Summary

本番口座接続準備の一環。staging / production worker を \`chanu.co\` zone 配下の custom domain で露出する。deploy 時に Cloudflare DNS record が自動生成される。

dev は \`workers.dev\` のまま (preview 用途、custom domain 不要)。

## 変更点

- \`wrangler.jsonc\` の \`env.staging\` / \`env.production\` に \`routes\` 追加 (\`custom_domain: true\`)
- \`docs/env-separation.md\` の env profile 表に **URL 列**を追加

## URL マッピング

| env | URL |
|---|---|
| local | localhost:8787 |
| dev | \`webull-trading-dev.*.workers.dev\` |
| staging | \`trading-staging.chanu.co\` |
| production | \`trading.chanu.co\` |

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm exec wrangler deploy --env staging --dry-run\` 通過
- [x] \`pnpm exec wrangler deploy --env production --dry-run\` 通過
- [ ] (post-deploy) DNS が解決して 401 (Access 未設定なので) または 200 を返す

## Follow-up (user-action)

このあとの Cloudflare Access application は \`trading-staging.chanu.co\` / \`trading.chanu.co\` を gate 対象として作成する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * 環境別プロファイル（local/dev/staging/production）の一覧テーブルにURL列を追加し、各環境のドメイン・D1・cronの対応を明確化しました。

* **Configuration**
  * Staging環境（trading-staging.chanu.co）とProduction環境（trading.chanu.co）のカスタムドメインルーティングを追加設定しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/289)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->