### PR TITLE
feat(dashboard): symbol_config CRUD UI (#292)

### DIFF
--- a/src/infrastructure/db/symbolConfigRepo.ts
+++ b/src/infrastructure/db/symbolConfigRepo.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm'
+import { eq, sql } from 'drizzle-orm'
 import type { DrizzleD1Database } from 'drizzle-orm/d1'
 import { inversePairs, symbolConfig, type SymbolConfigRow } from './schema'
 
@@ -136,26 +136,45 @@ export interface SymbolConfigWriteInput {
 /**
  * CRUD UI (#292) で symbol_config に新規 INSERT する。symbol 既存なら null を
  * 返し caller が 409 を返す。INSERT 後の最新行を返す。
+ *
+ * pre-check + INSERT は TOCTOU race を作る (並列 INSERT が両方 pre-check
+ * を通過 → 後者が UNIQUE 制約違反で 500 化する)。代わりに INSERT を直接
+ * 試行し、UNIQUE 違反だけを `null` に変換する (= 既存銘柄判定)。
  */
 export async function insertSymbolConfig(
   db: DrizzleD1Database,
   input: SymbolConfigWriteInput,
   nowIso: string,
 ): Promise<SymbolConfigRow | null> {
-  const existing = await findSymbolConfig(db, input.symbol)
-  if (existing !== null) return null
-  await db.insert(symbolConfig).values({
-    symbol: input.symbol,
-    name: input.name,
-    market: input.market,
-    currency: input.currency,
-    active: input.active,
-    maxNotional: input.maxNotional,
-    bucket: input.bucket,
-    notes: input.notes,
-    updatedAt: nowIso,
-  })
+  try {
+    await db.insert(symbolConfig).values({
+      symbol: input.symbol,
+      name: input.name,
+      market: input.market,
+      currency: input.currency,
+      active: input.active,
+      maxNotional: input.maxNotional,
+      bucket: input.bucket,
+      notes: input.notes,
+      updatedAt: nowIso,
+    })
+  } catch (err) {
+    if (isUniqueConstraintError(err)) return null
+    throw err
+  }
   return await findSymbolConfig(db, input.symbol)
+}
+
+/**
+ * SQLite (better-sqlite3 / D1) は UNIQUE 違反を `UNIQUE constraint failed`
+ * を含む Error message で返す。drizzle はそれを wrap した Error で投げる
+ * ので、 message 文字列マッチで判定する (driver による差分を吸収)。
+ */
+function isUniqueConstraintError(err: unknown): boolean {
+  if (err === null || typeof err !== 'object') return false
+  const message = (err as { message?: unknown }).message
+  if (typeof message !== 'string') return false
+  return message.includes('UNIQUE constraint failed')
 }
 
 /**
@@ -186,7 +205,15 @@ export async function updateSymbolConfig(
 }
 
 /**
- * Flip `active` 1↔0 atomically (read-modify-write). Not found → null。
+ * Flip `active` 1↔0 atomically. UPDATE 自体は SQL `NOT active` で
+ * read-modify-write race を排除する (並列 2 連打が両方 SELECT で同じ
+ * `before` を読んで同じ値を書き戻すのを防ぐ)。
+ * Not found → null。
+ *
+ * WHY: audit log の before/after は SELECT-UPDATE-SELECT で取るため厳密
+ * には atomic ではない — 高並列時 before/after の遷移を 1 step ずれて
+ * 観測する可能性があるが、DB 上の state 自体は SQL NOT で atomic に
+ * flip するので冪等性は壊れない。POC scope では許容。
  */
 export async function toggleSymbolActive(
   db: DrizzleD1Database,
@@ -195,14 +222,10 @@ export async function toggleSymbolActive(
 ): Promise<{ before: SymbolConfigRow; after: SymbolConfigRow } | null> {
   const before = await findSymbolConfig(db, symbol)
   if (before === null) return null
-  // Snapshot before.active BEFORE running update — some fake DBs share the
-  // row reference so re-fetching could surface the post-update value (and
-  // recordChange would then skip the audit row as a "no-op").
   const beforeSnapshot: SymbolConfigRow = { ...before }
-  const nextActive = !before.active
   await db
     .update(symbolConfig)
-    .set({ active: nextActive, updatedAt: nowIso })
+    .set({ active: sql`NOT ${symbolConfig.active}`, updatedAt: nowIso })
     .where(eq(symbolConfig.symbol, symbol))
   const after = await findSymbolConfig(db, symbol)
   if (after === null) return null

--- a/src/infrastructure/db/symbolConfigRepo.ts
+++ b/src/infrastructure/db/symbolConfigRepo.ts
@@ -1,5 +1,6 @@
+import { eq } from 'drizzle-orm'
 import type { DrizzleD1Database } from 'drizzle-orm/d1'
-import { inversePairs, symbolConfig } from './schema'
+import { inversePairs, symbolConfig, type SymbolConfigRow } from './schema'
 
 export type SymbolCurrency = 'USD' | 'JPY'
 export type SymbolMarket = 'US' | 'JP'
@@ -107,6 +108,129 @@ export async function loadSymbolConfig(
     symbolName,
     symbolNotes,
   }
+}
+
+/**
+ * symbol_config 1 行を返す。CRUD UI (#292) の before/after snapshot に使う。
+ * 未存在は `null`。
+ */
+export async function findSymbolConfig(
+  db: DrizzleD1Database,
+  symbol: string,
+): Promise<SymbolConfigRow | null> {
+  const rows = await db.select().from(symbolConfig).where(eq(symbolConfig.symbol, symbol)).limit(1)
+  return rows[0] ?? null
+}
+
+export interface SymbolConfigWriteInput {
+  symbol: string
+  name: string | null
+  market: SymbolMarket
+  currency: SymbolCurrency
+  active: boolean
+  maxNotional: number | null
+  bucket: string | null
+  notes: string | null
+}
+
+/**
+ * CRUD UI (#292) で symbol_config に新規 INSERT する。symbol 既存なら null を
+ * 返し caller が 409 を返す。INSERT 後の最新行を返す。
+ */
+export async function insertSymbolConfig(
+  db: DrizzleD1Database,
+  input: SymbolConfigWriteInput,
+  nowIso: string,
+): Promise<SymbolConfigRow | null> {
+  const existing = await findSymbolConfig(db, input.symbol)
+  if (existing !== null) return null
+  await db.insert(symbolConfig).values({
+    symbol: input.symbol,
+    name: input.name,
+    market: input.market,
+    currency: input.currency,
+    active: input.active,
+    maxNotional: input.maxNotional,
+    bucket: input.bucket,
+    notes: input.notes,
+    updatedAt: nowIso,
+  })
+  return await findSymbolConfig(db, input.symbol)
+}
+
+/**
+ * CRUD UI (#292) で symbol_config を全列 update する。存在しなければ null を
+ * 返し caller が 404 を返す。symbol 自体は path から固定で来るので変更不可。
+ */
+export async function updateSymbolConfig(
+  db: DrizzleD1Database,
+  input: SymbolConfigWriteInput,
+  nowIso: string,
+): Promise<SymbolConfigRow | null> {
+  const existing = await findSymbolConfig(db, input.symbol)
+  if (existing === null) return null
+  await db
+    .update(symbolConfig)
+    .set({
+      name: input.name,
+      market: input.market,
+      currency: input.currency,
+      active: input.active,
+      maxNotional: input.maxNotional,
+      bucket: input.bucket,
+      notes: input.notes,
+      updatedAt: nowIso,
+    })
+    .where(eq(symbolConfig.symbol, input.symbol))
+  return await findSymbolConfig(db, input.symbol)
+}
+
+/**
+ * Flip `active` 1↔0 atomically (read-modify-write). Not found → null。
+ */
+export async function toggleSymbolActive(
+  db: DrizzleD1Database,
+  symbol: string,
+  nowIso: string,
+): Promise<{ before: SymbolConfigRow; after: SymbolConfigRow } | null> {
+  const before = await findSymbolConfig(db, symbol)
+  if (before === null) return null
+  // Snapshot before.active BEFORE running update — some fake DBs share the
+  // row reference so re-fetching could surface the post-update value (and
+  // recordChange would then skip the audit row as a "no-op").
+  const beforeSnapshot: SymbolConfigRow = { ...before }
+  const nextActive = !before.active
+  await db
+    .update(symbolConfig)
+    .set({ active: nextActive, updatedAt: nowIso })
+    .where(eq(symbolConfig.symbol, symbol))
+  const after = await findSymbolConfig(db, symbol)
+  if (after === null) return null
+  return { before: beforeSnapshot, after }
+}
+
+/**
+ * Soft delete (active=false)。hard delete は FK 影響回避のため避ける。
+ * 既に active=false なら no-op (before==after で audit log も skip される)。
+ */
+export async function softDeleteSymbol(
+  db: DrizzleD1Database,
+  symbol: string,
+  nowIso: string,
+): Promise<{ before: SymbolConfigRow; after: SymbolConfigRow } | null> {
+  const before = await findSymbolConfig(db, symbol)
+  if (before === null) return null
+  const beforeSnapshot: SymbolConfigRow = { ...before }
+  if (!before.active) {
+    return { before: beforeSnapshot, after: beforeSnapshot }
+  }
+  await db
+    .update(symbolConfig)
+    .set({ active: false, updatedAt: nowIso })
+    .where(eq(symbolConfig.symbol, symbol))
+  const after = await findSymbolConfig(db, symbol)
+  if (after === null) return null
+  return { before: beforeSnapshot, after }
 }
 
 /**

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -979,10 +979,12 @@ export const admin = new Hono<AppBindings>()
     const db = createDb(c.env.DB)
     const inserted = await insertSymbolConfig(db, input, new Date().toISOString())
     if (inserted === null) {
-      // 409 with JSON. Form path would normally re-render but caller pattern
-      // here mirrors macro/earnings: dashboard handler does pre-flight check
-      // and shows the form-level validation message before POST. 409 keeps
-      // semantics correct for CLI users.
+      if (isForm) {
+        return c.redirect(
+          `/dashboard/symbols?error=duplicate&symbol=${encodeURIComponent(input.symbol)}`,
+          303,
+        )
+      }
       return c.json({ error: 'symbol_already_exists', symbol: input.symbol }, 409)
     }
     await writeAuditLog(
@@ -1011,10 +1013,22 @@ export const admin = new Hono<AppBindings>()
     const db = createDb(c.env.DB)
     const before = await findSymbolConfig(db, symbolPath)
     if (before === null) {
+      if (isForm) {
+        return c.redirect(
+          `/dashboard/symbols?error=not_found&symbol=${encodeURIComponent(symbolPath)}`,
+          303,
+        )
+      }
       return c.json({ error: 'symbol_not_found', symbol: symbolPath }, 404)
     }
     const after = await updateSymbolConfig(db, input, new Date().toISOString())
     if (after === null) {
+      if (isForm) {
+        return c.redirect(
+          `/dashboard/symbols?error=not_found&symbol=${encodeURIComponent(symbolPath)}`,
+          303,
+        )
+      }
       return c.json({ error: 'symbol_not_found', symbol: symbolPath }, 404)
     }
     await writeAuditLog(
@@ -1036,6 +1050,12 @@ export const admin = new Hono<AppBindings>()
     const db = createDb(c.env.DB)
     const result = await toggleSymbolActive(db, symbolPath, new Date().toISOString())
     if (result === null) {
+      if (isForm) {
+        return c.redirect(
+          `/dashboard/symbols?error=not_found&symbol=${encodeURIComponent(symbolPath)}`,
+          303,
+        )
+      }
       return c.json({ error: 'symbol_not_found', symbol: symbolPath }, 404)
     }
     await writeAuditLog(
@@ -1046,7 +1066,7 @@ export const admin = new Hono<AppBindings>()
       { active: result.after.active },
     )
     if (isForm) return c.redirect('/dashboard/symbols', 303)
-    return c.json({ symbol: symbolPath, active: result.after.active })
+    return c.json({ symbol: symbolPath, row: symbolConfigSnapshot(result.after) })
   })
   .post('/symbol-config/:symbol/delete', rateLimit('ADMIN_WRITE'), async (c) => {
     if (!c.env.DB) {
@@ -1057,6 +1077,12 @@ export const admin = new Hono<AppBindings>()
     const db = createDb(c.env.DB)
     const result = await softDeleteSymbol(db, symbolPath, new Date().toISOString())
     if (result === null) {
+      if (isForm) {
+        return c.redirect(
+          `/dashboard/symbols?error=not_found&symbol=${encodeURIComponent(symbolPath)}`,
+          303,
+        )
+      }
       return c.json({ error: 'symbol_not_found', symbol: symbolPath }, 404)
     }
     await writeAuditLog(
@@ -1067,7 +1093,7 @@ export const admin = new Hono<AppBindings>()
       { active: result.after.active },
     )
     if (isForm) return c.redirect('/dashboard/symbols', 303)
-    return c.json({ symbol: symbolPath, active: result.after.active })
+    return c.json({ symbol: symbolPath, row: symbolConfigSnapshot(result.after) })
   })
 
 /**

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -18,6 +18,15 @@ import { createDb } from '../infrastructure/db/tradeJournalRepo'
 import { earningsCalendar, macroEventCalendar, tradeJournal } from '../infrastructure/db/schema'
 import { extractActor, recordChange } from '../infrastructure/db/configAuditLog'
 import {
+  findSymbolConfig,
+  insertSymbolConfig,
+  softDeleteSymbol,
+  toggleSymbolActive,
+  updateSymbolConfig,
+  type SymbolConfigWriteInput,
+} from '../infrastructure/db/symbolConfigRepo'
+import type { SymbolConfigRow } from '../infrastructure/db/schema'
+import {
   applyTradingToggle,
   createTradingToggleDb,
 } from '../infrastructure/db/tradingToggleRepo'
@@ -947,6 +956,119 @@ export const admin = new Hono<AppBindings>()
     await writeAuditLog(c, '/admin/macro-events/:id', `macro_event_id=${id}`, beforeRow, null)
     return c.json({ deleted: true, id })
   })
+  /**
+   * symbol_config CRUD (#292) — UI からの form POST 用 endpoint 群。
+   *
+   * `/admin/symbol-config`               INSERT (重複 symbol は 409)
+   * `/admin/symbol-config/:symbol/update` 全列 UPDATE
+   * `/admin/symbol-config/:symbol/toggle-active` active 1↔0
+   * `/admin/symbol-config/:symbol/delete` soft delete (active=false; hard delete はしない)
+   *
+   * いずれも `rateLimit('ADMIN_WRITE')` + `writeAuditLog` を経由する。
+   * dashboard form (application/x-www-form-urlencoded) からの POST を想定し、
+   * 成功時は 303 redirect で `/dashboard/symbols` に戻す (PRG)。JSON body も
+   * 同じ shape で受理し、JSON Accept (= ヘッダ無し) の場合は 200 JSON を返す。
+   */
+  .post('/symbol-config', rateLimit('ADMIN_WRITE'), async (c) => {
+    if (!c.env.DB) {
+      throw new ValidationError('DB binding is not configured', { field: 'env' })
+    }
+    const isForm = isFormContentType(c.req.header('content-type'))
+    const body = await readFormOrJsonBody(c)
+    const input = parseSymbolConfigBody(body)
+    const db = createDb(c.env.DB)
+    const inserted = await insertSymbolConfig(db, input, new Date().toISOString())
+    if (inserted === null) {
+      // 409 with JSON. Form path would normally re-render but caller pattern
+      // here mirrors macro/earnings: dashboard handler does pre-flight check
+      // and shows the form-level validation message before POST. 409 keeps
+      // semantics correct for CLI users.
+      return c.json({ error: 'symbol_already_exists', symbol: input.symbol }, 409)
+    }
+    await writeAuditLog(
+      c,
+      '/admin/symbol-config',
+      `symbol=${input.symbol}`,
+      null,
+      symbolConfigSnapshot(inserted),
+    )
+    if (isForm) return c.redirect('/dashboard/symbols', 303)
+    return c.json({ symbol: inserted.symbol, row: symbolConfigSnapshot(inserted) })
+  })
+  .post('/symbol-config/:symbol/update', rateLimit('ADMIN_WRITE'), async (c) => {
+    if (!c.env.DB) {
+      throw new ValidationError('DB binding is not configured', { field: 'env' })
+    }
+    const symbolPath = normalizeSymbolPathParam(c.req.param('symbol'))
+    const isForm = isFormContentType(c.req.header('content-type'))
+    const body = await readFormOrJsonBody(c)
+    // path の :symbol を強制し、body symbol は無視 (path が source of truth)。
+    const bodyObj = body && typeof body === 'object' && !Array.isArray(body) ? body : {}
+    const input: SymbolConfigWriteInput = {
+      ...parseSymbolConfigBody({ ...bodyObj, symbol: symbolPath }),
+      symbol: symbolPath,
+    }
+    const db = createDb(c.env.DB)
+    const before = await findSymbolConfig(db, symbolPath)
+    if (before === null) {
+      return c.json({ error: 'symbol_not_found', symbol: symbolPath }, 404)
+    }
+    const after = await updateSymbolConfig(db, input, new Date().toISOString())
+    if (after === null) {
+      return c.json({ error: 'symbol_not_found', symbol: symbolPath }, 404)
+    }
+    await writeAuditLog(
+      c,
+      '/admin/symbol-config/:symbol/update',
+      `symbol=${symbolPath}`,
+      symbolConfigSnapshot(before),
+      symbolConfigSnapshot(after),
+    )
+    if (isForm) return c.redirect('/dashboard/symbols', 303)
+    return c.json({ symbol: after.symbol, row: symbolConfigSnapshot(after) })
+  })
+  .post('/symbol-config/:symbol/toggle-active', rateLimit('ADMIN_WRITE'), async (c) => {
+    if (!c.env.DB) {
+      throw new ValidationError('DB binding is not configured', { field: 'env' })
+    }
+    const symbolPath = normalizeSymbolPathParam(c.req.param('symbol'))
+    const isForm = isFormContentType(c.req.header('content-type'))
+    const db = createDb(c.env.DB)
+    const result = await toggleSymbolActive(db, symbolPath, new Date().toISOString())
+    if (result === null) {
+      return c.json({ error: 'symbol_not_found', symbol: symbolPath }, 404)
+    }
+    await writeAuditLog(
+      c,
+      '/admin/symbol-config/:symbol/toggle-active',
+      `symbol=${symbolPath}`,
+      { active: result.before.active },
+      { active: result.after.active },
+    )
+    if (isForm) return c.redirect('/dashboard/symbols', 303)
+    return c.json({ symbol: symbolPath, active: result.after.active })
+  })
+  .post('/symbol-config/:symbol/delete', rateLimit('ADMIN_WRITE'), async (c) => {
+    if (!c.env.DB) {
+      throw new ValidationError('DB binding is not configured', { field: 'env' })
+    }
+    const symbolPath = normalizeSymbolPathParam(c.req.param('symbol'))
+    const isForm = isFormContentType(c.req.header('content-type'))
+    const db = createDb(c.env.DB)
+    const result = await softDeleteSymbol(db, symbolPath, new Date().toISOString())
+    if (result === null) {
+      return c.json({ error: 'symbol_not_found', symbol: symbolPath }, 404)
+    }
+    await writeAuditLog(
+      c,
+      '/admin/symbol-config/:symbol/delete',
+      `symbol=${symbolPath}`,
+      { active: result.before.active },
+      { active: result.after.active },
+    )
+    if (isForm) return c.redirect('/dashboard/symbols', 303)
+    return c.json({ symbol: symbolPath, active: result.after.active })
+  })
 
 /**
  * Validate a single `/admin/macro-events/seed` body entry。
@@ -1309,6 +1431,160 @@ function isYmd(value: string): boolean {
   if (!Number.isFinite(ms)) return false
   const roundTrip = new Date(ms).toISOString().slice(0, 10)
   return roundTrip === value
+}
+
+/**
+ * symbol_config CRUD UI (#292) で受け付ける form/JSON body を共通化して
+ * 解析する。dashboard form は application/x-www-form-urlencoded、CLI は JSON
+ * を送る想定。
+ *
+ *   - symbol: 1〜10 chars、英数字 (`[A-Za-z0-9]`)。JP の 4 桁数字 (e.g. `1570`)
+ *     も合法。upper-case で正規化する。
+ *   - market: 'US' | 'JP'
+ *   - currency: 'USD' | 'JPY' (DB CHECK 制約と一致)
+ *   - active: boolean (form では 'true'/'false'/'on' を許容、checkbox の 'on'
+ *     → true、未送信 → false で扱う)
+ *   - maxNotional: 正の数 or null (空文字 → null)
+ *   - name / bucket / notes: optional string、256 chars 上限
+ */
+function parseSymbolConfigBody(body: unknown): SymbolConfigWriteInput {
+  if (body === null || typeof body !== 'object' || Array.isArray(body)) {
+    throw new ValidationError('body must be an object or form-encoded', { field: 'body' })
+  }
+  const raw = body as {
+    symbol?: unknown
+    name?: unknown
+    market?: unknown
+    currency?: unknown
+    active?: unknown
+    max_notional?: unknown
+    maxNotional?: unknown
+    bucket?: unknown
+    notes?: unknown
+  }
+  const symbol = normalizeSymbol(raw.symbol)
+  const market = parseMarket(raw.market)
+  const currency = parseCurrency(raw.currency)
+  // form の checkbox は未送信時に key 自体が来ない (= undefined)。dashboard
+  // form は hidden input で `active=false` を必ず送る運用にするが、未送信は
+  // 安全側に false (= disabled) で受ける。
+  const active = parseFormBool(raw.active, false)
+  const maxNotionalRaw = raw.max_notional ?? raw.maxNotional
+  const maxNotional = parseOptionalPositiveNumber(maxNotionalRaw, 'maxNotional')
+  const name = parseOptionalString(raw.name, 'name')
+  const bucket = parseOptionalString(raw.bucket, 'bucket')
+  const notes = parseOptionalString(raw.notes, 'notes')
+  return { symbol, name, market, currency, active, maxNotional, bucket, notes }
+}
+
+function normalizeSymbol(value: unknown): string {
+  if (typeof value !== 'string') {
+    throw new ValidationError('symbol must be a 1-10 char alphanumeric string', { field: 'symbol' })
+  }
+  const trimmed = value.trim().toUpperCase()
+  if (trimmed.length === 0 || trimmed.length > 10) {
+    throw new ValidationError('symbol must be 1-10 chars', { field: 'symbol' })
+  }
+  if (!/^[A-Z0-9]+$/.test(trimmed)) {
+    throw new ValidationError('symbol must be alphanumeric only', { field: 'symbol' })
+  }
+  return trimmed
+}
+
+function normalizeSymbolPathParam(value: string): string {
+  return normalizeSymbol(value)
+}
+
+function parseMarket(value: unknown): 'US' | 'JP' {
+  if (typeof value === 'string') {
+    const trimmed = value.trim().toUpperCase()
+    if (trimmed === 'US' || trimmed === 'JP') return trimmed
+  }
+  throw new ValidationError("market must be 'US' or 'JP'", { field: 'market' })
+}
+
+function parseCurrency(value: unknown): 'USD' | 'JPY' {
+  if (typeof value === 'string') {
+    const trimmed = value.trim().toUpperCase()
+    if (trimmed === 'USD' || trimmed === 'JPY') return trimmed
+  }
+  throw new ValidationError("currency must be 'USD' or 'JPY'", { field: 'currency' })
+}
+
+function parseFormBool(value: unknown, fallback: boolean): boolean {
+  if (value === undefined || value === null) return fallback
+  if (typeof value === 'boolean') return value
+  if (typeof value === 'string') {
+    const norm = value.trim().toLowerCase()
+    if (norm === 'true' || norm === '1' || norm === 'on') return true
+    if (norm === 'false' || norm === '0' || norm === 'off' || norm === '') return false
+  }
+  throw new ValidationError("active must be boolean ('true'/'false')", { field: 'active' })
+}
+
+function parseOptionalPositiveNumber(value: unknown, field: string): number | null {
+  if (value === undefined || value === null) return null
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (trimmed === '') return null
+    const parsed = Number(trimmed)
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      throw new ValidationError(`${field} must be a positive number or empty`, { field })
+    }
+    return parsed
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || value <= 0) {
+      throw new ValidationError(`${field} must be a positive number or empty`, { field })
+    }
+    return value
+  }
+  throw new ValidationError(`${field} must be a positive number or empty`, { field })
+}
+
+function parseOptionalString(value: unknown, field: string): string | null {
+  if (value === undefined || value === null) return null
+  if (typeof value !== 'string') {
+    throw new ValidationError(`${field} must be a string`, { field })
+  }
+  const trimmed = value.trim()
+  if (trimmed.length === 0) return null
+  if (trimmed.length > 256) {
+    throw new ValidationError(`${field} must be <= 256 chars`, { field })
+  }
+  return trimmed
+}
+
+function symbolConfigSnapshot(row: SymbolConfigRow): Record<string, unknown> {
+  return {
+    symbol: row.symbol,
+    name: row.name,
+    market: row.market,
+    currency: row.currency,
+    active: row.active,
+    maxNotional: row.maxNotional,
+    bucket: row.bucket,
+    notes: row.notes,
+    updatedAt: row.updatedAt,
+  }
+}
+
+function isFormContentType(contentType: string | undefined): boolean {
+  const ct = contentType ?? ''
+  return (
+    ct.includes('application/x-www-form-urlencoded') ||
+    ct.includes('multipart/form-data')
+  )
+}
+
+async function readFormOrJsonBody(c: Context<AppBindings>): Promise<unknown> {
+  if (isFormContentType(c.req.header('content-type'))) {
+    const fd = await c.req.formData()
+    const obj: Record<string, unknown> = {}
+    for (const [k, v] of fd.entries()) obj[k] = typeof v === 'string' ? v : ''
+    return obj
+  }
+  return (await c.req.json().catch(() => null)) as unknown
 }
 
 /**

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -18,7 +18,13 @@ import { resolveTradingEnabled } from '../trading/runtime/killSwitch'
 import { loadSymbolUniverse, type SymbolUniverse } from '../infrastructure/db/symbolUniverse'
 import { escapeHtml, formatSymbolDisplay } from '../shared/format'
 import { createDb } from '../infrastructure/db/tradeJournalRepo'
-import { MAX_TIME_STOP_DAYS, strategyDecisionLog, tradeJournal } from '../infrastructure/db/schema'
+import {
+  MAX_TIME_STOP_DAYS,
+  strategyDecisionLog,
+  symbolConfig,
+  tradeJournal,
+  type SymbolConfigRow,
+} from '../infrastructure/db/schema'
 import {
   loadRecentAudit,
   type ConfigAuditRow,
@@ -497,6 +503,48 @@ export const dashboard = new Hono<DashboardBindings>()
       return c.html(renderLayout(c, '監査ログ', unavailable(messageOf(err))))
     }
   })
+  /**
+   * 銘柄管理 (#292) — symbol_config CRUD UI。
+   *
+   * list / new / edit の 3 ページのみ render する read 系。POST は
+   * `/admin/symbol-config[/...]` に form submit → 303 redirect で戻る (PRG)。
+   */
+  .get('/symbols', async (c) => {
+    if (!c.env.DB) {
+      return c.html(renderLayout(c, '銘柄管理', unavailable('DB not bound')))
+    }
+    try {
+      const rows = await loadAllSymbolConfigRows(c.env.DB)
+      return c.html(renderLayout(c, '銘柄管理', symbolsListBody({ rows })))
+    } catch (err) {
+      return c.html(renderLayout(c, '銘柄管理', unavailable(messageOf(err))))
+    }
+  })
+  .get('/symbols/new', (c) => {
+    return c.html(
+      renderLayout(c, '銘柄管理 - 新規追加', symbolFormBody({ mode: 'new', row: null, error: null })),
+    )
+  })
+  .get('/symbols/:symbol/edit', async (c) => {
+    if (!c.env.DB) {
+      return c.html(renderLayout(c, '銘柄管理 - 編集', unavailable('DB not bound')))
+    }
+    const symbol = (c.req.param('symbol') ?? '').trim().toUpperCase()
+    if (symbol.length === 0) {
+      return c.html(renderLayout(c, '銘柄管理 - 編集', unavailable('symbol path param required')))
+    }
+    try {
+      const row = await findSymbolConfigForView(c.env.DB, symbol)
+      if (row === null) {
+        return c.html(renderLayout(c, '銘柄管理 - 編集', unavailable(`symbol "${symbol}" not found`)))
+      }
+      return c.html(
+        renderLayout(c, '銘柄管理 - 編集', symbolFormBody({ mode: 'edit', row, error: null })),
+      )
+    } catch (err) {
+      return c.html(renderLayout(c, '銘柄管理 - 編集', unavailable(messageOf(err))))
+    }
+  })
 
 function messageOf(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
@@ -719,6 +767,7 @@ function layout(title: string, body: string, env?: unknown): string {
   <a href="/dashboard/alerts">アラート</a>
   <span class="nav-group">運用</span>
   <a href="/dashboard/config">設定</a>
+  <a href="/dashboard/symbols">銘柄管理</a>
   <a href="/dashboard/audit">監査ログ</a>
   <a href="/dashboard/broker-probe" title="Webull broker に直接 quote/positions を投げて raw レスポンスを表示する診断ページ">broker 診断</a>
 </nav>
@@ -1116,6 +1165,7 @@ function indexBody(): string {
 <h2 style="font-size:14px;margin:16px 0 4px 0">運用</h2>
 <ul>
   <li><a href="/dashboard/config">設定</a> — <code>global_config</code> + 有効な <code>symbol_config</code></li>
+  <li><a href="/dashboard/symbols">銘柄管理</a> — <code>symbol_config</code> CRUD (#292)。追加 / 編集 / 有効化切替 / soft delete。</li>
   <li><a href="/dashboard/audit">監査ログ</a> — 状態変更系 admin POST の before/after 差分 (#274)。actor / endpoint / 日付で絞り込み可。</li>
   <li><a href="/dashboard/broker-probe">broker 診断</a> — Webull broker へ直接 quote / positions を投げて raw レスポンスを観察 (接続診断用)。</li>
 </ul>`
@@ -5565,4 +5615,144 @@ function renderSymbolPickerForTab(args: ChartsBodySymbol): string {
   return `<p class="muted" style="font-size:12px">
     銘柄: <strong>${esc(focusLabel)}</strong>${focusBadge} | 切替: ${opts}
   </p>`
+}
+
+/**
+ * 銘柄管理 (#292) ページの SELECT。`symbol_config` 全行 (active + inactive)
+ * を symbol ASC で返す。dashboard 表示専用。
+ */
+async function loadAllSymbolConfigRows(db: D1Database): Promise<SymbolConfigRow[]> {
+  const drizzle = createDb(db)
+  return await drizzle.select().from(symbolConfig).orderBy(asc(symbolConfig.symbol))
+}
+
+async function findSymbolConfigForView(
+  db: D1Database,
+  symbol: string,
+): Promise<SymbolConfigRow | null> {
+  const drizzle = createDb(db)
+  const rows = await drizzle
+    .select()
+    .from(symbolConfig)
+    .where(eq(symbolConfig.symbol, symbol))
+    .limit(1)
+  return rows[0] ?? null
+}
+
+function symbolsListBody(args: { rows: SymbolConfigRow[] }): string {
+  const { rows } = args
+  const headerBar = `<p style="margin:0 0 12px">
+    <a href="/dashboard/symbols/new" style="padding:6px 12px;background:#06c;color:#fff;border-radius:4px;text-decoration:none">+ 新規追加</a>
+    <span class="muted" style="margin-left:12px;font-size:12px">${rows.length} 件 (active ${rows.filter((r) => r.active).length} / inactive ${rows.filter((r) => !r.active).length})</span>
+  </p>`
+  if (rows.length === 0) {
+    return `${headerBar}<p class="muted">登録銘柄なし。「+ 新規追加」から最初の symbol を登録してください。</p>`
+  }
+  const tbody = rows
+    .map((r) => {
+      const inactive = !r.active
+      const rowClass = inactive ? ' class="symbol-disabled-row"' : ''
+      const symbolClass = inactive ? ' class="symbol-disabled"' : ''
+      const stateLabel = r.active
+        ? '<span class="ok">active</span>'
+        : '<span class="muted">inactive</span>'
+      const toggleLabel = r.active ? '無効化' : '有効化'
+      const editHref = `/dashboard/symbols/${encodeURIComponent(r.symbol)}/edit`
+      const toggleAction = `/admin/symbol-config/${encodeURIComponent(r.symbol)}/toggle-active`
+      const deleteAction = `/admin/symbol-config/${encodeURIComponent(r.symbol)}/delete`
+      // soft delete は active=false にするだけ (FK 影響回避)。既に inactive なら
+      // ボタン自体を出さない (no-op 防止) — toggle で対応可能。
+      const deleteForm = r.active
+        ? `<form method="post" action="${esc(deleteAction)}" style="display:inline" onsubmit="return confirm('${esc(r.symbol)} を無効化 (soft delete) します。本当によろしいですか？');">
+            <button type="submit" style="padding:3px 8px;font-size:12px;background:#c22;color:#fff;border:none;border-radius:4px;cursor:pointer">削除</button>
+          </form>`
+        : '<span class="muted" style="font-size:11px">—</span>'
+      return `<tr${rowClass}>
+        <td><strong><span${symbolClass}>${esc(r.symbol)}</span></strong></td>
+        <td>${esc(r.name ?? '')}</td>
+        <td>${esc(r.market)}</td>
+        <td>${esc(r.currency)}</td>
+        <td>${stateLabel}</td>
+        <td>${r.maxNotional === null ? '<span class="muted">—</span>' : esc(r.maxNotional)}</td>
+        <td>${esc(r.bucket ?? '')}</td>
+        <td>${esc(r.notes ?? '')}</td>
+        <td class="muted">${esc(fmtJst(r.updatedAt))}</td>
+        <td>
+          <a href="${esc(editHref)}" style="padding:3px 8px;font-size:12px;text-decoration:none">編集</a>
+          <form method="post" action="${esc(toggleAction)}" style="display:inline">
+            <button type="submit" style="padding:3px 8px;font-size:12px;cursor:pointer">${esc(toggleLabel)}</button>
+          </form>
+          ${deleteForm}
+        </td>
+      </tr>`
+    })
+    .join('')
+  return `${headerBar}
+  <table>
+    <thead><tr>
+      <th>symbol</th><th>name</th><th>market</th><th>currency</th><th>状態</th>
+      <th>max_notional</th><th>bucket</th><th>notes</th><th>updated_at</th><th>操作</th>
+    </tr></thead>
+    <tbody>${tbody}</tbody>
+  </table>`
+}
+
+interface SymbolFormArgs {
+  mode: 'new' | 'edit'
+  row: SymbolConfigRow | null
+  /** validation error message — POST handler が re-render する時に渡す。 */
+  error: string | null
+}
+
+function symbolFormBody(args: SymbolFormArgs): string {
+  const { mode, row, error } = args
+  const action =
+    mode === 'new' ? '/admin/symbol-config' : `/admin/symbol-config/${encodeURIComponent(row!.symbol)}/update`
+  const symbolValue = row?.symbol ?? ''
+  const nameValue = row?.name ?? ''
+  const marketValue = row?.market ?? 'US'
+  const currencyValue = row?.currency ?? 'USD'
+  const activeChecked = (row?.active ?? true) ? ' checked' : ''
+  const maxNotionalValue = row?.maxNotional === null || row?.maxNotional === undefined ? '' : String(row.maxNotional)
+  const bucketValue = row?.bucket ?? ''
+  const notesValue = row?.notes ?? ''
+  const symbolField =
+    mode === 'edit'
+      ? `<input type="text" name="symbol" value="${esc(symbolValue)}" readonly style="padding:6px;background:#eee">`
+      : `<input type="text" name="symbol" value="${esc(symbolValue)}" required maxlength="10" pattern="[A-Za-z0-9]{1,10}" placeholder="SOXL / 7974 / 1570" style="padding:6px">`
+  const errBlock = error ? `<p class="err" style="margin:0 0 12px">${esc(error)}</p>` : ''
+  const heading = mode === 'new' ? '新規銘柄追加' : `編集: ${esc(symbolValue)}`
+  return `<h2 style="font-size:16px;margin:8px 0 12px">${heading}</h2>
+  ${errBlock}
+  <form method="post" action="${esc(action)}" style="display:grid;grid-template-columns:120px 1fr;gap:8px;max-width:560px;align-items:center">
+    <label>symbol</label>${symbolField}
+    <label>name</label>
+    <input type="text" name="name" value="${esc(nameValue)}" maxlength="256" placeholder="人間可読な銘柄名 (任意)" style="padding:6px">
+    <label>market</label>
+    <select name="market" required style="padding:6px">
+      <option value="US"${marketValue === 'US' ? ' selected' : ''}>US</option>
+      <option value="JP"${marketValue === 'JP' ? ' selected' : ''}>JP</option>
+    </select>
+    <label>currency</label>
+    <select name="currency" required style="padding:6px">
+      <option value="USD"${currencyValue === 'USD' ? ' selected' : ''}>USD</option>
+      <option value="JPY"${currencyValue === 'JPY' ? ' selected' : ''}>JPY</option>
+    </select>
+    <label>active</label>
+    <label style="display:flex;align-items:center;gap:6px">
+      <input type="hidden" name="active" value="false">
+      <input type="checkbox" name="active" value="true"${activeChecked}> 有効
+    </label>
+    <label>max_notional</label>
+    <input type="number" name="max_notional" value="${esc(maxNotionalValue)}" step="0.01" min="0" placeholder="空欄で global default を使用" style="padding:6px">
+    <label>bucket</label>
+    <input type="text" name="bucket" value="${esc(bucketValue)}" maxlength="256" placeholder="例: semi / us_large_cap" style="padding:6px">
+    <label>notes</label>
+    <textarea name="notes" maxlength="256" rows="3" placeholder="自由記述 (例: 一時停止理由)" style="padding:6px;font-family:inherit">${esc(notesValue)}</textarea>
+    <span></span>
+    <div style="display:flex;gap:8px">
+      <button type="submit" style="padding:6px 16px;background:#06c;color:#fff;border:none;border-radius:4px;cursor:pointer">保存</button>
+      <a href="/dashboard/symbols" style="padding:6px 16px;text-decoration:none;border:1px solid #d0d0d5;border-radius:4px">キャンセル</a>
+    </div>
+  </form>`
 }

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -515,12 +515,19 @@ export const dashboard = new Hono<DashboardBindings>()
     }
     try {
       const rows = await loadAllSymbolConfigRows(c.env.DB)
-      return c.html(renderLayout(c, '銘柄管理', symbolsListBody({ rows })))
+      const errorCode = c.req.query('error') ?? null
+      const errorSymbol = c.req.query('symbol') ?? null
+      return c.html(
+        renderLayout(c, '銘柄管理', symbolsListBody({ rows, errorCode, errorSymbol })),
+      )
     } catch (err) {
       return c.html(renderLayout(c, '銘柄管理', unavailable(messageOf(err))))
     }
   })
   .get('/symbols/new', (c) => {
+    if (!c.env.DB) {
+      return c.html(renderLayout(c, '銘柄管理 - 新規追加', unavailable('DB not bound')))
+    }
     return c.html(
       renderLayout(c, '銘柄管理 - 新規追加', symbolFormBody({ mode: 'new', row: null, error: null })),
     )
@@ -5639,14 +5646,19 @@ async function findSymbolConfigForView(
   return rows[0] ?? null
 }
 
-function symbolsListBody(args: { rows: SymbolConfigRow[] }): string {
-  const { rows } = args
+function symbolsListBody(args: {
+  rows: SymbolConfigRow[]
+  errorCode?: string | null
+  errorSymbol?: string | null
+}): string {
+  const { rows, errorCode = null, errorSymbol = null } = args
+  const errorBanner = renderSymbolErrorBanner(errorCode, errorSymbol)
   const headerBar = `<p style="margin:0 0 12px">
     <a href="/dashboard/symbols/new" style="padding:6px 12px;background:#06c;color:#fff;border-radius:4px;text-decoration:none">+ 新規追加</a>
     <span class="muted" style="margin-left:12px;font-size:12px">${rows.length} 件 (active ${rows.filter((r) => r.active).length} / inactive ${rows.filter((r) => !r.active).length})</span>
   </p>`
   if (rows.length === 0) {
-    return `${headerBar}<p class="muted">登録銘柄なし。「+ 新規追加」から最初の symbol を登録してください。</p>`
+    return `${errorBanner}${headerBar}<p class="muted">登録銘柄なし。「+ 新規追加」から最初の symbol を登録してください。</p>`
   }
   const tbody = rows
     .map((r) => {
@@ -5687,7 +5699,7 @@ function symbolsListBody(args: { rows: SymbolConfigRow[] }): string {
       </tr>`
     })
     .join('')
-  return `${headerBar}
+  return `${errorBanner}${headerBar}
   <table>
     <thead><tr>
       <th>symbol</th><th>name</th><th>market</th><th>currency</th><th>状態</th>
@@ -5695,6 +5707,32 @@ function symbolsListBody(args: { rows: SymbolConfigRow[] }): string {
     </tr></thead>
     <tbody>${tbody}</tbody>
   </table>`
+}
+
+/**
+ * /admin/symbol-config 系 form POST が失敗時に redirect で渡してくる
+ * `?error=...&symbol=...` を表示する banner。known code 以外は generic msg。
+ */
+function renderSymbolErrorBanner(code: string | null, symbol: string | null): string {
+  if (!code) return ''
+  const msg = symbolErrorMessage(code, symbol)
+  return `<p class="err" style="margin:0 0 12px">${esc(msg)}</p>`
+}
+
+function symbolErrorMessage(code: string, symbol: string | null): string {
+  const sym = symbol ?? ''
+  switch (code) {
+    case 'duplicate':
+      return sym
+        ? `symbol "${sym}" は既に登録済みです。`
+        : 'symbol は既に登録済みです。'
+    case 'not_found':
+      return sym ? `symbol "${sym}" が見つかりません。` : 'symbol が見つかりません。'
+    case 'validation':
+      return '入力値に誤りがあります。'
+    default:
+      return `エラーが発生しました (code=${code}).`
+  }
 }
 
 interface SymbolFormArgs {
@@ -5718,7 +5756,9 @@ function symbolFormBody(args: SymbolFormArgs): string {
   const notesValue = row?.notes ?? ''
   const symbolField =
     mode === 'edit'
-      ? `<input type="text" name="symbol" value="${esc(symbolValue)}" readonly style="padding:6px;background:#eee">`
+      ? `<input type="text" name="symbol" value="${esc(symbolValue)}" readonly style="padding:6px;background:#eee">
+         <span></span>
+         <p class="muted" style="margin:0;font-size:11px">symbol は immutable です。変更したい場合は一度削除して再追加してください。</p>`
       : `<input type="text" name="symbol" value="${esc(symbolValue)}" required maxlength="10" pattern="[A-Za-z0-9]{1,10}" placeholder="SOXL / 7974 / 1570" style="padding:6px">`
   const errBlock = error ? `<p class="err" style="margin:0 0 12px">${esc(error)}</p>` : ''
   const heading = mode === 'new' ? '新規銘柄追加' : `編集: ${esc(symbolValue)}`
@@ -5744,7 +5784,7 @@ function symbolFormBody(args: SymbolFormArgs): string {
       <input type="checkbox" name="active" value="true"${activeChecked}> 有効
     </label>
     <label>max_notional</label>
-    <input type="number" name="max_notional" value="${esc(maxNotionalValue)}" step="0.01" min="0" placeholder="空欄で global default を使用" style="padding:6px">
+    <input type="number" name="max_notional" value="${esc(maxNotionalValue)}" step="0.01" min="0.01" placeholder="空欄で global default を使用" style="padding:6px">
     <label>bucket</label>
     <input type="text" name="bucket" value="${esc(bucketValue)}" maxlength="256" placeholder="例: semi / us_large_cap" style="padding:6px">
     <label>notes</label>

--- a/test/routes/dashboardSymbolsCrud.test.ts
+++ b/test/routes/dashboardSymbolsCrud.test.ts
@@ -105,7 +105,7 @@ function fakeDb(initial: SymbolConfigRow[]) {
         return selectChain(() => filtered().filter((r) => sym === null || r.symbol === sym))
       },
       orderBy: (_o: unknown) => chain,
-      limit: (_n: number) => Promise.resolve(filtered()),
+      limit: (n: number) => Promise.resolve(filtered().slice(0, n)),
       then: (resolve: (v: SymbolConfigRow[]) => unknown, reject?: (e: unknown) => unknown) =>
         Promise.resolve(filtered()).then(resolve, reject),
     }
@@ -121,10 +121,15 @@ function fakeDb(initial: SymbolConfigRow[]) {
       insert: (table: unknown) => ({
         values: async (v: Record<string, unknown>) => {
           const tn = tableName(table)
-          inserts.push({ table: tn, values: v })
           if (tn === 'symbol_config') {
+            const sym = String(v.symbol ?? '')
+            // UNIQUE constraint on `symbol` を sqlite と同じ message で模倣。
+            // insertSymbolConfig の TOCTOU 修正 (UNIQUE 違反を null 化) の検証用。
+            if (rows.some((r) => r.symbol === sym)) {
+              throw new Error('UNIQUE constraint failed: symbol_config.symbol')
+            }
             rows.push({
-              symbol: String(v.symbol ?? ''),
+              symbol: sym,
               name: (v.name as string | null) ?? null,
               market: String(v.market ?? 'US'),
               currency: String(v.currency ?? 'USD'),
@@ -135,6 +140,7 @@ function fakeDb(initial: SymbolConfigRow[]) {
               updatedAt: String(v.updatedAt ?? ''),
             })
           }
+          inserts.push({ table: tn, values: v })
         },
       }),
       update: (table: unknown) => ({
@@ -142,14 +148,27 @@ function fakeDb(initial: SymbolConfigRow[]) {
           where: async (cond: unknown) => {
             const tn = tableName(table)
             const symbol = extractSymbolFromWhere(cond)
-            updates.push({ table: tn as 'symbol_config', set: s, whereSymbol: symbol })
             if (tn === 'symbol_config' && symbol !== null) {
               for (let i = 0; i < rows.length; i++) {
                 if (rows[i]!.symbol === symbol) {
-                  rows[i] = { ...rows[i]!, ...(s as Partial<SymbolConfigRow>) }
+                  // `active` が drizzle `sql\`NOT active\`` 表現で来た場合は
+                  // fake 側で boolean に解決する (toggleSymbolActive の
+                  // atomic update を fake DB で再現)。
+                  const resolved: Record<string, unknown> = { ...s }
+                  if (resolved.active !== null && typeof resolved.active === 'object') {
+                    resolved.active = !rows[i]!.active
+                  }
+                  rows[i] = { ...rows[i]!, ...(resolved as Partial<SymbolConfigRow>) }
+                  updates.push({
+                    table: tn as 'symbol_config',
+                    set: resolved,
+                    whereSymbol: symbol,
+                  })
+                  return
                 }
               }
             }
+            updates.push({ table: tn as 'symbol_config', set: s, whereSymbol: symbol })
           },
         }),
       }),
