### PR TITLE
fix(dashboard): bucket suggest の (未分類) 行を click 不可

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -6160,25 +6160,38 @@ function symbolFormBody(args: SymbolFormArgs): string {
         list.style.display = 'block';
         return;
       }
+      // bucket を持っている銘柄を上、未分類を下 (= 探しやすい順)
+      matches.sort(function (a, b) {
+        var ab = a.bucket ? 0 : 1, bb = b.bucket ? 0 : 1;
+        if (ab !== bb) return ab - bb;
+        return a.symbol.localeCompare(b.symbol);
+      });
       matches.forEach(function (p) {
+        var hasBucket = !!p.bucket;
         var li = document.createElement('li');
-        li.style.cssText = 'padding:6px 10px;cursor:pointer;border-bottom:1px solid #eee;display:flex;justify-content:space-between;gap:8px';
+        li.style.cssText = hasBucket
+          ? 'padding:6px 10px;cursor:pointer;border-bottom:1px solid #eee;display:flex;justify-content:space-between;gap:8px'
+          : 'padding:6px 10px;cursor:not-allowed;border-bottom:1px solid #eee;display:flex;justify-content:space-between;gap:8px;opacity:0.55';
         var symEl = document.createElement('strong');
         symEl.textContent = p.symbol;
         var arrow = document.createElement('span');
         arrow.style.color = '#86868b';
         arrow.textContent = ' → ';
         var bucketEl = document.createElement('span');
-        bucketEl.style.color = p.bucket ? '#06c' : '#c22';
-        bucketEl.textContent = p.bucket || '(未分類)';
+        bucketEl.style.color = hasBucket ? '#06c' : '#c22';
+        bucketEl.textContent = hasBucket ? p.bucket : '(未分類、選択不可)';
         li.appendChild(symEl);
         li.appendChild(arrow);
         li.appendChild(bucketEl);
-        li.addEventListener('mousedown', function () {
-          window.pickSymbolFormBucket(p.bucket || '');
-        });
-        li.addEventListener('mouseover', function () { li.style.background = '#eef'; });
-        li.addEventListener('mouseout', function () { li.style.background = '#fff'; });
+        if (hasBucket) {
+          li.addEventListener('mousedown', function () {
+            window.pickSymbolFormBucket(p.bucket);
+          });
+          li.addEventListener('mouseover', function () { li.style.background = '#eef'; });
+          li.addEventListener('mouseout', function () { li.style.background = '#fff'; });
+        } else {
+          li.title = 'この銘柄は bucket 未設定のため click 不可。先にこの銘柄の bucket を編集してください。';
+        }
         list.appendChild(li);
       });
       list.style.display = 'block';


### PR DESCRIPTION
Refs #291 follow-up

## Summary

ユーザー報告: 「ホバーを選択してもフィールドに入力されないね」。

(未分類) = bucket=null の銘柄を click すると \`pickSymbolFormBucket('')\` が呼ばれて input が空文字に上書きされる挙動が「何も起きない」ように見えていた。

## Fix

- 未分類 li: \`cursor:not-allowed\` / \`opacity:0.55\` / mousedown handler 無し
- title attribute で「click 不可、先にこの銘柄の bucket を編集してください」を tooltip 表示
- 表示テキストも \`(未分類、選択不可)\` に変更
- ソート順: bucket 持ち優先 → symbol ASC、(未分類) は下に固める (有効な選択肢が上に来る)

bucket を持つ銘柄の click 挙動は変更なし。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **機能改善**
  * シンボル管理フォームのバケット候補表示が改善されました。バケット割り当てのある候補が上部に表示され、未分類の候補は選択不可に変更されました。未分類候補にはホバー時に補足情報を表示するようになりました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/309)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->