### PR TITLE
feat(dashboard): symbol live autocomplete (取得ボタン廃止) + bucket 括弧除去

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1105,49 +1105,65 @@ export const admin = new Hono<AppBindings>()
     return c.json({ symbol: symbolPath, deleted: true })
   })
   /**
-   * symbol lookup helper (form auto-fill 用)。
+   * symbol search (live autocomplete + form auto-fill 用)。
    *
-   * Yahoo Finance の public search endpoint で銘柄名を引きつつ、market /
-   * currency は symbol pattern (4 桁数字 = JP / それ以外 = US) から推測する。
+   * Yahoo Finance の public search endpoint を proxy する。query (`?q=AA` 等) の
+   * 部分マッチで複数候補を返す。JP 判定 (4 桁数字 → `.T` 付け足し) は
+   * server 側で行い、quotes は market / currency 推測込みで返す。
    *
-   * Yahoo 障害時は market / currency だけ返して name は null (form 側で
-   * user が手動入力すれば足りる)。auth は他 admin endpoint と同じ Access 通過
-   * 必須、rate-limit は ADMIN_WRITE と同じ枠で十分 (低頻度操作)。
+   * Yahoo 障害時は `matches: []` を返して client は手動入力に fallback。
+   * Access auth + ADMIN_WRITE rate-limit を通る。
    */
   .get('/symbol-config/lookup', rateLimit('ADMIN_WRITE'), async (c) => {
-    const symbolRaw = c.req.query('symbol') ?? ''
-    const symbol = symbolRaw.trim().toUpperCase()
-    if (!/^[A-Z0-9]{1,10}$/.test(symbol)) {
-      return c.json({ error: 'invalid_symbol', symbol: symbolRaw }, 400)
+    const queryRaw = c.req.query('q') ?? c.req.query('symbol') ?? ''
+    const query = queryRaw.trim().toUpperCase()
+    if (query.length < 2 || !/^[A-Z0-9.]+$/.test(query)) {
+      return c.json({ matches: [] })
     }
-    const isJp = /^\d{4}$/.test(symbol)
-    const market = isJp ? 'JP' : 'US'
-    const currency = isJp ? 'JPY' : 'USD'
-    const query = isJp ? `${symbol}.T` : symbol
+    const isJpExact = /^\d{4}$/.test(query)
+    const yahooQuery = isJpExact ? `${query}.T` : query
     try {
       const res = await fetch(
-        `https://query1.finance.yahoo.com/v1/finance/search?q=${encodeURIComponent(query)}&quotesCount=5&newsCount=0`,
+        `https://query1.finance.yahoo.com/v1/finance/search?q=${encodeURIComponent(yahooQuery)}&quotesCount=10&newsCount=0`,
         {
           headers: { 'User-Agent': 'Mozilla/5.0 (compatible; webull-trading-symbol-lookup/1.0)' },
           signal: AbortSignal.timeout(5000),
         },
       )
       if (!res.ok) {
-        return c.json({ symbol, name: null, market, currency, source: 'pattern_only', error: `yahoo_${res.status}` })
+        return c.json({ matches: [], error: `yahoo_${res.status}` })
       }
       const data = (await res.json()) as {
-        quotes?: Array<{ symbol?: string; shortname?: string; longname?: string }>
+        quotes?: Array<{
+          symbol?: string
+          shortname?: string
+          longname?: string
+          quoteType?: string
+          exchange?: string
+        }>
       }
-      const match = data.quotes?.find((q) => q.symbol === query) ?? data.quotes?.[0] ?? null
-      const name = match?.longname || match?.shortname || null
-      return c.json({ symbol, name, market, currency, source: name ? 'yahoo' : 'pattern_only' })
+      const quotes = data.quotes ?? []
+      const matches = quotes
+        .filter((q) => q.symbol && (q.quoteType === 'EQUITY' || q.quoteType === 'ETF'))
+        .slice(0, 10)
+        .map((q) => {
+          const ySym = q.symbol!
+          // `.T` suffix の銘柄は JP 扱い、それ以外は US (Yahoo の他取引所は将来拡張)
+          const isJp = ySym.endsWith('.T')
+          const cleanSym = isJp ? ySym.replace(/\.T$/, '') : ySym
+          return {
+            symbol: cleanSym,
+            name: q.longname || q.shortname || null,
+            market: isJp ? 'JP' : 'US',
+            currency: isJp ? 'JPY' : 'USD',
+            exchange: q.exchange ?? null,
+            quoteType: q.quoteType ?? null,
+          }
+        })
+      return c.json({ matches })
     } catch (err) {
       return c.json({
-        symbol,
-        name: null,
-        market,
-        currency,
-        source: 'pattern_only',
+        matches: [],
         error: err instanceof Error ? err.message : String(err),
       })
     }

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -6062,10 +6062,11 @@ function symbolFormBody(args: SymbolFormArgs): string {
          <span></span>
          <p class="muted" style="margin:0;font-size:11px">symbol は immutable です。変更したい場合は一度削除して再追加してください。</p>`
       : `<div>
-           <input type="text" name="symbol" id="symbol-form-symbol" value="${esc(symbolValue)}" required maxlength="10" pattern="[A-Za-z0-9]{1,10}" placeholder="SOXL / 7974 / 1570" style="padding:6px;width:160px">
-           <button type="button" id="symbol-form-lookup-btn" onclick="window.lookupSymbolAutoFill()" style="padding:6px 12px;margin-left:6px;background:#06c;color:#fff;border:none;border-radius:4px;cursor:pointer">取得</button>
-           <span id="symbol-form-lookup-status" class="muted" style="font-size:11px;margin-left:8px"></span>
-           <p class="muted" style="margin:4px 0 0;font-size:11px">symbol を入れて「取得」で銘柄名 / 市場 / 通貨を Yahoo Finance から自動補完 (失敗時は市場 / 通貨だけ symbol pattern で推測)。</p>
+           <div style="position:relative;display:inline-block">
+             <input type="text" name="symbol" id="symbol-form-symbol" value="${esc(symbolValue)}" required maxlength="10" pattern="[A-Za-z0-9]{1,10}" placeholder="SOXL / 7974 / 1570" autocomplete="off" oninput="window.searchSymbolSuggest(this.value)" onfocus="window.searchSymbolSuggest(this.value)" onblur="setTimeout(window.hideSymbolSuggest, 200)" style="padding:6px;width:200px">
+             <ul id="symbol-form-symbol-suggest" style="display:none;position:absolute;top:100%;left:0;margin:2px 0 0;padding:0;list-style:none;background:#fff;border:1px solid #d0d0d5;border-radius:4px;width:380px;max-height:280px;overflow-y:auto;z-index:10;box-shadow:0 2px 6px rgba(0,0,0,0.1)"></ul>
+           </div>
+           <p class="muted" style="margin:4px 0 0;font-size:11px">2 文字以上入力で Yahoo Finance から候補を suggest。click で銘柄 / 銘柄名 / 市場 / 通貨を自動入力。JP 銘柄は 4 桁数字 (例: 7203)。</p>
          </div>`
   const errBlock = error ? `<p class="err" style="margin:0 0 12px">${esc(error)}</p>` : ''
   const heading = mode === 'new' ? '新規銘柄追加' : `編集: ${esc(symbolValue)}`
@@ -6179,12 +6180,12 @@ function symbolFormBody(args: SymbolFormArgs): string {
         arrow.textContent = ' → ';
         var bucketEl = document.createElement('span');
         bucketEl.style.color = hasBucket ? '#06c' : '#86868b';
-        bucketEl.textContent = hasBucket ? p.bucket : '(未分類、click で「' + p.symbol + '」挿入)';
+        bucketEl.textContent = hasBucket ? p.bucket : '未分類';
         li.appendChild(symEl);
         li.appendChild(arrow);
         li.appendChild(bucketEl);
         if (!hasBucket) {
-          li.title = 'bucket 未設定銘柄。click すると銘柄名 (' + p.symbol + ') が仮挿入される — 必要に応じて編集してください。';
+          li.title = 'click で銘柄名 (' + p.symbol + ') を bucket に仮挿入。';
         }
         li.addEventListener('mousedown', function () {
           window.pickSymbolFormBucket(insertValue);
@@ -6201,45 +6202,66 @@ function symbolFormBody(args: SymbolFormArgs): string {
       window.hideSymbolFormBucketSuggest();
       if (input) input.focus();
     };
-    window.lookupSymbolAutoFill = async function () {
+    window.hideSymbolSuggest = function () {
+      var list = document.getElementById('symbol-form-symbol-suggest');
+      if (list) list.style.display = 'none';
+    };
+    window._symbolSuggestTimer = null;
+    window._symbolSuggestSeq = 0;
+    window.searchSymbolSuggest = function (q) {
+      var list = document.getElementById('symbol-form-symbol-suggest');
+      if (!list) return;
+      var query = (q || '').trim();
+      if (query.length < 2) { list.style.display = 'none'; return; }
+      if (window._symbolSuggestTimer) clearTimeout(window._symbolSuggestTimer);
+      window._symbolSuggestTimer = setTimeout(function () {
+        var mySeq = ++window._symbolSuggestSeq;
+        fetch('/admin/symbol-config/lookup?q=' + encodeURIComponent(query), { credentials: 'same-origin' })
+          .then(function (res) { return res.ok ? res.json() : { matches: [] }; })
+          .then(function (data) {
+            if (mySeq !== window._symbolSuggestSeq) return; // 古い response は捨てる
+            var matches = (data && data.matches) || [];
+            list.innerHTML = '';
+            if (matches.length === 0) {
+              var hint = document.createElement('li');
+              hint.style.cssText = 'padding:6px 10px;color:#86868b;font-size:11px;font-style:italic;cursor:default';
+              hint.textContent = '"' + query + '" に一致する銘柄無し (Yahoo Finance)。手動入力で続行可。';
+              list.appendChild(hint);
+              list.style.display = 'block';
+              return;
+            }
+            matches.forEach(function (m) {
+              var li = document.createElement('li');
+              li.style.cssText = 'padding:6px 10px;cursor:pointer;border-bottom:1px solid #eee';
+              var sym = document.createElement('strong');
+              sym.textContent = m.symbol;
+              var nameSpan = document.createElement('span');
+              nameSpan.style.cssText = 'color:#86868b;margin-left:8px;font-size:12px';
+              nameSpan.textContent = (m.name || '?') + ' (' + m.market + '/' + m.currency + ')';
+              li.appendChild(sym);
+              li.appendChild(nameSpan);
+              li.addEventListener('mousedown', function () { window.pickSymbolSuggest(m); });
+              li.addEventListener('mouseover', function () { li.style.background = '#eef'; });
+              li.addEventListener('mouseout', function () { li.style.background = '#fff'; });
+              list.appendChild(li);
+            });
+            list.style.display = 'block';
+          })
+          .catch(function () { list.style.display = 'none'; });
+      }, 250);
+    };
+    window.pickSymbolSuggest = function (m) {
       var symInput = document.getElementById('symbol-form-symbol');
-      var statusEl = document.getElementById('symbol-form-lookup-status');
-      var btn = document.getElementById('symbol-form-lookup-btn');
-      if (!symInput || !statusEl) return;
-      var sym = (symInput.value || '').trim().toUpperCase();
-      if (!sym) { statusEl.textContent = 'symbol を先に入力してください'; return; }
-      statusEl.textContent = '取得中…';
-      if (btn) {
-        btn.disabled = true;
-        btn.dataset.origLabel = btn.textContent || '取得';
-        btn.textContent = '取得中…';
-        btn.style.opacity = '0.6';
-        btn.style.cursor = 'wait';
-      }
-      try {
-        var res = await fetch('/admin/symbol-config/lookup?symbol=' + encodeURIComponent(sym), { credentials: 'same-origin' });
-        if (!res.ok) { statusEl.textContent = '取得失敗 (HTTP ' + res.status + ')'; return; }
-        var data = await res.json();
-        var nameInput = document.getElementById('symbol-form-name');
-        var marketSel = document.getElementById('symbol-form-market');
-        var currencySel = document.getElementById('symbol-form-currency');
-        if (data.name && nameInput) nameInput.value = data.name;
-        if (data.market && marketSel) marketSel.value = data.market;
-        if (data.currency && currencySel) currencySel.value = data.currency;
-        if (data.currency) window.syncSymbolFormCurrencyUnits(data.currency);
-        statusEl.textContent = data.name
-          ? '✓ ' + data.source + ' から取得'
-          : '⚠ 名前は取得失敗 (' + data.source + ')、市場/通貨のみ反映';
-      } catch (err) {
-        statusEl.textContent = '取得エラー: ' + (err && err.message ? err.message : err);
-      } finally {
-        if (btn) {
-          btn.disabled = false;
-          btn.textContent = btn.dataset.origLabel || '取得';
-          btn.style.opacity = '';
-          btn.style.cursor = 'pointer';
-        }
-      }
+      var nameInput = document.getElementById('symbol-form-name');
+      var marketSel = document.getElementById('symbol-form-market');
+      var currencySel = document.getElementById('symbol-form-currency');
+      if (symInput) symInput.value = m.symbol;
+      if (m.name && nameInput) nameInput.value = m.name;
+      if (m.market && marketSel) marketSel.value = m.market;
+      if (m.currency && currencySel) currencySel.value = m.currency;
+      if (m.currency) window.syncSymbolFormCurrencyUnits(m.currency);
+      window.hideSymbolSuggest();
+      if (symInput) symInput.focus();
     };
   </script>`
 }


### PR DESCRIPTION
Refs #291 follow-up

## Summary

- 取得ボタン廃止 → symbol input に **live autocomplete** (2 文字以上 / 250ms debounce / Yahoo 経由)
- bucket suggest の \`(未分類、click で「SOXL」挿入)\` 括弧説明文除去

## 変更点

### Symbol field
- 2 文字以上入力で suggest dropdown
- list item: \`SYMBOL\` + 銘柄名 + (市場/通貨)
- click → symbol / name / market / currency を一括 fill

### Lookup endpoint
- 単一 match → matches[] 返しに shape 変更
- quoteType フィルタ (EQUITY/ETF)、JP は .T suffix 除去
- old race race condition は seq number で対策

### Bucket suggest
- \`未分類\` のみ表示、title attr で tooltip 残す

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ダッシュボードの銘柄フィールドにインライン検索機能を追加。入力時に候補が自動表示され、クリックで銘柄情報を自動入力できるようになりました。

* **改善**
  * 銘柄検索の応答形式を刷新し、複数の候補を同時に表示可能に。グループ分類の表示ラベルも改善されました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/311)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->