### PR TITLE
feat(dashboard): hard delete on inactive rows + thousand-separator numbers

### DIFF
--- a/src/infrastructure/db/symbolConfigRepo.ts
+++ b/src/infrastructure/db/symbolConfigRepo.ts
@@ -233,27 +233,28 @@ export async function toggleSymbolActive(
 }
 
 /**
- * Soft delete (active=false)。hard delete は FK 影響回避のため避ける。
- * 既に active=false なら no-op (before==after で audit log も skip される)。
+ * Hard delete。inactive (active=false) 行のみ削除可、active 行は削除拒否
+ * ({ rejected: 'still_active' } 返却)。
+ *
+ * 旧 soft-delete (active=false 化) は toggle-active で代替できるため重複機能を
+ * 廃止し、UI 上「削除」= row そのものの除去を意味するように整理 (audit row は
+ * 別 table のため、削除後も操作履歴は残る)。
+ *
+ * FK は明示宣言されてないが、削除後に historical trade_journal などが symbol
+ * 文字列を保持するのは OK (orphan reference、表示時 inactive 扱い)。
  */
-export async function softDeleteSymbol(
+export async function hardDeleteSymbol(
   db: DrizzleD1Database,
   symbol: string,
-  nowIso: string,
-): Promise<{ before: SymbolConfigRow; after: SymbolConfigRow } | null> {
+): Promise<{ before: SymbolConfigRow } | { rejected: 'still_active' } | null> {
   const before = await findSymbolConfig(db, symbol)
   if (before === null) return null
-  const beforeSnapshot: SymbolConfigRow = { ...before }
-  if (!before.active) {
-    return { before: beforeSnapshot, after: beforeSnapshot }
+  if (before.active) {
+    return { rejected: 'still_active' }
   }
-  await db
-    .update(symbolConfig)
-    .set({ active: false, updatedAt: nowIso })
-    .where(eq(symbolConfig.symbol, symbol))
-  const after = await findSymbolConfig(db, symbol)
-  if (after === null) return null
-  return { before: beforeSnapshot, after }
+  const beforeSnapshot: SymbolConfigRow = { ...before }
+  await db.delete(symbolConfig).where(eq(symbolConfig.symbol, symbol))
+  return { before: beforeSnapshot }
 }
 
 /**

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -20,7 +20,7 @@ import { extractActor, recordChange } from '../infrastructure/db/configAuditLog'
 import {
   findSymbolConfig,
   insertSymbolConfig,
-  softDeleteSymbol,
+  hardDeleteSymbol,
   toggleSymbolActive,
   updateSymbolConfig,
   type SymbolConfigWriteInput,
@@ -1075,7 +1075,7 @@ export const admin = new Hono<AppBindings>()
     const symbolPath = normalizeSymbolPathParam(c.req.param('symbol'))
     const isForm = isFormContentType(c.req.header('content-type'))
     const db = createDb(c.env.DB)
-    const result = await softDeleteSymbol(db, symbolPath, new Date().toISOString())
+    const result = await hardDeleteSymbol(db, symbolPath)
     if (result === null) {
       if (isForm) {
         return c.redirect(
@@ -1085,15 +1085,24 @@ export const admin = new Hono<AppBindings>()
       }
       return c.json({ error: 'symbol_not_found', symbol: symbolPath }, 404)
     }
+    if ('rejected' in result) {
+      if (isForm) {
+        return c.redirect(
+          `/dashboard/symbols?error=still_active&symbol=${encodeURIComponent(symbolPath)}`,
+          303,
+        )
+      }
+      return c.json({ error: 'still_active', symbol: symbolPath }, 400)
+    }
     await writeAuditLog(
       c,
       '/admin/symbol-config/:symbol/delete',
       `symbol=${symbolPath}`,
-      { active: result.before.active },
-      { active: result.after.active },
+      symbolConfigSnapshot(result.before),
+      null,
     )
     if (isForm) return c.redirect('/dashboard/symbols', 303)
-    return c.json({ symbol: symbolPath, row: symbolConfigSnapshot(result.after) })
+    return c.json({ symbol: symbolPath, deleted: true })
   })
 
 /**

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -874,7 +874,10 @@ const esc = escapeHtml
 
 function fmtNumber(n: number | null | undefined, digits = 2): string {
   if (n === null || n === undefined || !Number.isFinite(n)) return '-'
-  return n.toFixed(digits)
+  return n.toLocaleString('ja-JP', {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+  })
 }
 
 const JST_FORMATTER = new Intl.DateTimeFormat('en-CA', {
@@ -2533,7 +2536,7 @@ function describeCronReason(reason: string | null | undefined): string {
 function formatRealizedPnl(value: number): string {
   const sign = value > 0 ? '+' : ''
   const cls = value > 0 ? 'ok' : value < 0 ? 'err' : 'muted'
-  return `<span class="${cls}">${sign}${value.toFixed(2)}</span>`
+  return `<span class="${cls}">${sign}${value.toLocaleString('ja-JP', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>`
 }
 
 /**
@@ -5932,20 +5935,20 @@ function symbolsListBody(args: {
       const editHref = `/dashboard/symbols/${encodeURIComponent(r.symbol)}/edit`
       const toggleAction = `/admin/symbol-config/${encodeURIComponent(r.symbol)}/toggle-active`
       const deleteAction = `/admin/symbol-config/${encodeURIComponent(r.symbol)}/delete`
-      // soft delete は active=false にするだけ (FK 影響回避)。既に inactive なら
-      // ボタン自体を出さない (no-op 防止) — toggle で対応可能。
+      // hard delete は inactive 行のみ。active 行に削除を出すと「無効化」と機能重複に
+      // なるため、運用フローを「先に無効化 → 確認 → 削除」と段階化。
       const deleteForm = r.active
-        ? `<form method="post" action="${esc(deleteAction)}" style="display:inline" onsubmit="return confirm('${esc(r.symbol)} を無効化 (soft delete) します。本当によろしいですか？');">
+        ? '<span class="muted" style="font-size:11px" title="削除するには先に無効化してください">—</span>'
+        : `<form method="post" action="${esc(deleteAction)}" style="display:inline" onsubmit="return confirm('${esc(r.symbol)} を完全に削除します (DB row 自体を消去)。元に戻せません。よろしいですか？');">
             <button type="submit" style="padding:3px 8px;font-size:12px;background:#c22;color:#fff;border:none;border-radius:4px;cursor:pointer">削除</button>
           </form>`
-        : '<span class="muted" style="font-size:11px">—</span>'
       return `<tr${rowClass}>
         <td><strong><span${symbolClass}>${esc(r.symbol)}</span></strong></td>
         <td>${esc(r.name ?? '')}</td>
         <td>${esc(r.market)}</td>
         <td>${esc(r.currency)}</td>
         <td>${stateLabel}</td>
-        <td>${r.maxNotional === null ? '<span class="muted" title="未設定 = global の MAX_ORDER_NOTIONAL を使用">— (global)</span>' : `${esc(r.maxNotional)} <span class="muted" style="font-size:11px">${esc(r.currency)}</span>`}</td>
+        <td>${r.maxNotional === null ? '<span class="muted" title="未設定 = global の MAX_ORDER_NOTIONAL を使用">— (global)</span>' : `${esc(r.maxNotional.toLocaleString('ja-JP'))} <span class="muted" style="font-size:11px">${esc(r.currency)}</span>`}</td>
         <td>${esc(r.bucket ?? '')}</td>
         <td>${esc(r.notes ?? '')}</td>
         <td class="muted">${esc(fmtJst(r.updatedAt))}</td>
@@ -5996,6 +5999,10 @@ function symbolErrorMessage(code: string, symbol: string | null): string {
         : 'symbol は既に登録済みです。'
     case 'not_found':
       return sym ? `symbol "${sym}" が見つかりません。` : 'symbol が見つかりません。'
+    case 'still_active':
+      return sym
+        ? `symbol "${sym}" は有効化中のため削除できません。先に無効化してから削除してください。`
+        : 'symbol が有効化中のため削除できません。先に無効化してください。'
     case 'validation':
       return '入力値に誤りがあります。'
     default:

--- a/test/routes/dashboardSymbolsCrud.test.ts
+++ b/test/routes/dashboardSymbolsCrud.test.ts
@@ -53,6 +53,7 @@ function fakeDb(initial: SymbolConfigRow[]) {
   const rows: SymbolConfigRow[] = [...initial]
   const inserts: InsertCall[] = []
   const updates: UpdateCall[] = []
+  const deletes: { table: string; whereSymbol: string | null }[] = []
 
   const tableName = (t: unknown): InsertCall['table'] => {
     // drizzle SQLite table object stores name in `[Symbol.for('drizzle:Name')]` or `_.name`。
@@ -115,9 +116,21 @@ function fakeDb(initial: SymbolConfigRow[]) {
   return {
     inserts,
     updates,
+    deletes,
     rows,
     drizzleLike: {
       select: () => selectChain(() => rows),
+      delete: (table: unknown) => ({
+        where: async (cond: unknown) => {
+          const tn = tableName(table)
+          const symbol = extractSymbolFromWhere(cond)
+          if (tn === 'symbol_config' && symbol !== null) {
+            const idx = rows.findIndex((r) => r.symbol === symbol)
+            if (idx !== -1) rows.splice(idx, 1)
+          }
+          deletes.push({ table: tn, whereSymbol: symbol })
+        },
+      }),
       insert: (table: unknown) => ({
         values: async (v: Record<string, unknown>) => {
           const tn = tableName(table)
@@ -216,9 +229,9 @@ describe('dashboard symbol_config CRUD UI (#292)', () => {
     // action links per row
     expect(body).toContain('/dashboard/symbols/SOXL/edit')
     expect(body).toContain('/admin/symbol-config/SOXL/toggle-active')
-    // soft delete button only on active row
-    expect(body).toContain('/admin/symbol-config/SOXL/delete')
-    expect(body).not.toContain('/admin/symbol-config/7203/delete')
+    // hard delete button only on inactive row (active 行は無効化先行を要求)
+    expect(body).toContain('/admin/symbol-config/7203/delete')
+    expect(body).not.toContain('/admin/symbol-config/SOXL/delete')
     // counts
     expect(body).toContain('active 1 / inactive 1')
   })
@@ -340,8 +353,31 @@ describe('dashboard symbol_config CRUD UI (#292)', () => {
     expect(JSON.parse(String(auditInsert!.values.afterJson))).toEqual({ active: false })
   })
 
-  // --- POST delete (soft) ---
-  it('POST /admin/symbol-config/:symbol/delete soft-deletes (active=false) without hard delete', async () => {
+  // --- POST delete (hard, inactive only) ---
+  it('POST /admin/symbol-config/:symbol/delete hard-deletes inactive row', async () => {
+    const db = fakeDb([row({ symbol: 'SOXL', active: false })])
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const app = createApp()
+    const res = await app.request(
+      '/admin/symbol-config/SOXL/delete',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...authHeader },
+        body: '',
+      },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    expect(res.status).toBe(303)
+    // DELETE 1 件、UPDATE は走らないこと
+    const deletes = db.deletes.filter((d) => d.table === 'symbol_config')
+    expect(deletes).toHaveLength(1)
+    const auditInsert = db.inserts.find((i) => i.table === 'config_audit_log')
+    expect(auditInsert).toBeDefined()
+    // audit log の after_json は JSON.stringify(null) = 文字列 "null" (削除を意味)
+    expect(auditInsert!.values.afterJson).toBe('null')
+  })
+
+  it('POST /admin/symbol-config/:symbol/delete on active row → 303 redirect ?error=still_active (no DELETE)', async () => {
     const db = fakeDb([row({ symbol: 'SOXL', active: true })])
     vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
     const app = createApp()
@@ -355,13 +391,9 @@ describe('dashboard symbol_config CRUD UI (#292)', () => {
       { ...baseEnv, DB: {} as D1Database },
     )
     expect(res.status).toBe(303)
-    // UPDATE 1 件のみ — DELETE は呼ばれないこと
-    const updates = db.updates.filter((u) => u.table === 'symbol_config')
-    expect(updates).toHaveLength(1)
-    expect(updates[0]!.set).toMatchObject({ active: false })
-    const auditInsert = db.inserts.find((i) => i.table === 'config_audit_log')
-    expect(auditInsert).toBeDefined()
-    expect(JSON.parse(String(auditInsert!.values.afterJson))).toEqual({ active: false })
+    expect(res.headers.get('location')).toBe('/dashboard/symbols?error=still_active&symbol=SOXL')
+    const deletes = db.deletes.filter((d) => d.table === 'symbol_config')
+    expect(deletes).toHaveLength(0)
   })
 
   // --- Validation ---


### PR DESCRIPTION
Refs #291 follow-up

## Summary

UX 修正 2 件:

### 1. 削除ボタンの挙動を運用フローに沿わせる
- **旧**: active 行に「削除」ボタン → soft delete (active=false) = 「無効化」ボタンと機能重複 + ラベルと実挙動の乖離
- **新**: inactive 行に「削除」ボタン → **hard delete** (DB row 削除)
- active 行で \`/delete\` API 叩くと 400 \`still_active\` で reject、UI に「先に無効化してください」の error banner
- 操作フロー: 無効化 → 確認 → 削除 (誤削除しにくい)

### 2. 数値に thousand 区切り
- \`fmtNumber\` を \`toLocaleString('ja-JP')\` ベースに変更 → 全 fmtNumber call site で \`1,000\` 区切り
- max_notional 表示: \`30000 JPY\` → \`30,000 JPY\`
- \`formatRealizedPnl\` も同様

## 影響範囲

- \`src/infrastructure/db/symbolConfigRepo.ts\`: \`softDeleteSymbol\` → \`hardDeleteSymbol\` (新規)、reject signal \`{ rejected: 'still_active' }\` 追加
- \`src/routes/admin.ts\`: \`/admin/symbol-config/:symbol/delete\` の実装変更
- \`src/routes/dashboard.ts\`: 削除ボタン位置切替 / fmtNumber 中身 / formatRealizedPnl / max_notional セル / error banner にメッセージ追加
- \`test/routes/dashboardSymbolsCrud.test.ts\`: 削除テストを hard delete 用に書換、still_active reject テスト追加、fakeDb に delete メソッド追加

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` 1066/79 files pass (+1 still_active reject test、既存 1 件書換)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * シンボル削除処理を改善。アクティブな銘柄は先に無効化が必要になりました。

* **改善**
  * 数値表示フォーマットを改善（より正確な丸め表示に対応）。
  * シンボル管理画面の削除ボタン表示を最適化（無効化済み銘柄のみ削除可能に）。
  * 削除できない場合のエラーメッセージを追加。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/298)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->