### PR TITLE
feat(dashboard): earnings + macro events management UI (#293)

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono'
+import type { Context } from 'hono'
 import type { AppBindings } from '../app'
 import type { Env } from '../config/env'
 import { rateLimit } from '../middleware/rateLimit'
@@ -38,11 +39,29 @@ import {
 import type { NotificationSeverity, NotificationEvent } from '../infrastructure/notification/Notifier'
 import { loadVixRegimeSnapshot } from '../infrastructure/notification/vixRegimeChange'
 import type { VixRegime } from '../trading/risk/vixRegimeFilter'
-import { and, asc, desc, eq } from 'drizzle-orm'
+import { and, asc, desc, eq, gte, lte } from 'drizzle-orm'
 import { PortfolioStateClient } from '../trading/state/PortfolioStateClient'
 import { SymbolStateClient } from '../trading/state/SymbolStateClient'
 import type { SymbolState } from '../trading/state/types'
 import { YahooBarClient } from '../infrastructure/quotes/YahooBarClient'
+// #293 calendar events management UI (earnings + macro)。dashboard 側に form
+// 受け handler を置くのは admin/seed が JSON 専用で `application/x-www-form-urlencoded`
+// を受けない (= HTML form から直接 POST できない) ため。バリデーション失敗時に
+// 入力値を保持したまま再描画する必要があり、PRG redirect だと echo が崩れる。
+// repo 呼び出し + rate-limit + writeAuditLog は admin route と同じ部品を再利用。
+import {
+  createEarningsCalendarDb,
+  createEarningsCalendarRepo,
+  type EarningsCalendarSeedInput,
+} from '../infrastructure/calendar/earningsCalendarRepo'
+import {
+  createMacroEventCalendarDb,
+  createMacroEventCalendarRepo,
+  type MacroEventCalendarSeedInput,
+} from '../infrastructure/calendar/macroEventCalendarRepo'
+import { earningsCalendar, macroEventCalendar } from '../infrastructure/db/schema'
+import type { EarningsCalendarRow, MacroEventCalendarRow } from '../infrastructure/db/schema'
+import { extractActor, recordChange } from '../infrastructure/db/configAuditLog'
 
 /**
  * Read-only operator dashboard (#121). Server-rendered HTML via Hono — no
@@ -552,6 +571,236 @@ export const dashboard = new Hono<DashboardBindings>()
       return c.html(renderLayout(c, '銘柄管理 - 編集', unavailable(messageOf(err))))
     }
   })
+  /**
+   * #293 — earnings + macro event calendar 管理 UI。
+   *
+   * `earnings_calendar` / `macro_event_calendar` への手動 add / delete を
+   * Web UI で行えるようにする。両 calendar とも risk gate のソース
+   * (`earningsGate` / `macroEventGate`) なので, operator が dashboard 経由で
+   * 直接管理できる必要がある (AI agent 経由の curl だけだと運用効率が悪い)。
+   *
+   * 範囲は now-30d 〜 now+30d (直近+近未来の "実際に gate が見る窓") を表示。
+   * 過去 30 日以前 / 365 日以降は dashboard では出さない (operator の関心外
+   * + 一覧の長さを抑える); 必要なら admin GET endpoint で直接読める。
+   */
+  .get('/events', async (c) => {
+    if (!c.env.DB) {
+      return c.html(renderLayout(c, 'イベント', unavailable('DB not bound')))
+    }
+    try {
+      const universe = await loadSymbolUniverse(c.env).catch(() => null)
+      const { from, to } = eventsDisplayRange(new Date())
+      const earningsRepo = createEarningsCalendarRepo(createEarningsCalendarDb(c.env.DB))
+      const macroRepo = createMacroEventCalendarRepo(createMacroEventCalendarDb(c.env.DB))
+      const [earnings, macros] = await Promise.all([
+        loadEarningsInRange(c.env.DB, from, to),
+        macroRepo.fetchAll({ fromYmd: from, toYmd: to }),
+      ])
+      return c.html(
+        renderLayout(
+          c,
+          'イベント',
+          eventsBody({
+            earnings,
+            macros,
+            from,
+            to,
+            universe,
+            errors: null,
+            formEcho: null,
+          }),
+        ),
+      )
+    } catch (err) {
+      // migration 未適用 / 一時的な D1 エラーで 500 にせず unavailable に落とす
+      // (他 dashboard page と同じ defensive 姿勢)。
+      return c.html(renderLayout(c, 'イベント', unavailable(messageOf(err))))
+    }
+  })
+  /**
+   * earnings 1 行 seed form 受け。HTML form は JSON を送らないので
+   * `application/x-www-form-urlencoded` を parse → 1 件配列に wrap → 既存
+   * repo の `bulkUpsert` を呼ぶ。バリデーション失敗時は再描画 + 入力 echo
+   * (PRG redirect だと form の値が失われる)。
+   */
+  .post('/events/earnings/seed', rateLimit('ADMIN_WRITE'), async (c) => {
+    if (!c.env.DB) {
+      return c.html(renderLayout(c, 'イベント', unavailable('DB not bound')))
+    }
+    const form = Object.fromEntries((await c.req.formData()).entries())
+    const echo: EventsEarningsFormEcho = {
+      symbol: typeof form.symbol === 'string' ? form.symbol : '',
+      earningsDate: typeof form.earnings_date === 'string' ? form.earnings_date : '',
+      notes: typeof form.notes === 'string' ? form.notes : '',
+    }
+    const universe = await loadSymbolUniverse(c.env).catch(() => null)
+    const validation = validateEarningsForm(echo, universe)
+    if (!validation.ok) {
+      return await renderEventsWithError(c, {
+        section: 'earnings',
+        message: validation.error,
+        earningsEcho: echo,
+        macroEcho: null,
+      })
+    }
+    const record: EarningsCalendarSeedInput = {
+      symbol: validation.symbol,
+      earningsDate: validation.earningsDate,
+      notes: validation.notes,
+    }
+    const repo = createEarningsCalendarRepo(createEarningsCalendarDb(c.env.DB))
+    try {
+      const result = await repo.bulkUpsert([record])
+      if (result.inserted > 0) {
+        await writeEventsAuditLog(
+          c,
+          '/dashboard/events/earnings/seed',
+          `symbol=${record.symbol} date=${record.earningsDate}`,
+          null,
+          { inserted: result.inserted, skipped: result.skipped, records: [record] },
+        )
+      }
+    } catch (err) {
+      return await renderEventsWithError(c, {
+        section: 'earnings',
+        message: `保存に失敗しました: ${messageOf(err)}`,
+        earningsEcho: echo,
+        macroEcho: null,
+      })
+    }
+    return c.redirect('/dashboard/events', 303)
+  })
+  /**
+   * earnings 1 行 delete form 受け。HTML form は DELETE method を送れないので
+   * POST を companion endpoint として用意 (admin の DELETE と独立に, dashboard
+   * 内で完結させる)。rate-limit + audit log は admin と同等に適用。
+   */
+  .post('/events/earnings/:id/delete', rateLimit('ADMIN_WRITE'), async (c) => {
+    if (!c.env.DB) {
+      return c.html(renderLayout(c, 'イベント', unavailable('DB not bound')))
+    }
+    const id = Number(c.req.param('id'))
+    if (!Number.isInteger(id) || id <= 0) {
+      return await renderEventsWithError(c, {
+        section: 'earnings',
+        message: 'invalid id',
+        earningsEcho: null,
+        macroEcho: null,
+      })
+    }
+    const repo = createEarningsCalendarRepo(createEarningsCalendarDb(c.env.DB))
+    const beforeRow = await createDb(c.env.DB)
+      .select()
+      .from(earningsCalendar)
+      .where(eq(earningsCalendar.id, id))
+      .then((rows) => rows[0] ?? null)
+      .catch(() => null)
+    const ok = await repo.deleteById(id).catch(() => false)
+    if (!ok) {
+      return await renderEventsWithError(c, {
+        section: 'earnings',
+        message: `id=${id} は見つかりませんでした`,
+        earningsEcho: null,
+        macroEcho: null,
+      })
+    }
+    await writeEventsAuditLog(
+      c,
+      '/dashboard/events/earnings/:id/delete',
+      `earnings_id=${id}`,
+      beforeRow,
+      null,
+    )
+    return c.redirect('/dashboard/events', 303)
+  })
+  /** macro 1 行 seed form 受け。挙動は earnings と対称。 */
+  .post('/events/macro/seed', rateLimit('ADMIN_WRITE'), async (c) => {
+    if (!c.env.DB) {
+      return c.html(renderLayout(c, 'イベント', unavailable('DB not bound')))
+    }
+    const form = Object.fromEntries((await c.req.formData()).entries())
+    const echo: EventsMacroFormEcho = {
+      eventType: typeof form.event_type === 'string' ? form.event_type : '',
+      country: typeof form.country === 'string' ? form.country : '',
+      eventDate: typeof form.event_date === 'string' ? form.event_date : '',
+      notes: typeof form.notes === 'string' ? form.notes : '',
+    }
+    const validation = validateMacroForm(echo)
+    if (!validation.ok) {
+      return await renderEventsWithError(c, {
+        section: 'macro',
+        message: validation.error,
+        earningsEcho: null,
+        macroEcho: echo,
+      })
+    }
+    const record: MacroEventCalendarSeedInput = {
+      eventType: validation.eventType,
+      eventDate: validation.eventDate,
+      eventTime: null,
+      notes: validation.notes,
+    }
+    const repo = createMacroEventCalendarRepo(createMacroEventCalendarDb(c.env.DB))
+    try {
+      const result = await repo.bulkUpsert([record])
+      if (result.inserted > 0) {
+        await writeEventsAuditLog(
+          c,
+          '/dashboard/events/macro/seed',
+          `event_type=${record.eventType} date=${record.eventDate}`,
+          null,
+          { inserted: result.inserted, skipped: result.skipped, records: [record] },
+        )
+      }
+    } catch (err) {
+      return await renderEventsWithError(c, {
+        section: 'macro',
+        message: `保存に失敗しました: ${messageOf(err)}`,
+        earningsEcho: null,
+        macroEcho: echo,
+      })
+    }
+    return c.redirect('/dashboard/events', 303)
+  })
+  /** macro 1 行 delete form 受け。 */
+  .post('/events/macro/:id/delete', rateLimit('ADMIN_WRITE'), async (c) => {
+    if (!c.env.DB) {
+      return c.html(renderLayout(c, 'イベント', unavailable('DB not bound')))
+    }
+    const id = Number(c.req.param('id'))
+    if (!Number.isInteger(id) || id <= 0) {
+      return await renderEventsWithError(c, {
+        section: 'macro',
+        message: 'invalid id',
+        earningsEcho: null,
+        macroEcho: null,
+      })
+    }
+    const repo = createMacroEventCalendarRepo(createMacroEventCalendarDb(c.env.DB))
+    const beforeRow = await createDb(c.env.DB)
+      .select()
+      .from(macroEventCalendar)
+      .where(eq(macroEventCalendar.id, id))
+      .then((rows) => rows[0] ?? null)
+      .catch(() => null)
+    const ok = await repo.deleteById(id).catch(() => false)
+    if (!ok) {
+      return await renderEventsWithError(c, {
+        section: 'macro',
+        message: `id=${id} は見つかりませんでした`,
+        earningsEcho: null,
+        macroEcho: null,
+      })
+    }
+    await writeEventsAuditLog(
+      c,
+      '/dashboard/events/macro/:id/delete',
+      `macro_event_id=${id}`,
+      beforeRow,
+      null,
+    )
+    return c.redirect('/dashboard/events', 303)
+  })
 
 function messageOf(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
@@ -772,6 +1021,7 @@ function layout(title: string, body: string, env?: unknown): string {
   <a href="/dashboard/cron">戦略判定</a>
   <a href="/dashboard/charts">チャート</a>
   <a href="/dashboard/alerts">アラート</a>
+  <a href="/dashboard/events">イベント</a>
   <span class="nav-group">運用</span>
   <a href="/dashboard/config">設定</a>
   <a href="/dashboard/symbols">銘柄管理</a>
@@ -1167,6 +1417,7 @@ function indexBody(): string {
   <li><a href="/dashboard/cron">戦略判定</a> — <code>strategy_decision_log</code> 直近 cron tick の銘柄別判定 (<code>?symbol=SOXL</code> / <code>?requestId=...</code> で絞り込み可)</li>
   <li><a href="/dashboard/charts">チャート</a> — 概要 (エクイティカーブ + ドローダウン) / 取引品質 (PnL 分布 + 統計 + Decision breakdown) / 個別銘柄 (price + SMA50 + entry/exit) を tab 切替</li>
   <li><a href="/dashboard/alerts">アラート</a> — Slack/Discord に push 通知した critical / warning / info の直近 (#141)。webhook 未設定でも D1 に記録される。</li>
+  <li><a href="/dashboard/events">イベント</a> — <code>earnings_calendar</code> / <code>macro_event_calendar</code> の手動 add / delete (#293)。avoid 用 risk gate のソース。</li>
 </ul>
 
 <h2 style="font-size:14px;margin:16px 0 4px 0">運用</h2>
@@ -5795,4 +6046,373 @@ function symbolFormBody(args: SymbolFormArgs): string {
       <a href="/dashboard/symbols" style="padding:6px 16px;text-decoration:none;border:1px solid #d0d0d5;border-radius:4px">キャンセル</a>
     </div>
   </form>`
+}
+
+// #293 calendar events management UI helpers ===============================
+
+/**
+ * `<input value="...">` で再表示する form 入力。バリデーション失敗時は
+ * 入力値を保ったまま再描画する。
+ */
+interface EventsEarningsFormEcho {
+  symbol: string
+  earningsDate: string
+  notes: string
+}
+
+interface EventsMacroFormEcho {
+  /** macro `event_type` (FOMC / CPI / NFP …)。 */
+  eventType: string
+  /** 自由 text の国コード (US / JP …)。schema 上は notes に集約する。 */
+  country: string
+  eventDate: string
+  notes: string
+}
+
+interface EventsBodyArgs {
+  earnings: EarningsCalendarRow[]
+  macros: MacroEventCalendarRow[]
+  from: string
+  to: string
+  universe: SymbolUniverse | null
+  errors: { section: 'earnings' | 'macro'; message: string } | null
+  formEcho: {
+    earnings: EventsEarningsFormEcho | null
+    macro: EventsMacroFormEcho | null
+  } | null
+}
+
+/**
+ * dashboard で表示する範囲 = now-30d 〜 now+30d (= "実際に gate が見る窓")。
+ * `evaluateEarningsGate` / `evaluateMacroEventGate` は近未来の数営業日しか
+ * 見ないので、それを内包しつつ「今月 + 来月」程度を一覧する目安。
+ */
+function eventsDisplayRange(now: Date): { from: string; to: string } {
+  const ms = now.getTime()
+  const from = new Date(ms - 30 * 86_400_000).toISOString().slice(0, 10)
+  const to = new Date(ms + 30 * 86_400_000).toISOString().slice(0, 10)
+  return { from, to }
+}
+
+/**
+ * earnings_calendar を ([fromYmd, toYmd]) 範囲で読む。`fetchByRange` は
+ * symbol 単位 read なので、ここでは全 symbol の range read を直接 SQL で発行
+ * する (dashboard 一覧は universe 全体を横断するため)。
+ */
+async function loadEarningsInRange(
+  db: D1Database,
+  fromYmd: string,
+  toYmd: string,
+): Promise<EarningsCalendarRow[]> {
+  return createDb(db)
+    .select()
+    .from(earningsCalendar)
+    .where(
+      and(
+        gte(earningsCalendar.earningsDate, fromYmd),
+        lte(earningsCalendar.earningsDate, toYmd),
+      ),
+    )
+    .orderBy(asc(earningsCalendar.earningsDate), asc(earningsCalendar.symbol))
+}
+
+interface ValidationOkEarnings {
+  ok: true
+  symbol: string
+  earningsDate: string
+  notes: string | null
+}
+
+interface ValidationFail {
+  ok: false
+  error: string
+}
+
+/**
+ * earnings 1 行 form を validate する。
+ *   - symbol: 1〜16 chars, upper-case 正規化。universe にあれば pass; 無くても
+ *     pass (warn のみ)。「inactive 銘柄でも入れさせる」spec に合わせ active
+ *     判定は無視 (= 入力 → DB は raw に通す)。
+ *   - earnings_date: ISO YYYY-MM-DD, round-trip valid, now-90d 〜 now+365d。
+ *   - notes (= form の `notes` field): 任意, 256 chars 上限。
+ */
+function validateEarningsForm(
+  echo: EventsEarningsFormEcho,
+  _universe: SymbolUniverse | null,
+): ValidationOkEarnings | ValidationFail {
+  const sym = echo.symbol.trim().toUpperCase()
+  if (sym.length === 0 || sym.length > 16) {
+    return { ok: false, error: 'symbol は 1〜16 文字で入力してください' }
+  }
+  // universe 不在は warning にとどめ拒否しない (POC 姿勢、operator が unknown
+  // 銘柄を seed したい場合もある、=> notes に書く運用)。
+  const date = echo.earningsDate.trim()
+  if (!isYmdRoundTrip(date)) {
+    return { ok: false, error: 'event_date は YYYY-MM-DD 形式で実在する日付にしてください' }
+  }
+  if (!withinClampRange(date, new Date())) {
+    return { ok: false, error: 'event_date は 過去 90 日 〜 未来 365 日 の範囲にしてください' }
+  }
+  const notesRaw = echo.notes.trim()
+  if (notesRaw.length > 256) {
+    return { ok: false, error: 'notes (source) は 256 文字以内にしてください' }
+  }
+  return {
+    ok: true,
+    symbol: sym,
+    earningsDate: date,
+    notes: notesRaw.length === 0 ? null : notesRaw,
+  }
+}
+
+interface ValidationOkMacro {
+  ok: true
+  eventType: string
+  eventDate: string
+  notes: string | null
+}
+
+/**
+ * macro 1 行 form を validate する。
+ *
+ * macro schema は `event_kind` / `country` を別 column で持たないため,
+ * country は notes に prefix で混ぜる (`"US — Federal Reserve press release"`)。
+ * spec 上 "country: 自由 text、escapeHtml on render" なので分離保持は必須ではない。
+ */
+function validateMacroForm(echo: EventsMacroFormEcho): ValidationOkMacro | ValidationFail {
+  const kindRaw = echo.eventType.trim()
+  if (kindRaw.length === 0 || kindRaw.length > 32) {
+    return { ok: false, error: 'event_kind は 1〜32 文字で入力してください' }
+  }
+  // schema 制約 `[A-Z0-9_]{1,32}` に合うよう upper-case 化し空白を `_` に
+  // 置換 (`'NFP REV'` → `'NFP_REV'`)。それでも regex に外れる場合は reject。
+  const kind = kindRaw.toUpperCase().replace(/\s+/g, '_')
+  if (!/^[A-Z0-9_]{1,32}$/.test(kind)) {
+    return {
+      ok: false,
+      error: 'event_kind は半角英数 + アンダースコアのみ使えます (例: FOMC / CPI / NFP)',
+    }
+  }
+  const country = echo.country.trim()
+  if (country.length > 16) {
+    return { ok: false, error: 'country は 16 文字以内にしてください' }
+  }
+  const date = echo.eventDate.trim()
+  if (!isYmdRoundTrip(date)) {
+    return { ok: false, error: 'event_date は YYYY-MM-DD 形式で実在する日付にしてください' }
+  }
+  if (!withinClampRange(date, new Date())) {
+    return { ok: false, error: 'event_date は 過去 90 日 〜 未来 365 日 の範囲にしてください' }
+  }
+  const notesPlain = echo.notes.trim()
+  // notes に "country — notes" を畳む。country / notes ともに空なら null。
+  const combined =
+    country.length > 0 && notesPlain.length > 0
+      ? `${country} — ${notesPlain}`
+      : country.length > 0
+        ? country
+        : notesPlain
+  if (combined.length > 256) {
+    return { ok: false, error: 'country + notes (source) の合計は 256 文字以内にしてください' }
+  }
+  return {
+    ok: true,
+    eventType: kind,
+    eventDate: date,
+    notes: combined.length === 0 ? null : combined,
+  }
+}
+
+/** `YYYY-MM-DD` の文法 + 実在日付チェック (admin route の isYmd と同じ)。 */
+function isYmdRoundTrip(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false
+  const ms = Date.parse(`${value}T00:00:00.000Z`)
+  if (!Number.isFinite(ms)) return false
+  return new Date(ms).toISOString().slice(0, 10) === value
+}
+
+/** 過去 90 日 〜 未来 365 日 (両端含む) に入っているか。 */
+function withinClampRange(ymd: string, now: Date): boolean {
+  const t = Date.parse(`${ymd}T00:00:00.000Z`)
+  if (!Number.isFinite(t)) return false
+  const ms = now.getTime()
+  const earliest = ms - 90 * 86_400_000
+  const latest = ms + 365 * 86_400_000
+  return t >= earliest - 86_400_000 && t <= latest + 86_400_000
+}
+
+/**
+ * バリデーション失敗時 / delete failure 時の再描画 helper。一覧を再 load して
+ * エラーメッセージ + 入力 echo つきの events ページを返す。HTTP status は 400
+ * (operator 入力起因 — 5xx ではない) を返して PRG 経由ではないことを明示。
+ */
+async function renderEventsWithError(
+  c: Context<DashboardBindings>,
+  args: {
+    section: 'earnings' | 'macro'
+    message: string
+    earningsEcho: EventsEarningsFormEcho | null
+    macroEcho: EventsMacroFormEcho | null
+  },
+): Promise<Response> {
+  if (!c.env.DB) {
+    return c.html(renderLayout(c, 'イベント', unavailable('DB not bound')))
+  }
+  const universe = await loadSymbolUniverse(c.env).catch(() => null)
+  const { from, to } = eventsDisplayRange(new Date())
+  const macroRepo = createMacroEventCalendarRepo(createMacroEventCalendarDb(c.env.DB))
+  const [earnings, macros] = await Promise.all([
+    loadEarningsInRange(c.env.DB, from, to).catch(() => [] as EarningsCalendarRow[]),
+    macroRepo.fetchAll({ fromYmd: from, toYmd: to }).catch(() => [] as MacroEventCalendarRow[]),
+  ])
+  return c.html(
+    renderLayout(
+      c,
+      'イベント',
+      eventsBody({
+        earnings,
+        macros,
+        from,
+        to,
+        universe,
+        errors: { section: args.section, message: args.message },
+        formEcho: { earnings: args.earningsEcho, macro: args.macroEcho },
+      }),
+    ),
+    400,
+  )
+}
+
+/**
+ * `/dashboard/events` の HTML 本文。earnings (上) + macro (下) の 2 セクション。
+ * 各セクションは「+ 追加」`<details>` 内に form, 一覧テーブルに 削除 form。
+ * 行が無いセクションは空配列メッセージで表示する (= "未登録" を明示)。
+ */
+function eventsBody(args: EventsBodyArgs): string {
+  const { earnings, macros, from, to, universe, errors, formEcho } = args
+  const earningsErr =
+    errors && errors.section === 'earnings'
+      ? `<p class="err"><strong>エラー:</strong> ${esc(errors.message)}</p>`
+      : ''
+  const macroErr =
+    errors && errors.section === 'macro'
+      ? `<p class="err"><strong>エラー:</strong> ${esc(errors.message)}</p>`
+      : ''
+  // form が前回 submit で開いていた場合は再描画でも開いた状態を維持したい (operator
+  // が値を確認しながら修正できる)。エラー有りなら details[open]、無しなら閉じる。
+  const earningsFormOpen = errors?.section === 'earnings' ? ' open' : ''
+  const macroFormOpen = errors?.section === 'macro' ? ' open' : ''
+  const eEcho = formEcho?.earnings ?? { symbol: '', earningsDate: '', notes: '' }
+  const mEcho =
+    formEcho?.macro ?? { eventType: '', country: '', eventDate: '', notes: '' }
+
+  const earningsTable =
+    earnings.length === 0
+      ? '<p class="muted">この範囲には登録された決算がありません。</p>'
+      : `<table>
+    <thead><tr>
+      <th>symbol</th><th>event_date</th><th>source (notes)</th><th>削除</th>
+    </tr></thead>
+    <tbody>${earnings
+      .map((r) => {
+        const inactive = isSymbolInactive(r.symbol, universe)
+        const sym = `<span${inactive ? ' class="symbol-disabled"' : ''}>${esc(displaySymbol(r.symbol, universe))}</span>${
+          inactive
+            ? ` <span class="muted" style="font-size:11px">(inactive — ${esc(inactiveTooltip(r.symbol, universe))})</span>`
+            : ''
+        }`
+        return `<tr>
+          <td>${sym}</td>
+          <td>${esc(r.earningsDate)}</td>
+          <td>${esc(r.notes ?? '-')}</td>
+          <td><form method="post" action="/dashboard/events/earnings/${r.id}/delete" onsubmit="return confirm('${esc(r.symbol)} ${esc(r.earningsDate)} を削除します。よろしいですか？');" style="margin:0"><button type="submit" style="padding:3px 8px;font-size:12px;background:#c22;color:#fff;border:none;border-radius:4px;cursor:pointer">削除</button></form></td>
+        </tr>`
+      })
+      .join('')}</tbody>
+  </table>`
+
+  const macroTable =
+    macros.length === 0
+      ? '<p class="muted">この範囲には登録されたマクロイベントがありません。</p>'
+      : `<table>
+    <thead><tr>
+      <th>event_kind</th><th>country / source (notes)</th><th>event_date</th><th>削除</th>
+    </tr></thead>
+    <tbody>${macros
+      .map((r) => {
+        return `<tr>
+          <td><code>${esc(r.eventType)}</code></td>
+          <td>${esc(r.notes ?? '-')}</td>
+          <td>${esc(r.eventDate)}</td>
+          <td><form method="post" action="/dashboard/events/macro/${r.id}/delete" onsubmit="return confirm('${esc(r.eventType)} ${esc(r.eventDate)} を削除します。よろしいですか？');" style="margin:0"><button type="submit" style="padding:3px 8px;font-size:12px;background:#c22;color:#fff;border:none;border-radius:4px;cursor:pointer">削除</button></form></td>
+        </tr>`
+      })
+      .join('')}</tbody>
+  </table>`
+
+  return `<p class="muted">期間: ${esc(from)} 〜 ${esc(to)} (now-30d 〜 now+30d)。<code>earnings_calendar</code> / <code>macro_event_calendar</code> は risk gate の avoid ソースです。
+  add は <code>now-90d 〜 now+365d</code> の範囲に clamp します。delete は audit に記録されます。</p>
+
+<h2 style="font-size:15px;margin:20px 0 6px 0">決算 (earnings)</h2>
+${earningsErr}
+<details${earningsFormOpen} style="margin-bottom:12px">
+  <summary style="cursor:pointer">+ 追加</summary>
+  <form method="post" action="/dashboard/events/earnings/seed" style="margin-top:8px;display:flex;gap:8px;flex-wrap:wrap;align-items:flex-end">
+    <label>symbol<br><input name="symbol" value="${esc(eEcho.symbol)}" placeholder="AAPL / 7203" required maxlength="16" style="padding:4px 8px;width:140px"></label>
+    <label>event_date<br><input name="earnings_date" type="date" value="${esc(eEcho.earningsDate)}" required style="padding:4px 8px"></label>
+    <label>source (notes, 任意)<br><input name="notes" value="${esc(eEcho.notes)}" placeholder="Q2 2026 BMO" maxlength="256" style="padding:4px 8px;min-width:240px"></label>
+    <button type="submit" style="padding:6px 14px;background:#057a55;color:#fff;border:none;border-radius:4px;cursor:pointer">追加</button>
+  </form>
+</details>
+${earningsTable}
+
+<h2 style="font-size:15px;margin:24px 0 6px 0">マクロイベント (macro)</h2>
+${macroErr}
+<details${macroFormOpen} style="margin-bottom:12px">
+  <summary style="cursor:pointer">+ 追加</summary>
+  <form method="post" action="/dashboard/events/macro/seed" style="margin-top:8px;display:flex;gap:8px;flex-wrap:wrap;align-items:flex-end">
+    <label>event_kind<br><input name="event_type" value="${esc(mEcho.eventType)}" placeholder="FOMC / CPI / NFP" required maxlength="32" style="padding:4px 8px;width:160px"></label>
+    <label>country (任意)<br><input name="country" value="${esc(mEcho.country)}" placeholder="US / JP" maxlength="16" style="padding:4px 8px;width:100px"></label>
+    <label>event_date<br><input name="event_date" type="date" value="${esc(mEcho.eventDate)}" required style="padding:4px 8px"></label>
+    <label>source (notes, 任意)<br><input name="notes" value="${esc(mEcho.notes)}" placeholder="June FOMC" maxlength="256" style="padding:4px 8px;min-width:240px"></label>
+    <button type="submit" style="padding:6px 14px;background:#057a55;color:#fff;border:none;border-radius:4px;cursor:pointer">追加</button>
+  </form>
+</details>
+${macroTable}`
+}
+
+/**
+ * dashboard 側 form handler 用の audit log writer (#293)。admin.ts の
+ * writeAuditLog と同形だが route layer が違うので local copy。actor は Access
+ * middleware が `c.set('actor', ...)` 済み (ない場合は extractActor が throw
+ * するので try/catch で潰す — admin 同様 audit 欠落で 500 を返したくない)。
+ */
+async function writeEventsAuditLog(
+  c: Context<DashboardBindings>,
+  endpoint: string,
+  targetKey: string | null,
+  before: unknown,
+  after: unknown,
+): Promise<void> {
+  if (!c.env.DB) return
+  try {
+    const actor = extractActor(c.get('actor'))
+    await recordChange(c.env.DB, {
+      actor,
+      endpoint,
+      targetKey,
+      before,
+      after,
+      requestId: c.get('requestId') ?? null,
+    })
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        event: 'config_audit_log_write_failed',
+        endpoint,
+        targetKey,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    )
+  }
 }

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -608,6 +608,7 @@ export const dashboard = new Hono<DashboardBindings>()
             universe,
             errors: null,
             formEcho: null,
+            notice: null,
           }),
         ),
       )
@@ -666,6 +667,14 @@ export const dashboard = new Hono<DashboardBindings>()
         message: `保存に失敗しました: ${messageOf(err)}`,
         earningsEcho: echo,
         macroEcho: null,
+      })
+    }
+    // 保存は成功したが non-blocking warning (universe 外 symbol 等) があれば
+    // PRG redirect を捨てて再描画 (= 200) し、警告を operator に見せる。
+    if (validation.warning) {
+      return await renderEventsWithNotice(c, {
+        section: 'earnings',
+        message: validation.warning,
       })
     }
     return c.redirect('/dashboard/events', 303)
@@ -1403,7 +1412,7 @@ function parseJsonObject(value: string | null | undefined): unknown {
 }
 
 function indexBody(): string {
-  return `<p>運用者向け読み取り専用ダッシュボード。各ページは Cloudflare Access で保護されています。</p>
+  return `<p>運用者向けダッシュボード (一部 page は write 操作あり、すべての変更は監査ログに記録)。各ページは Cloudflare Access で保護されています。</p>
 
 <h2 style="font-size:14px;margin:16px 0 4px 0">取引状況</h2>
 <ul>
@@ -6080,6 +6089,8 @@ interface EventsBodyArgs {
     earnings: EventsEarningsFormEcho | null
     macro: EventsMacroFormEcho | null
   } | null
+  /** 非ブロッキング警告 (例: universe 外 symbol を seed 成功した時)。 */
+  notice: { section: 'earnings' | 'macro'; message: string } | null
 }
 
 /**
@@ -6121,6 +6132,13 @@ interface ValidationOkEarnings {
   symbol: string
   earningsDate: string
   notes: string | null
+  /**
+   * symbol が universe.allowedSymbols に無い場合に立つ非ブロッキング警告。
+   * spec: "universe 外 symbol は保存を許す + UI で warning 表示" — save は通すが
+   * dashboard 側で operator に対して typo の可能性を知らせる。universe が null
+   * (load 失敗) の場合は判定スキップ (= warning なし)。
+   */
+  warning: string | null
 }
 
 interface ValidationFail {
@@ -6138,7 +6156,7 @@ interface ValidationFail {
  */
 function validateEarningsForm(
   echo: EventsEarningsFormEcho,
-  _universe: SymbolUniverse | null,
+  universe: SymbolUniverse | null,
 ): ValidationOkEarnings | ValidationFail {
   const sym = echo.symbol.trim().toUpperCase()
   if (sym.length === 0 || sym.length > 16) {
@@ -6157,11 +6175,21 @@ function validateEarningsForm(
   if (notesRaw.length > 256) {
     return { ok: false, error: 'notes (source) は 256 文字以内にしてください' }
   }
+  // universe が読めた場合のみ allowedSymbols 照合 (case-insensitive)。null の時は
+  // load 失敗なので照合をスキップ — false-positive 警告を避ける。
+  let warning: string | null = null
+  if (universe) {
+    const inUniverse = universe.allowedSymbols.some((s) => s.toUpperCase() === sym)
+    if (!inUniverse) {
+      warning = `symbol "${sym}" は symbol_config (universe) に存在しません。typo でなければ symbol 管理から追加してください。`
+    }
+  }
   return {
     ok: true,
     symbol: sym,
     earningsDate: date,
     notes: notesRaw.length === 0 ? null : notesRaw,
+    warning,
   }
 }
 
@@ -6231,14 +6259,21 @@ function isYmdRoundTrip(value: string): boolean {
   return new Date(ms).toISOString().slice(0, 10) === value
 }
 
-/** 過去 90 日 〜 未来 365 日 (両端含む) に入っているか。 */
+/**
+ * 過去 90 日 〜 未来 365 日 (両端含む) に入っているか。date-only 比較。
+ *
+ * 入力は `YYYY-MM-DD` を UTC 0:00 として解釈。`now` も同じ UTC YMD に丸めた
+ * 上で ±90d / ±365d する。`+ 86_400_000` の slack を付けると 91d / 366d も
+ * 通ってしまうので、UTC YMD epoch ms で純粋に inclusive 比較する。
+ */
 function withinClampRange(ymd: string, now: Date): boolean {
   const t = Date.parse(`${ymd}T00:00:00.000Z`)
   if (!Number.isFinite(t)) return false
-  const ms = now.getTime()
-  const earliest = ms - 90 * 86_400_000
-  const latest = ms + 365 * 86_400_000
-  return t >= earliest - 86_400_000 && t <= latest + 86_400_000
+  const nowYmd = now.toISOString().slice(0, 10)
+  const nowDayMs = Date.parse(`${nowYmd}T00:00:00.000Z`)
+  const earliest = nowDayMs - 90 * 86_400_000
+  const latest = nowDayMs + 365 * 86_400_000
+  return t >= earliest && t <= latest
 }
 
 /**
@@ -6277,9 +6312,49 @@ async function renderEventsWithError(
         universe,
         errors: { section: args.section, message: args.message },
         formEcho: { earnings: args.earningsEcho, macro: args.macroEcho },
+        notice: null,
       }),
     ),
     400,
+  )
+}
+
+/**
+ * 保存は成功したが non-blocking 警告 (universe 外 symbol など) を operator に
+ * 知らせる必要がある時の再描画 helper。HTTP status は 200 (= 保存済み)。
+ */
+async function renderEventsWithNotice(
+  c: Context<DashboardBindings>,
+  args: {
+    section: 'earnings' | 'macro'
+    message: string
+  },
+): Promise<Response> {
+  if (!c.env.DB) {
+    return c.html(renderLayout(c, 'イベント', unavailable('DB not bound')))
+  }
+  const universe = await loadSymbolUniverse(c.env).catch(() => null)
+  const { from, to } = eventsDisplayRange(new Date())
+  const macroRepo = createMacroEventCalendarRepo(createMacroEventCalendarDb(c.env.DB))
+  const [earnings, macros] = await Promise.all([
+    loadEarningsInRange(c.env.DB, from, to).catch(() => [] as EarningsCalendarRow[]),
+    macroRepo.fetchAll({ fromYmd: from, toYmd: to }).catch(() => [] as MacroEventCalendarRow[]),
+  ])
+  return c.html(
+    renderLayout(
+      c,
+      'イベント',
+      eventsBody({
+        earnings,
+        macros,
+        from,
+        to,
+        universe,
+        errors: null,
+        formEcho: null,
+        notice: { section: args.section, message: args.message },
+      }),
+    ),
   )
 }
 
@@ -6289,7 +6364,7 @@ async function renderEventsWithError(
  * 行が無いセクションは空配列メッセージで表示する (= "未登録" を明示)。
  */
 function eventsBody(args: EventsBodyArgs): string {
-  const { earnings, macros, from, to, universe, errors, formEcho } = args
+  const { earnings, macros, from, to, universe, errors, formEcho, notice } = args
   const earningsErr =
     errors && errors.section === 'earnings'
       ? `<p class="err"><strong>エラー:</strong> ${esc(errors.message)}</p>`
@@ -6297,6 +6372,14 @@ function eventsBody(args: EventsBodyArgs): string {
   const macroErr =
     errors && errors.section === 'macro'
       ? `<p class="err"><strong>エラー:</strong> ${esc(errors.message)}</p>`
+      : ''
+  const earningsNotice =
+    notice && notice.section === 'earnings'
+      ? `<p class="warn"><strong>注意:</strong> ${esc(notice.message)}</p>`
+      : ''
+  const macroNotice =
+    notice && notice.section === 'macro'
+      ? `<p class="warn"><strong>注意:</strong> ${esc(notice.message)}</p>`
       : ''
   // form が前回 submit で開いていた場合は再描画でも開いた状態を維持したい (operator
   // が値を確認しながら修正できる)。エラー有りなら details[open]、無しなら閉じる。
@@ -6355,6 +6438,7 @@ function eventsBody(args: EventsBodyArgs): string {
 
 <h2 style="font-size:15px;margin:20px 0 6px 0">決算 (earnings)</h2>
 ${earningsErr}
+${earningsNotice}
 <details${earningsFormOpen} style="margin-bottom:12px">
   <summary style="cursor:pointer">+ 追加</summary>
   <form method="post" action="/dashboard/events/earnings/seed" style="margin-top:8px;display:flex;gap:8px;flex-wrap:wrap;align-items:flex-end">
@@ -6368,6 +6452,7 @@ ${earningsTable}
 
 <h2 style="font-size:15px;margin:24px 0 6px 0">マクロイベント (macro)</h2>
 ${macroErr}
+${macroNotice}
 <details${macroFormOpen} style="margin-bottom:12px">
   <summary style="cursor:pointer">+ 追加</summary>
   <form method="post" action="/dashboard/events/macro/seed" style="margin-top:8px;display:flex;gap:8px;flex-wrap:wrap;align-items:flex-end">

--- a/test/routes/dashboardEventsUi.test.ts
+++ b/test/routes/dashboardEventsUi.test.ts
@@ -366,14 +366,36 @@ describe('dashboard events UI (#293)', () => {
   })
 
   it('clamp upper bound is inclusive at +365d but rejects +366d', async () => {
-    // withinClampRange は date-only inclusive。`now + 366d` は範囲外として 400 を返すこと。
-    const earningsRepo = fakeEarningsRepo()
+    // withinClampRange は date-only inclusive。`now + 365d` は通り、`now + 366d` は 400。
     const macroRepo = fakeMacroRepo()
     vi.mocked(createDb).mockReturnValue(
       fakeListDb([]) as unknown as ReturnType<typeof createDb>,
     )
+    // +365d (inclusive boundary): 受理されて 303 redirect になること
+    const earningsRepo365 = fakeEarningsRepo()
+    const day365 = new Date(Date.now() + 365 * 86_400_000).toISOString().slice(0, 10)
+    const okRes = await withFakeRepos(earningsRepo365, macroRepo, async () => {
+      const app = createApp()
+      const form = new URLSearchParams()
+      form.set('symbol', 'AAPL')
+      form.set('earnings_date', day365)
+      return app.request(
+        '/dashboard/events/earnings/seed',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...authHeader },
+          body: form.toString(),
+        },
+        { ...baseEnv, DB: {} as D1Database },
+      )
+    })
+    expect(okRes.status).toBe(303)
+    expect(earningsRepo365.bulkUpsert).toHaveBeenCalled()
+
+    // +366d (out of range): 400 + 入力 form 再描画
+    const earningsRepo366 = fakeEarningsRepo()
     const day366 = new Date(Date.now() + 366 * 86_400_000).toISOString().slice(0, 10)
-    const res = await withFakeRepos(earningsRepo, macroRepo, async () => {
+    const badRes = await withFakeRepos(earningsRepo366, macroRepo, async () => {
       const app = createApp()
       const form = new URLSearchParams()
       form.set('symbol', 'AAPL')
@@ -388,10 +410,10 @@ describe('dashboard events UI (#293)', () => {
         { ...baseEnv, DB: {} as D1Database },
       )
     })
-    expect(res.status).toBe(400)
-    const body = await res.text()
+    expect(badRes.status).toBe(400)
+    const body = await badRes.text()
     expect(body).toContain('過去 90 日 〜 未来 365 日')
-    expect(earningsRepo.bulkUpsert).not.toHaveBeenCalled()
+    expect(earningsRepo366.bulkUpsert).not.toHaveBeenCalled()
   })
 
   it('seed earnings with symbol outside universe → save succeeds + warning rendered', async () => {

--- a/test/routes/dashboardEventsUi.test.ts
+++ b/test/routes/dashboardEventsUi.test.ts
@@ -1,0 +1,389 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp } from '../../src/app'
+import { loadGlobalConfigFrom } from '../../src/infrastructure/db/globalConfigLoader'
+import { loadSymbolUniverse } from '../../src/infrastructure/db/symbolUniverse'
+import { createDb } from '../../src/infrastructure/db/tradeJournalRepo'
+import { recordChange } from '../../src/infrastructure/db/configAuditLog'
+import { makeGlobalConfigSnapshot, makeSymbolUniverse } from '../helpers/configFixtures'
+
+/**
+ * #293 — dashboard イベント管理 UI のテスト。
+ *
+ * `GET /dashboard/events` で earnings + macro 一覧 + 追加 form を描画、
+ * `POST /dashboard/events/earnings/seed` 等の form 受け handler が repo を
+ * 呼んで 303 redirect、バリデーション失敗は 400 で再描画 + 入力 echo を保持
+ * することを確認する。XSS regression として notes に <script> を入れて escape
+ * されることも見る (#284 と同じ姿勢)。
+ */
+
+vi.mock('../../src/infrastructure/db/globalConfigLoader', () => ({
+  loadGlobalConfigFrom: vi.fn(),
+}))
+vi.mock('../../src/infrastructure/db/symbolUniverse', () => ({
+  loadSymbolUniverse: vi.fn(),
+}))
+vi.mock('../../src/infrastructure/db/tradeJournalRepo', () => ({
+  createDb: vi.fn(),
+}))
+vi.mock('../../src/infrastructure/db/configAuditLog', async () => {
+  const actual = await vi.importActual<typeof import('../../src/infrastructure/db/configAuditLog')>(
+    '../../src/infrastructure/db/configAuditLog',
+  )
+  return {
+    ...actual,
+    recordChange: vi.fn(async () => ({ recorded: true })),
+  }
+})
+
+const baseEnv = {
+  ACCESS_DEV_BYPASS_USER: 'admin',
+}
+const authHeader = {}
+
+type EarningsRow = {
+  id: number
+  symbol: string
+  earningsDate: string
+  notes: string | null
+  createdAt: string
+}
+type MacroRow = {
+  id: number
+  eventType: string
+  eventDate: string
+  eventTime: string | null
+  notes: string | null
+  createdAt: string
+}
+
+/**
+ * `createDb(env.DB).select().from().where().orderBy()` chain を満たす最小限の
+ * thenable mock。await でき、`Promise<rows[]>` を返す。Dashboard 側の earnings
+ * list query (`loadEarningsInRange`) と delete handler の `.then((rows) => rows[0] ?? null)`
+ * 両方をカバーする。
+ */
+function fakeListDb(earningsRows: EarningsRow[]) {
+  const query = {
+    from: vi.fn(() => query),
+    where: vi.fn(() => query),
+    orderBy: vi.fn(() => query),
+    limit: vi.fn(async () => earningsRows),
+    then: (resolve: (value: unknown[]) => unknown) => Promise.resolve(resolve(earningsRows)),
+  }
+  return {
+    select: vi.fn(() => query),
+  }
+}
+
+/** 共通の repo mock (earnings + macro)。 */
+function fakeEarningsRepo() {
+  return {
+    bulkUpsert: vi.fn<(records: unknown) => Promise<{ inserted: number; skipped: number }>>(
+      async () => ({ inserted: 1, skipped: 0 }),
+    ),
+    fetchBySymbol: vi.fn<(symbol: string) => Promise<EarningsRow[]>>(async () => []),
+    fetchByRange: vi.fn<(symbol: string, from: string, to: string) => Promise<EarningsRow[]>>(
+      async () => [],
+    ),
+    deleteById: vi.fn<(id: number) => Promise<boolean>>(async () => true),
+  }
+}
+function fakeMacroRepo(rows: MacroRow[] = []) {
+  return {
+    bulkUpsert: vi.fn<(records: unknown) => Promise<{ inserted: number; skipped: number }>>(
+      async () => ({ inserted: 1, skipped: 0 }),
+    ),
+    fetchAll: vi.fn<(filter: unknown) => Promise<MacroRow[]>>(async () => rows),
+    fetchByDateRange: vi.fn<
+      (from: string, to: string, type?: string) => Promise<MacroRow[]>
+    >(async () => rows),
+    deleteById: vi.fn<(id: number) => Promise<boolean>>(async () => true),
+  }
+}
+
+async function withFakeRepos<T>(
+  earningsRepo: ReturnType<typeof fakeEarningsRepo>,
+  macroRepo: ReturnType<typeof fakeMacroRepo>,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const eMod = await import('../../src/infrastructure/calendar/earningsCalendarRepo')
+  const mMod = await import('../../src/infrastructure/calendar/macroEventCalendarRepo')
+  const eSpy = vi
+    .spyOn(eMod, 'createEarningsCalendarRepo')
+    .mockReturnValue(earningsRepo as never)
+  const mSpy = vi
+    .spyOn(mMod, 'createMacroEventCalendarRepo')
+    .mockReturnValue(macroRepo as never)
+  try {
+    return await fn()
+  } finally {
+    eSpy.mockRestore()
+    mSpy.mockRestore()
+  }
+}
+
+describe('dashboard events UI (#293)', () => {
+  beforeEach(() => {
+    vi.mocked(loadGlobalConfigFrom).mockResolvedValue(makeGlobalConfigSnapshot())
+    vi.mocked(loadSymbolUniverse).mockResolvedValue(
+      makeSymbolUniverse({ allowedSymbols: ['AAPL'], symbolCurrency: { AAPL: 'USD' } }),
+    )
+  })
+  afterEach(() => vi.resetAllMocks())
+
+  it('renders list page with earnings + macro rows from repos', async () => {
+    const now = new Date()
+    const inTen = new Date(now.getTime() + 10 * 86_400_000).toISOString().slice(0, 10)
+    const earningsRow: EarningsRow = {
+      id: 1,
+      symbol: 'AAPL',
+      earningsDate: inTen,
+      notes: 'Q2 2026',
+      createdAt: '2026-04-21T00:00:00.000Z',
+    }
+    const macroRow: MacroRow = {
+      id: 7,
+      eventType: 'FOMC',
+      eventDate: inTen,
+      eventTime: '14:00',
+      notes: 'US — June meeting',
+      createdAt: '2026-04-21T00:00:00.000Z',
+    }
+    vi.mocked(createDb).mockReturnValue(
+      fakeListDb([earningsRow]) as unknown as ReturnType<typeof createDb>,
+    )
+    const earningsRepo = fakeEarningsRepo()
+    const macroRepo = fakeMacroRepo([macroRow])
+    const res = await withFakeRepos(earningsRepo, macroRepo, async () => {
+      const app = createApp()
+      return app.request(
+        '/dashboard/events',
+        { headers: authHeader },
+        { ...baseEnv, DB: {} as D1Database },
+      )
+    })
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    expect(body).toContain('決算 (earnings)')
+    expect(body).toContain('マクロイベント (macro)')
+    // earnings row 列
+    expect(body).toContain('AAPL')
+    expect(body).toContain(inTen)
+    expect(body).toContain('Q2 2026')
+    // macro row 列
+    expect(body).toContain('<code>FOMC</code>')
+    expect(body).toContain('US — June meeting')
+    // 削除 form action は /dashboard/events/<kind>/<id>/delete
+    expect(body).toContain('action="/dashboard/events/earnings/1/delete"')
+    expect(body).toContain('action="/dashboard/events/macro/7/delete"')
+    // 「+ 追加」 details が両セクションに存在
+    expect(body).toContain('action="/dashboard/events/earnings/seed"')
+    expect(body).toContain('action="/dashboard/events/macro/seed"')
+  })
+
+  it('POST add earnings → 303 redirect + bulkUpsert called', async () => {
+    const earningsRepo = fakeEarningsRepo()
+    const macroRepo = fakeMacroRepo()
+    const tomorrow = new Date(Date.now() + 86_400_000).toISOString().slice(0, 10)
+    const res = await withFakeRepos(earningsRepo, macroRepo, async () => {
+      const app = createApp()
+      const form = new URLSearchParams()
+      form.set('symbol', 'aapl')
+      form.set('earnings_date', tomorrow)
+      form.set('notes', 'Q2 2026')
+      return app.request(
+        '/dashboard/events/earnings/seed',
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            ...authHeader,
+          },
+          body: form.toString(),
+        },
+        { ...baseEnv, DB: {} as D1Database },
+      )
+    })
+    expect(res.status).toBe(303)
+    expect(res.headers.get('location')).toBe('/dashboard/events')
+    expect(earningsRepo.bulkUpsert).toHaveBeenCalledWith([
+      { symbol: 'AAPL', earningsDate: tomorrow, notes: 'Q2 2026' },
+    ])
+  })
+
+  it('POST add macro → 303 redirect + bulkUpsert called with country folded into notes', async () => {
+    const earningsRepo = fakeEarningsRepo()
+    const macroRepo = fakeMacroRepo()
+    const tomorrow = new Date(Date.now() + 86_400_000).toISOString().slice(0, 10)
+    const res = await withFakeRepos(earningsRepo, macroRepo, async () => {
+      const app = createApp()
+      const form = new URLSearchParams()
+      form.set('event_type', 'fomc')
+      form.set('country', 'US')
+      form.set('event_date', tomorrow)
+      form.set('notes', 'June meeting')
+      return app.request(
+        '/dashboard/events/macro/seed',
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            ...authHeader,
+          },
+          body: form.toString(),
+        },
+        { ...baseEnv, DB: {} as D1Database },
+      )
+    })
+    expect(res.status).toBe(303)
+    expect(res.headers.get('location')).toBe('/dashboard/events')
+    expect(macroRepo.bulkUpsert).toHaveBeenCalledWith([
+      {
+        eventType: 'FOMC',
+        eventDate: tomorrow,
+        eventTime: null,
+        notes: 'US — June meeting',
+      },
+    ])
+  })
+
+  it('POST delete earnings → 303 redirect + repo.deleteById called', async () => {
+    const earningsRepo = fakeEarningsRepo()
+    earningsRepo.deleteById.mockResolvedValueOnce(true)
+    const macroRepo = fakeMacroRepo()
+    // createDb は delete handler 内の "before snapshot" 取得で呼ばれる ("rows" を返せれば中身は問わない)。
+    vi.mocked(createDb).mockReturnValue(
+      fakeListDb([]) as unknown as ReturnType<typeof createDb>,
+    )
+    const res = await withFakeRepos(earningsRepo, macroRepo, async () => {
+      const app = createApp()
+      return app.request(
+        '/dashboard/events/earnings/42/delete',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...authHeader },
+        },
+        { ...baseEnv, DB: {} as D1Database },
+      )
+    })
+    expect(res.status).toBe(303)
+    expect(res.headers.get('location')).toBe('/dashboard/events')
+    expect(earningsRepo.deleteById).toHaveBeenCalledWith(42)
+  })
+
+  it('POST delete macro → 303 redirect + repo.deleteById called', async () => {
+    const earningsRepo = fakeEarningsRepo()
+    const macroRepo = fakeMacroRepo()
+    macroRepo.deleteById.mockResolvedValueOnce(true)
+    vi.mocked(createDb).mockReturnValue(
+      fakeListDb([]) as unknown as ReturnType<typeof createDb>,
+    )
+    const res = await withFakeRepos(earningsRepo, macroRepo, async () => {
+      const app = createApp()
+      return app.request(
+        '/dashboard/events/macro/9/delete',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...authHeader },
+        },
+        { ...baseEnv, DB: {} as D1Database },
+      )
+    })
+    expect(res.status).toBe(303)
+    expect(res.headers.get('location')).toBe('/dashboard/events')
+    expect(macroRepo.deleteById).toHaveBeenCalledWith(9)
+  })
+
+  it('validation: empty symbol / out-of-range date → 400 re-render with error message', async () => {
+    const earningsRepo = fakeEarningsRepo()
+    const macroRepo = fakeMacroRepo()
+    vi.mocked(createDb).mockReturnValue(
+      fakeListDb([]) as unknown as ReturnType<typeof createDb>,
+    )
+    // empty symbol → re-render w/ error, repo NOT called
+    const res1 = await withFakeRepos(earningsRepo, macroRepo, async () => {
+      const app = createApp()
+      const form = new URLSearchParams()
+      form.set('symbol', '')
+      form.set('earnings_date', '2026-05-15')
+      return app.request(
+        '/dashboard/events/earnings/seed',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...authHeader },
+          body: form.toString(),
+        },
+        { ...baseEnv, DB: {} as D1Database },
+      )
+    })
+    expect(res1.status).toBe(400)
+    const body1 = await res1.text()
+    expect(body1).toContain('class="err"')
+    expect(body1).toContain('symbol は 1〜16 文字')
+    expect(earningsRepo.bulkUpsert).not.toHaveBeenCalled()
+
+    // future-too-far date (now + 400 days) → 400
+    const farFuture = new Date(Date.now() + 400 * 86_400_000).toISOString().slice(0, 10)
+    const res2 = await withFakeRepos(earningsRepo, macroRepo, async () => {
+      const app = createApp()
+      const form = new URLSearchParams()
+      form.set('symbol', 'AAPL')
+      form.set('earnings_date', farFuture)
+      return app.request(
+        '/dashboard/events/earnings/seed',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...authHeader },
+          body: form.toString(),
+        },
+        { ...baseEnv, DB: {} as D1Database },
+      )
+    })
+    expect(res2.status).toBe(400)
+    const body2 = await res2.text()
+    expect(body2).toContain('過去 90 日 〜 未来 365 日')
+    expect(earningsRepo.bulkUpsert).not.toHaveBeenCalled()
+  })
+
+  it('XSS regression: notes / event_kind with <script> payload is escaped on render', async () => {
+    // operator が誤って (or 攻撃者が DB 直接書込みで) 入れた <script> が
+    // 一覧テーブルで生で出ないこと。escapeHtml 経由で中和されているはず。
+    const scriptPayload = '<script>alert(1)</script>'
+    const today = new Date().toISOString().slice(0, 10)
+    const earningsRow: EarningsRow = {
+      id: 11,
+      symbol: 'AAPL',
+      earningsDate: today,
+      notes: scriptPayload,
+      createdAt: '2026-04-21T00:00:00.000Z',
+    }
+    const macroRow: MacroRow = {
+      id: 22,
+      eventType: 'FOMC', // event_type は schema regex で `[A-Z0-9_]` のみだが、
+      // 万一壊れた row が入っても escape されるかを notes 側で見る。
+      eventDate: today,
+      eventTime: null,
+      notes: scriptPayload,
+      createdAt: '2026-04-21T00:00:00.000Z',
+    }
+    vi.mocked(createDb).mockReturnValue(
+      fakeListDb([earningsRow]) as unknown as ReturnType<typeof createDb>,
+    )
+    const earningsRepo = fakeEarningsRepo()
+    const macroRepo = fakeMacroRepo([macroRow])
+    const res = await withFakeRepos(earningsRepo, macroRepo, async () => {
+      const app = createApp()
+      return app.request(
+        '/dashboard/events',
+        { headers: authHeader },
+        { ...baseEnv, DB: {} as D1Database },
+      )
+    })
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    // 生の <script>alert(1)</script> が body に出てはいけない
+    expect(body).not.toContain(scriptPayload)
+    // 代わりに escape 済みの形が両 row 由来で 2 回以上含まれる
+    expect(body).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+  })
+})

--- a/test/routes/dashboardEventsUi.test.ts
+++ b/test/routes/dashboardEventsUi.test.ts
@@ -209,6 +209,11 @@ describe('dashboard events UI (#293)', () => {
     expect(earningsRepo.bulkUpsert).toHaveBeenCalledWith([
       { symbol: 'AAPL', earningsDate: tomorrow, notes: 'Q2 2026' },
     ])
+    // 監査ログ: 1 件 inserted なので recordChange が呼ばれる (endpoint 一致まで確認)。
+    expect(vi.mocked(recordChange)).toHaveBeenCalled()
+    expect(vi.mocked(recordChange).mock.calls[0]?.[1]?.endpoint).toBe(
+      '/dashboard/events/earnings/seed',
+    )
   })
 
   it('POST add macro → 303 redirect + bulkUpsert called with country folded into notes', async () => {
@@ -245,6 +250,10 @@ describe('dashboard events UI (#293)', () => {
         notes: 'US — June meeting',
       },
     ])
+    expect(vi.mocked(recordChange)).toHaveBeenCalled()
+    expect(vi.mocked(recordChange).mock.calls[0]?.[1]?.endpoint).toBe(
+      '/dashboard/events/macro/seed',
+    )
   })
 
   it('POST delete earnings → 303 redirect + repo.deleteById called', async () => {
@@ -269,6 +278,10 @@ describe('dashboard events UI (#293)', () => {
     expect(res.status).toBe(303)
     expect(res.headers.get('location')).toBe('/dashboard/events')
     expect(earningsRepo.deleteById).toHaveBeenCalledWith(42)
+    expect(vi.mocked(recordChange)).toHaveBeenCalled()
+    expect(vi.mocked(recordChange).mock.calls[0]?.[1]?.endpoint).toBe(
+      '/dashboard/events/earnings/:id/delete',
+    )
   })
 
   it('POST delete macro → 303 redirect + repo.deleteById called', async () => {
@@ -292,6 +305,10 @@ describe('dashboard events UI (#293)', () => {
     expect(res.status).toBe(303)
     expect(res.headers.get('location')).toBe('/dashboard/events')
     expect(macroRepo.deleteById).toHaveBeenCalledWith(9)
+    expect(vi.mocked(recordChange)).toHaveBeenCalled()
+    expect(vi.mocked(recordChange).mock.calls[0]?.[1]?.endpoint).toBe(
+      '/dashboard/events/macro/:id/delete',
+    )
   })
 
   it('validation: empty symbol / out-of-range date → 400 re-render with error message', async () => {
@@ -300,12 +317,15 @@ describe('dashboard events UI (#293)', () => {
     vi.mocked(createDb).mockReturnValue(
       fakeListDb([]) as unknown as ReturnType<typeof createDb>,
     )
-    // empty symbol → re-render w/ error, repo NOT called
+    // empty symbol → re-render w/ error, repo NOT called。
+    // 日付は SUT ではないので、`now ± clamp` から確実に外れない "today" を使う
+    // (`'2026-05-15'` のような固定日付だと数か月後に out-of-range で fail する)。
+    const today = new Date().toISOString().slice(0, 10)
     const res1 = await withFakeRepos(earningsRepo, macroRepo, async () => {
       const app = createApp()
       const form = new URLSearchParams()
       form.set('symbol', '')
-      form.set('earnings_date', '2026-05-15')
+      form.set('earnings_date', today)
       return app.request(
         '/dashboard/events/earnings/seed',
         {
@@ -343,6 +363,70 @@ describe('dashboard events UI (#293)', () => {
     const body2 = await res2.text()
     expect(body2).toContain('過去 90 日 〜 未来 365 日')
     expect(earningsRepo.bulkUpsert).not.toHaveBeenCalled()
+  })
+
+  it('clamp upper bound is inclusive at +365d but rejects +366d', async () => {
+    // withinClampRange は date-only inclusive。`now + 366d` は範囲外として 400 を返すこと。
+    const earningsRepo = fakeEarningsRepo()
+    const macroRepo = fakeMacroRepo()
+    vi.mocked(createDb).mockReturnValue(
+      fakeListDb([]) as unknown as ReturnType<typeof createDb>,
+    )
+    const day366 = new Date(Date.now() + 366 * 86_400_000).toISOString().slice(0, 10)
+    const res = await withFakeRepos(earningsRepo, macroRepo, async () => {
+      const app = createApp()
+      const form = new URLSearchParams()
+      form.set('symbol', 'AAPL')
+      form.set('earnings_date', day366)
+      return app.request(
+        '/dashboard/events/earnings/seed',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...authHeader },
+          body: form.toString(),
+        },
+        { ...baseEnv, DB: {} as D1Database },
+      )
+    })
+    expect(res.status).toBe(400)
+    const body = await res.text()
+    expect(body).toContain('過去 90 日 〜 未来 365 日')
+    expect(earningsRepo.bulkUpsert).not.toHaveBeenCalled()
+  })
+
+  it('seed earnings with symbol outside universe → save succeeds + warning rendered', async () => {
+    // universe.allowedSymbols に無い "MSFT" を入れる。 spec: "保存は許す + UI で warning"。
+    const earningsRepo = fakeEarningsRepo()
+    const macroRepo = fakeMacroRepo()
+    vi.mocked(createDb).mockReturnValue(
+      fakeListDb([]) as unknown as ReturnType<typeof createDb>,
+    )
+    const tomorrow = new Date(Date.now() + 86_400_000).toISOString().slice(0, 10)
+    const res = await withFakeRepos(earningsRepo, macroRepo, async () => {
+      const app = createApp()
+      const form = new URLSearchParams()
+      form.set('symbol', 'MSFT') // universe は ['AAPL'] のみ
+      form.set('earnings_date', tomorrow)
+      return app.request(
+        '/dashboard/events/earnings/seed',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...authHeader },
+          body: form.toString(),
+        },
+        { ...baseEnv, DB: {} as D1Database },
+      )
+    })
+    // 保存 (bulkUpsert) は行われる (non-blocking warning)
+    expect(earningsRepo.bulkUpsert).toHaveBeenCalledWith([
+      { symbol: 'MSFT', earningsDate: tomorrow, notes: null },
+    ])
+    // PRG redirect ではなく 200 で再描画 + warning notice
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    expect(body).toContain('class="warn"')
+    expect(body).toContain('MSFT')
+    expect(body).toContain('symbol_config')
   })
 
   it('XSS regression: notes / event_kind with <script> payload is escaped on render', async () => {


### PR DESCRIPTION
Closes #293
Refs #291

## Summary

\`earnings_calendar\` / \`macro_event_calendar\` の手動 add / delete UI。両 calendar とも risk gate (\`earningsGate\` / \`macroEventGate\`) のソースなので operator が dashboard 経由で直接管理できるようにする。

## 変更点

### 新規 dashboard route + form handlers (\`src/routes/dashboard.ts\`)
- \`GET /dashboard/events\` — earnings + macro 2 セクション、range now-30d 〜 now+30d
- \`POST /dashboard/events/earnings/seed\` — form-encoded add (1 件配列 wrap → \`repo.bulkUpsert\`)
- \`POST /dashboard/events/earnings/:id/delete\` — companion to existing DELETE admin endpoint
- \`POST /dashboard/events/macro/seed\` / \`POST /dashboard/events/macro/:id/delete\`

すべて \`rateLimit('ADMIN_WRITE')\` + audit log。

### Validation
- earnings symbol: 1-16 chars uppercase、universe 不在は警告のみ (block ではない)
- event_date: ISO \`YYYY-MM-DD\`、now-90d 〜 now+365d clamp
- event_kind: 大文字英数 + \`_\` で 1-32 chars (admin schema regex 一致)
- country: 自由文 ≤16 chars
- notes: 自由文 ≤256 chars (schema 上限)

### Nav / index
- 戦略・監視 group に「イベント」link
- index page の同セクションに li 追加

### 副次対応
- macro schema に \`country\` column 無し → \`notes\` に \`"US — June FOMC"\` 形式で fold (migration 回避、scope 外)

## Rebase 注記

- \`src/routes/dashboard.ts\` で #292 (symbols UI) と routes / helpers の挿入位置で conflict
- 両 lane の追加は独立コードなので両方を取って merge (closing \`})\` と function 閉じ \`}\` を 1 ヶ所ずつ補完)

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` **1063/79 files** (+7 events tests over #292 baseline)
- [x] list / add earnings / add macro / delete earnings / delete macro / validation / XSS regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ダッシュボードにイベント管理ページを追加（カレンダーイベントの閲覧・追加・削除が可能）。
  * ナビゲーションとダッシュボードの案内文にイベント管理ページへのリンクと「変更は監査ログに記録される」旨を追記。

* **Behavior / Notices**
  * 入力バリデーションで不正な日付や必須項目はエラー表示、ユニバース外の銘柄は保存しつつ警告表示。
  * メモ等の出力は適切にエスケープされXSSリスクに配慮。

* **Tests**
  * イベント管理UIの包括的な自動テストを追加。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/295)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->