### PR TITLE
feat(portfolio): 総資産 snapshot table + 口座サマリにチャート表示

### DIFF
--- a/drizzle/0018_portfolio_equity_snapshot.sql
+++ b/drizzle/0018_portfolio_equity_snapshot.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `portfolio_equity_snapshot` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`snapshot_at` text NOT NULL,
+	`daily_start_equity_usd` real,
+	`daily_start_equity_jpy` real,
+	`daily_realized_pnl_usd` real,
+	`daily_realized_pnl_jpy` real,
+	`drawdown_pct` real,
+	`request_id` text
+);
+--> statement-breakpoint
+CREATE INDEX `portfolio_equity_snapshot_at_idx` ON `portfolio_equity_snapshot` (`snapshot_at`);

--- a/drizzle/meta/0018_snapshot.json
+++ b/drizzle/meta/0018_snapshot.json
@@ -1,0 +1,1287 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b424b4d4-51f8-4f7f-8122-cb92311b6d93",
+  "prevId": "d1b5a873-7bdd-4a2f-85d5-0f2f965606f7",
+  "tables": {
+    "config_audit_log": {
+      "name": "config_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before_json": {
+          "name": "before_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "after_json": {
+          "name": "after_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "config_audit_log_timestamp_id_idx": {
+          "name": "config_audit_log_timestamp_id_idx",
+          "columns": [
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "config_audit_log_actor_timestamp_id_idx": {
+          "name": "config_audit_log_actor_timestamp_id_idx",
+          "columns": [
+            "actor",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "config_audit_log_endpoint_timestamp_id_idx": {
+          "name": "config_audit_log_endpoint_timestamp_id_idx",
+          "columns": [
+            "endpoint",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "config_state_snapshot": {
+      "name": "config_state_snapshot",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "earnings_calendar": {
+      "name": "earnings_calendar",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "earnings_date": {
+          "name": "earnings_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "earnings_calendar_symbol_date_unique": {
+          "name": "earnings_calendar_symbol_date_unique",
+          "columns": [
+            "symbol",
+            "earnings_date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "global_config": {
+      "name": "global_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "trading_enabled": {
+          "name": "trading_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "market_hours_check": {
+          "name": "market_hours_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "max_order_notional": {
+          "name": "max_order_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "max_order_notional_usd": {
+          "name": "max_order_notional_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2000
+        },
+        "max_order_notional_jpy": {
+          "name": "max_order_notional_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100000
+        },
+        "total_capital_usd": {
+          "name": "total_capital_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_capital_jpy": {
+          "name": "total_capital_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_portfolio_exposure_pct": {
+          "name": "max_portfolio_exposure_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.6
+        },
+        "drawdown_kill_threshold": {
+          "name": "drawdown_kill_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.02
+        },
+        "stale_quote_ms": {
+          "name": "stale_quote_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 900000
+        },
+        "gap_reject_pct": {
+          "name": "gap_reject_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.03
+        },
+        "spread_limit_pct_us": {
+          "name": "spread_limit_pct_us",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.0025
+        },
+        "spread_limit_pct_jp": {
+          "name": "spread_limit_pct_jp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.006
+        },
+        "pullback_default_stop_pct": {
+          "name": "pullback_default_stop_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.04
+        },
+        "pullback_default_take_profit_pct": {
+          "name": "pullback_default_take_profit_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.07
+        },
+        "pullback_default_time_stop_days": {
+          "name": "pullback_default_time_stop_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "pullback_default_pullback_max": {
+          "name": "pullback_default_pullback_max",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.03
+        },
+        "pullback_default_pullback_min": {
+          "name": "pullback_default_pullback_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.06
+        },
+        "pullback_default_min_return_50d": {
+          "name": "pullback_default_min_return_50d",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.08
+        },
+        "pullback_default_require_above_sma50": {
+          "name": "pullback_default_require_above_sma50",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "pullback_default_k_atr": {
+          "name": "pullback_default_k_atr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "risk_base_per_trade_pct": {
+          "name": "risk_base_per_trade_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.004
+        },
+        "risk_dd_half_threshold": {
+          "name": "risk_dd_half_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.05
+        },
+        "risk_dd_halt_threshold": {
+          "name": "risk_dd_halt_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.1
+        },
+        "bucket_exposure_pct": {
+          "name": "bucket_exposure_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.3
+        },
+        "vix_warning_threshold": {
+          "name": "vix_warning_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 25
+        },
+        "vix_critical_threshold": {
+          "name": "vix_critical_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "vix_warning_size_scale": {
+          "name": "vix_warning_size_scale",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.5
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "global_config_max_order_notional_range": {
+          "name": "global_config_max_order_notional_range",
+          "value": "\"global_config\".\"max_order_notional\" > 0 AND \"global_config\".\"max_order_notional\" <= 10000000"
+        },
+        "global_config_max_order_notional_usd_range": {
+          "name": "global_config_max_order_notional_usd_range",
+          "value": "\"global_config\".\"max_order_notional_usd\" > 0 AND \"global_config\".\"max_order_notional_usd\" <= 1000000"
+        },
+        "global_config_max_order_notional_jpy_range": {
+          "name": "global_config_max_order_notional_jpy_range",
+          "value": "\"global_config\".\"max_order_notional_jpy\" > 0 AND \"global_config\".\"max_order_notional_jpy\" <= 100000000"
+        },
+        "global_config_total_capital_usd_range": {
+          "name": "global_config_total_capital_usd_range",
+          "value": "\"global_config\".\"total_capital_usd\" IS NULL OR \"global_config\".\"total_capital_usd\" > 0"
+        },
+        "global_config_total_capital_jpy_range": {
+          "name": "global_config_total_capital_jpy_range",
+          "value": "\"global_config\".\"total_capital_jpy\" IS NULL OR \"global_config\".\"total_capital_jpy\" > 0"
+        },
+        "global_config_max_portfolio_exposure_pct_range": {
+          "name": "global_config_max_portfolio_exposure_pct_range",
+          "value": "\"global_config\".\"max_portfolio_exposure_pct\" > 0 AND \"global_config\".\"max_portfolio_exposure_pct\" <= 1"
+        },
+        "global_config_drawdown_kill_threshold_range": {
+          "name": "global_config_drawdown_kill_threshold_range",
+          "value": "\"global_config\".\"drawdown_kill_threshold\" >= -1 AND \"global_config\".\"drawdown_kill_threshold\" <= 0"
+        },
+        "global_config_stale_quote_ms_range": {
+          "name": "global_config_stale_quote_ms_range",
+          "value": "\"global_config\".\"stale_quote_ms\" >= 0"
+        },
+        "global_config_gap_reject_pct_range": {
+          "name": "global_config_gap_reject_pct_range",
+          "value": "\"global_config\".\"gap_reject_pct\" >= 0 AND \"global_config\".\"gap_reject_pct\" <= 1"
+        },
+        "global_config_spread_limit_pct_us_range": {
+          "name": "global_config_spread_limit_pct_us_range",
+          "value": "\"global_config\".\"spread_limit_pct_us\" >= 0 AND \"global_config\".\"spread_limit_pct_us\" <= 1"
+        },
+        "global_config_spread_limit_pct_jp_range": {
+          "name": "global_config_spread_limit_pct_jp_range",
+          "value": "\"global_config\".\"spread_limit_pct_jp\" >= 0 AND \"global_config\".\"spread_limit_pct_jp\" <= 1"
+        },
+        "global_config_pullback_default_stop_pct_range": {
+          "name": "global_config_pullback_default_stop_pct_range",
+          "value": "\"global_config\".\"pullback_default_stop_pct\" < 0 AND \"global_config\".\"pullback_default_stop_pct\" >= -1"
+        },
+        "global_config_pullback_default_take_profit_pct_range": {
+          "name": "global_config_pullback_default_take_profit_pct_range",
+          "value": "\"global_config\".\"pullback_default_take_profit_pct\" > 0 AND \"global_config\".\"pullback_default_take_profit_pct\" <= 1"
+        },
+        "global_config_pullback_default_time_stop_days_range": {
+          "name": "global_config_pullback_default_time_stop_days_range",
+          "value": "\"global_config\".\"pullback_default_time_stop_days\" > 0 AND \"global_config\".\"pullback_default_time_stop_days\" <= ?"
+        },
+        "global_config_pullback_default_pullback_max_range": {
+          "name": "global_config_pullback_default_pullback_max_range",
+          "value": "\"global_config\".\"pullback_default_pullback_max\" <= 0 AND \"global_config\".\"pullback_default_pullback_max\" >= -1"
+        },
+        "global_config_pullback_default_pullback_min_range": {
+          "name": "global_config_pullback_default_pullback_min_range",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= 0 AND \"global_config\".\"pullback_default_pullback_min\" >= -1"
+        },
+        "global_config_pullback_default_min_return_50d_range": {
+          "name": "global_config_pullback_default_min_return_50d_range",
+          "value": "\"global_config\".\"pullback_default_min_return_50d\" >= -1 AND \"global_config\".\"pullback_default_min_return_50d\" <= 10"
+        },
+        "global_config_pullback_default_k_atr_range": {
+          "name": "global_config_pullback_default_k_atr_range",
+          "value": "\"global_config\".\"pullback_default_k_atr\" > 0 AND \"global_config\".\"pullback_default_k_atr\" <= 10"
+        },
+        "global_config_pullback_default_pullback_window_order": {
+          "name": "global_config_pullback_default_pullback_window_order",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= \"global_config\".\"pullback_default_pullback_max\""
+        },
+        "global_config_risk_base_per_trade_pct_range": {
+          "name": "global_config_risk_base_per_trade_pct_range",
+          "value": "\"global_config\".\"risk_base_per_trade_pct\" > 0 AND \"global_config\".\"risk_base_per_trade_pct\" <= 1"
+        },
+        "global_config_risk_dd_half_threshold_range": {
+          "name": "global_config_risk_dd_half_threshold_range",
+          "value": "\"global_config\".\"risk_dd_half_threshold\" < 0 AND \"global_config\".\"risk_dd_half_threshold\" >= -1"
+        },
+        "global_config_risk_dd_halt_threshold_range": {
+          "name": "global_config_risk_dd_halt_threshold_range",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" < 0 AND \"global_config\".\"risk_dd_halt_threshold\" >= -1"
+        },
+        "global_config_risk_dd_threshold_order": {
+          "name": "global_config_risk_dd_threshold_order",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" <= \"global_config\".\"risk_dd_half_threshold\""
+        },
+        "global_config_bucket_exposure_pct_range": {
+          "name": "global_config_bucket_exposure_pct_range",
+          "value": "\"global_config\".\"bucket_exposure_pct\" > 0 AND \"global_config\".\"bucket_exposure_pct\" <= 1"
+        },
+        "global_config_vix_warning_threshold_range": {
+          "name": "global_config_vix_warning_threshold_range",
+          "value": "\"global_config\".\"vix_warning_threshold\" > 0 AND \"global_config\".\"vix_warning_threshold\" <= 200"
+        },
+        "global_config_vix_critical_threshold_range": {
+          "name": "global_config_vix_critical_threshold_range",
+          "value": "\"global_config\".\"vix_critical_threshold\" > 0 AND \"global_config\".\"vix_critical_threshold\" <= 200"
+        },
+        "global_config_vix_threshold_order": {
+          "name": "global_config_vix_threshold_order",
+          "value": "\"global_config\".\"vix_warning_threshold\" <= \"global_config\".\"vix_critical_threshold\""
+        },
+        "global_config_vix_warning_size_scale_range": {
+          "name": "global_config_vix_warning_size_scale_range",
+          "value": "\"global_config\".\"vix_warning_size_scale\" >= 0 AND \"global_config\".\"vix_warning_size_scale\" <= 1"
+        }
+      }
+    },
+    "inverse_pairs": {
+      "name": "inverse_pairs",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inverse": {
+          "name": "inverse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "macro_event_calendar": {
+      "name": "macro_event_calendar",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_time": {
+          "name": "event_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "macro_event_calendar_type_date_unique": {
+          "name": "macro_event_calendar_type_date_unique",
+          "columns": [
+            "event_type",
+            "event_date"
+          ],
+          "isUnique": true
+        },
+        "macro_event_calendar_date_idx": {
+          "name": "macro_event_calendar_date_idx",
+          "columns": [
+            "event_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_emit_log": {
+      "name": "notification_emit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cause": {
+          "name": "cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notification_emit_log_timestamp_id_idx": {
+          "name": "notification_emit_log_timestamp_id_idx",
+          "columns": [
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "notification_emit_log_severity_timestamp_id_idx": {
+          "name": "notification_emit_log_severity_timestamp_id_idx",
+          "columns": [
+            "severity",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "notification_emit_log_event_type_timestamp_id_idx": {
+          "name": "notification_emit_log_event_type_timestamp_id_idx",
+          "columns": [
+            "event_type",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "portfolio_equity_snapshot": {
+      "name": "portfolio_equity_snapshot",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "daily_start_equity_usd": {
+          "name": "daily_start_equity_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_start_equity_jpy": {
+          "name": "daily_start_equity_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_realized_pnl_usd": {
+          "name": "daily_realized_pnl_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_realized_pnl_jpy": {
+          "name": "daily_realized_pnl_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "drawdown_pct": {
+          "name": "drawdown_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "portfolio_equity_snapshot_at_idx": {
+          "name": "portfolio_equity_snapshot_at_idx",
+          "columns": [
+            "snapshot_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "strategy_decision_log": {
+      "name": "strategy_decision_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indicators_json": {
+          "name": "indicators_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "strategy_decision_log_symbol_id_idx": {
+          "name": "strategy_decision_log_symbol_id_idx",
+          "columns": [
+            "symbol",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "strategy_decision_log_coid_idx": {
+          "name": "strategy_decision_log_coid_idx",
+          "columns": [
+            "client_order_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "symbol_config": {
+      "name": "symbol_config",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "market": {
+          "name": "market",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_notional": {
+          "name": "max_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "symbol_config_currency_enum": {
+          "name": "symbol_config_currency_enum",
+          "value": "\"symbol_config\".\"currency\" IN ('USD', 'JPY')"
+        }
+      }
+    },
+    "trade_journal": {
+      "name": "trade_journal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trade_event_type": {
+          "name": "trade_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "strategy_name": {
+          "name": "strategy_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_action": {
+          "name": "signal_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_reason": {
+          "name": "signal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_allowed": {
+          "name": "risk_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_reasons": {
+          "name": "risk_reasons",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "limit_price": {
+          "name": "limit_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notional": {
+          "name": "notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "broker_status": {
+          "name": "broker_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "submitted": {
+          "name": "submitted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_qty": {
+          "name": "filled_qty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_price": {
+          "name": "filled_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "realized_pnl": {
+          "name": "realized_pnl",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hold_days": {
+          "name": "hold_days",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_reason": {
+          "name": "exit_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_applied_at": {
+          "name": "state_applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_error": {
+          "name": "state_apply_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_attempts": {
+          "name": "state_apply_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trading_toggle_history": {
+      "name": "trading_toggle_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before": {
+          "name": "before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "after": {
+          "name": "after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1778828802046,
       "tag": "0017_trading_toggle_history",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "6",
+      "when": 1778863329960,
+      "tag": "0018_portfolio_equity_snapshot",
+      "breakpoints": true
     }
   ]
 }

--- a/src/infrastructure/db/portfolioEquitySnapshotRepo.ts
+++ b/src/infrastructure/db/portfolioEquitySnapshotRepo.ts
@@ -1,0 +1,90 @@
+import { and, asc, gte, lte, type SQL } from 'drizzle-orm'
+import {
+  portfolioEquitySnapshot,
+  type PortfolioEquitySnapshotRow,
+} from './schema'
+import { createDb } from './tradeJournalRepo'
+
+/**
+ * Daily snapshot writer / reader for `portfolio_equity_snapshot`. Wraps the
+ * raw `D1Database` so callers don't repeat the drizzle bootstrap. Each
+ * `recordPortfolioEquitySnapshot` is intended to be called once per
+ * `PortfolioStateDO.rollDaily()` execution (manual `/admin/portfolio/roll-daily`
+ * or the EOD `runPortfolioRoll` cron); same-day duplicates are intentionally
+ * accepted because the table doubles as an audit trail.
+ *
+ * `loadPortfolioEquitySnapshots` returns rows in ASC order so the dashboard
+ * chart can feed echarts directly without a client-side reverse.
+ */
+
+export interface RecordPortfolioEquitySnapshotPayload {
+  /**
+   * ISO timestamp the snapshot was taken. Callers should use the same
+   * `state.updatedAt` that `rollDaily()` returns so the snapshot timestamp
+   * aligns with the DO transition.
+   */
+  snapshotAt: string
+  dailyStartEquityUsd?: number | null
+  dailyStartEquityJpy?: number | null
+  dailyRealizedPnlUsd?: number | null
+  dailyRealizedPnlJpy?: number | null
+  /**
+   * `dailyRealizedPnl / dailyStartEquity` (fraction、負が drawdown)。
+   * 計算側で start equity が 0 / 無効なら null を渡す。
+   */
+  drawdownPct?: number | null
+  requestId?: string | null
+}
+
+export async function recordPortfolioEquitySnapshot(
+  d1: D1Database,
+  payload: RecordPortfolioEquitySnapshotPayload,
+): Promise<void> {
+  const db = createDb(d1)
+  await db.insert(portfolioEquitySnapshot).values({
+    snapshotAt: payload.snapshotAt,
+    dailyStartEquityUsd: payload.dailyStartEquityUsd ?? null,
+    dailyStartEquityJpy: payload.dailyStartEquityJpy ?? null,
+    dailyRealizedPnlUsd: payload.dailyRealizedPnlUsd ?? null,
+    dailyRealizedPnlJpy: payload.dailyRealizedPnlJpy ?? null,
+    drawdownPct: payload.drawdownPct ?? null,
+    requestId: payload.requestId ?? null,
+  })
+}
+
+export interface LoadPortfolioEquitySnapshotOptions {
+  /** ISO timestamp inclusive lower bound. */
+  from?: string
+  /** ISO timestamp inclusive upper bound. */
+  to?: string
+  /**
+   * Cap on returned rows. Default 365, max 3650 (~10y of daily snapshots).
+   * Values <= 0 or non-finite fall back to the default.
+   */
+  limit?: number
+}
+
+const DEFAULT_LIMIT = 365
+const MAX_LIMIT = 3650
+
+export async function loadPortfolioEquitySnapshots(
+  d1: D1Database,
+  opts: LoadPortfolioEquitySnapshotOptions = {},
+): Promise<PortfolioEquitySnapshotRow[]> {
+  const db = createDb(d1)
+  const conditions: SQL[] = []
+  if (opts.from) conditions.push(gte(portfolioEquitySnapshot.snapshotAt, opts.from))
+  if (opts.to) conditions.push(lte(portfolioEquitySnapshot.snapshotAt, opts.to))
+  let query = db.select().from(portfolioEquitySnapshot).$dynamic()
+  if (conditions.length > 0) {
+    query = query.where(conditions.length === 1 ? conditions[0] : and(...conditions))
+  }
+  return await query
+    .orderBy(asc(portfolioEquitySnapshot.snapshotAt), asc(portfolioEquitySnapshot.id))
+    .limit(clampLimit(opts.limit))
+}
+
+function clampLimit(raw: number | undefined): number {
+  if (raw === undefined || !Number.isFinite(raw) || raw <= 0) return DEFAULT_LIMIT
+  return Math.min(Math.floor(raw), MAX_LIMIT)
+}

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -622,3 +622,43 @@ export const tradingToggleHistory = sqliteTable('trading_toggle_history', {
 
 export type TradingToggleHistoryRow = typeof tradingToggleHistory.$inferSelect
 export type TradingToggleHistoryInsert = typeof tradingToggleHistory.$inferInsert
+
+/**
+ * Daily portfolio equity snapshot (1 row per `rollDaily()` execution). Persists
+ * `PortfolioStateDO.dailyStartEquity` over time so the `/dashboard/portfolio`
+ * page can render the "真の総資産チャート" — cash + holdings — rather than the
+ * `/dashboard/charts?tab=overview` curve which only sums `trade_journal.realized_pnl`.
+ *
+ * USD / JPY are kept as separate columns so multi-currency snapshots can be
+ * recorded without ad-hoc JSON. The DO today stores a single `dailyStartEquity`
+ * number; today this populates USD by default with JPY left NULL until the DO
+ * is split per-currency (out of scope of this PR). Either column may be NULL.
+ *
+ * One row per roll-daily call. We do NOT dedupe within a day — multiple
+ * manual rolls on the same day intentionally produce multiple rows so the
+ * audit trail keeps every transition.
+ */
+export const portfolioEquitySnapshot = sqliteTable(
+  'portfolio_equity_snapshot',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    snapshotAt: text('snapshot_at').notNull(),
+    /** `PortfolioStateDO.dailyStartEquity` 等価 (USD denomination)。 */
+    dailyStartEquityUsd: real('daily_start_equity_usd'),
+    /** `PortfolioStateDO.dailyStartEquity` 等価 (JPY denomination)。 */
+    dailyStartEquityJpy: real('daily_start_equity_jpy'),
+    dailyRealizedPnlUsd: real('daily_realized_pnl_usd'),
+    dailyRealizedPnlJpy: real('daily_realized_pnl_jpy'),
+    /** dailyRealizedPnl / dailyStartEquity (fraction、負が drawdown)。 */
+    drawdownPct: real('drawdown_pct'),
+    /** roll-daily を起こした request id (cron / 手動 trace 用)。任意。 */
+    requestId: text('request_id'),
+  },
+  (t) => ({
+    // chart 表示は snapshotAt ASC で range スキャンする (`loadPortfolioEquitySnapshots`)。
+    snapshotAtIdx: index('portfolio_equity_snapshot_at_idx').on(t.snapshotAt),
+  }),
+)
+
+export type PortfolioEquitySnapshotRow = typeof portfolioEquitySnapshot.$inferSelect
+export type PortfolioEquitySnapshotInsert = typeof portfolioEquitySnapshot.$inferInsert

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -17,6 +17,7 @@ import { loadGlobalConfigFrom } from '../infrastructure/db/globalConfigLoader'
 import { createDb } from '../infrastructure/db/tradeJournalRepo'
 import { earningsCalendar, macroEventCalendar, tradeJournal } from '../infrastructure/db/schema'
 import { extractActor, recordChange } from '../infrastructure/db/configAuditLog'
+import { recordPortfolioEquitySnapshot } from '../infrastructure/db/portfolioEquitySnapshotRepo'
 import {
   findSymbolConfig,
   insertSymbolConfig,
@@ -721,6 +722,35 @@ export const admin = new Hono<AppBindings>()
         dailyRealizedPnl: after.dailyRealizedPnl,
       },
     )
+    // 総資産チャート (`/dashboard/portfolio`) 用の時系列スナップショット。
+    // PortfolioStateDO は通貨を区別しない単一値 (慣例的 USD) なので USD カラムに
+    // 書き込み、JPY は per-currency split が入るまで NULL。書込失敗で handler
+    // 本体は止めない (audit と同じ姿勢 — DO 状態変更は既に成立済)。
+    if (c.env.DB) {
+      const drawdownPct =
+        before.dailyStartEquity > 0
+          ? before.dailyRealizedPnl / before.dailyStartEquity
+          : null
+      try {
+        await recordPortfolioEquitySnapshot(c.env.DB, {
+          snapshotAt: after.updatedAt,
+          dailyStartEquityUsd: before.dailyStartEquity,
+          dailyStartEquityJpy: null,
+          dailyRealizedPnlUsd: before.dailyRealizedPnl,
+          dailyRealizedPnlJpy: null,
+          drawdownPct,
+          requestId: c.get('requestId') ?? null,
+        })
+      } catch (err) {
+        console.error(
+          JSON.stringify({
+            event: 'portfolio_equity_snapshot_write_failed',
+            endpoint: '/admin/portfolio/roll-daily',
+            error: err instanceof Error ? err.message : String(err),
+          }),
+        )
+      }
+    }
     return c.json({
       rolledAt: after.updatedAt,
       rolledDelta: before.dailyRealizedPnl,

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -38,6 +38,11 @@ import {
 } from '../infrastructure/notification/notificationEmitLog'
 import type { NotificationSeverity, NotificationEvent } from '../infrastructure/notification/Notifier'
 import { loadVixRegimeSnapshot } from '../infrastructure/notification/vixRegimeChange'
+import {
+  loadPortfolioEquitySnapshots,
+  type LoadPortfolioEquitySnapshotOptions,
+} from '../infrastructure/db/portfolioEquitySnapshotRepo'
+import type { PortfolioEquitySnapshotRow } from '../infrastructure/db/schema'
 import type { VixRegime } from '../trading/risk/vixRegimeFilter'
 import { and, asc, desc, eq, gte, lte } from 'drizzle-orm'
 import { PortfolioStateClient } from '../trading/state/PortfolioStateClient'
@@ -133,7 +138,19 @@ export const dashboard = new Hono<DashboardBindings>()
       const vixRegime = c.env.DB
         ? await loadVixRegimeSnapshot(c.env.DB, c.get('requestId'))
         : null
-      return c.html(renderLayout(c, '口座サマリ', portfolioBody(portfolio, vixRegime)))
+      const range = parseEquityRange(c.req.query('range'))
+      // 総資産時系列 (roll-daily 経由で 1 row / 日)。DB 不在 / load 失敗時は
+      // 空配列で fallback → チャート枠は出さず "データ無し" メッセージにする。
+      const snapshots: PortfolioEquitySnapshotRow[] = c.env.DB
+        ? await safeLoadPortfolioSnapshots(c.env.DB, range)
+        : []
+      return c.html(
+        renderLayout(
+          c,
+          '口座サマリ',
+          portfolioBody(portfolio, vixRegime, { snapshots, range }),
+        ),
+      )
     } catch (err) {
       return c.html(renderLayout(c, '口座サマリ', unavailable(messageOf(err))))
     }
@@ -1599,14 +1616,17 @@ function portfolioBody(p: {
   tradingDisabledUntil: string | null
   lastRolledAt?: string | null
   updatedAt: string
-}, vixRegime: VixRegime | null): string {
+}, vixRegime: VixRegime | null, equity?: {
+  snapshots: PortfolioEquitySnapshotRow[]
+  range: EquityRange
+}): string {
   const drawdownPct =
     p.dailyStartEquity > 0 ? (p.dailyRealizedPnl / p.dailyStartEquity) * 100 : null
   const ddClass = drawdownPct === null ? 'muted' : drawdownPct >= 0 ? 'ok' : 'err'
   const kill = p.tradingDisabledUntil
   const lastRolledCell = renderLastRolledCell(p.lastRolledAt ?? null)
   const vixCell = renderVixRegimeCell(vixRegime)
-  return `<table>
+  const summaryTable = `<table>
     <tbody>
       <tr><th>当日始値資産 (dailyStartEquity)</th><td>${fmtNumber(p.dailyStartEquity, 2)}</td></tr>
       <tr><th>当日実現損益 (dailyRealizedPnl)</th><td class="${ddClass}">${fmtNumber(p.dailyRealizedPnl, 2)}</td></tr>
@@ -1617,6 +1637,163 @@ function portfolioBody(p: {
       <tr><th>更新時刻 (updatedAt)</th><td class="muted">${esc(fmtJst(p.updatedAt))}</td></tr>
     </tbody>
   </table>`
+  const chartSection = equity ? renderPortfolioEquityChart(equity.snapshots, equity.range) : ''
+  return summaryTable + chartSection
+}
+
+/**
+ * `?range=30d|90d|365d|all` の解釈。default は 90d (3 ヶ月で trend が読める粒度)。
+ * 不正値は default に倒す。`all` は cap 内 (3650 件) で全件返し。
+ */
+export type EquityRange = '30d' | '90d' | '365d' | 'all'
+
+export function parseEquityRange(value: string | undefined): EquityRange {
+  if (value === '30d' || value === '90d' || value === '365d' || value === 'all') return value
+  return '90d'
+}
+
+function equityRangeLimit(range: EquityRange): number {
+  if (range === '30d') return 30
+  if (range === '90d') return 90
+  if (range === '365d') return 365
+  return 3650
+}
+
+/**
+ * `loadPortfolioEquitySnapshots` を try/catch で wrap。table 未 migration や
+ * D1 エラー時は空配列で fallback → ページ自体は描画。チャート枠は "データ無し"
+ * メッセージに置き換わる。
+ */
+async function safeLoadPortfolioSnapshots(
+  db: D1Database,
+  range: EquityRange,
+): Promise<PortfolioEquitySnapshotRow[]> {
+  const opts: LoadPortfolioEquitySnapshotOptions = { limit: equityRangeLimit(range) }
+  try {
+    return await loadPortfolioEquitySnapshots(db, opts)
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        event: 'portfolio_equity_snapshot_load_failed',
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    )
+    return []
+  }
+}
+
+/**
+ * `/dashboard/portfolio` の総資産チャート。echarts inline JS で USD / JPY の
+ * 2 ライン (片方 NULL は skip)。
+ *
+ * - X: snapshotAt の日付部分 (UTC date)
+ * - Y: dailyStartEquity (通貨別)
+ * - range tab で 30d / 90d / 365d / all 切替 (URL `?range=` を維持)
+ */
+function renderPortfolioEquityChart(
+  snapshots: PortfolioEquitySnapshotRow[],
+  range: EquityRange,
+): string {
+  const rangeTabs = renderEquityRangeTabs(range)
+  if (snapshots.length === 0) {
+    return `<h3 style="margin-top:24px">総資産チャート</h3>
+    ${rangeTabs}
+    <p class="muted">まだ roll-daily 実行履歴がありません。<code>/admin/portfolio/roll-daily</code> を実行すると、ここに時系列が描画されます。</p>`
+  }
+  const usdPoints: Array<{ date: string; value: number | null }> = []
+  const jpyPoints: Array<{ date: string; value: number | null }> = []
+  let hasUsd = false
+  let hasJpy = false
+  for (const row of snapshots) {
+    const date = (row.snapshotAt ?? '').slice(0, 10)
+    const usd =
+      typeof row.dailyStartEquityUsd === 'number' && Number.isFinite(row.dailyStartEquityUsd)
+        ? row.dailyStartEquityUsd
+        : null
+    const jpy =
+      typeof row.dailyStartEquityJpy === 'number' && Number.isFinite(row.dailyStartEquityJpy)
+        ? row.dailyStartEquityJpy
+        : null
+    if (usd !== null) hasUsd = true
+    if (jpy !== null) hasJpy = true
+    usdPoints.push({ date, value: usd })
+    jpyPoints.push({ date, value: jpy })
+  }
+  const initScript = `
+    document.addEventListener('DOMContentLoaded', function () {
+      if (typeof echarts === 'undefined') return;
+      var data = window.__equityChartData;
+      var dates = data.usd.map(function (p) { return p.date; });
+      var series = [];
+      if (data.hasUsd) {
+        series.push({
+          name: 'USD',
+          type: 'line',
+          data: data.usd.map(function (p) { return p.value; }),
+          connectNulls: false,
+          smooth: false,
+          lineStyle: { width: 2, color: '#1471a8' },
+          itemStyle: { color: '#1471a8' },
+        });
+      }
+      if (data.hasJpy) {
+        series.push({
+          name: 'JPY',
+          type: 'line',
+          yAxisIndex: data.hasUsd ? 1 : 0,
+          data: data.jpy.map(function (p) { return p.value; }),
+          connectNulls: false,
+          smooth: false,
+          lineStyle: { width: 2, color: '#b25000' },
+          itemStyle: { color: '#b25000' },
+        });
+      }
+      var yAxis = [{ type: 'value', name: 'USD', axisLabel: { formatter: '{value}' } }];
+      if (data.hasUsd && data.hasJpy) {
+        yAxis.push({ type: 'value', name: 'JPY', axisLabel: { formatter: '{value}' } });
+      } else if (!data.hasUsd && data.hasJpy) {
+        yAxis = [{ type: 'value', name: 'JPY', axisLabel: { formatter: '{value}' } }];
+      }
+      var chart = echarts.init(document.getElementById('portfolio-equity-chart'));
+      chart.setOption({
+        title: { text: '総資産 (dailyStartEquity) 時系列', left: 'center', textStyle: { fontSize: 14 } },
+        tooltip: { trigger: 'axis', valueFormatter: function (v) { return v == null ? '—' : Number(v).toFixed(2); } },
+        legend: { top: 24 },
+        grid: { left: 60, right: 60, top: 60, bottom: 40 },
+        xAxis: { type: 'category', data: dates },
+        yAxis: yAxis,
+        series: series,
+      });
+      window.addEventListener('resize', function () { chart.resize(); });
+    });
+  `
+  return `<h3 style="margin-top:24px">総資産チャート</h3>
+  ${rangeTabs}
+  <p class="muted" style="font-size:12px">
+    <code>PortfolioStateDO.dailyStartEquity</code> の roll-daily 時点スナップショット。
+    <code>/dashboard/charts?tab=overview</code> は <code>trade_journal.realized_pnl</code> の
+    累積で、こちらは口座総資産そのもの (cash + 保有時価)。USD / JPY を別軸でプロット。
+  </p>
+  <div id="portfolio-equity-chart" style="width:100%;height:320px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;margin-top:12px"></div>
+  ${safeJsonScript('__equityChartData', { usd: usdPoints, jpy: jpyPoints, hasUsd, hasJpy })}
+  <script src="${ECHARTS_CDN}" defer></script>
+  <script>${initScript}</script>`
+}
+
+function renderEquityRangeTabs(active: EquityRange): string {
+  const options: Array<{ id: EquityRange; label: string }> = [
+    { id: '30d', label: '30 日' },
+    { id: '90d', label: '90 日' },
+    { id: '365d', label: '365 日' },
+    { id: 'all', label: '全期間' },
+  ]
+  const links = options
+    .map((opt) => {
+      const cls = opt.id === active ? 'tab tab-active' : 'tab'
+      return `<a class="${cls}" href="/dashboard/portfolio?range=${opt.id}">${opt.label}</a>`
+    })
+    .join(' ')
+  return `<div class="tab-strip" style="margin-top:12px">${links}</div>`
 }
 
 /**

--- a/test/infrastructure/db/portfolioEquitySnapshotRepo.test.ts
+++ b/test/infrastructure/db/portfolioEquitySnapshotRepo.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  recordPortfolioEquitySnapshot,
+  loadPortfolioEquitySnapshots,
+} from '../../../src/infrastructure/db/portfolioEquitySnapshotRepo'
+import { createDb } from '../../../src/infrastructure/db/tradeJournalRepo'
+
+vi.mock('../../../src/infrastructure/db/tradeJournalRepo', () => ({
+  createDb: vi.fn(),
+}))
+
+function fakeInsertChain() {
+  const chain = {
+    values: vi.fn(async (_v: unknown) => undefined),
+  }
+  return {
+    chain,
+    db: {
+      insert: vi.fn(() => chain),
+    },
+  }
+}
+
+function fakeSelectChain(rows: unknown[]) {
+  const query = {
+    from: vi.fn(() => query),
+    $dynamic: vi.fn(() => query),
+    where: vi.fn((_arg: unknown) => query),
+    orderBy: vi.fn((..._args: unknown[]) => query),
+    limit: vi.fn(async (_n: number) => rows),
+  }
+  return {
+    query,
+    db: {
+      select: vi.fn(() => query),
+    },
+  }
+}
+
+const fakeD1 = {} as D1Database
+
+describe('recordPortfolioEquitySnapshot', () => {
+  it('inserts a row with all fields populated', async () => {
+    const { db, chain } = fakeInsertChain()
+    vi.mocked(createDb).mockReturnValue(db as unknown as ReturnType<typeof createDb>)
+
+    await recordPortfolioEquitySnapshot(fakeD1, {
+      snapshotAt: '2026-05-16T00:00:00.000Z',
+      dailyStartEquityUsd: 10000,
+      dailyStartEquityJpy: 1500000,
+      dailyRealizedPnlUsd: -50,
+      dailyRealizedPnlJpy: -8000,
+      drawdownPct: -0.005,
+      requestId: 'req-roll-1',
+    })
+
+    expect(chain.values).toHaveBeenCalledTimes(1)
+    expect(chain.values.mock.calls[0]![0]).toEqual({
+      snapshotAt: '2026-05-16T00:00:00.000Z',
+      dailyStartEquityUsd: 10000,
+      dailyStartEquityJpy: 1500000,
+      dailyRealizedPnlUsd: -50,
+      dailyRealizedPnlJpy: -8000,
+      drawdownPct: -0.005,
+      requestId: 'req-roll-1',
+    })
+  })
+
+  it('defaults nullable fields to null when omitted', async () => {
+    const { db, chain } = fakeInsertChain()
+    vi.mocked(createDb).mockReturnValue(db as unknown as ReturnType<typeof createDb>)
+
+    await recordPortfolioEquitySnapshot(fakeD1, {
+      snapshotAt: '2026-05-16T00:00:00.000Z',
+      dailyStartEquityUsd: 10000,
+    })
+
+    expect(chain.values).toHaveBeenCalledWith({
+      snapshotAt: '2026-05-16T00:00:00.000Z',
+      dailyStartEquityUsd: 10000,
+      dailyStartEquityJpy: null,
+      dailyRealizedPnlUsd: null,
+      dailyRealizedPnlJpy: null,
+      drawdownPct: null,
+      requestId: null,
+    })
+  })
+})
+
+describe('loadPortfolioEquitySnapshots', () => {
+  it('applies from/to range together and orders ASC', async () => {
+    const { db, query } = fakeSelectChain([])
+    vi.mocked(createDb).mockReturnValue(db as unknown as ReturnType<typeof createDb>)
+
+    await loadPortfolioEquitySnapshots(fakeD1, {
+      from: '2026-05-01T00:00:00.000Z',
+      to: '2026-05-16T00:00:00.000Z',
+      limit: 50,
+    })
+
+    expect(query.where).toHaveBeenCalledTimes(1)
+    expect(query.orderBy).toHaveBeenCalledTimes(1)
+    expect(query.limit).toHaveBeenCalledWith(50)
+  })
+
+  it('omits where() when no range is given and defaults limit to 365', async () => {
+    const { db, query } = fakeSelectChain([])
+    vi.mocked(createDb).mockReturnValue(db as unknown as ReturnType<typeof createDb>)
+
+    await loadPortfolioEquitySnapshots(fakeD1, {})
+
+    expect(query.where).not.toHaveBeenCalled()
+    expect(query.limit).toHaveBeenCalledWith(365)
+  })
+
+  it('clamps an excessive limit to 3650', async () => {
+    const { db, query } = fakeSelectChain([])
+    vi.mocked(createDb).mockReturnValue(db as unknown as ReturnType<typeof createDb>)
+
+    await loadPortfolioEquitySnapshots(fakeD1, { limit: 9_999_999 })
+
+    expect(query.limit).toHaveBeenCalledWith(3650)
+  })
+
+  it('coerces non-finite / non-positive limit to the default', async () => {
+    const { db, query } = fakeSelectChain([])
+    vi.mocked(createDb).mockReturnValue(db as unknown as ReturnType<typeof createDb>)
+
+    await loadPortfolioEquitySnapshots(fakeD1, { limit: -10 })
+    expect(query.limit).toHaveBeenCalledWith(365)
+
+    vi.mocked(createDb).mockReturnValue(fakeSelectChain([]).db as unknown as ReturnType<typeof createDb>)
+    await loadPortfolioEquitySnapshots(fakeD1, { limit: Number.NaN })
+  })
+
+  it('returns rows as-is from the underlying query', async () => {
+    const rows = [
+      { id: 1, snapshotAt: '2026-05-15T00:00:00.000Z', dailyStartEquityUsd: 10000 },
+    ]
+    const { db } = fakeSelectChain(rows)
+    vi.mocked(createDb).mockReturnValue(db as unknown as ReturnType<typeof createDb>)
+
+    const result = await loadPortfolioEquitySnapshots(fakeD1, {})
+    expect(result).toBe(rows)
+  })
+})

--- a/test/routes/dashboardPortfolioEquityChart.test.ts
+++ b/test/routes/dashboardPortfolioEquityChart.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp } from '../../src/app'
+import { loadGlobalConfigFrom } from '../../src/infrastructure/db/globalConfigLoader'
+import { loadSymbolUniverse } from '../../src/infrastructure/db/symbolUniverse'
+import { loadPortfolioEquitySnapshots } from '../../src/infrastructure/db/portfolioEquitySnapshotRepo'
+import { makeGlobalConfigSnapshot, makeSymbolUniverse } from '../helpers/configFixtures'
+
+vi.mock('../../src/infrastructure/db/globalConfigLoader', () => ({
+  loadGlobalConfigFrom: vi.fn(),
+}))
+vi.mock('../../src/infrastructure/db/symbolUniverse', () => ({
+  loadSymbolUniverse: vi.fn(),
+}))
+vi.mock('../../src/infrastructure/db/portfolioEquitySnapshotRepo', () => ({
+  loadPortfolioEquitySnapshots: vi.fn(),
+}))
+
+const baseEnv = {
+  ACCESS_DEV_BYPASS_USER: 'admin',
+}
+
+const authHeader = {}
+
+function fakePortfolioNamespace() {
+  const stub = {
+    async getPortfolio() {
+      return {
+        dailyStartEquity: 10000,
+        dailyRealizedPnl: -50,
+        tradingDisabledUntil: null,
+        lastRolledAt: '2026-05-16T00:00:00.000Z',
+        updatedAt: '2026-05-16T00:00:00.000Z',
+      }
+    },
+  }
+  return {
+    idFromName: () => 'id',
+    get: () => stub,
+  } as unknown
+}
+
+describe('/dashboard/portfolio equity chart', () => {
+  beforeEach(() => {
+    vi.mocked(loadGlobalConfigFrom).mockResolvedValue(makeGlobalConfigSnapshot())
+    vi.mocked(loadSymbolUniverse).mockResolvedValue(makeSymbolUniverse({ allowedSymbols: ['SOXL'], symbolCurrency: { SOXL: 'USD' } }))
+  })
+  afterEach(() => vi.resetAllMocks())
+
+  it('renders the chart container + payload when snapshots exist', async () => {
+    vi.mocked(loadPortfolioEquitySnapshots).mockResolvedValue([
+      {
+        id: 1,
+        snapshotAt: '2026-05-14T00:00:00.000Z',
+        dailyStartEquityUsd: 10000,
+        dailyStartEquityJpy: null,
+        dailyRealizedPnlUsd: 0,
+        dailyRealizedPnlJpy: null,
+        drawdownPct: null,
+        requestId: null,
+      },
+      {
+        id: 2,
+        snapshotAt: '2026-05-15T00:00:00.000Z',
+        dailyStartEquityUsd: 10500,
+        dailyStartEquityJpy: 1_500_000,
+        dailyRealizedPnlUsd: 500,
+        dailyRealizedPnlJpy: 10000,
+        drawdownPct: 0.05,
+        requestId: 'req-1',
+      },
+    ])
+    const env = {
+      ...baseEnv,
+      DB: {} as D1Database,
+      PORTFOLIO_STATE: fakePortfolioNamespace(),
+    }
+    const app = createApp()
+    const res = await app.request('/dashboard/portfolio', { headers: authHeader }, env)
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    expect(body).toContain('総資産チャート')
+    expect(body).toContain('id="portfolio-equity-chart"')
+    expect(body).toContain('window.__equityChartData')
+    // Both USD and JPY series should be flagged on at least one row.
+    expect(body).toContain('"hasUsd":true')
+    expect(body).toContain('"hasJpy":true')
+    // Range tabs for the chart.
+    expect(body).toContain('/dashboard/portfolio?range=30d')
+    expect(body).toContain('/dashboard/portfolio?range=90d')
+    expect(body).toContain('/dashboard/portfolio?range=365d')
+    expect(body).toContain('/dashboard/portfolio?range=all')
+  })
+
+  it('shows the "no data" message and no chart container when there are no snapshots', async () => {
+    vi.mocked(loadPortfolioEquitySnapshots).mockResolvedValue([])
+    const env = {
+      ...baseEnv,
+      DB: {} as D1Database,
+      PORTFOLIO_STATE: fakePortfolioNamespace(),
+    }
+    const app = createApp()
+    const res = await app.request('/dashboard/portfolio', { headers: authHeader }, env)
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    expect(body).toContain('総資産チャート')
+    expect(body).toContain('まだ roll-daily 実行履歴がありません')
+    expect(body).not.toContain('id="portfolio-equity-chart"')
+  })
+
+  it('falls back to default range when ?range= is invalid', async () => {
+    const spy = vi.mocked(loadPortfolioEquitySnapshots).mockResolvedValue([])
+    const env = {
+      ...baseEnv,
+      DB: {} as D1Database,
+      PORTFOLIO_STATE: fakePortfolioNamespace(),
+    }
+    const app = createApp()
+    const res = await app.request('/dashboard/portfolio?range=garbage', { headers: authHeader }, env)
+    expect(res.status).toBe(200)
+    // default = 90d → limit = 90
+    expect(spy).toHaveBeenCalledWith({}, { limit: 90 })
+    const body = await res.text()
+    // The 90d tab should be active.
+    expect(body).toMatch(/class="tab tab-active"[^>]*href="\/dashboard\/portfolio\?range=90d"/)
+  })
+
+  it('honours ?range=all by lifting the snapshot limit', async () => {
+    const spy = vi.mocked(loadPortfolioEquitySnapshots).mockResolvedValue([])
+    const env = {
+      ...baseEnv,
+      DB: {} as D1Database,
+      PORTFOLIO_STATE: fakePortfolioNamespace(),
+    }
+    const app = createApp()
+    const res = await app.request('/dashboard/portfolio?range=all', { headers: authHeader }, env)
+    expect(res.status).toBe(200)
+    expect(spy).toHaveBeenCalledWith({}, { limit: 3650 })
+  })
+
+  it('survives a snapshot-load failure with the rest of the page intact', async () => {
+    vi.mocked(loadPortfolioEquitySnapshots).mockRejectedValue(new Error('table missing'))
+    const env = {
+      ...baseEnv,
+      DB: {} as D1Database,
+      PORTFOLIO_STATE: fakePortfolioNamespace(),
+    }
+    const app = createApp()
+    const res = await app.request('/dashboard/portfolio', { headers: authHeader }, env)
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    // Summary table still rendered.
+    expect(body).toContain('dailyStartEquity')
+    // Chart degrades to the "no data" message rather than blowing up the page.
+    expect(body).toContain('まだ roll-daily 実行履歴がありません')
+  })
+})


### PR DESCRIPTION
Refs #291 follow-up

## Summary

`PortfolioStateDO.dailyStartEquity` の時系列を DB に snapshot し、口座サマリ (`/dashboard/portfolio`) に「総資産チャート」を表示。

既存の `/dashboard/charts → 概要` は trade_journal 由来の **累積実現損益**チャート。本 PR の総資産チャートは口座スナップショット系列 (cash + 保有時価合計の代理)。

## 変更点

### DB
- 新 table \`portfolio_equity_snapshot\` (migration 0018):
  - id / snapshot_at / daily_start_equity_usd / daily_start_equity_jpy / daily_realized_pnl_* / drawdown_pct / request_id
  - snapshot_at index
- 同日複数 snapshot 許容 (audit 性のため上書き無し)

### Repo
- \`recordPortfolioEquitySnapshot\` / \`loadPortfolioEquitySnapshots\` (limit default 365 / cap 3650, ASC order)

### Roll-daily
- \`/admin/portfolio/roll-daily\` が DO 更新後に snapshot 1 件書き込み (try/catch で D1 失敗時も handler 成功維持)
- audit log は既存 wrap で拾われる

### Dashboard
- \`/dashboard/portfolio\` (口座サマリ) の下に **総資産チャート** section 追加
- echarts inline JS、USD/JPY 2 line (null-skip per row)
- range tabs: \`?range=30d|90d|365d|all\` (default 90d)
- データ 0 件時は「no data」CTA fallback

### Edge cases
- snapshot 書込失敗 → log のみ、handler 続行
- snapshot 読込失敗 → \"no data\" 表示で degrade
- drawdown_pct は dailyStartEquity > 0 の時だけ計算
- JPY は現状 DO single-currency なので NULL、shape は将来拡張用に確保

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` 1078/81 files pass (+12 新規 / 既存影響無し)