### PR TITLE
feat(webull): split JP API host into trade / quotes / events with JP prod defaults (#21)

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -14,17 +14,17 @@ WEBULL_APP_KEY=
 WEBULL_APP_SECRET=
 # Run `pnpm run accounts` after setting the two above to fetch account_id.
 WEBULL_ACCOUNT_ID=
-# Webull JP host (#21)。JP UAT (`jp-openapi-alb.uat.webullbroker.com`) では ALB が
-# trade/quotes/events を 1 ホストに束ねるので 3 var とも同じ値を入れる。JP 本番では
-#   WEBULL_TRADE_API_BASE=https://api.webull.co.jp
-#   WEBULL_QUOTES_API_BASE=https://data-api.webull.co.jp
-#   WEBULL_EVENTS_API_BASE=https://events-api.webull.co.jp
-# のように分離する。fallback 無し (未設定なら client 生成時 throw)。
-# events は本リポジトリにまだ consumer が無いが、SDK の region 定義に存在するため
-# 将来用に declare してある (= 設定漏れを発見しやすくするため空でも書いておく)。
-WEBULL_TRADE_API_BASE=
-WEBULL_QUOTES_API_BASE=
-WEBULL_EVENTS_API_BASE=
+# Webull JP host (#21)。env 未設定なら JP **prod** default に fallback:
+#   WEBULL_TRADE_API_BASE  default = https://api.webull.co.jp
+#   WEBULL_QUOTES_API_BASE default = https://data-api.webull.co.jp
+#   WEBULL_EVENTS_API_BASE default = https://events-api.webull.co.jp  (consumer 未実装)
+# JP UAT (`jp-openapi-alb.uat.webullbroker.com`) では ALB が trade/quotes/events を
+# 1 ホストに束ねるので、UAT を叩くときは 3 var とも UAT ALB URL に override する。
+# 本番は default で動くので prod env では secret 投入不要 (= 設定漏れ事故が起き
+# 得ない)。default は SDK の公開 region 定義より取得 (endpoints.json region=jp)。
+# WEBULL_TRADE_API_BASE=https://jp-openapi-alb.uat.webullbroker.com
+# WEBULL_QUOTES_API_BASE=https://jp-openapi-alb.uat.webullbroker.com
+# WEBULL_EVENTS_API_BASE=https://jp-openapi-alb.uat.webullbroker.com
 ALLOWED_SYMBOLS=SOXL,SOXS
 MAX_ORDER_NOTIONAL=100
 SYMBOL_MAX_NOTIONAL={"SOXL":200,"SOXS":150}

--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -6,15 +6,25 @@
 #   Override locally by uncommenting the block at the bottom.
 # - Sensitive (personal strategy / credentials / non-public endpoint):
 #   ALLOWED_SYMBOLS / MAX_ORDER_NOTIONAL / SYMBOL_MAX_NOTIONAL /
-#   WEBULL_API_BASE / BASIC_AUTH_* / EVENT_INGEST_SECRET / WEBULL_APP_* / WEBULL_ACCOUNT_ID
+#   WEBULL_TRADE_API_BASE / WEBULL_QUOTES_API_BASE / WEBULL_EVENTS_API_BASE /
+#   BASIC_AUTH_* / EVENT_INGEST_SECRET / WEBULL_APP_* / WEBULL_ACCOUNT_ID
 #   → set below for local dev, use `wrangler secret put` for deployed envs.
 
 WEBULL_APP_KEY=
 WEBULL_APP_SECRET=
 # Run `pnpm run accounts` after setting the two above to fetch account_id.
 WEBULL_ACCOUNT_ID=
-# Sandbox default. Use https://openapi.webull.com for production.
-WEBULL_API_BASE=https://api.sandbox.webull.hk
+# Webull JP host (#21)。JP UAT (`jp-openapi-alb.uat.webullbroker.com`) では ALB が
+# trade/quotes/events を 1 ホストに束ねるので 3 var とも同じ値を入れる。JP 本番では
+#   WEBULL_TRADE_API_BASE=https://api.webull.co.jp
+#   WEBULL_QUOTES_API_BASE=https://data-api.webull.co.jp
+#   WEBULL_EVENTS_API_BASE=https://events-api.webull.co.jp
+# のように分離する。fallback 無し (未設定なら client 生成時 throw)。
+# events は本リポジトリにまだ consumer が無いが、SDK の region 定義に存在するため
+# 将来用に declare してある (= 設定漏れを発見しやすくするため空でも書いておく)。
+WEBULL_TRADE_API_BASE=
+WEBULL_QUOTES_API_BASE=
+WEBULL_EVENTS_API_BASE=
 ALLOWED_SYMBOLS=SOXL,SOXS
 MAX_ORDER_NOTIONAL=100
 SYMBOL_MAX_NOTIONAL={"SOXL":200,"SOXS":150}
@@ -38,7 +48,7 @@ DASHBOARD_BASE_URL=
 # #257: trade/account endpoint path 上書き (optional、append at end 規約)。
 # default は旧 path (/openapi/account/*)。staging で新 path に切替えるとき
 # 設定する。値は `/` で始まる絶対パスのみ受理、空 / whitespace / 相対 URL
-# は default fallback (broken request 投げない / WEBULL_API_BASE bypass 防止)。
+# は default fallback (broken request 投げない / WEBULL_TRADE_API_BASE bypass 防止)。
 # WEBULL_PATH_POSITIONS=/openapi/assets/positions
 # WEBULL_PATH_ORDERS_HISTORY=/openapi/trade/order/history
 # WEBULL_PATH_ORDERS_PLACE=/openapi/trade/order/place

--- a/README.md
+++ b/README.md
@@ -166,7 +166,9 @@ Cron:
 |---|---|
 | `BASIC_AUTH_USER` / `BASIC_AUTH_PASSWORD` | `/trade/*` / `/webull/*` / `/admin/*` 認証 |
 | `WEBULL_APP_KEY` / `WEBULL_APP_SECRET` / `WEBULL_ACCOUNT_ID` | broker 署名・口座 |
-| `WEBULL_API_BASE` | sandbox host (非公開) |
+| `WEBULL_TRADE_API_BASE` | trade API host override (#21)。未設定なら JP prod default (`https://api.webull.co.jp`)。UAT は ALB URL を投入 |
+| `WEBULL_QUOTES_API_BASE` | quotes API host override (#21)。未設定なら JP prod default (`https://data-api.webull.co.jp`)。UAT は ALB URL を投入 |
+| `WEBULL_EVENTS_API_BASE` | events API host override (#21、consumer 未実装)。未設定なら JP prod default (`https://events-api.webull.co.jp`) |
 | `WEBULL_GRPC_ENDPOINT` | bridge の gRPC 接続先 (非公開) |
 | `EVENT_INGEST_URL` | bridge 側から叩く Worker URL (`https://.../events/trade`) |
 | `EVENT_INGEST_SECRET` | `/events/trade` header |
@@ -179,12 +181,16 @@ pnpm wrangler secret list --env=staging   # 9 件揃ったか確認
 
 ### Webull account_id を取得する
 
-Webull sandbox は dashboard で account_id を見られないので、app_key + app_secret だけで API を叩いて取得する:
+Webull sandbox は dashboard で account_id を見られないので、app_key + app_secret だけで API を叩いて取得する。host は env 未設定なら JP prod default (`api.webull.co.jp`):
 
 ```bash
 WEBULL_APP_KEY="$(op read 'op://Personal/WEBULL_APP_KEY/credential')" \
 WEBULL_APP_SECRET="$(op read 'op://Personal/WEBULL_APP_SECRET/credential')" \
-WEBULL_API_BASE=https://api.sandbox.webull.hk \
+  pnpm run accounts
+
+# UAT で叩く場合は ALB URL を override:
+WEBULL_APP_KEY=... WEBULL_APP_SECRET=... \
+WEBULL_TRADE_API_BASE=https://jp-openapi-alb.uat.webullbroker.com \
   pnpm run accounts
 ```
 

--- a/docs/env-separation.md
+++ b/docs/env-separation.md
@@ -66,7 +66,13 @@ deployed env では `ACCESS_DEV_BYPASS_USER` を絶対に投入しない (middle
 `CF_ACCESS_TEAM_DOMAIN` が立っていれば bypass を honor しないが、二重防御で
 secret 自体を投入しない運用にする)。
 
-**production の Webull credentials は staging/dev と別物にする**。staging は sandbox key (`api.sandbox.webull.hk`)、production は live key (`openapi.webull.com`)。`WEBULL_API_BASE` も env ごと別 secret として投入する事で混同を防ぐ。
+**production の Webull credentials は staging/dev と別物にする**。staging は JP UAT key (`jp-openapi-alb.uat.webullbroker.com` — ALB が trade/quotes/events を 1 ホストに束ねてる)、production は JP live key で 3 API が分離されている (下表)。env ごと別 secret として投入する事で混同を防ぐ — UAT は 3 var とも同じ ALB URL、本番は分離 URL。fallback は無いので未投入なら client 生成時 throw (#21)。
+
+| API | 本番 host | 環境変数 |
+|---|---|---|
+| trade (account / assets / orders) | `api.webull.co.jp` | `WEBULL_TRADE_API_BASE` |
+| quotes (snapshot / bars) | `data-api.webull.co.jp` | `WEBULL_QUOTES_API_BASE` |
+| events (consumer 未実装、SDK 定義のみ) | `events-api.webull.co.jp` | `WEBULL_EVENTS_API_BASE` |
 
 ### 4. DO namespace
 

--- a/docs/env-separation.md
+++ b/docs/env-separation.md
@@ -66,9 +66,11 @@ deployed env では `ACCESS_DEV_BYPASS_USER` を絶対に投入しない (middle
 `CF_ACCESS_TEAM_DOMAIN` が立っていれば bypass を honor しないが、二重防御で
 secret 自体を投入しない運用にする)。
 
-**production の Webull credentials は staging/dev と別物にする**。staging は JP UAT key (`jp-openapi-alb.uat.webullbroker.com` — ALB が trade/quotes/events を 1 ホストに束ねてる)、production は JP live key で 3 API が分離されている (下表)。env ごと別 secret として投入する事で混同を防ぐ — UAT は 3 var とも同じ ALB URL、本番は分離 URL。fallback は無いので未投入なら client 生成時 throw (#21)。
+**production の Webull credentials は staging/dev と別物にする**。staging は JP UAT key (`jp-openapi-alb.uat.webullbroker.com` — ALB が trade/quotes/events を 1 ホストに束ねてる)、production は JP live key で 3 API が分離されている (下表)。
 
-| API | 本番 host | 環境変数 |
+host 系 env var は **未設定なら JP prod default に fallback** する (値は SDK の公開 region 定義に書かれており隠す価値なし)。staging / UAT は 3 var とも ALB URL に override 必要、production は env 投入不要 (default が prod を指す)。
+
+| API | 本番 host (= default 値) | 環境変数 (override 用) |
 |---|---|---|
 | trade (account / assets / orders) | `api.webull.co.jp` | `WEBULL_TRADE_API_BASE` |
 | quotes (snapshot / bars) | `data-api.webull.co.jp` | `WEBULL_QUOTES_API_BASE` |

--- a/scripts/list-webull-accounts.ts
+++ b/scripts/list-webull-accounts.ts
@@ -1,8 +1,12 @@
 /**
  * One-off helper: fetch Webull subscriptions (account_id list) for your app.
  *
- * Usage:
- *   WEBULL_APP_KEY=... WEBULL_APP_SECRET=... WEBULL_TRADE_API_BASE=https://api.sandbox.webull.hk \
+ * Usage (defaults to JP prod host `api.webull.co.jp`):
+ *   WEBULL_APP_KEY=... WEBULL_APP_SECRET=... pnpm run accounts
+ *
+ * UAT で叩く場合は ALB URL を override:
+ *   WEBULL_APP_KEY=... WEBULL_APP_SECRET=... \
+ *     WEBULL_TRADE_API_BASE=https://jp-openapi-alb.uat.webullbroker.com \
  *     pnpm run accounts
  *
  * Copy the account_id into `.dev.vars` as WEBULL_ACCOUNT_ID.
@@ -12,22 +16,16 @@ import { createWebullHttpClient } from '../src/infrastructure/webull/WebullHttpC
 
 const appKey = process.env.WEBULL_APP_KEY
 const appSecret = process.env.WEBULL_APP_SECRET
-const apiBase = process.env.WEBULL_TRADE_API_BASE
 
 if (!appKey || !appSecret) {
   console.error('Set WEBULL_APP_KEY and WEBULL_APP_SECRET in the environment first.')
   process.exit(1)
 }
 
-if (!apiBase) {
-  console.error('Set WEBULL_TRADE_API_BASE (e.g. https://api.sandbox.webull.hk).')
-  process.exit(1)
-}
-
 const client = createWebullHttpClient({
   WEBULL_APP_KEY: appKey,
   WEBULL_APP_SECRET: appSecret,
-  WEBULL_TRADE_API_BASE: apiBase,
+  WEBULL_TRADE_API_BASE: process.env.WEBULL_TRADE_API_BASE,
 })
 
 const subscriptions = await client.listSubscriptions()

--- a/scripts/list-webull-accounts.ts
+++ b/scripts/list-webull-accounts.ts
@@ -2,7 +2,7 @@
  * One-off helper: fetch Webull subscriptions (account_id list) for your app.
  *
  * Usage:
- *   WEBULL_APP_KEY=... WEBULL_APP_SECRET=... WEBULL_API_BASE=https://api.sandbox.webull.hk \
+ *   WEBULL_APP_KEY=... WEBULL_APP_SECRET=... WEBULL_TRADE_API_BASE=https://api.sandbox.webull.hk \
  *     pnpm run accounts
  *
  * Copy the account_id into `.dev.vars` as WEBULL_ACCOUNT_ID.
@@ -12,7 +12,7 @@ import { createWebullHttpClient } from '../src/infrastructure/webull/WebullHttpC
 
 const appKey = process.env.WEBULL_APP_KEY
 const appSecret = process.env.WEBULL_APP_SECRET
-const apiBase = process.env.WEBULL_API_BASE
+const apiBase = process.env.WEBULL_TRADE_API_BASE
 
 if (!appKey || !appSecret) {
   console.error('Set WEBULL_APP_KEY and WEBULL_APP_SECRET in the environment first.')
@@ -20,14 +20,14 @@ if (!appKey || !appSecret) {
 }
 
 if (!apiBase) {
-  console.error('Set WEBULL_API_BASE (e.g. https://api.sandbox.webull.hk).')
+  console.error('Set WEBULL_TRADE_API_BASE (e.g. https://api.sandbox.webull.hk).')
   process.exit(1)
 }
 
 const client = createWebullHttpClient({
   WEBULL_APP_KEY: appKey,
   WEBULL_APP_SECRET: appSecret,
-  WEBULL_API_BASE: apiBase,
+  WEBULL_TRADE_API_BASE: apiBase,
 })
 
 const subscriptions = await client.listSubscriptions()

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -46,7 +46,7 @@ export interface Env {
   WEBULL_APP_KEY?: string
   WEBULL_APP_SECRET?: string
   WEBULL_ACCOUNT_ID_JP_CASH?: string
-  WEBULL_API_BASE?: string
+  WEBULL_TRADE_API_BASE?: string
   /** Override the snapshot endpoint path (POC: UAT 未確定なので env で差し替え). */
   WEBULL_QUOTE_PATH?: string
 }
@@ -320,7 +320,7 @@ export interface Env {
 // は末尾 append 規約)。新 OpenAPI docs (#251) で `/openapi/account/*` →
 // `/openapi/assets/positions` / `/openapi/trade/order/*` への drift。env を
 // 切替えるだけで段階移行できる。default は旧 path、未設定 / 空 / whitespace
-// のみ / `/` で始まらない値は fallback (絶対 URL 注入で WEBULL_API_BASE を
+// のみ / `/` で始まらない値は fallback (絶対 URL 注入で WEBULL_TRADE_API_BASE を
 // bypass する事故防止、CodeRabbit #264)。
 //
 //   旧                                  →  新
@@ -398,4 +398,21 @@ export interface Env {
   STATE_CHANGE_RATE_LIMIT?: RateLimit
   ADMIN_WRITE_RATE_LIMIT?: RateLimit
   DASHBOARD_RATE_LIMIT?: RateLimit
+}
+
+
+// #21: Webull JP 本番ホスト分離 (append 規約)。
+// JP 本番では 3 つの API host が分離されてる:
+//   trade  : api.webull.co.jp         → WEBULL_TRADE_API_BASE
+//   quotes : data-api.webull.co.jp    → WEBULL_QUOTES_API_BASE
+//   events : events-api.webull.co.jp  → WEBULL_EVENTS_API_BASE (consumer 未実装、reserved)
+// JP UAT (jp-openapi-alb.uat.webullbroker.com) は ALB が全部を 1 ホストに束ねて
+// ルーティングするので、UAT では 3 var とも同じ URL を入れて使う。fallback は
+// 設けない (= 未設定なら client 生成時 throw)。誤ったホストに request が流れる
+// 事故を絶対に防ぐためで、operator は本番切替時に必ず 3 つとも投入する。
+// events API は SDK の region 定義 (webull-openapi-python-sdk endpoints.json) に
+// 存在するが、本リポジトリにはまだ consumer がない。declare のみ。
+export interface Env {
+  WEBULL_QUOTES_API_BASE?: string
+  WEBULL_EVENTS_API_BASE?: string
 }

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -406,12 +406,13 @@ export interface Env {
 //   trade  : api.webull.co.jp         → WEBULL_TRADE_API_BASE
 //   quotes : data-api.webull.co.jp    → WEBULL_QUOTES_API_BASE
 //   events : events-api.webull.co.jp  → WEBULL_EVENTS_API_BASE (consumer 未実装、reserved)
-// JP UAT (jp-openapi-alb.uat.webullbroker.com) は ALB が全部を 1 ホストに束ねて
-// ルーティングするので、UAT では 3 var とも同じ URL を入れて使う。fallback は
-// 設けない (= 未設定なら client 生成時 throw)。誤ったホストに request が流れる
-// 事故を絶対に防ぐためで、operator は本番切替時に必ず 3 つとも投入する。
-// events API は SDK の region 定義 (webull-openapi-python-sdk endpoints.json) に
-// 存在するが、本リポジトリにはまだ consumer がない。declare のみ。
+// 値は SDK の公開 region 定義 (webull-openapi-python-sdk endpoints.json) に
+// 載っており隠す価値はゼロなので、各 client factory は env 未設定 / 空 /
+// whitespace のとき JP **prod** default に fallback する。env が explicit に
+// セットされてれば override (UAT / 将来 region 用)。JP UAT
+// (jp-openapi-alb.uat.webullbroker.com) は ALB が全部を 1 ホストに束ねるので、
+// UAT を叩くときは 3 var とも UAT ALB URL を override 投入する運用。
+// events API は consumer がまだ無いので declare のみ (default は引いてある)。
 export interface Env {
   WEBULL_QUOTES_API_BASE?: string
   WEBULL_EVENTS_API_BASE?: string

--- a/src/infrastructure/quotes/BarClient.ts
+++ b/src/infrastructure/quotes/BarClient.ts
@@ -48,13 +48,17 @@ export interface BarClient {
 export interface WebullBarClientEnv {
   WEBULL_APP_KEY?: string
   WEBULL_APP_SECRET?: string
-  WEBULL_API_BASE?: string
+  /**
+   * Quotes host (#21)。JP 本番では trade と分離 (`data-api.webull.co.jp`)。
+   * JP UAT (ALB) では trade と同じ URL を入れる。未設定は fail-closed で throw。
+   */
+  WEBULL_QUOTES_API_BASE?: string
   WEBULL_BARS_PATH?: string
 }
 
 interface WebullBarClientOptions {
   auth: WebullAuth
-  baseUrl?: string
+  baseUrl: string
   barsPath?: string
   timeoutMs?: number
   fetchFn?: typeof fetch
@@ -74,7 +78,7 @@ export class WebullBarClient implements BarClient {
   private readonly fetchFn: typeof fetch
 
   constructor(private readonly options: WebullBarClientOptions) {
-    this.baseUrl = (options.baseUrl ?? 'https://api.sandbox.webull.hk').replace(/\/+$/, '')
+    this.baseUrl = options.baseUrl.replace(/\/+$/, '')
     // JP UAT tenant (jp-openapi-alb.uat.webullbroker.com) only exposes the
     // v2 bars endpoint at `/openapi/market-data/stock/bars`. The Java SDK's
     // v1 `/openapi/market-data/bars` returns 404 on this tenant. See #84
@@ -162,12 +166,16 @@ export function createWebullBarClient(
   env: WebullBarClientEnv,
   options?: { fetchFn?: typeof fetch; timeoutMs?: number },
 ): WebullBarClient {
+  const baseUrl = env.WEBULL_QUOTES_API_BASE?.trim()
+  if (!baseUrl) {
+    throw new Error('WEBULL_QUOTES_API_BASE is not set')
+  }
   return new WebullBarClient({
     auth: new WebullAuth({
       appKey: env.WEBULL_APP_KEY,
       appSecret: env.WEBULL_APP_SECRET,
     }),
-    baseUrl: env.WEBULL_API_BASE,
+    baseUrl,
     barsPath: env.WEBULL_BARS_PATH,
     fetchFn: options?.fetchFn,
     timeoutMs: options?.timeoutMs,

--- a/src/infrastructure/quotes/BarClient.ts
+++ b/src/infrastructure/quotes/BarClient.ts
@@ -162,14 +162,20 @@ export class WebullBarClient implements BarClient {
   }
 }
 
+/**
+ * Webull JP **production** quotes host (#21)。SDK region=jp の公開値。
+ * UAT (1 ホスト束ね) は `WEBULL_QUOTES_API_BASE` env で override する。
+ * `WebullQuoteClient` と同じ host を共有 (quotes は単一 host)。
+ */
+const DEFAULT_QUOTES_API_BASE = 'https://data-api.webull.co.jp'
+
 export function createWebullBarClient(
   env: WebullBarClientEnv,
   options?: { fetchFn?: typeof fetch; timeoutMs?: number },
 ): WebullBarClient {
-  const baseUrl = env.WEBULL_QUOTES_API_BASE?.trim()
-  if (!baseUrl) {
-    throw new Error('WEBULL_QUOTES_API_BASE is not set')
-  }
+  // env 空 / undefined / whitespace は JP prod default。env が明示されてれば
+  // override (UAT / 将来 region 用)。
+  const baseUrl = env.WEBULL_QUOTES_API_BASE?.trim() || DEFAULT_QUOTES_API_BASE
   return new WebullBarClient({
     auth: new WebullAuth({
       appKey: env.WEBULL_APP_KEY,

--- a/src/infrastructure/quotes/BarClient.ts
+++ b/src/infrastructure/quotes/BarClient.ts
@@ -50,7 +50,9 @@ export interface WebullBarClientEnv {
   WEBULL_APP_SECRET?: string
   /**
    * Quotes host (#21)。JP 本番では trade と分離 (`data-api.webull.co.jp`)。
-   * JP UAT (ALB) では trade と同じ URL を入れる。未設定は fail-closed で throw。
+   * JP UAT (ALB) では trade と同じ URL を入れる。未設定 / 空 / whitespace なら
+   * JP prod default (`DEFAULT_QUOTES_API_BASE`) に fallback、env が explicit に
+   * セットされてれば override。
    */
   WEBULL_QUOTES_API_BASE?: string
   WEBULL_BARS_PATH?: string

--- a/src/infrastructure/quotes/WebullQuoteClient.ts
+++ b/src/infrastructure/quotes/WebullQuoteClient.ts
@@ -23,7 +23,11 @@ export interface QuoteResult {
 export interface WebullQuoteClientEnv {
   WEBULL_APP_KEY?: string
   WEBULL_APP_SECRET?: string
-  WEBULL_API_BASE?: string
+  /**
+   * Quotes host (#21)。JP 本番では trade とホストが分離 (`data-api.webull.co.jp`)。
+   * JP UAT (ALB) では trade と同じ URL を入れる。未設定は fail-closed で throw。
+   */
+  WEBULL_QUOTES_API_BASE?: string
   /**
    * Optional override for the snapshot endpoint path. Webull UAT endpoints are
    * not finalised for this POC, so the path is kept configurable per
@@ -34,7 +38,7 @@ export interface WebullQuoteClientEnv {
 
 interface WebullQuoteClientOptions {
   auth: WebullAuth
-  baseUrl?: string
+  baseUrl: string
   quotePath?: string
   timeoutMs?: number
   fetchFn?: typeof fetch
@@ -56,9 +60,10 @@ interface RawSnapshotEntry {
   ap?: number | string
 }
 
-// Confirmed working combination on the JP UAT tenant (our `WEBULL_API_BASE`
-// resolves to jp-openapi-alb.uat.webullbroker.com — not the generic
-// api.sandbox.webull.hk fallback):
+// Confirmed working combination on the JP UAT tenant (our `WEBULL_QUOTES_API_BASE`
+// resolves to jp-openapi-alb.uat.webullbroker.com — the JP UAT ALB which serves
+// trade/quotes/events from a single host; JP 本番では `data-api.webull.co.jp`
+// に分離される):
 // - path `/openapi/market-data/stock/snapshot`
 // - x-version: v2
 // - category: US_ETF / US_STOCK (underscore — matches EasyEnum.__str__ = name)
@@ -80,7 +85,7 @@ export class WebullQuoteClient {
   private readonly now: () => Date
 
   constructor(private readonly options: WebullQuoteClientOptions) {
-    this.baseUrl = (options.baseUrl ?? 'https://api.sandbox.webull.hk').replace(/\/+$/, '')
+    this.baseUrl = options.baseUrl.replace(/\/+$/, '')
     this.quotePath = options.quotePath ?? DEFAULT_QUOTE_PATH
     this.timeoutMs = options.timeoutMs ?? 5000
     // Workers の global `fetch` はメソッド呼び出し扱いで `this` を globalThis
@@ -170,12 +175,16 @@ export function createWebullQuoteClient(
   env: WebullQuoteClientEnv,
   options?: { fetchFn?: typeof fetch; timeoutMs?: number; now?: () => Date },
 ): WebullQuoteClient {
+  const baseUrl = env.WEBULL_QUOTES_API_BASE?.trim()
+  if (!baseUrl) {
+    throw new Error('WEBULL_QUOTES_API_BASE is not set')
+  }
   return new WebullQuoteClient({
     auth: new WebullAuth({
       appKey: env.WEBULL_APP_KEY,
       appSecret: env.WEBULL_APP_SECRET,
     }),
-    baseUrl: env.WEBULL_API_BASE,
+    baseUrl,
     quotePath: env.WEBULL_QUOTE_PATH,
     timeoutMs: options?.timeoutMs,
     fetchFn: options?.fetchFn,

--- a/src/infrastructure/quotes/WebullQuoteClient.ts
+++ b/src/infrastructure/quotes/WebullQuoteClient.ts
@@ -25,7 +25,9 @@ export interface WebullQuoteClientEnv {
   WEBULL_APP_SECRET?: string
   /**
    * Quotes host (#21)。JP 本番では trade とホストが分離 (`data-api.webull.co.jp`)。
-   * JP UAT (ALB) では trade と同じ URL を入れる。未設定は fail-closed で throw。
+   * JP UAT (ALB) では trade と同じ URL を入れる。未設定 / 空 / whitespace なら
+   * JP prod default (`DEFAULT_QUOTES_API_BASE`) に fallback、env が explicit に
+   * セットされてれば override。
    */
   WEBULL_QUOTES_API_BASE?: string
   /**

--- a/src/infrastructure/quotes/WebullQuoteClient.ts
+++ b/src/infrastructure/quotes/WebullQuoteClient.ts
@@ -70,6 +70,11 @@ interface RawSnapshotEntry {
 // - `extend_hour_required=false` + `overnight_required=false` REQUIRED
 //   (omitting them → 417 Expectation Failed; see probe trace in #84)
 const DEFAULT_QUOTE_PATH = '/openapi/market-data/stock/snapshot'
+/**
+ * Webull JP **production** quotes host (#21)。SDK region=jp の公開値。
+ * UAT (1 ホスト束ね) は `WEBULL_QUOTES_API_BASE` env で override する。
+ */
+const DEFAULT_QUOTES_API_BASE = 'https://data-api.webull.co.jp'
 
 /**
  * Minimal Webull market-data snapshot client. Signs requests with the same
@@ -175,10 +180,9 @@ export function createWebullQuoteClient(
   env: WebullQuoteClientEnv,
   options?: { fetchFn?: typeof fetch; timeoutMs?: number; now?: () => Date },
 ): WebullQuoteClient {
-  const baseUrl = env.WEBULL_QUOTES_API_BASE?.trim()
-  if (!baseUrl) {
-    throw new Error('WEBULL_QUOTES_API_BASE is not set')
-  }
+  // env 空 / undefined / whitespace は JP prod default。env が明示されてれば
+  // override (UAT / 将来 region 用)。
+  const baseUrl = env.WEBULL_QUOTES_API_BASE?.trim() || DEFAULT_QUOTES_API_BASE
   return new WebullQuoteClient({
     auth: new WebullAuth({
       appKey: env.WEBULL_APP_KEY,

--- a/src/infrastructure/webull/WebullHttpClient.ts
+++ b/src/infrastructure/webull/WebullHttpClient.ts
@@ -100,6 +100,13 @@ const DEFAULT_ORDERS_HISTORY_PATH = '/openapi/account/orders/history'
 const DEFAULT_ORDERS_PLACE_PATH = '/openapi/account/orders/place'
 const DEFAULT_TRADE_VERSION = 'v1'
 const DEFAULT_PLACE_ORDER_SCHEMA: PlaceOrderSchemaVersion = 'v1'
+/**
+ * Webull JP **production** trade host (#21)。値は SDK の region 定義に書かれた
+ * 公開情報なのでハードコード。UAT (`jp-openapi-alb.uat.webullbroker.com`) は
+ * 非公開なので `WEBULL_TRADE_API_BASE` env で override する運用。
+ * source: webull-openapi-python-sdk `webull/core/data/endpoints.json` region=jp。
+ */
+const DEFAULT_TRADE_API_BASE = 'https://api.webull.co.jp'
 
 export class WebullHttpClient {
   private readonly baseUrl: string
@@ -446,10 +453,9 @@ export function createWebullHttpClient(
     if (t === 'v1' || t === 'v2') return t
     return undefined
   }
-  const baseUrl = env.WEBULL_TRADE_API_BASE?.trim()
-  if (!baseUrl) {
-    throw new Error('WEBULL_TRADE_API_BASE is not set')
-  }
+  // env 空 / undefined / whitespace は JP prod default に fallback。env が
+  // 明示的にセットされてれば override (UAT / 将来 region 用)。
+  const baseUrl = env.WEBULL_TRADE_API_BASE?.trim() || DEFAULT_TRADE_API_BASE
   return new WebullHttpClient({
     auth: new WebullAuth({
       appKey: env.WEBULL_APP_KEY,

--- a/src/infrastructure/webull/WebullHttpClient.ts
+++ b/src/infrastructure/webull/WebullHttpClient.ts
@@ -17,8 +17,9 @@ export interface WebullClientEnv {
   /**
    * Webull **trade** API host (account / assets / orders)。JP 本番では
    * `api.webull.co.jp`、JP UAT では `jp-openapi-alb.uat.webullbroker.com`
-   * (ALB が trade/quotes/events を 1 ホストに束ねる)。未設定なら fail-closed
-   * で throw (#21)。
+   * (ALB が trade/quotes/events を 1 ホストに束ねる)。未設定 / 空 / whitespace
+   * なら JP prod default (`DEFAULT_TRADE_API_BASE`) に fallback、env が
+   * explicit にセットされてれば override (#21)。
    */
   WEBULL_TRADE_API_BASE?: string
   /**

--- a/src/infrastructure/webull/WebullHttpClient.ts
+++ b/src/infrastructure/webull/WebullHttpClient.ts
@@ -14,7 +14,13 @@ import { WebullAuth } from './WebullAuth'
 export interface WebullClientEnv {
   WEBULL_APP_KEY?: string
   WEBULL_APP_SECRET?: string
-  WEBULL_API_BASE?: string
+  /**
+   * Webull **trade** API host (account / assets / orders)。JP 本番では
+   * `api.webull.co.jp`、JP UAT では `jp-openapi-alb.uat.webullbroker.com`
+   * (ALB が trade/quotes/events を 1 ホストに束ねる)。未設定なら fail-closed
+   * で throw (#21)。
+   */
+  WEBULL_TRADE_API_BASE?: string
   /**
    * JP CASH account ID. On the Webull JP tenant this is a multi-currency
    * cash account that holds BOTH JPY and USD positions (the probe confirmed
@@ -67,7 +73,7 @@ interface WebullHttpClientOptions {
   auth: WebullAuth
   /** JP CASH account id — required. Receives every order (US + JP). */
   accountId?: string
-  baseUrl?: string
+  baseUrl: string
   timeoutMs?: number
   retry?: WebullRetryOptions
   fetchFn?: typeof fetch
@@ -109,7 +115,7 @@ export class WebullHttpClient {
   private readonly placeOrderSchema: PlaceOrderSchemaVersion
 
   constructor(private readonly options: WebullHttpClientOptions) {
-    this.baseUrl = (options.baseUrl ?? 'https://api.sandbox.webull.hk').replace(/\/+$/, '')
+    this.baseUrl = options.baseUrl.replace(/\/+$/, '')
     this.host = new URL(this.baseUrl).host
     this.timeoutMs = options.timeoutMs ?? 5000
     // Workers の global `fetch` はメソッド呼び出し扱いで `this` を globalThis
@@ -412,7 +418,7 @@ export function createWebullHttpClient(
   // #257: env で trade/account path を上書き可能。受理条件:
   //   - 文字列であること
   //   - trim 後が非空
-  //   - `/` で始まる絶対パス (= WEBULL_API_BASE を bypass する絶対 URL を弾く、
+  //   - `/` で始まる絶対パス (= WEBULL_TRADE_API_BASE を bypass する絶対 URL を弾く、
   //     CodeRabbit #264 finding)
   // 上記を満たさない場合は undefined を返して default path にフォールバック。
   const trim = (v: string | undefined): string | undefined => {
@@ -440,13 +446,17 @@ export function createWebullHttpClient(
     if (t === 'v1' || t === 'v2') return t
     return undefined
   }
+  const baseUrl = env.WEBULL_TRADE_API_BASE?.trim()
+  if (!baseUrl) {
+    throw new Error('WEBULL_TRADE_API_BASE is not set')
+  }
   return new WebullHttpClient({
     auth: new WebullAuth({
       appKey: env.WEBULL_APP_KEY,
       appSecret: env.WEBULL_APP_SECRET,
     }),
     accountId: env.WEBULL_ACCOUNT_ID_JP_CASH,
-    baseUrl: env.WEBULL_API_BASE,
+    baseUrl,
     timeoutMs: options?.timeoutMs,
     retry: options?.retry,
     fetchFn: options?.fetchFn,

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -480,10 +480,12 @@ export const admin = new Hono<AppBindings>()
    * status / ok / body fields null but msTaken set; response phase: error
    * null). Body is truncated to 4 kB to avoid log blowup on HTML error pages.
    *
-   * Pre-condition: `WEBULL_API_BASE` / `WEBULL_APP_KEY` / `WEBULL_APP_SECRET`
-   * / `WEBULL_ACCOUNT_ID_JP_CASH` must all be set (non-whitespace). Missing
-   * env returns `400 ValidationError` with the missing var names listed —
-   * "I forgot to set X" should never silently look like "broker rejected".
+   * Pre-condition: `WEBULL_TRADE_API_BASE` / `WEBULL_QUOTES_API_BASE` / `WEBULL_APP_KEY`
+   * / `WEBULL_APP_SECRET` / `WEBULL_ACCOUNT_ID_JP_CASH` must all be set
+   * (non-whitespace). Missing env returns `400 ValidationError` with the
+   * missing var names listed — "I forgot to set X" should never silently
+   * look like "broker rejected". JP UAT (ALB) では trade と quotes に同じ URL を
+   * 入れるが、本番は `data-api.webull.co.jp` に分離するため別 var にしてある。
    *
    * Read-only: no DO writes, no D1 writes. Safe to call from operator browser.
    */
@@ -494,29 +496,34 @@ export const admin = new Hono<AppBindings>()
     // 返却 (CodeRabbit #243 初版の auto-fix) は ambiguous (ユーザが「設定したつ
     // もり」になる) なので、設定漏れ / 半角空白だけのケースは ValidationError で
     // 400 を返す ("正規の設定" のときだけ probe を走らせる)。
-    const baseUrl = (c.env.WEBULL_API_BASE ?? '').trim()
+    const baseUrl = (c.env.WEBULL_TRADE_API_BASE ?? '').trim()
+    const quotesBaseUrl = (c.env.WEBULL_QUOTES_API_BASE ?? '').trim()
     const appKey = (c.env.WEBULL_APP_KEY ?? '').trim()
     const appSecret = (c.env.WEBULL_APP_SECRET ?? '').trim()
     const accountId = (c.env.WEBULL_ACCOUNT_ID_JP_CASH ?? '').trim()
     const missingEnv: string[] = []
-    if (baseUrl.length === 0) missingEnv.push('WEBULL_API_BASE')
+    if (baseUrl.length === 0) missingEnv.push('WEBULL_TRADE_API_BASE')
+    if (quotesBaseUrl.length === 0) missingEnv.push('WEBULL_QUOTES_API_BASE')
     if (appKey.length === 0) missingEnv.push('WEBULL_APP_KEY')
     if (appSecret.length === 0) missingEnv.push('WEBULL_APP_SECRET')
     if (accountId.length === 0) missingEnv.push('WEBULL_ACCOUNT_ID_JP_CASH')
-    // baseUrl は length > 0 でも http(s):// で parse できないと probeOnce 内の
+    // base URL は length > 0 でも http(s):// で parse できないと probeOnce 内の
     // `new URL(args.path, ${baseUrl}/)` が同期的に TypeError を吐いて 500 で
     // 落ちる。明示的に validate して 400 で返す方が運用視点で扱いやすい。
-    if (baseUrl.length > 0) {
+    const validateAbsoluteHttpUrl = (value: string, varName: string): void => {
+      if (value.length === 0) return
       let parsed: URL | null = null
       try {
-        parsed = new URL(baseUrl)
+        parsed = new URL(value)
       } catch {
         parsed = null
       }
       if (!parsed || (parsed.protocol !== 'https:' && parsed.protocol !== 'http:')) {
-        missingEnv.push('WEBULL_API_BASE (invalid: must be absolute http/https URL)')
+        missingEnv.push(`${varName} (invalid: must be absolute http/https URL)`)
       }
     }
+    validateAbsoluteHttpUrl(baseUrl, 'WEBULL_TRADE_API_BASE')
+    validateAbsoluteHttpUrl(quotesBaseUrl, 'WEBULL_QUOTES_API_BASE')
     if (missingEnv.length > 0) {
       throw new ValidationError(
         `Webull env var(s) missing or invalid: ${missingEnv.join(', ')}`,
@@ -542,8 +549,14 @@ export const admin = new Hono<AppBindings>()
       path: string
       query: Record<string, string>
       version?: string
+      /**
+       * 既定は trade host (`WEBULL_TRADE_API_BASE`)。snapshot probe は quotes host
+       * (`WEBULL_QUOTES_API_BASE`) を明示的に渡す — JP 本番では data-api 系に
+       * 分離されてるため。
+       */
+      host?: string
     }): Promise<ProbeResult> {
-      const url = new URL(args.path, `${baseUrl}/`)
+      const url = new URL(args.path, `${args.host ?? baseUrl}/`)
       for (const [k, v] of Object.entries(args.query)) url.searchParams.set(k, v)
 
       let headers: Record<string, string>
@@ -631,6 +644,9 @@ export const admin = new Hono<AppBindings>()
           overnight_required: 'false',
         },
         version: 'v2',
+        // JP 本番は trade と quotes が別ホスト (`data-api.webull.co.jp`)。
+        // JP UAT (ALB) では同じ URL が入るので no-op。
+        host: quotesBaseUrl,
       }),
       // OLD: WebullHttpClient.getPositions (現行 cron が叩く path + v1)
       probeOnce({
@@ -670,7 +686,7 @@ export const admin = new Hono<AppBindings>()
     c.header('Cache-Control', 'no-store')
     return c.json({
       timestamp: new Date().toISOString(),
-      sandbox: baseUrl,
+      sandbox: { trade: baseUrl, quotes: quotesBaseUrl },
       input: { symbol, category, accountIdConfigured: accountId.length > 0 },
       quote: quoteResult,
       // 後方互換: dashboard UI が `positions` を保有銘柄リスト描画に使うので

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -480,12 +480,12 @@ export const admin = new Hono<AppBindings>()
    * status / ok / body fields null but msTaken set; response phase: error
    * null). Body is truncated to 4 kB to avoid log blowup on HTML error pages.
    *
-   * Pre-condition: `WEBULL_TRADE_API_BASE` / `WEBULL_QUOTES_API_BASE` / `WEBULL_APP_KEY`
-   * / `WEBULL_APP_SECRET` / `WEBULL_ACCOUNT_ID_JP_CASH` must all be set
-   * (non-whitespace). Missing env returns `400 ValidationError` with the
-   * missing var names listed — "I forgot to set X" should never silently
-   * look like "broker rejected". JP UAT (ALB) では trade と quotes に同じ URL を
-   * 入れるが、本番は `data-api.webull.co.jp` に分離するため別 var にしてある。
+   * Pre-condition: `WEBULL_APP_KEY` / `WEBULL_APP_SECRET` / `WEBULL_ACCOUNT_ID_JP_CASH`
+   * must be set (non-whitespace). Missing returns `400 ValidationError` —
+   * "I forgot to set X" should never silently look like "broker rejected".
+   * `WEBULL_TRADE_API_BASE` / `WEBULL_QUOTES_API_BASE` は env 未設定なら JP
+   * prod default (`api.webull.co.jp` / `data-api.webull.co.jp`) を使う (#21)。
+   * UAT で叩く場合は env を explicit に投入する (ALB hostname を override)。
    *
    * Read-only: no DO writes, no D1 writes. Safe to call from operator browser.
    */
@@ -496,20 +496,25 @@ export const admin = new Hono<AppBindings>()
     // 返却 (CodeRabbit #243 初版の auto-fix) は ambiguous (ユーザが「設定したつ
     // もり」になる) なので、設定漏れ / 半角空白だけのケースは ValidationError で
     // 400 を返す ("正規の設定" のときだけ probe を走らせる)。
-    const baseUrl = (c.env.WEBULL_TRADE_API_BASE ?? '').trim()
-    const quotesBaseUrl = (c.env.WEBULL_QUOTES_API_BASE ?? '').trim()
+    //
+    // host 系 (WEBULL_TRADE_API_BASE / WEBULL_QUOTES_API_BASE) は env 未設定なら
+    // JP prod default (#21) を使うので missing チェック対象外。env が explicit に
+    // セットされてる時のみ URL format を validate する。
+    const tradeBaseExplicit = (c.env.WEBULL_TRADE_API_BASE ?? '').trim()
+    const quotesBaseExplicit = (c.env.WEBULL_QUOTES_API_BASE ?? '').trim()
+    const baseUrl = tradeBaseExplicit || 'https://api.webull.co.jp'
+    const quotesBaseUrl = quotesBaseExplicit || 'https://data-api.webull.co.jp'
     const appKey = (c.env.WEBULL_APP_KEY ?? '').trim()
     const appSecret = (c.env.WEBULL_APP_SECRET ?? '').trim()
     const accountId = (c.env.WEBULL_ACCOUNT_ID_JP_CASH ?? '').trim()
     const missingEnv: string[] = []
-    if (baseUrl.length === 0) missingEnv.push('WEBULL_TRADE_API_BASE')
-    if (quotesBaseUrl.length === 0) missingEnv.push('WEBULL_QUOTES_API_BASE')
     if (appKey.length === 0) missingEnv.push('WEBULL_APP_KEY')
     if (appSecret.length === 0) missingEnv.push('WEBULL_APP_SECRET')
     if (accountId.length === 0) missingEnv.push('WEBULL_ACCOUNT_ID_JP_CASH')
     // base URL は length > 0 でも http(s):// で parse できないと probeOnce 内の
     // `new URL(args.path, ${baseUrl}/)` が同期的に TypeError を吐いて 500 で
     // 落ちる。明示的に validate して 400 で返す方が運用視点で扱いやすい。
+    // env が explicit にセットされてる値だけチェック (default 値は format 保証済)。
     const validateAbsoluteHttpUrl = (value: string, varName: string): void => {
       if (value.length === 0) return
       let parsed: URL | null = null
@@ -522,8 +527,8 @@ export const admin = new Hono<AppBindings>()
         missingEnv.push(`${varName} (invalid: must be absolute http/https URL)`)
       }
     }
-    validateAbsoluteHttpUrl(baseUrl, 'WEBULL_TRADE_API_BASE')
-    validateAbsoluteHttpUrl(quotesBaseUrl, 'WEBULL_QUOTES_API_BASE')
+    validateAbsoluteHttpUrl(tradeBaseExplicit, 'WEBULL_TRADE_API_BASE')
+    validateAbsoluteHttpUrl(quotesBaseExplicit, 'WEBULL_QUOTES_API_BASE')
     if (missingEnv.length > 0) {
       throw new ValidationError(
         `Webull env var(s) missing or invalid: ${missingEnv.join(', ')}`,

--- a/test/infrastructure/quotes/webullBarClient.test.ts
+++ b/test/infrastructure/quotes/webullBarClient.test.ts
@@ -3,6 +3,7 @@ import { WebullBarClient } from '../../../src/infrastructure/quotes/BarClient'
 import { WebullAuth } from '../../../src/infrastructure/webull/WebullAuth'
 
 const baseAuth = new WebullAuth({ appKey: 'ak', appSecret: 'sk' })
+const TEST_BASE_URL = 'https://test.example'
 
 function mockJsonResponse(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), {
@@ -40,7 +41,7 @@ describe('WebullBarClient.getDailyBars', () => {
       ]),
     ) as unknown as typeof fetch
 
-    const client = new WebullBarClient({ auth: baseAuth, fetchFn })
+    const client = new WebullBarClient({ auth: baseAuth, baseUrl: TEST_BASE_URL, fetchFn })
     const bars = await client.getDailyBars('SOXL', 2)
 
     expect(bars).toHaveLength(2)
@@ -68,7 +69,7 @@ describe('WebullBarClient.getDailyBars', () => {
       return mockJsonResponse({ data: [] })
     }) as unknown as typeof fetch
 
-    const client = new WebullBarClient({ auth: baseAuth, fetchFn })
+    const client = new WebullBarClient({ auth: baseAuth, baseUrl: TEST_BASE_URL, fetchFn })
     await client.getDailyBars('SOXL', 30)
 
     expect(capturedUrl?.pathname).toBe('/openapi/market-data/stock/bars')
@@ -92,7 +93,7 @@ describe('WebullBarClient.getDailyBars', () => {
       return mockJsonResponse({ data: [] })
     }) as unknown as typeof fetch
 
-    const client = new WebullBarClient({ auth: baseAuth, fetchFn })
+    const client = new WebullBarClient({ auth: baseAuth, baseUrl: TEST_BASE_URL, fetchFn })
     await client.getDailyBars('SOXL', 1)
     await client.getDailyBars('AAPL', 1)
     await client.getDailyBars('285A', 1)
@@ -111,7 +112,7 @@ describe('WebullBarClient.getDailyBars', () => {
     }) as unknown as typeof fetch
 
     const client = new WebullBarClient({
-      auth: baseAuth,
+      auth: baseAuth, baseUrl: TEST_BASE_URL,
       fetchFn,
       barsPath: '/market-data/candles',
     })

--- a/test/infrastructure/quotes/webullQuoteClient.bidAsk.test.ts
+++ b/test/infrastructure/quotes/webullQuoteClient.bidAsk.test.ts
@@ -3,6 +3,7 @@ import { WebullQuoteClient } from '../../../src/infrastructure/quotes/WebullQuot
 import { WebullAuth } from '../../../src/infrastructure/webull/WebullAuth'
 
 const baseAuth = new WebullAuth({ appKey: 'ak', appSecret: 'sk' })
+const TEST_BASE_URL = 'https://test.example'
 
 function mockFetch(responseBody: unknown, init: ResponseInit = { status: 200 }): typeof fetch {
   const json = JSON.stringify(responseBody)
@@ -23,7 +24,7 @@ describe('WebullQuoteClient.getSnapshots bid/ask', () => {
       data: [{ symbol: 'SOXL', last_price: 10.25, bid: '10.24', ask: 10.26 }],
     })
     const client = new WebullQuoteClient({
-      auth: baseAuth,
+      auth: baseAuth, baseUrl: TEST_BASE_URL,
       fetchFn,
       now: () => new Date('2026-04-18T10:00:05.000Z'),
     })
@@ -38,7 +39,7 @@ describe('WebullQuoteClient.getSnapshots bid/ask', () => {
       data: [{ symbol: 'SOXL', last_price: 10.25, bid_price: 10.2 }],
     })
     const client = new WebullQuoteClient({
-      auth: baseAuth,
+      auth: baseAuth, baseUrl: TEST_BASE_URL,
       fetchFn,
       now: () => new Date('2026-04-18T10:00:05.000Z'),
     })
@@ -53,7 +54,7 @@ describe('WebullQuoteClient.getSnapshots bid/ask', () => {
       data: [{ symbol: 'SOXL', last_price: 10.25, bp: '10.1', ap: '10.3' }],
     })
     const client = new WebullQuoteClient({
-      auth: baseAuth,
+      auth: baseAuth, baseUrl: TEST_BASE_URL,
       fetchFn,
       now: () => new Date('2026-04-18T10:00:05.000Z'),
     })
@@ -67,7 +68,7 @@ describe('WebullQuoteClient.getSnapshots bid/ask', () => {
       data: [{ symbol: 'SOXL', last_price: 10.25 }],
     })
     const client = new WebullQuoteClient({
-      auth: baseAuth,
+      auth: baseAuth, baseUrl: TEST_BASE_URL,
       fetchFn,
       now: () => new Date('2026-04-18T10:00:05.000Z'),
     })
@@ -87,7 +88,7 @@ describe('WebullQuoteClient.getSnapshots bid/ask', () => {
       ],
     })
     const client = new WebullQuoteClient({
-      auth: baseAuth,
+      auth: baseAuth, baseUrl: TEST_BASE_URL,
       fetchFn,
       now: () => new Date('2026-04-18T10:00:05.000Z'),
     })

--- a/test/infrastructure/quotes/webullQuoteClient.test.ts
+++ b/test/infrastructure/quotes/webullQuoteClient.test.ts
@@ -6,6 +6,7 @@ import {
 import { WebullAuth } from '../../../src/infrastructure/webull/WebullAuth'
 
 const baseAuth = new WebullAuth({ appKey: 'ak', appSecret: 'sk' })
+const TEST_BASE_URL = 'https://test.example'
 
 function mockFetch(responseBody: unknown, init: ResponseInit = { status: 200 }): typeof fetch {
   const json = JSON.stringify(responseBody)
@@ -46,7 +47,7 @@ describe('WebullQuoteClient.getSnapshots', () => {
       capturedHeaders = new Headers(init?.headers)
       return new Response(JSON.stringify({ data: [] }), { status: 200 })
     }) as unknown as typeof fetch
-    const client = new WebullQuoteClient({ auth: baseAuth, fetchFn })
+    const client = new WebullQuoteClient({ auth: baseAuth, baseUrl: TEST_BASE_URL, fetchFn })
     await client.getSnapshots(['SOXL'], 'US_ETF')
     expect(capturedUrl?.pathname).toBe('/openapi/market-data/stock/snapshot')
     expect(capturedUrl?.searchParams.get('extend_hour_required')).toBe('false')
@@ -67,7 +68,7 @@ describe('WebullQuoteClient.getSnapshots', () => {
     }) as unknown as typeof fetch
     const overridePath = '/openapi/market-data/snapshot'
     const client = new WebullQuoteClient({
-      auth: baseAuth,
+      auth: baseAuth, baseUrl: TEST_BASE_URL,
       fetchFn,
       quotePath: overridePath,
     })
@@ -86,14 +87,14 @@ describe('WebullQuoteClient.getSnapshots', () => {
       expect(url.searchParams.get('category')).toBe('US_ETF')
       return new Response(JSON.stringify({ data: [] }), { status: 200 })
     }) as unknown as typeof fetch
-    const client = new WebullQuoteClient({ auth: baseAuth, fetchFn })
+    const client = new WebullQuoteClient({ auth: baseAuth, baseUrl: TEST_BASE_URL, fetchFn })
     await client.getSnapshots(['SOXL'], 'US_ETF')
     expect(fetchFn).toHaveBeenCalledTimes(1)
   })
 
   it('returns an empty array when no symbols are requested', async () => {
     const fetchFn = vi.fn() as unknown as typeof fetch
-    const client = new WebullQuoteClient({ auth: baseAuth, fetchFn })
+    const client = new WebullQuoteClient({ auth: baseAuth, baseUrl: TEST_BASE_URL, fetchFn })
     const result = await client.getSnapshots([], 'US_STOCK')
     expect(result).toEqual([])
     expect(fetchFn).not.toHaveBeenCalled()
@@ -107,7 +108,7 @@ describe('WebullQuoteClient.getSnapshots', () => {
       ],
     })
     const client = new WebullQuoteClient({
-      auth: baseAuth,
+      auth: baseAuth, baseUrl: TEST_BASE_URL,
       fetchFn,
       now: () => new Date('2026-04-18T10:00:05.000Z'),
     })
@@ -128,7 +129,7 @@ describe('WebullQuoteClient.getSnapshots', () => {
       ],
     })
     const client = new WebullQuoteClient({
-      auth: baseAuth,
+      auth: baseAuth, baseUrl: TEST_BASE_URL,
       fetchFn,
       now: () => new Date('2026-04-18T10:00:05.000Z'),
     })
@@ -138,7 +139,7 @@ describe('WebullQuoteClient.getSnapshots', () => {
 
   it('throws BrokerRequestError on non-2xx response', async () => {
     const fetchFn = mockFetch({ error: 'bad' }, { status: 500 })
-    const client = new WebullQuoteClient({ auth: baseAuth, fetchFn })
+    const client = new WebullQuoteClient({ auth: baseAuth, baseUrl: TEST_BASE_URL, fetchFn })
     await expect(client.getSnapshots(['AAPL'], 'US_STOCK')).rejects.toThrow(/status 500/)
   })
 })

--- a/test/infrastructure/webull/webullHttpClient.test.ts
+++ b/test/infrastructure/webull/webullHttpClient.test.ts
@@ -624,7 +624,7 @@ describe('WebullHttpClient', () => {
           WEBULL_APP_KEY: 'k',
           WEBULL_APP_SECRET: 's',
           WEBULL_ACCOUNT_ID_JP_CASH: 'acct',
-          WEBULL_API_BASE: 'https://broker.example.test',
+          WEBULL_TRADE_API_BASE: 'https://broker.example.test',
         },
         { fetchFn: fetchMock, retry: { maxAttempts: 1, baseDelayMs: 0, multiplier: 1, jitter: 0 } },
       )
@@ -643,7 +643,7 @@ describe('WebullHttpClient', () => {
           WEBULL_APP_KEY: 'k',
           WEBULL_APP_SECRET: 's',
           WEBULL_ACCOUNT_ID_JP_CASH: 'acct',
-          WEBULL_API_BASE: 'https://broker.example.test',
+          WEBULL_TRADE_API_BASE: 'https://broker.example.test',
           WEBULL_PATH_POSITIONS: '/openapi/assets/positions',
           WEBULL_PATH_ORDERS_HISTORY: '/openapi/trade/order/history',
           WEBULL_PATH_ORDERS_PLACE: '/openapi/trade/order/place',
@@ -659,7 +659,7 @@ describe('WebullHttpClient', () => {
     })
 
     it('rejects override values that are not absolute paths (security: prevent base URL bypass)', async () => {
-      // 絶対 URL や相対値だと WEBULL_API_BASE を bypass されるリスクがあるので、
+      // 絶対 URL や相対値だと WEBULL_TRADE_API_BASE を bypass されるリスクがあるので、
       // `/` で始まらない値は default fallback (CodeRabbit #264)。
       const fetchMock = vi.fn<typeof fetch>().mockImplementation(async () =>
         new Response(JSON.stringify([]), { status: 200 }),
@@ -669,7 +669,7 @@ describe('WebullHttpClient', () => {
           WEBULL_APP_KEY: 'k',
           WEBULL_APP_SECRET: 's',
           WEBULL_ACCOUNT_ID_JP_CASH: 'acct',
-          WEBULL_API_BASE: 'https://broker.example.test',
+          WEBULL_TRADE_API_BASE: 'https://broker.example.test',
           // 絶対 URL や 相対 path は reject されて default fallback
           WEBULL_PATH_POSITIONS: 'https://attacker.example.com/positions',
           WEBULL_PATH_ORDERS_HISTORY: 'orders/history',
@@ -691,7 +691,7 @@ describe('WebullHttpClient', () => {
           WEBULL_APP_KEY: 'k',
           WEBULL_APP_SECRET: 's',
           WEBULL_ACCOUNT_ID_JP_CASH: 'acct',
-          WEBULL_API_BASE: 'https://broker.example.test',
+          WEBULL_TRADE_API_BASE: 'https://broker.example.test',
           // 空文字 / whitespace-only は "未設定" 扱い (broken request 回避)
           WEBULL_PATH_POSITIONS: '   ',
           WEBULL_PATH_ORDERS_HISTORY: '',
@@ -716,7 +716,7 @@ describe('WebullHttpClient', () => {
           WEBULL_APP_KEY: 'k',
           WEBULL_APP_SECRET: 's',
           WEBULL_ACCOUNT_ID_JP_CASH: 'acct',
-          WEBULL_API_BASE: 'https://broker.example.test',
+          WEBULL_TRADE_API_BASE: 'https://broker.example.test',
         },
         { fetchFn: fetchMock, retry: { maxAttempts: 1, baseDelayMs: 0, multiplier: 1, jitter: 0 } },
       )
@@ -735,7 +735,7 @@ describe('WebullHttpClient', () => {
           WEBULL_APP_KEY: 'k',
           WEBULL_APP_SECRET: 's',
           WEBULL_ACCOUNT_ID_JP_CASH: 'acct',
-          WEBULL_API_BASE: 'https://broker.example.test',
+          WEBULL_TRADE_API_BASE: 'https://broker.example.test',
           WEBULL_TRADE_VERSION: 'v2',
         },
         { fetchFn: fetchMock, retry: { maxAttempts: 1, baseDelayMs: 0, multiplier: 1, jitter: 0 } },
@@ -755,7 +755,7 @@ describe('WebullHttpClient', () => {
           WEBULL_APP_KEY: 'k',
           WEBULL_APP_SECRET: 's',
           WEBULL_ACCOUNT_ID_JP_CASH: 'acct',
-          WEBULL_API_BASE: 'https://broker.example.test',
+          WEBULL_TRADE_API_BASE: 'https://broker.example.test',
           // 任意文字列 / 空 / whitespace は v1 fallback (auth signing が壊れる
           // のを防ぐ strict allow-list)
           WEBULL_TRADE_VERSION: 'v3',
@@ -783,7 +783,7 @@ describe('WebullHttpClient', () => {
           WEBULL_APP_KEY: 'k',
           WEBULL_APP_SECRET: 's',
           WEBULL_ACCOUNT_ID_JP_CASH: 'acct-1',
-          WEBULL_API_BASE: 'https://broker.example.test',
+          WEBULL_TRADE_API_BASE: 'https://broker.example.test',
         },
         { fetchFn: fetchMock, retry: { maxAttempts: 1, baseDelayMs: 0, multiplier: 1, jitter: 0 } },
       )
@@ -810,7 +810,7 @@ describe('WebullHttpClient', () => {
           WEBULL_APP_KEY: 'k',
           WEBULL_APP_SECRET: 's',
           WEBULL_ACCOUNT_ID_JP_CASH: 'acct-1',
-          WEBULL_API_BASE: 'https://broker.example.test',
+          WEBULL_TRADE_API_BASE: 'https://broker.example.test',
           WEBULL_PLACE_ORDER_SCHEMA: 'v2',
         },
         { fetchFn: fetchMock, retry: { maxAttempts: 1, baseDelayMs: 0, multiplier: 1, jitter: 0 } },
@@ -836,7 +836,7 @@ describe('WebullHttpClient', () => {
           WEBULL_APP_KEY: 'k',
           WEBULL_APP_SECRET: 's',
           WEBULL_ACCOUNT_ID_JP_CASH: 'acct-1',
-          WEBULL_API_BASE: 'https://broker.example.test',
+          WEBULL_TRADE_API_BASE: 'https://broker.example.test',
           // 任意文字列 / 空 は v1 fallback (broken body 防止)
           WEBULL_PLACE_ORDER_SCHEMA: 'v3',
         },

--- a/test/routes/trade.test.ts
+++ b/test/routes/trade.test.ts
@@ -167,7 +167,7 @@ describe('trade routes', () => {
         ...env,
         WEBULL_APP_KEY: 'app-key',
         WEBULL_APP_SECRET: 'app-secret',
-        
+        WEBULL_TRADE_API_BASE: 'https://broker.example.test',
         WEBULL_ACCOUNT_ID_JP_CASH: 'acct-jp-1',
       },
     )


### PR DESCRIPTION
## Summary
- Webull JP の OpenAPI を **trade / quotes / events** の 3 ホストに分離 (#21 follow-up)。SDK の region 定義に従い `WEBULL_TRADE_API_BASE` / `WEBULL_QUOTES_API_BASE` / `WEBULL_EVENTS_API_BASE` を追加し、JP 本番ホストを **default 値としてハードコード** (公開情報のため隠す価値なし)。env はそれぞれ override (UAT / 将来 region 用)。
- `WEBULL_API_BASE` → `WEBULL_TRADE_API_BASE` に rename (alias なし)、quotes 系 client (`WebullQuoteClient` / `WebullBarClient`) は `WEBULL_QUOTES_API_BASE` を使う。events API は SDK にあるが本リポジトリに consumer 未実装、reserved declare のみ。
- `/admin/broker/probe` を 2 host (trade / quotes) 別々に validate するように更新。

## なぜ
- JP 本番では trade / quotes / events のホストが分離されてる (`api.webull.co.jp` / `data-api.webull.co.jp` / `events-api.webull.co.jp`)。sandbox (`jp-openapi-alb.uat.webullbroker.com`) は ALB が 3 つを 1 ホストに束ねるが、本番切替時にコード側が単一 base URL 前提だと quotes が trade ホストに流れる事故が起きる
- env 必須運用は ceremony 過多なので、公開値である本番ホストを default に倒し、UAT 等の非公開 URL のみ env で override する設計に変更

## Deploy 前提 (重要)
本 PR を staging/dev へ deploy する**前**に、UAT ALB URL を 3 var とも secret 投入する必要あり (env 未設定だと default = JP prod を叩く):
\`\`\`bash
pnpm wrangler secret put WEBULL_TRADE_API_BASE   --env=staging  # https://jp-openapi-alb.uat.webullbroker.com
pnpm wrangler secret put WEBULL_QUOTES_API_BASE  --env=staging  # 同上
pnpm wrangler secret put WEBULL_EVENTS_API_BASE  --env=staging  # 同上 (consumer 未実装だが揃える)
# dev も同様
\`\`\`
本番 (production) は default が `api.webull.co.jp` 系を指すため、secret 投入不要 (旧 `WEBULL_API_BASE` が残ってる場合は `wrangler secret delete --env=production` で掃除)。

## Test plan
- [x] \`pnpm typecheck\` ✅
- [x] \`pnpm test\` (1085 tests pass) ✅
- [ ] staging deploy 後に \`/admin/broker/probe\` で trade / quotes 両方が 200 を返す事を確認 (env を ALB に向けてる事を確認)
- [ ] production deploy 後 (live trading 開始時) に \`/admin/broker/probe\` で default の prod URL に向いてる事を JSON \`sandbox.{trade,quotes}\` field から確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Webull API設定を単一エンドポイントから「トレード／クオート／イベント」の3つの個別エンドポイントに分離。環境ごとの上書きが可能に

* **ドキュメント**
  * 環境変数ガイダンスと運用説明を更新（JP prodフォールバック、UATでの上書き例、sandboxでのaccount_id取得手順を明示）

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/322?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->