### PR TITLE
feat(dashboard): symbol 新規追加で「取得」ボタンによる name/market/currency 自動入力

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1104,6 +1104,54 @@ export const admin = new Hono<AppBindings>()
     if (isForm) return c.redirect('/dashboard/symbols', 303)
     return c.json({ symbol: symbolPath, deleted: true })
   })
+  /**
+   * symbol lookup helper (form auto-fill 用)。
+   *
+   * Yahoo Finance の public search endpoint で銘柄名を引きつつ、market /
+   * currency は symbol pattern (4 桁数字 = JP / それ以外 = US) から推測する。
+   *
+   * Yahoo 障害時は market / currency だけ返して name は null (form 側で
+   * user が手動入力すれば足りる)。auth は他 admin endpoint と同じ Access 通過
+   * 必須、rate-limit は ADMIN_WRITE と同じ枠で十分 (低頻度操作)。
+   */
+  .get('/symbol-config/lookup', rateLimit('ADMIN_WRITE'), async (c) => {
+    const symbolRaw = c.req.query('symbol') ?? ''
+    const symbol = symbolRaw.trim().toUpperCase()
+    if (!/^[A-Z0-9]{1,10}$/.test(symbol)) {
+      return c.json({ error: 'invalid_symbol', symbol: symbolRaw }, 400)
+    }
+    const isJp = /^\d{4}$/.test(symbol)
+    const market = isJp ? 'JP' : 'US'
+    const currency = isJp ? 'JPY' : 'USD'
+    const query = isJp ? `${symbol}.T` : symbol
+    try {
+      const res = await fetch(
+        `https://query1.finance.yahoo.com/v1/finance/search?q=${encodeURIComponent(query)}&quotesCount=5&newsCount=0`,
+        {
+          headers: { 'User-Agent': 'Mozilla/5.0 (compatible; webull-trading-symbol-lookup/1.0)' },
+          signal: AbortSignal.timeout(5000),
+        },
+      )
+      if (!res.ok) {
+        return c.json({ symbol, name: null, market, currency, source: 'pattern_only', error: `yahoo_${res.status}` })
+      }
+      const data = (await res.json()) as {
+        quotes?: Array<{ symbol?: string; shortname?: string; longname?: string }>
+      }
+      const match = data.quotes?.find((q) => q.symbol === query) ?? data.quotes?.[0] ?? null
+      const name = match?.longname || match?.shortname || null
+      return c.json({ symbol, name, market, currency, source: name ? 'yahoo' : 'pattern_only' })
+    } catch (err) {
+      return c.json({
+        symbol,
+        name: null,
+        market,
+        currency,
+        source: 'pattern_only',
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  })
 
 /**
  * Validate a single `/admin/macro-events/seed` body entry。

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -6034,7 +6034,12 @@ function symbolFormBody(args: SymbolFormArgs): string {
       ? `<input type="text" name="symbol" value="${esc(symbolValue)}" readonly style="padding:6px;background:#eee">
          <span></span>
          <p class="muted" style="margin:0;font-size:11px">symbol は immutable です。変更したい場合は一度削除して再追加してください。</p>`
-      : `<input type="text" name="symbol" value="${esc(symbolValue)}" required maxlength="10" pattern="[A-Za-z0-9]{1,10}" placeholder="SOXL / 7974 / 1570" style="padding:6px">`
+      : `<div>
+           <input type="text" name="symbol" id="symbol-form-symbol" value="${esc(symbolValue)}" required maxlength="10" pattern="[A-Za-z0-9]{1,10}" placeholder="SOXL / 7974 / 1570" style="padding:6px;width:160px">
+           <button type="button" onclick="window.lookupSymbolAutoFill()" style="padding:6px 12px;margin-left:6px;background:#06c;color:#fff;border:none;border-radius:4px;cursor:pointer">取得</button>
+           <span id="symbol-form-lookup-status" class="muted" style="font-size:11px;margin-left:8px"></span>
+           <p class="muted" style="margin:4px 0 0;font-size:11px">symbol を入れて「取得」で銘柄名 / 市場 / 通貨を Yahoo Finance から自動補完 (失敗時は市場 / 通貨だけ symbol pattern で推測)。</p>
+         </div>`
   const errBlock = error ? `<p class="err" style="margin:0 0 12px">${esc(error)}</p>` : ''
   const heading = mode === 'new' ? '新規銘柄追加' : `編集: ${esc(symbolValue)}`
   return `<h2 style="font-size:16px;margin:8px 0 12px">${heading}</h2>
@@ -6042,7 +6047,7 @@ function symbolFormBody(args: SymbolFormArgs): string {
   <form method="post" action="${esc(action)}" style="display:grid;grid-template-columns:160px 1fr;gap:8px;max-width:600px;align-items:center">
     <label>銘柄 <span class="muted" style="font-size:11px">(symbol)</span></label>${symbolField}
     <label>銘柄名 <span class="muted" style="font-size:11px">(name)</span></label>
-    <input type="text" name="name" value="${esc(nameValue)}" maxlength="256" placeholder="人間可読な銘柄名 (任意)" style="padding:6px">
+    <input type="text" name="name" id="symbol-form-name" value="${esc(nameValue)}" maxlength="256" placeholder="人間可読な銘柄名 (任意)" style="padding:6px">
     <label>市場 <span class="muted" style="font-size:11px">(market)</span></label>
     <select name="market" id="symbol-form-market" required style="padding:6px" onchange="window.syncSymbolFormCurrencyFromMarket(this.value)">
       <option value="US"${marketValue === 'US' ? ' selected' : ''}>US (米国)</option>
@@ -6089,6 +6094,31 @@ function symbolFormBody(args: SymbolFormArgs): string {
       var sel = document.getElementById('symbol-form-currency');
       if (sel) sel.value = cur;
       window.syncSymbolFormCurrencyUnits(cur);
+    };
+    window.lookupSymbolAutoFill = async function () {
+      var symInput = document.getElementById('symbol-form-symbol');
+      var statusEl = document.getElementById('symbol-form-lookup-status');
+      if (!symInput || !statusEl) return;
+      var sym = (symInput.value || '').trim().toUpperCase();
+      if (!sym) { statusEl.textContent = 'symbol を先に入力してください'; return; }
+      statusEl.textContent = '取得中…';
+      try {
+        var res = await fetch('/admin/symbol-config/lookup?symbol=' + encodeURIComponent(sym), { credentials: 'same-origin' });
+        if (!res.ok) { statusEl.textContent = '取得失敗 (HTTP ' + res.status + ')'; return; }
+        var data = await res.json();
+        var nameInput = document.getElementById('symbol-form-name');
+        var marketSel = document.getElementById('symbol-form-market');
+        var currencySel = document.getElementById('symbol-form-currency');
+        if (data.name && nameInput) nameInput.value = data.name;
+        if (data.market && marketSel) marketSel.value = data.market;
+        if (data.currency && currencySel) currencySel.value = data.currency;
+        if (data.currency) window.syncSymbolFormCurrencyUnits(data.currency);
+        statusEl.textContent = data.name
+          ? '✓ ' + data.source + ' から取得'
+          : '⚠ 名前は取得失敗 (' + data.source + ')、市場/通貨のみ反映';
+      } catch (err) {
+        statusEl.textContent = '取得エラー: ' + (err && err.message ? err.message : err);
+      }
     };
   </script>`
 }


### PR DESCRIPTION
Refs #291 follow-up

## Summary

\`/dashboard/symbols/new\` で symbol を入力後 「取得」 ボタンを押すと、銘柄名・市場・通貨が自動入力される。

## 変更点

### 新 endpoint
\`GET /admin/symbol-config/lookup?symbol=AAPL\`
- Yahoo Finance public search API (\`query1.finance.yahoo.com/v1/finance/search\`) を call
- 4 桁数字 symbol は \`.T\` 付きで JP として query
- response: \`{ symbol, name, market, currency, source: 'yahoo' | 'pattern_only' }\`
- Yahoo 失敗時は market/currency のみ pattern 推測、name は null
- 5 秒 timeout、Access auth + \`rateLimit('ADMIN_WRITE')\`

### Form 側
- symbol input の右に「取得」ボタン
- inline JS \`window.lookupSymbolAutoFill\` が fetch + form populate + status 表示
- 取得結果メッセージ: \`✓ yahoo から取得\` / \`⚠ 名前は取得失敗、市場/通貨のみ反映\` / エラー

## 例

| symbol | 期待 result |
|---|---|
| \`AAPL\` | name=\"Apple Inc.\" / market=US / currency=USD |
| \`SOXL\` | name=\"Direxion Daily Semiconductor Bull 3X Shares\" / US / USD |
| \`7203\` | name=\"Toyota Motor Corp\" / JP / JPY (Yahoo に \`7203.T\` で query) |
| \`UNKNOWN\` | name=null / US / USD / source=\"pattern_only\" |

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` 1066/79 files pass (新 endpoint は Yahoo 依存なので unit test skip、staging で動作確認)
- [ ] (post-deploy) staging で \`AAPL\` / \`7203\` を入力 → 取得 → 名前 / 市場 / 通貨が自動入力されること