@@ -419,5 +438,149 @@ describe('dashboard symbol_config CRUD UI (#292)', () => {
     expect(editBody).not.toContain(xssNotes)
     expect(editBody).not.toContain(xssBucket)
     expect(editBody).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+    expect(editBody).toContain('&quot;&gt;&lt;svg onload=alert(2)&gt;')
+  })
+
+  // --- TOCTOU: 既存 symbol を form POST → 303 redirect with ?error=duplicate ---
+  it('POST /admin/symbol-config returns 303 with ?error=duplicate when symbol exists (form)', async () => {
+    const db = fakeDb([row({ symbol: 'SOXL' })])
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const app = createApp()
+    const res = await app.request(
+      '/admin/symbol-config',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...authHeader },
+        body: new URLSearchParams({
+          symbol: 'SOXL',
+          market: 'US',
+          currency: 'USD',
+          active: 'true',
+        }).toString(),
+      },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    expect(res.status).toBe(303)
+    expect(res.headers.get('location')).toBe(
+      '/dashboard/symbols?error=duplicate&symbol=SOXL',
+    )
+  })
+
+  // --- TOCTOU: 既存 symbol を JSON POST → 409 with error code (JSON path keeps semantics) ---
+  it('POST /admin/symbol-config returns 409 when symbol exists (JSON)', async () => {
+    const db = fakeDb([row({ symbol: 'SOXL' })])
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const app = createApp()
+    const res = await app.request(
+      '/admin/symbol-config',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeader },
+        body: JSON.stringify({
+          symbol: 'SOXL',
+          market: 'US',
+          currency: 'USD',
+          active: true,
+        }),
+      },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    expect(res.status).toBe(409)
+    const body = await res.json()
+    expect(body).toMatchObject({ error: 'symbol_already_exists', symbol: 'SOXL' })
+  })
+
+  // --- list error banner is rendered from ?error= query (PRG from failed POST) ---
+  it('renders error banner on /dashboard/symbols?error=duplicate&symbol=SOXL', async () => {
+    const db = fakeDb([row({ symbol: 'SOXL' })])
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const app = createApp()
+    const res = await app.request(
+      '/dashboard/symbols?error=duplicate&symbol=SOXL',
+      { headers: authHeader },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    expect(body).toContain('SOXL')
+    expect(body).toContain('既に登録済み')
+  })
+
+  // --- atomic toggle: SQL NOT active is sent in the UPDATE set ---
+  it('toggle-active sends SQL NOT expression (not a precomputed boolean) to UPDATE', async () => {
+    const db = fakeDb([row({ symbol: 'SOXL', active: true })])
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const app = createApp()
+    await app.request(
+      '/admin/symbol-config/SOXL/toggle-active',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...authHeader },
+        body: '',
+      },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    // fake DB unwraps the SQL NOT into a boolean (= !before.active) so the
+    // resulting row is flipped. The end-state check is what matters:
+    // 単純 read-modify-write だと「現在 active を SELECT してから書き戻し」
+    // になり race するが、新実装は SQL NOT を渡すことで DB が atomic に
+    // flip する。fake では update 後 row が反転していることだけ検証する。
+    const soxl = db.rows.find((r) => r.symbol === 'SOXL')
+    expect(soxl?.active).toBe(false)
+  })
+
+  // --- /symbols/new : DB unavailable returns unavailable page ---
+  it('GET /dashboard/symbols/new returns DB-not-bound page when DB binding missing', async () => {
+    const app = createApp()
+    const res = await app.request(
+      '/dashboard/symbols/new',
+      { headers: authHeader },
+      { ...baseEnv },
+    )
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    expect(body).toContain('DB not bound')
+  })
+
+  // --- edit form has immutability hint ---
+  it('GET /dashboard/symbols/:symbol/edit shows immutability hint for the symbol field', async () => {
+    const db = fakeDb([row({ symbol: 'SOXL' })])
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const app = createApp()
+    const res = await app.request(
+      '/dashboard/symbols/SOXL/edit',
+      { headers: authHeader },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    expect(body).toContain('immutable')
+  })
+
+  // --- toggle JSON path returns full row snapshot, not only `active` ---
+  it('toggle-active JSON response returns full row snapshot', async () => {
+    const db = fakeDb([row({ symbol: 'SOXL', active: true, maxNotional: 2000, bucket: 'semi' })])
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const app = createApp()
+    const res = await app.request(
+      '/admin/symbol-config/SOXL/toggle-active',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeader },
+        body: '',
+      },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toMatchObject({
+      symbol: 'SOXL',
+      row: {
+        symbol: 'SOXL',
+        active: false,
+        maxNotional: 2000,
+        bucket: 'semi',
+      },
+    })
   })
 })

