### PR TITLE
feat(dashboard): symbol form bucket を chip 風 UI に (空状態対応)

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -6100,18 +6100,21 @@ function symbolFormBody(args: SymbolFormArgs): string {
     </div>
     <label style="align-self:start;padding-top:4px">相関グループ <span class="muted" style="font-size:11px">(bucket)</span></label>
     <div>
+      <input type="text" name="bucket" id="symbol-form-bucket-input" value="${esc(bucketValue)}" maxlength="256" placeholder="例: semi / us_large_cap / jp_auto (任意)" style="padding:6px;width:280px">
       ${
         knownBuckets.length > 0
-          ? `<input type="search" id="symbol-form-bucket-filter" placeholder="🔍 既存 bucket を絞り込み" oninput="window.filterSymbolFormBuckets(this.value)" style="padding:6px;width:240px;margin-bottom:4px">
-             <br>
-             <select id="symbol-form-bucket-list" size="${Math.min(6, knownBuckets.length)}" onchange="window.pickSymbolFormBucket(this.value)" style="padding:4px;width:240px;font-family:inherit">
-               ${knownBuckets.map((b) => `<option value="${esc(b)}"${b === bucketValue ? ' selected' : ''}>${esc(b)}</option>`).join('')}
-             </select>
-             <p class="muted" style="margin:4px 0 2px;font-size:11px">↑ 既存値から選択、または ↓ で新規入力</p>`
-          : '<p class="muted" style="margin:0 0 4px;font-size:11px">既存 bucket はまだ無し — 下に直接入力してください。</p>'
+          ? `<div style="margin-top:6px;display:flex;flex-wrap:wrap;gap:4px;align-items:center">
+               <span class="muted" style="font-size:11px;margin-right:4px">既存 (click で挿入):</span>
+               ${knownBuckets
+                 .map(
+                   (b) =>
+                     `<button type="button" onclick="window.pickSymbolFormBucket('${esc(b).replace(/'/g, '&#39;')}')" style="padding:2px 8px;font-size:11px;background:#fff;border:1px solid #d0d0d5;border-radius:12px;cursor:pointer;color:#06c">${esc(b)}</button>`,
+                 )
+                 .join('')}
+             </div>`
+          : ''
       }
-      <input type="text" name="bucket" id="symbol-form-bucket-input" value="${esc(bucketValue)}" maxlength="256" placeholder="新規入力 (任意、空欄なら bucket 未分類)" style="padding:6px;width:240px">
-      <p class="muted" style="margin:4px 0 0;font-size:11px">同 bucket の銘柄は portfolio 上で合計 notional 上限を共有する (\`global_config.bucket_exposure_pct\`)。</p>
+      <p class="muted" style="margin:6px 0 0;font-size:11px">同 bucket の銘柄は portfolio 上で合計 notional 上限を共有する (\`global_config.bucket_exposure_pct\`)。空欄なら bucket 未分類。</p>
     </div>
     <label>メモ <span class="muted" style="font-size:11px">(notes)</span></label>
     <textarea name="notes" maxlength="256" rows="3" placeholder="自由記述 (例: 一時停止理由 / 上限を絞ってる事情)" style="padding:6px;font-family:inherit">${esc(notesValue)}</textarea>
@@ -6136,15 +6139,9 @@ function symbolFormBody(args: SymbolFormArgs): string {
     };
     window.pickSymbolFormBucket = function (val) {
       var input = document.getElementById('symbol-form-bucket-input');
-      if (input) input.value = val;
-    };
-    window.filterSymbolFormBuckets = function (q) {
-      var list = document.getElementById('symbol-form-bucket-list');
-      if (!list) return;
-      var needle = (q || '').toLowerCase();
-      for (var i = 0; i < list.options.length; i++) {
-        var opt = list.options[i];
-        opt.hidden = needle.length > 0 && opt.value.toLowerCase().indexOf(needle) === -1;
+      if (input) {
+        input.value = val;
+        input.focus();
       }
     };
     window.lookupSymbolAutoFill = async function () {


### PR DESCRIPTION
Refs #291 follow-up, supersedes #300 / #301

## Summary

bucket 入力を text input + chip 列に整理。空状態でも入力に集中できる。

## 変更点

| 状態 | UI |
|---|---|
| 既存値あり | text input + 下に \`既存 (click で挿入): [chip1] [chip2] [chip3]\` |
| 既存値なし | text input のみ (placeholder で例示) |

- chip クリック → text input に値挿入 + focus
- chip は pill 形状 (\`border-radius:12px\`)、青文字白背景
- 新規入力は text input に直接

## 直前 PR との差分

- #300 datalist: browser-dependent UX で意図と違った
- #301 listbox + 検索 + text: 空状態で listbox が隠れて「最初の追加で何も出ない」が悪かった
- 今回 chip: empty / non-empty の両方で同じ primary control (text input) を維持、既存値は補助 chip でビジュアル化

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` 1066/79 files pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
* 銘柄管理画面の bucket 入力UIが改善されました。既知の bucket をクリック可能なボタン群から選択でき、選択すると入力欄に自動フォーカスするようになりました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/302)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->