### PR TITLE
feat(strategy): per-symbol time_stop_days / kAtr override (#316)

### DIFF
--- a/drizzle/0019_numerous_nightshade.sql
+++ b/drizzle/0019_numerous_nightshade.sql
@@ -1,0 +1,11 @@
+-- Per-symbol strategy override columns (issue #316)。NULL = global_config の
+-- pullback default を使う (fall-through)、値があれば SymbolRule build 時に override。
+-- 3x leveraged ETF (SOXL / 1570 等) で短い hold / 緩い ATR stop を効かせる用途。
+--
+-- drizzle-kit は table rebuild SQL を提案してくるが、(1) MAX_TIME_STOP_DAYS が
+-- bind parameter として `?` で emit されて apply 不能、(2) 全列 rebuild は
+-- 既存 symbol_config 行の整合性 risk が高い、ので ALTER TABLE ADD COLUMN
+-- (SQLite ≥ 3.25, D1 OK) で additive に運用する。CHECK 制約は column 単位で
+-- ADD COLUMN に同梱可。0017 と同じ「additive only」方針。
+ALTER TABLE `symbol_config` ADD COLUMN `time_stop_days_override` integer CHECK(`time_stop_days_override` IS NULL OR (`time_stop_days_override` >= 1 AND `time_stop_days_override` <= 365));--> statement-breakpoint
+ALTER TABLE `symbol_config` ADD COLUMN `k_atr_override` real CHECK(`k_atr_override` IS NULL OR (`k_atr_override` >= 0.5 AND `k_atr_override` <= 5.0));

--- a/drizzle/meta/0019_snapshot.json
+++ b/drizzle/meta/0019_snapshot.json
@@ -1,0 +1,1309 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "683b915c-f5e5-4ea8-a758-066df1b8e5c5",
+  "prevId": "b424b4d4-51f8-4f7f-8122-cb92311b6d93",
+  "tables": {
+    "config_audit_log": {
+      "name": "config_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before_json": {
+          "name": "before_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "after_json": {
+          "name": "after_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "config_audit_log_timestamp_id_idx": {
+          "name": "config_audit_log_timestamp_id_idx",
+          "columns": [
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "config_audit_log_actor_timestamp_id_idx": {
+          "name": "config_audit_log_actor_timestamp_id_idx",
+          "columns": [
+            "actor",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "config_audit_log_endpoint_timestamp_id_idx": {
+          "name": "config_audit_log_endpoint_timestamp_id_idx",
+          "columns": [
+            "endpoint",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "config_state_snapshot": {
+      "name": "config_state_snapshot",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "earnings_calendar": {
+      "name": "earnings_calendar",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "earnings_date": {
+          "name": "earnings_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "earnings_calendar_symbol_date_unique": {
+          "name": "earnings_calendar_symbol_date_unique",
+          "columns": [
+            "symbol",
+            "earnings_date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "global_config": {
+      "name": "global_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "trading_enabled": {
+          "name": "trading_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "market_hours_check": {
+          "name": "market_hours_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "max_order_notional": {
+          "name": "max_order_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "max_order_notional_usd": {
+          "name": "max_order_notional_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2000
+        },
+        "max_order_notional_jpy": {
+          "name": "max_order_notional_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100000
+        },
+        "total_capital_usd": {
+          "name": "total_capital_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_capital_jpy": {
+          "name": "total_capital_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_portfolio_exposure_pct": {
+          "name": "max_portfolio_exposure_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.6
+        },
+        "drawdown_kill_threshold": {
+          "name": "drawdown_kill_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.02
+        },
+        "stale_quote_ms": {
+          "name": "stale_quote_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 900000
+        },
+        "gap_reject_pct": {
+          "name": "gap_reject_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.03
+        },
+        "spread_limit_pct_us": {
+          "name": "spread_limit_pct_us",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.0025
+        },
+        "spread_limit_pct_jp": {
+          "name": "spread_limit_pct_jp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.006
+        },
+        "pullback_default_stop_pct": {
+          "name": "pullback_default_stop_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.04
+        },
+        "pullback_default_take_profit_pct": {
+          "name": "pullback_default_take_profit_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.07
+        },
+        "pullback_default_time_stop_days": {
+          "name": "pullback_default_time_stop_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "pullback_default_pullback_max": {
+          "name": "pullback_default_pullback_max",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.03
+        },
+        "pullback_default_pullback_min": {
+          "name": "pullback_default_pullback_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.06
+        },
+        "pullback_default_min_return_50d": {
+          "name": "pullback_default_min_return_50d",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.08
+        },
+        "pullback_default_require_above_sma50": {
+          "name": "pullback_default_require_above_sma50",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "pullback_default_k_atr": {
+          "name": "pullback_default_k_atr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "risk_base_per_trade_pct": {
+          "name": "risk_base_per_trade_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.004
+        },
+        "risk_dd_half_threshold": {
+          "name": "risk_dd_half_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.05
+        },
+        "risk_dd_halt_threshold": {
+          "name": "risk_dd_halt_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.1
+        },
+        "bucket_exposure_pct": {
+          "name": "bucket_exposure_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.3
+        },
+        "vix_warning_threshold": {
+          "name": "vix_warning_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 25
+        },
+        "vix_critical_threshold": {
+          "name": "vix_critical_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "vix_warning_size_scale": {
+          "name": "vix_warning_size_scale",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.5
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "global_config_max_order_notional_range": {
+          "name": "global_config_max_order_notional_range",
+          "value": "\"global_config\".\"max_order_notional\" > 0 AND \"global_config\".\"max_order_notional\" <= 10000000"
+        },
+        "global_config_max_order_notional_usd_range": {
+          "name": "global_config_max_order_notional_usd_range",
+          "value": "\"global_config\".\"max_order_notional_usd\" > 0 AND \"global_config\".\"max_order_notional_usd\" <= 1000000"
+        },
+        "global_config_max_order_notional_jpy_range": {
+          "name": "global_config_max_order_notional_jpy_range",
+          "value": "\"global_config\".\"max_order_notional_jpy\" > 0 AND \"global_config\".\"max_order_notional_jpy\" <= 100000000"
+        },
+        "global_config_total_capital_usd_range": {
+          "name": "global_config_total_capital_usd_range",
+          "value": "\"global_config\".\"total_capital_usd\" IS NULL OR \"global_config\".\"total_capital_usd\" > 0"
+        },
+        "global_config_total_capital_jpy_range": {
+          "name": "global_config_total_capital_jpy_range",
+          "value": "\"global_config\".\"total_capital_jpy\" IS NULL OR \"global_config\".\"total_capital_jpy\" > 0"
+        },
+        "global_config_max_portfolio_exposure_pct_range": {
+          "name": "global_config_max_portfolio_exposure_pct_range",
+          "value": "\"global_config\".\"max_portfolio_exposure_pct\" > 0 AND \"global_config\".\"max_portfolio_exposure_pct\" <= 1"
+        },
+        "global_config_drawdown_kill_threshold_range": {
+          "name": "global_config_drawdown_kill_threshold_range",
+          "value": "\"global_config\".\"drawdown_kill_threshold\" >= -1 AND \"global_config\".\"drawdown_kill_threshold\" <= 0"
+        },
+        "global_config_stale_quote_ms_range": {
+          "name": "global_config_stale_quote_ms_range",
+          "value": "\"global_config\".\"stale_quote_ms\" >= 0"
+        },
+        "global_config_gap_reject_pct_range": {
+          "name": "global_config_gap_reject_pct_range",
+          "value": "\"global_config\".\"gap_reject_pct\" >= 0 AND \"global_config\".\"gap_reject_pct\" <= 1"
+        },
+        "global_config_spread_limit_pct_us_range": {
+          "name": "global_config_spread_limit_pct_us_range",
+          "value": "\"global_config\".\"spread_limit_pct_us\" >= 0 AND \"global_config\".\"spread_limit_pct_us\" <= 1"
+        },
+        "global_config_spread_limit_pct_jp_range": {
+          "name": "global_config_spread_limit_pct_jp_range",
+          "value": "\"global_config\".\"spread_limit_pct_jp\" >= 0 AND \"global_config\".\"spread_limit_pct_jp\" <= 1"
+        },
+        "global_config_pullback_default_stop_pct_range": {
+          "name": "global_config_pullback_default_stop_pct_range",
+          "value": "\"global_config\".\"pullback_default_stop_pct\" < 0 AND \"global_config\".\"pullback_default_stop_pct\" >= -1"
+        },
+        "global_config_pullback_default_take_profit_pct_range": {
+          "name": "global_config_pullback_default_take_profit_pct_range",
+          "value": "\"global_config\".\"pullback_default_take_profit_pct\" > 0 AND \"global_config\".\"pullback_default_take_profit_pct\" <= 1"
+        },
+        "global_config_pullback_default_time_stop_days_range": {
+          "name": "global_config_pullback_default_time_stop_days_range",
+          "value": "\"global_config\".\"pullback_default_time_stop_days\" > 0 AND \"global_config\".\"pullback_default_time_stop_days\" <= ?"
+        },
+        "global_config_pullback_default_pullback_max_range": {
+          "name": "global_config_pullback_default_pullback_max_range",
+          "value": "\"global_config\".\"pullback_default_pullback_max\" <= 0 AND \"global_config\".\"pullback_default_pullback_max\" >= -1"
+        },
+        "global_config_pullback_default_pullback_min_range": {
+          "name": "global_config_pullback_default_pullback_min_range",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= 0 AND \"global_config\".\"pullback_default_pullback_min\" >= -1"
+        },
+        "global_config_pullback_default_min_return_50d_range": {
+          "name": "global_config_pullback_default_min_return_50d_range",
+          "value": "\"global_config\".\"pullback_default_min_return_50d\" >= -1 AND \"global_config\".\"pullback_default_min_return_50d\" <= 10"
+        },
+        "global_config_pullback_default_k_atr_range": {
+          "name": "global_config_pullback_default_k_atr_range",
+          "value": "\"global_config\".\"pullback_default_k_atr\" > 0 AND \"global_config\".\"pullback_default_k_atr\" <= 10"
+        },
+        "global_config_pullback_default_pullback_window_order": {
+          "name": "global_config_pullback_default_pullback_window_order",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= \"global_config\".\"pullback_default_pullback_max\""
+        },
+        "global_config_risk_base_per_trade_pct_range": {
+          "name": "global_config_risk_base_per_trade_pct_range",
+          "value": "\"global_config\".\"risk_base_per_trade_pct\" > 0 AND \"global_config\".\"risk_base_per_trade_pct\" <= 1"
+        },
+        "global_config_risk_dd_half_threshold_range": {
+          "name": "global_config_risk_dd_half_threshold_range",
+          "value": "\"global_config\".\"risk_dd_half_threshold\" < 0 AND \"global_config\".\"risk_dd_half_threshold\" >= -1"
+        },
+        "global_config_risk_dd_halt_threshold_range": {
+          "name": "global_config_risk_dd_halt_threshold_range",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" < 0 AND \"global_config\".\"risk_dd_halt_threshold\" >= -1"
+        },
+        "global_config_risk_dd_threshold_order": {
+          "name": "global_config_risk_dd_threshold_order",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" <= \"global_config\".\"risk_dd_half_threshold\""
+        },
+        "global_config_bucket_exposure_pct_range": {
+          "name": "global_config_bucket_exposure_pct_range",
+          "value": "\"global_config\".\"bucket_exposure_pct\" > 0 AND \"global_config\".\"bucket_exposure_pct\" <= 1"
+        },
+        "global_config_vix_warning_threshold_range": {
+          "name": "global_config_vix_warning_threshold_range",
+          "value": "\"global_config\".\"vix_warning_threshold\" > 0 AND \"global_config\".\"vix_warning_threshold\" <= 200"
+        },
+        "global_config_vix_critical_threshold_range": {
+          "name": "global_config_vix_critical_threshold_range",
+          "value": "\"global_config\".\"vix_critical_threshold\" > 0 AND \"global_config\".\"vix_critical_threshold\" <= 200"
+        },
+        "global_config_vix_threshold_order": {
+          "name": "global_config_vix_threshold_order",
+          "value": "\"global_config\".\"vix_warning_threshold\" <= \"global_config\".\"vix_critical_threshold\""
+        },
+        "global_config_vix_warning_size_scale_range": {
+          "name": "global_config_vix_warning_size_scale_range",
+          "value": "\"global_config\".\"vix_warning_size_scale\" >= 0 AND \"global_config\".\"vix_warning_size_scale\" <= 1"
+        }
+      }
+    },
+    "inverse_pairs": {
+      "name": "inverse_pairs",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inverse": {
+          "name": "inverse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "macro_event_calendar": {
+      "name": "macro_event_calendar",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_time": {
+          "name": "event_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "macro_event_calendar_type_date_unique": {
+          "name": "macro_event_calendar_type_date_unique",
+          "columns": [
+            "event_type",
+            "event_date"
+          ],
+          "isUnique": true
+        },
+        "macro_event_calendar_date_idx": {
+          "name": "macro_event_calendar_date_idx",
+          "columns": [
+            "event_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_emit_log": {
+      "name": "notification_emit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cause": {
+          "name": "cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notification_emit_log_timestamp_id_idx": {
+          "name": "notification_emit_log_timestamp_id_idx",
+          "columns": [
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "notification_emit_log_severity_timestamp_id_idx": {
+          "name": "notification_emit_log_severity_timestamp_id_idx",
+          "columns": [
+            "severity",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "notification_emit_log_event_type_timestamp_id_idx": {
+          "name": "notification_emit_log_event_type_timestamp_id_idx",
+          "columns": [
+            "event_type",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "portfolio_equity_snapshot": {
+      "name": "portfolio_equity_snapshot",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "daily_start_equity_usd": {
+          "name": "daily_start_equity_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_start_equity_jpy": {
+          "name": "daily_start_equity_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_realized_pnl_usd": {
+          "name": "daily_realized_pnl_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_realized_pnl_jpy": {
+          "name": "daily_realized_pnl_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "drawdown_pct": {
+          "name": "drawdown_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "portfolio_equity_snapshot_at_idx": {
+          "name": "portfolio_equity_snapshot_at_idx",
+          "columns": [
+            "snapshot_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "strategy_decision_log": {
+      "name": "strategy_decision_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indicators_json": {
+          "name": "indicators_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "strategy_decision_log_symbol_id_idx": {
+          "name": "strategy_decision_log_symbol_id_idx",
+          "columns": [
+            "symbol",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "strategy_decision_log_coid_idx": {
+          "name": "strategy_decision_log_coid_idx",
+          "columns": [
+            "client_order_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "symbol_config": {
+      "name": "symbol_config",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "market": {
+          "name": "market",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_notional": {
+          "name": "max_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_stop_days_override": {
+          "name": "time_stop_days_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "k_atr_override": {
+          "name": "k_atr_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "symbol_config_currency_enum": {
+          "name": "symbol_config_currency_enum",
+          "value": "\"symbol_config\".\"currency\" IN ('USD', 'JPY')"
+        },
+        "symbol_config_time_stop_days_override_range": {
+          "name": "symbol_config_time_stop_days_override_range",
+          "value": "\"symbol_config\".\"time_stop_days_override\" IS NULL OR (\"symbol_config\".\"time_stop_days_override\" >= 1 AND \"symbol_config\".\"time_stop_days_override\" <= ?)"
+        },
+        "symbol_config_k_atr_override_range": {
+          "name": "symbol_config_k_atr_override_range",
+          "value": "\"symbol_config\".\"k_atr_override\" IS NULL OR (\"symbol_config\".\"k_atr_override\" >= 0.5 AND \"symbol_config\".\"k_atr_override\" <= 5.0)"
+        }
+      }
+    },
+    "trade_journal": {
+      "name": "trade_journal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trade_event_type": {
+          "name": "trade_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "strategy_name": {
+          "name": "strategy_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_action": {
+          "name": "signal_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_reason": {
+          "name": "signal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_allowed": {
+          "name": "risk_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_reasons": {
+          "name": "risk_reasons",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "limit_price": {
+          "name": "limit_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notional": {
+          "name": "notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "broker_status": {
+          "name": "broker_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "submitted": {
+          "name": "submitted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_qty": {
+          "name": "filled_qty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_price": {
+          "name": "filled_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "realized_pnl": {
+          "name": "realized_pnl",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hold_days": {
+          "name": "hold_days",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_reason": {
+          "name": "exit_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_applied_at": {
+          "name": "state_applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_error": {
+          "name": "state_apply_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_attempts": {
+          "name": "state_apply_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trading_toggle_history": {
+      "name": "trading_toggle_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before": {
+          "name": "before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "after": {
+          "name": "after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1778863329960,
       "tag": "0018_portfolio_equity_snapshot",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "6",
+      "when": 1778895040599,
+      "tag": "0019_numerous_nightshade",
+      "breakpoints": true
     }
   ]
 }

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -111,12 +111,30 @@ export const symbolConfig = sqliteTable(
      */
     bucket: text('bucket'),
     notes: text('notes'),
+    /**
+     * 個別銘柄 override (NULL = global_config の default を使う、整数 1-365)。
+     * 3x leveraged ETF 等で短い hold が望ましいケース用 (#316)。
+     */
+    timeStopDaysOverride: integer('time_stop_days_override'),
+    /**
+     * 個別銘柄 override (NULL = global_config の default を使う、float 0.5-5.0)。
+     * 高ボラ銘柄で stop を緩めるケース用 (#316)。
+     */
+    kAtrOverride: real('k_atr_override'),
     updatedAt: text('updated_at').notNull(),
   },
   (t) => ({
     currencyEnum: check(
       'symbol_config_currency_enum',
       sql`${t.currency} IN ('USD', 'JPY')`,
+    ),
+    timeStopDaysOverrideRange: check(
+      'symbol_config_time_stop_days_override_range',
+      sql`${t.timeStopDaysOverride} IS NULL OR (${t.timeStopDaysOverride} >= 1 AND ${t.timeStopDaysOverride} <= ${MAX_TIME_STOP_DAYS})`,
+    ),
+    kAtrOverrideRange: check(
+      'symbol_config_k_atr_override_range',
+      sql`${t.kAtrOverride} IS NULL OR (${t.kAtrOverride} >= 0.5 AND ${t.kAtrOverride} <= 5.0)`,
     ),
   }),
 )

--- a/src/infrastructure/db/symbolConfigRepo.ts
+++ b/src/infrastructure/db/symbolConfigRepo.ts
@@ -44,6 +44,18 @@ export interface SymbolConfigSnapshot {
    * 銘柄の tooltip 表示に使う。active=0 / active=1 両方含む。
    */
   symbolNotes: Record<string, string>
+  /**
+   * symbol → time_stop_days_override (integer 1-365)。NULL は map に含めない
+   * (= global_config.pullback_default_time_stop_days を使う fall-through)。
+   * 3x leveraged ETF 等で短い hold を強制したい時に使う (#316)。
+   */
+  symbolTimeStopDaysOverride: Record<string, number>
+  /**
+   * symbol → k_atr_override (float 0.5-5.0)。NULL は map に含めない
+   * (= global_config.pullback_default_k_atr を使う fall-through)。
+   * 高ボラ銘柄で ATR stop を緩めたい時に使う (#316)。
+   */
+  symbolKAtrOverride: Record<string, number>
 }
 
 /**
@@ -68,6 +80,8 @@ export async function loadSymbolConfig(
   const symbolMarket: Record<string, SymbolMarket> = {}
   const symbolName: Record<string, string> = {}
   const symbolNotes: Record<string, string> = {}
+  const symbolTimeStopDaysOverride: Record<string, number> = {}
+  const symbolKAtrOverride: Record<string, number> = {}
   for (const row of rows) {
     const symbol = row.symbol.toUpperCase()
     if (row.active) {
@@ -97,6 +111,22 @@ export async function loadSymbolConfig(
     if (trimmedNotes && trimmedNotes.length > 0) {
       symbolNotes[symbol] = trimmedNotes
     }
+    // override 値は DB CHECK で範囲済み。Number.isFinite で defensive 確認だけ
+    // 入れて (NaN を絶対に下流に流さない)、NULL は map に出さず fall-through。
+    if (
+      row.timeStopDaysOverride !== null &&
+      row.timeStopDaysOverride !== undefined &&
+      Number.isFinite(row.timeStopDaysOverride)
+    ) {
+      symbolTimeStopDaysOverride[symbol] = row.timeStopDaysOverride
+    }
+    if (
+      row.kAtrOverride !== null &&
+      row.kAtrOverride !== undefined &&
+      Number.isFinite(row.kAtrOverride)
+    ) {
+      symbolKAtrOverride[symbol] = row.kAtrOverride
+    }
   }
   return {
     allowedSymbols,
@@ -107,6 +137,8 @@ export async function loadSymbolConfig(
     symbolMarket,
     symbolName,
     symbolNotes,
+    symbolTimeStopDaysOverride,
+    symbolKAtrOverride,
   }
 }
 
@@ -131,6 +163,16 @@ export interface SymbolConfigWriteInput {
   maxNotional: number | null
   bucket: string | null
   notes: string | null
+  /**
+   * Per-symbol time_stop_days override (NULL = global default 使用、1-365 整数)。
+   * 3x leveraged ETF 等で短い hold を強制 (#316)。
+   */
+  timeStopDaysOverride: number | null
+  /**
+   * Per-symbol k_atr override (NULL = global default 使用、0.5-5.0 float)。
+   * 高ボラ銘柄で ATR stop を緩める (#316)。
+   */
+  kAtrOverride: number | null
 }
 
 /**
@@ -156,6 +198,8 @@ export async function insertSymbolConfig(
       maxNotional: input.maxNotional,
       bucket: input.bucket,
       notes: input.notes,
+      timeStopDaysOverride: input.timeStopDaysOverride,
+      kAtrOverride: input.kAtrOverride,
       updatedAt: nowIso,
     })
   } catch (err) {
@@ -198,6 +242,8 @@ export async function updateSymbolConfig(
       maxNotional: input.maxNotional,
       bucket: input.bucket,
       notes: input.notes,
+      timeStopDaysOverride: input.timeStopDaysOverride,
+      kAtrOverride: input.kAtrOverride,
       updatedAt: nowIso,
     })
     .where(eq(symbolConfig.symbol, input.symbol))

--- a/src/infrastructure/db/symbolUniverse.ts
+++ b/src/infrastructure/db/symbolUniverse.ts
@@ -27,6 +27,16 @@ export interface SymbolUniverse {
    * dashboard が disabled 銘柄の tooltip 表示に使う。null / 空文字は map に不在。
    */
   symbolNotes: Record<string, string>
+  /**
+   * symbol → time_stop_days override (1-365 整数)。空 map のキーは
+   * global_config.pullback_default_time_stop_days を使う (fall-through、#316)。
+   */
+  symbolTimeStopDaysOverride: Record<string, number>
+  /**
+   * symbol → k_atr override (0.5-5.0 float)。空 map のキーは
+   * global_config.pullback_default_k_atr を使う (fall-through、#316)。
+   */
+  symbolKAtrOverride: Record<string, number>
   inversePairs: Record<string, string>
   source: 'd1'
 }
@@ -56,6 +66,8 @@ export async function loadSymbolUniverse(env: UniverseEnv): Promise<SymbolUniver
     symbolMarket: config.symbolMarket,
     symbolName: config.symbolName,
     symbolNotes: config.symbolNotes,
+    symbolTimeStopDaysOverride: config.symbolTimeStopDaysOverride,
+    symbolKAtrOverride: config.symbolKAtrOverride,
     inversePairs: pairs,
     source: 'd1',
   }

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1590,6 +1590,10 @@ function parseSymbolConfigBody(body: unknown): SymbolConfigWriteInput {
     maxNotional?: unknown
     bucket?: unknown
     notes?: unknown
+    time_stop_days_override?: unknown
+    timeStopDaysOverride?: unknown
+    k_atr_override?: unknown
+    kAtrOverride?: unknown
   }
   const symbol = normalizeSymbol(raw.symbol)
   const market = parseMarket(raw.market)
@@ -1603,7 +1607,32 @@ function parseSymbolConfigBody(body: unknown): SymbolConfigWriteInput {
   const name = parseOptionalString(raw.name, 'name')
   const bucket = parseOptionalString(raw.bucket, 'bucket')
   const notes = parseOptionalString(raw.notes, 'notes')
-  return { symbol, name, market, currency, active, maxNotional, bucket, notes }
+  // Per-symbol pullback override (#316)。空文字 / undefined → NULL (= global
+  // default fall-through)。範囲外は ValidationError、DB CHECK と二重防御。
+  const timeStopDaysOverride = parseOptionalIntegerInRange(
+    raw.time_stop_days_override ?? raw.timeStopDaysOverride,
+    'timeStopDaysOverride',
+    1,
+    365,
+  )
+  const kAtrOverride = parseOptionalNumberInRange(
+    raw.k_atr_override ?? raw.kAtrOverride,
+    'kAtrOverride',
+    0.5,
+    5.0,
+  )
+  return {
+    symbol,
+    name,
+    market,
+    currency,
+    active,
+    maxNotional,
+    bucket,
+    notes,
+    timeStopDaysOverride,
+    kAtrOverride,
+  }
 }
 
 function normalizeSymbol(value: unknown): string {
@@ -1671,6 +1700,84 @@ function parseOptionalPositiveNumber(value: unknown, field: string): number | nu
   throw new ValidationError(`${field} must be a positive number or empty`, { field })
 }
 
+/**
+ * Optional integer in [min,max]。空文字 / undefined / null → null (fall-through)。
+ * 整数 (Number.isInteger) でない値は ValidationError。範囲外も ValidationError。
+ * Per-symbol override (#316) で time_stop_days_override の受け口に使う。
+ */
+function parseOptionalIntegerInRange(
+  value: unknown,
+  field: string,
+  min: number,
+  max: number,
+): number | null {
+  if (value === undefined || value === null) return null
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (trimmed === '') return null
+    const parsed = Number(trimmed)
+    if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < min || parsed > max) {
+      throw new ValidationError(
+        `${field} must be an integer between ${min} and ${max}, or empty`,
+        { field },
+      )
+    }
+    return parsed
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || !Number.isInteger(value) || value < min || value > max) {
+      throw new ValidationError(
+        `${field} must be an integer between ${min} and ${max}, or empty`,
+        { field },
+      )
+    }
+    return value
+  }
+  throw new ValidationError(
+    `${field} must be an integer between ${min} and ${max}, or empty`,
+    { field },
+  )
+}
+
+/**
+ * Optional finite float in [min,max]。空文字 / undefined / null → null
+ * (fall-through)。範囲外 / 非数値は ValidationError。Per-symbol override
+ * (#316) で k_atr_override の受け口に使う。
+ */
+function parseOptionalNumberInRange(
+  value: unknown,
+  field: string,
+  min: number,
+  max: number,
+): number | null {
+  if (value === undefined || value === null) return null
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (trimmed === '') return null
+    const parsed = Number(trimmed)
+    if (!Number.isFinite(parsed) || parsed < min || parsed > max) {
+      throw new ValidationError(
+        `${field} must be a number between ${min} and ${max}, or empty`,
+        { field },
+      )
+    }
+    return parsed
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || value < min || value > max) {
+      throw new ValidationError(
+        `${field} must be a number between ${min} and ${max}, or empty`,
+        { field },
+      )
+    }
+    return value
+  }
+  throw new ValidationError(
+    `${field} must be a number between ${min} and ${max}, or empty`,
+    { field },
+  )
+}
+
 function parseOptionalString(value: unknown, field: string): string | null {
   if (value === undefined || value === null) return null
   if (typeof value !== 'string') {
@@ -1694,6 +1801,8 @@ function symbolConfigSnapshot(row: SymbolConfigRow): Record<string, unknown> {
     maxNotional: row.maxNotional,
     bucket: row.bucket,
     notes: row.notes,
+    timeStopDaysOverride: row.timeStopDaysOverride,
+    kAtrOverride: row.kAtrOverride,
     updatedAt: row.updatedAt,
   }
 }

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -571,11 +571,20 @@ export const dashboard = new Hono<DashboardBindings>()
       return c.html(renderLayout(c, '銘柄管理 - 新規追加', unavailable('DB not bound')))
     }
     const knownPairs = await loadKnownSymbolBuckets(c.env.DB).catch(() => [])
+    // global default は placeholder 表示 (#316) — operator が「空欄なら何の値が
+    // 適用されるか」を一目で把握できるようにする。読込失敗は fallback null で
+    // placeholder 無表示にする (form 自体は出す)。
+    const globalDefaults = await loadGlobalConfigFrom(c.env, c.get('requestId'))
+      .then((g) => ({
+        timeStopDays: g.pullbackDefaultTimeStopDays,
+        kAtr: g.pullbackDefaultKAtr,
+      }))
+      .catch(() => null)
     return c.html(
       renderLayout(
         c,
         '銘柄管理 - 新規追加',
-        symbolFormBody({ mode: 'new', row: null, error: null, knownPairs }),
+        symbolFormBody({ mode: 'new', row: null, error: null, knownPairs, globalDefaults }),
       ),
     )
   })
@@ -593,11 +602,17 @@ export const dashboard = new Hono<DashboardBindings>()
         return c.html(renderLayout(c, '銘柄管理 - 編集', unavailable(`symbol "${symbol}" not found`)))
       }
       const knownPairs = await loadKnownSymbolBuckets(c.env.DB).catch(() => [])
+      const globalDefaults = await loadGlobalConfigFrom(c.env, c.get('requestId'))
+        .then((g) => ({
+          timeStopDays: g.pullbackDefaultTimeStopDays,
+          kAtr: g.pullbackDefaultKAtr,
+        }))
+        .catch(() => null)
       return c.html(
         renderLayout(
           c,
           '銘柄管理 - 編集',
-          symbolFormBody({ mode: 'edit', row, error: null, knownPairs }),
+          symbolFormBody({ mode: 'edit', row, error: null, knownPairs, globalDefaults }),
         ),
       )
     } catch (err) {
@@ -6289,10 +6304,15 @@ interface SymbolFormArgs {
   error: string | null
   /** 既存 (symbol, bucket) ペア、bucket 入力の suggest 用。 */
   knownPairs: SymbolBucketPair[]
+  /**
+   * Pullback rule の global default。override 入力欄の placeholder に「空欄
+   * なら N が適用される」と見せるために使う (#316)。読込失敗時 null。
+   */
+  globalDefaults: { timeStopDays: number; kAtr: number } | null
 }
 
 function symbolFormBody(args: SymbolFormArgs): string {
-  const { mode, row, error, knownPairs } = args
+  const { mode, row, error, knownPairs, globalDefaults } = args
   const action =
     mode === 'new' ? '/admin/symbol-config' : `/admin/symbol-config/${encodeURIComponent(row!.symbol)}/update`
   const symbolValue = row?.symbol ?? ''
@@ -6303,6 +6323,18 @@ function symbolFormBody(args: SymbolFormArgs): string {
   const maxNotionalValue = row?.maxNotional === null || row?.maxNotional === undefined ? '' : String(row.maxNotional)
   const bucketValue = row?.bucket ?? ''
   const notesValue = row?.notes ?? ''
+  const timeStopDaysOverrideValue =
+    row?.timeStopDaysOverride === null || row?.timeStopDaysOverride === undefined
+      ? ''
+      : String(row.timeStopDaysOverride)
+  const kAtrOverrideValue =
+    row?.kAtrOverride === null || row?.kAtrOverride === undefined ? '' : String(row.kAtrOverride)
+  const timeStopPlaceholder = globalDefaults
+    ? `空欄で global default (${globalDefaults.timeStopDays}日) を使用`
+    : '空欄で global default を使用'
+  const kAtrPlaceholder = globalDefaults
+    ? `空欄で global default (${globalDefaults.kAtr}) を使用`
+    : '空欄で global default を使用'
   const symbolField =
     mode === 'edit'
       ? `<input type="text" name="symbol" value="${esc(symbolValue)}" readonly style="padding:6px;background:#eee">
@@ -6354,6 +6386,18 @@ function symbolFormBody(args: SymbolFormArgs): string {
         <ul id="symbol-form-bucket-suggest" data-known='${esc(JSON.stringify(knownPairs))}' style="display:none;position:absolute;top:100%;left:0;margin:2px 0 0;padding:0;list-style:none;background:#fff;border:1px solid #d0d0d5;border-radius:4px;width:320px;max-height:240px;overflow-y:auto;z-index:10;box-shadow:0 2px 6px rgba(0,0,0,0.1)"></ul>
       </div>
       <p class="muted" style="margin:6px 0 0;font-size:11px">同 bucket の銘柄は portfolio 上で合計 notional 上限を共有する (\`global_config.bucket_exposure_pct\`)。2 文字以上入力で既存銘柄から suggest (click するとその銘柄の bucket が挿入される / 新規 bucket もそのまま入力で OK)。</p>
+    </div>
+    <label>保有上限 <span class="muted" style="font-size:11px">(time_stop_days)</span></label>
+    <div>
+      <input type="number" name="time_stop_days_override" value="${esc(timeStopDaysOverrideValue)}" step="1" min="1" max="365" placeholder="${esc(timeStopPlaceholder)}" style="padding:6px;width:160px">
+      <span class="muted" style="font-size:12px;margin-left:6px">日 (business days)</span>
+      <p class="muted" style="margin:4px 0 0;font-size:11px">空欄 → global の <code>pullback_default_time_stop_days</code> を使用。3x leveraged ETF (SOXL / 1570 等) は短い hold (5-7) が推奨 (#316)。1-365 の整数。</p>
+    </div>
+    <label>ATR stop 倍率 <span class="muted" style="font-size:11px">(k_atr)</span></label>
+    <div>
+      <input type="number" name="k_atr_override" value="${esc(kAtrOverrideValue)}" step="0.1" min="0.5" max="5.0" placeholder="${esc(kAtrPlaceholder)}" style="padding:6px;width:160px">
+      <span class="muted" style="font-size:12px;margin-left:6px">× ATR20</span>
+      <p class="muted" style="margin:4px 0 0;font-size:11px">空欄 → global の <code>pullback_default_k_atr</code> を使用。高ボラ銘柄では緩めに (2.5-3.5)、低ボラは引き締めに (1.5-2.0)。0.5-5.0 の数値 (#316)。</p>
     </div>
     <label>メモ <span class="muted" style="font-size:11px">(notes)</span></label>
     <textarea name="notes" maxlength="256" rows="3" placeholder="自由記述 (例: 一時停止理由 / 上限を絞ってる事情)" style="padding:6px;font-family:inherit">${esc(notesValue)}</textarea>

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -231,6 +231,23 @@ export async function runStrategyCron(
     requireAboveSma50: global.pullbackDefaultRequireAboveSma50,
     kAtr: global.pullbackDefaultKAtr,
   }
+  // Per-symbol override map (#316)。symbol_config の time_stop_days_override /
+  // k_atr_override を defaultRule に重ね、3x leveraged ETF 等の銘柄固有事情
+  // (短い hold が望ましい / 高ボラで stop を緩めたい) を rule に注入する。
+  // override が NULL の symbol は rulesMap に含めない (= defaultRule そのまま)。
+  const rulesMap: Record<string, typeof defaultRule> = {}
+  const overrideSymbols = new Set<string>([
+    ...Object.keys(universe.symbolTimeStopDaysOverride),
+    ...Object.keys(universe.symbolKAtrOverride),
+  ])
+  for (const sym of overrideSymbols) {
+    rulesMap[sym] = {
+      ...defaultRule,
+      timeStopDays:
+        universe.symbolTimeStopDaysOverride[sym] ?? defaultRule.timeStopDays,
+      kAtr: universe.symbolKAtrOverride[sym] ?? defaultRule.kAtr,
+    }
+  }
   const byCurrency: Record<SymbolCurrency, string[]> = { USD: [], JPY: [] }
   for (const sym of universe.allowedSymbols) {
     const cur = universe.symbolCurrency[sym] ?? 'USD'
@@ -546,6 +563,7 @@ export async function runStrategyCron(
       symbolBucketMap: universe.symbolBucket,
       bucketCapMap,
       defaultRule,
+      rulesMap,
       riskPerTradePct: scaledRiskPerTradePct,
       requestId: options.requestId,
       notifier,

--- a/test/helpers/configFixtures.ts
+++ b/test/helpers/configFixtures.ts
@@ -54,6 +54,8 @@ export function makeSymbolUniverse(overrides: Partial<SymbolUniverse> = {}): Sym
     symbolMarket: { SOXL: 'US', SOXS: 'US' },
     symbolName: {},
     symbolNotes: {},
+    symbolTimeStopDaysOverride: {},
+    symbolKAtrOverride: {},
     inversePairs: {},
     source: 'd1',
     ...overrides,

--- a/test/routes/admin.test.ts
+++ b/test/routes/admin.test.ts
@@ -1136,6 +1136,8 @@ describe('POST /admin/orders/sync-holdings', () => {
       symbolMarket: {},
       symbolName: {},
       symbolNotes: {},
+      symbolTimeStopDaysOverride: {},
+      symbolKAtrOverride: {},
       inversePairs: {},
       source: 'd1',
     })

--- a/test/routes/dashboardSymbolsCrud.test.ts
+++ b/test/routes/dashboardSymbolsCrud.test.ts
@@ -150,6 +150,8 @@ function fakeDb(initial: SymbolConfigRow[]) {
               maxNotional: (v.maxNotional as number | null) ?? null,
               bucket: (v.bucket as string | null) ?? null,
               notes: (v.notes as string | null) ?? null,
+              timeStopDaysOverride: (v.timeStopDaysOverride as number | null) ?? null,
+              kAtrOverride: (v.kAtrOverride as number | null) ?? null,
               updatedAt: String(v.updatedAt ?? ''),
             })
           }
@@ -199,6 +201,8 @@ function row(overrides: Partial<SymbolConfigRow> = {}): SymbolConfigRow {
     maxNotional: 2000,
     bucket: 'semi',
     notes: null,
+    timeStopDaysOverride: null,
+    kAtrOverride: null,
     updatedAt: '2026-04-23T00:00:00.000Z',
     ...overrides,
   }
@@ -614,5 +618,197 @@ describe('dashboard symbol_config CRUD UI (#292)', () => {
         bucket: 'semi',
       },
     })
+  })
+
+  // --- Per-symbol strategy override (#316) ---
+  it('POST /admin/symbol-config persists timeStopDaysOverride / kAtrOverride from form', async () => {
+    // SOXL (3x leveraged ETF) で time_stop=5 / k_atr=3.0 を入れて DB に
+    // 書かれることを確認。global default は別途 placeholder で表示するだけ。
+    const db = fakeDb([])
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const app = createApp()
+    const form = new URLSearchParams({
+      symbol: 'SOXL',
+      market: 'US',
+      currency: 'USD',
+      active: 'true',
+      max_notional: '2000',
+      bucket: 'semi',
+      time_stop_days_override: '5',
+      k_atr_override: '3.0',
+    })
+    const res = await app.request(
+      '/admin/symbol-config',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...authHeader },
+        body: form.toString(),
+      },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    expect(res.status).toBe(303)
+    const insert = db.inserts.find((i) => i.table === 'symbol_config')
+    expect(insert).toBeDefined()
+    expect(insert!.values).toMatchObject({
+      symbol: 'SOXL',
+      timeStopDaysOverride: 5,
+      kAtrOverride: 3.0,
+    })
+  })
+
+  it('POST /admin/symbol-config treats empty override fields as NULL (global fall-through)', async () => {
+    // 空文字 → null (= global default を使う) の挙動を保証。3x ETF 以外の
+    // 一般銘柄 form ではこちらが既定の path。
+    const db = fakeDb([])
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const app = createApp()
+    const form = new URLSearchParams({
+      symbol: 'AAPL',
+      market: 'US',
+      currency: 'USD',
+      active: 'true',
+      max_notional: '1000',
+      time_stop_days_override: '',
+      k_atr_override: '',
+    })
+    const res = await app.request(
+      '/admin/symbol-config',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...authHeader },
+        body: form.toString(),
+      },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    expect(res.status).toBe(303)
+    const insert = db.inserts.find((i) => i.table === 'symbol_config')
+    expect(insert).toBeDefined()
+    expect(insert!.values.timeStopDaysOverride).toBeNull()
+    expect(insert!.values.kAtrOverride).toBeNull()
+  })
+
+  it('POST /admin/symbol-config rejects out-of-range overrides with 400', async () => {
+    // DB CHECK と二重防御。timeStopDays は 1-365 整数、kAtr は 0.5-5.0 float。
+    const db = fakeDb([])
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const app = createApp()
+
+    // timeStop 0 (下限未満)
+    const tooLowDays = await app.request(
+      '/admin/symbol-config',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...authHeader },
+        body: new URLSearchParams({
+          symbol: 'SOXL',
+          market: 'US',
+          currency: 'USD',
+          active: 'true',
+          time_stop_days_override: '0',
+        }).toString(),
+      },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    expect(tooLowDays.status).toBe(400)
+
+    // kAtr 0.1 (下限未満)
+    const tooLowAtr = await app.request(
+      '/admin/symbol-config',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...authHeader },
+        body: new URLSearchParams({
+          symbol: 'SOXL',
+          market: 'US',
+          currency: 'USD',
+          active: 'true',
+          k_atr_override: '0.1',
+        }).toString(),
+      },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    expect(tooLowAtr.status).toBe(400)
+
+    // kAtr 6.0 (上限超え)
+    const tooHighAtr = await app.request(
+      '/admin/symbol-config',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...authHeader },
+        body: new URLSearchParams({
+          symbol: 'SOXL',
+          market: 'US',
+          currency: 'USD',
+          active: 'true',
+          k_atr_override: '6.0',
+        }).toString(),
+      },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    expect(tooHighAtr.status).toBe(400)
+
+    expect(db.inserts.filter((i) => i.table === 'symbol_config')).toHaveLength(0)
+  })
+
+  it('POST /admin/symbol-config/:symbol/update persists override values + audit log', async () => {
+    // Update path で override 値が DB に書かれて audit before/after が乗ること。
+    const db = fakeDb([row({ symbol: 'SOXL', timeStopDaysOverride: null, kAtrOverride: null })])
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const app = createApp()
+    const form = new URLSearchParams({
+      symbol: 'SOXL',
+      market: 'US',
+      currency: 'USD',
+      active: 'true',
+      max_notional: '2000',
+      bucket: 'semi',
+      time_stop_days_override: '7',
+      k_atr_override: '2.5',
+    })
+    const res = await app.request(
+      '/admin/symbol-config/SOXL/update',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...authHeader },
+        body: form.toString(),
+      },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    expect(res.status).toBe(303)
+    const update = db.updates.find((u) => u.table === 'symbol_config')
+    expect(update).toBeDefined()
+    expect(update!.set).toMatchObject({
+      timeStopDaysOverride: 7,
+      kAtrOverride: 2.5,
+    })
+    const auditInsert = db.inserts.find((i) => i.table === 'config_audit_log')
+    expect(auditInsert).toBeDefined()
+    const before = JSON.parse(String(auditInsert!.values.beforeJson))
+    const after = JSON.parse(String(auditInsert!.values.afterJson))
+    expect(before.timeStopDaysOverride).toBeNull()
+    expect(before.kAtrOverride).toBeNull()
+    expect(after.timeStopDaysOverride).toBe(7)
+    expect(after.kAtrOverride).toBe(2.5)
+  })
+
+  it('GET /dashboard/symbols/:symbol/edit renders override fields with current values + global placeholders', async () => {
+    const db = fakeDb([row({ symbol: 'SOXL', timeStopDaysOverride: 5, kAtrOverride: 3.0 })])
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const app = createApp()
+    const res = await app.request(
+      '/dashboard/symbols/SOXL/edit',
+      { headers: authHeader },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    // form input が存在
+    expect(body).toContain('name="time_stop_days_override"')
+    expect(body).toContain('name="k_atr_override"')
+    // 現在値が反映 (value 属性)
+    expect(body).toMatch(/name="time_stop_days_override"[^>]*value="5"/)
+    expect(body).toMatch(/name="k_atr_override"[^>]*value="3"/)
+    // placeholder に global default が表示される (makeGlobalConfigSnapshot の値)
+    expect(body).toContain('global default')
   })
 })

--- a/test/trading/strategy/pullbackScheduler.test.ts
+++ b/test/trading/strategy/pullbackScheduler.test.ts
@@ -1451,3 +1451,88 @@ describe('runPullbackScheduler sanity_failed cooldown gate', () => {
     expect(reject?.reason).toContain('sanity_failed cooldown active')
   })
 })
+
+describe('runPullbackScheduler per-symbol rule override (#316)', () => {
+  // 3x leveraged ETF を念頭に「銘柄ごとに timeStopDays / kAtr を上書きできる」
+  // ことを検証。default rule timeStopDays=10、override で 5 にすると holdBD≥5
+  // の銘柄が time-stop SELL に乗る。同じ holdBD で override 無しの銘柄は HOLD。
+  const defaultRule = {
+    stopPct: -0.04,
+    takeProfitPct: 0.07,
+    timeStopDays: 10,
+    pullbackMax: -0.03,
+    pullbackMin: -0.06,
+    minReturn50d: 0.08,
+    requireAboveSma50: true,
+    kAtr: 2.0,
+  }
+
+  it('applies timeStopDays override to the matching symbol and falls through for others', async () => {
+    // 7 BD 前に open した position を 2 銘柄に同条件で持たせ、SOXL 側だけ
+    // timeStopDays=5 override する。SOXL は time-stop SELL、AAPL は default
+    // (10d) 未到達で HOLD。avgPrice=117 は last close=117.5 とほぼ同値で
+    // take-profit / stop-loss を発火させない (時間切れだけが起きる)。
+    const heldState = (symbol: string): SymbolState => ({
+      ...emptySymbolState(symbol, () => now),
+      position: {
+        qty: 5,
+        avgPrice: 117,
+        // 7 business days 前。default rule timeStopDays=10 では未到達、
+        // override timeStopDays=5 では到達する境界。
+        openedAt: new Date('2026-04-09T00:00:00.000Z').toISOString(),
+      },
+    })
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['SOXL', 'AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({
+        SOXL: heldState('SOXL'),
+        AAPL: heldState('AAPL'),
+      }),
+      execution,
+      defaultRule,
+      rulesMap: { SOXL: { ...defaultRule, timeStopDays: 5 } },
+      now: () => now,
+    })
+
+    const soxlDecision = summary.decisions.find((d) => d.symbol === 'SOXL')
+    const aaplDecision = summary.decisions.find((d) => d.symbol === 'AAPL')
+    // SOXL は override timeStopDays=5 で time-stop に乗る。
+    expect(soxlDecision?.decision).toBe('SELL')
+    expect(soxlDecision?.reason).toMatch(/time-stop hit.*>=\s*5d/)
+    // AAPL は default の 10d 未到達 — time-stop は発火しない (HOLD 経路)。
+    expect(aaplDecision?.decision).toBe('HOLD')
+    expect(aaplDecision?.reason ?? '').not.toMatch(/time-stop hit/)
+  })
+
+  it('uses defaultRule when rulesMap is empty (NULL override fall-through)', async () => {
+    // Override が無い場合は default 通り。7 BD 前は default (10d) 未到達 →
+    // time-stop は発火せず HOLD で抜ける。
+    const heldState: SymbolState = {
+      ...emptySymbolState('SOXL', () => now),
+      position: {
+        qty: 5,
+        avgPrice: 117,
+        // 7 BD 前 → default (10d) 未到達。
+        openedAt: new Date('2026-04-09T00:00:00.000Z').toISOString(),
+      },
+    }
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['SOXL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({ SOXL: heldState }),
+      execution,
+      defaultRule,
+      // rulesMap 未指定 → 全 symbol が defaultRule を使う。
+      now: () => now,
+    })
+
+    const soxl = summary.decisions.find((d) => d.symbol === 'SOXL')
+    expect(soxl?.decision).toBe('HOLD')
+    expect(soxl?.reason ?? '').not.toMatch(/time-stop hit/)
+  })
+})


### PR DESCRIPTION
Closes #316
Refs #314

## Summary

trading-strategist 指摘 (修正推奨): 3x leveraged ETF (SOXL / 1570) は default で daily rebalancing decay と相性悪。**per-symbol で override** 可能に。

## 変更点

- migration **0019** (additive ALTER TABLE ADD COLUMN + CHECK)
- \`symbol_config.time_stop_days_override\` (INTEGER 1-365、NULL = global default)
- \`symbol_config.k_atr_override\` (REAL 0.5-5.0、NULL = global default)
- \`runStrategyCron\` で per-symbol rulesMap 構築、override がある symbol のみ defaultRule 上書き
- form UI: 2 入力欄 (placeholder で global default 表示、空欄で NULL)
- 既存 audit log wrap で picked up

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` 1085/81 files (+7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 銘柄ごとの取引戦略パラメータをカスタマイズできるようになりました。グローバル設定に加えて、個別銘柄に対して時間停止日数とATR係数をオーバーライド設定可能です。
  * 銘柄編集画面に新たな設定入力欄を追加。空欄の場合はグローバルデフォルト値が自動適用されます。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/321?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->