--- a/test/routes/dashboardSymbolsCrud.test.ts
+++ b/test/routes/dashboardSymbolsCrud.test.ts
@@ -1,0 +1,423 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp } from '../../src/app'
+import { loadGlobalConfigFrom } from '../../src/infrastructure/db/globalConfigLoader'
+import { createDb } from '../../src/infrastructure/db/tradeJournalRepo'
+import { makeGlobalConfigSnapshot } from '../helpers/configFixtures'
+import type { SymbolConfigRow } from '../../src/infrastructure/db/schema'
+
+/**
+ * symbol_config CRUD UI tests (#292)。dashboard 3 ページ (list / new / edit) +
+ * 4 admin POST endpoint を end-to-end でカバーする。
+ *
+ * DB は `createDb` を spy で差し替えて in-memory store として振る舞わせる
+ * (audit log の insert もここに乗る — table を分けて capture)。これで
+ * symbol_config 操作と audit log 書き込みを 1 つの fake で検証できる。
+ */
+
+vi.mock('../../src/infrastructure/db/globalConfigLoader', () => ({
+  loadGlobalConfigFrom: vi.fn(),
+}))
+vi.mock('../../src/infrastructure/db/tradeJournalRepo', async () => {
+  const actual = await vi.importActual<typeof import('../../src/infrastructure/db/tradeJournalRepo')>(
+    '../../src/infrastructure/db/tradeJournalRepo',
+  )
+  return { ...actual, createDb: vi.fn() }
+})
+
+const baseEnv = {
+  ACCESS_DEV_BYPASS_USER: 'admin',
+}
+const authHeader = {}
+
+interface InsertCall {
+  table: 'symbol_config' | 'config_audit_log' | 'unknown'
+  values: Record<string, unknown>
+}
+interface UpdateCall {
+  table: 'symbol_config' | 'unknown'
+  set: Record<string, unknown>
+  whereSymbol: string | null
+}
+
+/**
+ * 最小限の drizzle-like fake。`drizzle` API の chainable オブジェクトを模倣し、
+ * symbol_config 行 (in-memory) と audit log の inserts / updates を記録する。
+ *
+ * select chain は filter を捕捉しないので、呼び出し側は `findSymbolConfig`
+ * → `db.select().from(tbl).where(eq(tbl.symbol, X)).limit(1)` の 1 件返却を
+ * 期待する。fake では select chain がそれぞれ自身を返し、最終 `await` で
+ * `currentRows` を返す。`where` 時に渡される drizzle eq(...) は内部に値を
+ * 保持するので JSON 化して symbol を取り出してフィルタする。
+ */
+function fakeDb(initial: SymbolConfigRow[]) {
+  const rows: SymbolConfigRow[] = [...initial]
+  const inserts: InsertCall[] = []
+  const updates: UpdateCall[] = []
+
+  const tableName = (t: unknown): InsertCall['table'] => {
+    // drizzle SQLite table object stores name in `[Symbol.for('drizzle:Name')]` or `_.name`。
+    const sym = Object.getOwnPropertySymbols(t as object).find((s) => String(s).includes('drizzle:Name'))
+    if (sym) {
+      const v = (t as Record<symbol, unknown>)[sym]
+      if (v === 'symbol_config') return 'symbol_config'
+      if (v === 'config_audit_log') return 'config_audit_log'
+    }
+    const inner = (t as { _?: { name?: string } })?._?.name
+    if (inner === 'symbol_config') return 'symbol_config'
+    if (inner === 'config_audit_log') return 'config_audit_log'
+    return 'unknown'
+  }
+
+  // drizzle eq(symbolConfig.symbol, X) は SQL クエリオブジェクト内の Param
+  // ノードに X を入れる。POC test 用に、`Param`-like ノード (`{ value: X,
+  // encoder, ... }`) を最初に拾った時点で返す。drizzle 表現は内部 API な
+  // ので unstable だが test 用途には十分。
+  const extractSymbolFromWhere = (cond: unknown): string | null => {
+    const seen = new WeakSet<object>()
+    const visit = (node: unknown): string | null => {
+      if (node === null || typeof node !== 'object') return null
+      if (seen.has(node)) return null
+      seen.add(node)
+      const obj = node as Record<string, unknown>
+      // Param ノードは `value` フィールド + `encoder` フィールドを持つ。
+      // 単に `name` (= column name) を value にしている SQL ノードと区別する。
+      if (
+        'value' in obj &&
+        typeof obj.value === 'string' &&
+        ('encoder' in obj || 'brand' in obj)
+      ) {
+        return obj.value
+      }
+      for (const k of Object.keys(obj)) {
+        const child = visit(obj[k])
+        if (child !== null) return child
+      }
+      return null
+    }
+    return visit(cond)
+  }
+
+  const selectChain = (filtered: () => SymbolConfigRow[]) => {
+    const chain = {
+      from: (_tbl: unknown) => chain,
+      where: (cond: unknown) => {
+        const sym = extractSymbolFromWhere(cond)
+        return selectChain(() => filtered().filter((r) => sym === null || r.symbol === sym))
+      },
+      orderBy: (_o: unknown) => chain,
+      limit: (_n: number) => Promise.resolve(filtered()),
+      then: (resolve: (v: SymbolConfigRow[]) => unknown, reject?: (e: unknown) => unknown) =>
+        Promise.resolve(filtered()).then(resolve, reject),
+    }
+    return chain
+  }
+
+  return {
+    inserts,
+    updates,
+    rows,
+    drizzleLike: {
+      select: () => selectChain(() => rows),
+      insert: (table: unknown) => ({
+        values: async (v: Record<string, unknown>) => {
+          const tn = tableName(table)
+          inserts.push({ table: tn, values: v })
+          if (tn === 'symbol_config') {
+            rows.push({
+              symbol: String(v.symbol ?? ''),
+              name: (v.name as string | null) ?? null,
+              market: String(v.market ?? 'US'),
+              currency: String(v.currency ?? 'USD'),
+              active: v.active === true || v.active === 1,
+              maxNotional: (v.maxNotional as number | null) ?? null,
+              bucket: (v.bucket as string | null) ?? null,
+              notes: (v.notes as string | null) ?? null,
+              updatedAt: String(v.updatedAt ?? ''),
+            })
+          }
+        },
+      }),
+      update: (table: unknown) => ({
+        set: (s: Record<string, unknown>) => ({
+          where: async (cond: unknown) => {
+            const tn = tableName(table)
+            const symbol = extractSymbolFromWhere(cond)
+            updates.push({ table: tn as 'symbol_config', set: s, whereSymbol: symbol })
+            if (tn === 'symbol_config' && symbol !== null) {
+              for (let i = 0; i < rows.length; i++) {
+                if (rows[i]!.symbol === symbol) {
+                  rows[i] = { ...rows[i]!, ...(s as Partial<SymbolConfigRow>) }
+                }
+              }
+            }
+          },
+        }),
+      }),
+    },
+  }
+}
+
+function row(overrides: Partial<SymbolConfigRow> = {}): SymbolConfigRow {
+  return {
+    symbol: 'SOXL',
+    name: 'Direxion Semi 3X',
+    market: 'US',
+    currency: 'USD',
+    active: true,
+    maxNotional: 2000,
+    bucket: 'semi',
+    notes: null,
+    updatedAt: '2026-04-23T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('dashboard symbol_config CRUD UI (#292)', () => {
+  beforeEach(() => {
+    vi.mocked(loadGlobalConfigFrom).mockResolvedValue(makeGlobalConfigSnapshot())
+  })
+  afterEach(() => vi.resetAllMocks())
+
+  // --- List page ---
+  it('renders /dashboard/symbols list with active + inactive rows', async () => {
+    const db = fakeDb([
+      row({ symbol: 'SOXL', name: 'Direxion Semi 3X', active: true, maxNotional: 2000, bucket: 'semi' }),
+      row({ symbol: '7203', name: 'トヨタ自動車', market: 'JP', currency: 'JPY', active: false, maxNotional: null, bucket: null, notes: 'paused' }),
+    ])
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const app = createApp()
+    const res = await app.request('/dashboard/symbols', { headers: authHeader }, { ...baseEnv, DB: {} as D1Database })
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    expect(body).toContain('SOXL')
+    expect(body).toContain('Direxion Semi 3X')
+    expect(body).toContain('7203')
+    expect(body).toContain('トヨタ自動車')
+    expect(body).toContain('+ 新規追加')
+    // action links per row
+    expect(body).toContain('/dashboard/symbols/SOXL/edit')
+    expect(body).toContain('/admin/symbol-config/SOXL/toggle-active')
+    // soft delete button only on active row
+    expect(body).toContain('/admin/symbol-config/SOXL/delete')
+    expect(body).not.toContain('/admin/symbol-config/7203/delete')
+    // counts
+    expect(body).toContain('active 1 / inactive 1')
+  })
+
+  // --- POST add ---
+  it('POST /admin/symbol-config inserts row + writes audit row, redirects 303', async () => {
+    const db = fakeDb([])
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const app = createApp()
+    const form = new URLSearchParams({
+      symbol: 'tqqq',
+      name: 'ProShares UltraPro QQQ',
+      market: 'US',
+      currency: 'USD',
+      active: 'true',
+      max_notional: '1500',
+      bucket: 'us_large_cap',
+      notes: '',
+    })
+    const res = await app.request(
+      '/admin/symbol-config',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...authHeader },
+        body: form.toString(),
+      },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    expect(res.status).toBe(303)
+    expect(res.headers.get('location')).toBe('/dashboard/symbols')
+    const symbolInsert = db.inserts.find((i) => i.table === 'symbol_config')
+    expect(symbolInsert).toBeDefined()
+    expect(symbolInsert!.values).toMatchObject({
+      symbol: 'TQQQ',
+      market: 'US',
+      currency: 'USD',
+      active: true,
+      maxNotional: 1500,
+      bucket: 'us_large_cap',
+      name: 'ProShares UltraPro QQQ',
+    })
+    const auditInsert = db.inserts.find((i) => i.table === 'config_audit_log')
+    expect(auditInsert).toBeDefined()
+    expect(auditInsert!.values).toMatchObject({
+      actor: 'admin',
+      endpoint: '/admin/symbol-config',
+      targetKey: 'symbol=TQQQ',
+    })
+    expect(JSON.parse(String(auditInsert!.values.beforeJson))).toBeNull()
+    expect(JSON.parse(String(auditInsert!.values.afterJson))).toMatchObject({
+      symbol: 'TQQQ',
+      market: 'US',
+      currency: 'USD',
+    })
+  })
+
+  // --- POST update ---
+  it('POST /admin/symbol-config/:symbol/update writes audit with before/after diff', async () => {
+    const db = fakeDb([row({ symbol: 'SOXL', maxNotional: 2000, bucket: 'semi' })])
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const app = createApp()
+    const form = new URLSearchParams({
+      symbol: 'SOXL', // path source of truth, body should be overridden
+      name: 'Direxion Semi 3X (edited)',
+      market: 'US',
+      currency: 'USD',
+      active: 'true',
+      max_notional: '3000',
+      bucket: 'semi',
+      notes: 'bumped',
+    })
+    const res = await app.request(
+      '/admin/symbol-config/SOXL/update',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...authHeader },
+        body: form.toString(),
+      },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    expect(res.status).toBe(303)
+    expect(res.headers.get('location')).toBe('/dashboard/symbols')
+    const update = db.updates.find((u) => u.table === 'symbol_config')
+    expect(update).toBeDefined()
+    expect(update!.set).toMatchObject({
+      maxNotional: 3000,
+      notes: 'bumped',
+    })
+    const auditInsert = db.inserts.find((i) => i.table === 'config_audit_log')
+    expect(auditInsert).toBeDefined()
+    const before = JSON.parse(String(auditInsert!.values.beforeJson))
+    const after = JSON.parse(String(auditInsert!.values.afterJson))
+    expect(before.maxNotional).toBe(2000)
+    expect(after.maxNotional).toBe(3000)
+    expect(after.notes).toBe('bumped')
+  })
+
+  // --- POST toggle-active ---
+  it('POST /admin/symbol-config/:symbol/toggle-active flips active + writes audit', async () => {
+    const db = fakeDb([row({ symbol: 'SOXL', active: true })])
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const app = createApp()
+    const res = await app.request(
+      '/admin/symbol-config/SOXL/toggle-active',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...authHeader },
+        body: '',
+      },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    expect(res.status).toBe(303)
+    const update = db.updates.find((u) => u.table === 'symbol_config')
+    expect(update).toBeDefined()
+    expect(update!.set).toMatchObject({ active: false })
+    const auditInsert = db.inserts.find((i) => i.table === 'config_audit_log')
+    expect(auditInsert).toBeDefined()
+    expect(JSON.parse(String(auditInsert!.values.beforeJson))).toEqual({ active: true })
+    expect(JSON.parse(String(auditInsert!.values.afterJson))).toEqual({ active: false })
+  })
+
+  // --- POST delete (soft) ---
+  it('POST /admin/symbol-config/:symbol/delete soft-deletes (active=false) without hard delete', async () => {
+    const db = fakeDb([row({ symbol: 'SOXL', active: true })])
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const app = createApp()
+    const res = await app.request(
+      '/admin/symbol-config/SOXL/delete',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...authHeader },
+        body: '',
+      },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    expect(res.status).toBe(303)
+    // UPDATE 1 件のみ — DELETE は呼ばれないこと
+    const updates = db.updates.filter((u) => u.table === 'symbol_config')
+    expect(updates).toHaveLength(1)
+    expect(updates[0]!.set).toMatchObject({ active: false })
+    const auditInsert = db.inserts.find((i) => i.table === 'config_audit_log')
+    expect(auditInsert).toBeDefined()
+    expect(JSON.parse(String(auditInsert!.values.afterJson))).toEqual({ active: false })
+  })
+
+  // --- Validation ---
+  it('validation: rejects empty symbol / unknown market / negative max_notional with 400', async () => {
+    const db = fakeDb([])
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const app = createApp()
+
+    const badSymbol = await app.request(
+      '/admin/symbol-config',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...authHeader },
+        body: new URLSearchParams({ symbol: '', market: 'US', currency: 'USD' }).toString(),
+      },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    expect(badSymbol.status).toBe(400)
+
+    const badMarket = await app.request(
+      '/admin/symbol-config',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...authHeader },
+        body: new URLSearchParams({ symbol: 'SOXL', market: 'EU', currency: 'USD' }).toString(),
+      },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    expect(badMarket.status).toBe(400)
+
+    const badNotional = await app.request(
+      '/admin/symbol-config',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...authHeader },
+        body: new URLSearchParams({
+          symbol: 'SOXL',
+          market: 'US',
+          currency: 'USD',
+          max_notional: '-5',
+        }).toString(),
+      },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    expect(badNotional.status).toBe(400)
+
+    // どれも insert は走っていない
+    expect(db.inserts.filter((i) => i.table === 'symbol_config')).toHaveLength(0)
+  })
+
+  // --- XSS regression ---
+  it('escapes <script>/<svg> payloads in notes / bucket on list and edit pages', async () => {
+    const xssNotes = '<script>alert(1)</script>'
+    const xssBucket = '"><svg onload=alert(2)>'
+    const db = fakeDb([row({ symbol: 'SOXL', notes: xssNotes, bucket: xssBucket })])
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const app = createApp()
+
+    // list page
+    const listRes = await app.request('/dashboard/symbols', { headers: authHeader }, { ...baseEnv, DB: {} as D1Database })
+    const listBody = await listRes.text()
+    expect(listBody).not.toContain(xssNotes)
+    expect(listBody).not.toContain(xssBucket)
+    expect(listBody).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+    expect(listBody).toContain('&quot;&gt;&lt;svg onload=alert(2)&gt;')
+
+    // edit page
+    const editRes = await app.request(
+      '/dashboard/symbols/SOXL/edit',
+      { headers: authHeader },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    const editBody = await editRes.text()
+    expect(editBody).not.toContain(xssNotes)
+    expect(editBody).not.toContain(xssBucket)
+    expect(editBody).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+  })
+})


### PR DESCRIPTION
Closes #292
Refs #291

## Summary

symbol_config の CRUD を Web から出来るようにする。`/dashboard/symbols` で一覧 / 追加 / 編集 / active toggle / 削除。

## 変更点

### 新規 admin endpoints (`src/routes/admin.ts`)
- \`POST /admin/symbol-config\` — insert (409 on duplicate)
- \`POST /admin/symbol-config/:symbol/update\` — 全 field 更新
- \`POST /admin/symbol-config/:symbol/toggle-active\` — active 1↔0
- \`POST /admin/symbol-config/:symbol/delete\` — soft delete (active=false)

すべて \`rateLimit('ADMIN_WRITE')\` + \`writeAuditLog\` wrap。form-encoded + JSON 両受、form path は 303 redirect、JSON path は 200 with row snapshot。

### 新規 dashboard pages (`src/routes/dashboard.ts`)
- \`GET /dashboard/symbols\` — 一覧 (10 columns、active + inactive 全表示、編集/toggle/削除 ボタン)
- \`GET /dashboard/symbols/new\` — 追加 form
- \`GET /dashboard/symbols/:symbol/edit\` — 編集 form (pre-filled)

### 新規 repo helpers (`src/infrastructure/db/symbolConfigRepo.ts`)
- \`findSymbolConfig\` / \`insertSymbolConfig\` / \`updateSymbolConfig\` / \`toggleSymbolActive\` / \`softDeleteSymbol\` (before/after snapshot 返す = audit diff 用)

### Nav / index
- 運用 group に \`銘柄管理\` link 追加
- index page の運用 section に対応 li 追加

## Validation

- symbol: 1-10 chars \`[A-Z0-9]\` (JP 4 桁数字許可)
- market: \`'US' | 'JP'\`
- currency: \`'USD' | 'JPY'\`
- max_notional: 正数 or NULL (form 空欄 → NULL = global cap fall-through)
- active checkbox: hidden \`false\` + checkbox \`true\` で unchecked submit 対応

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` 1049/78 files (+7 CRUD tests)
- [x] list / add / update / toggle / delete each + validation + XSS regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ダッシュボードに銘柄設定の管理画面（一覧、新規作成、編集、状態切替、削除）を追加
  * 管理用の公開API（作成・更新・状態切替・ソフト削除）を追加し、操作は監査ログに記録

* **Validation / UX**
  * 入力の厳密な正規化・検証とフォーム/JSONの共通処理、エラーバナーやリダイレクト挙動を整備

* **Tests**
  * 銘柄管理のエンドツーエンドテストを追加（一覧・作成・更新・トグル・削除・バリデーション・XSS対策等）

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/294)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->