### PR TITLE
feat(webull): pass x-access-token from env to support JP 2FA token flow (#21)

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -25,6 +25,15 @@ WEBULL_ACCOUNT_ID=
 # WEBULL_TRADE_API_BASE=https://jp-openapi-alb.uat.webullbroker.com
 # WEBULL_QUOTES_API_BASE=https://jp-openapi-alb.uat.webullbroker.com
 # WEBULL_EVENTS_API_BASE=https://jp-openapi-alb.uat.webullbroker.com
+
+# Webull `x-access-token` (#21、token flow 別の supplemental auth):
+#   1. operator が Webull 公式ツールで token 発行 (PENDING 初期 status)
+#   2. Webull モバイルアプリで 2FA SMS verify (5 min 以内) → NORMAL 化
+#   3. その token 値を投入 (`wrangler secret put WEBULL_ACCESS_TOKEN --env=...`)
+#   4. 15 days inactivity で INVALID → 期限切れ監視 / 再投入は別 issue
+# テスト環境は 2FA 不要で auto-NORMAL、staging では未設定でも動くケース有り。
+# prod では設定漏れ → 401 で発覚させる方針 (= fail-closed ではなく throw しない)。
+WEBULL_ACCESS_TOKEN=
 ALLOWED_SYMBOLS=SOXL,SOXS
 MAX_ORDER_NOTIONAL=100
 SYMBOL_MAX_NOTIONAL={"SOXL":200,"SOXS":150}

--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -26,14 +26,6 @@ WEBULL_ACCOUNT_ID=
 # WEBULL_QUOTES_API_BASE=https://jp-openapi-alb.uat.webullbroker.com
 # WEBULL_EVENTS_API_BASE=https://jp-openapi-alb.uat.webullbroker.com
 
-# Webull `x-access-token` (#21、token flow 別の supplemental auth):
-#   1. operator が Webull 公式ツールで token 発行 (PENDING 初期 status)
-#   2. Webull モバイルアプリで 2FA SMS verify (5 min 以内) → NORMAL 化
-#   3. その token 値を投入 (`wrangler secret put WEBULL_ACCESS_TOKEN --env=...`)
-#   4. 15 days inactivity で INVALID → 期限切れ監視 / 再投入は別 issue
-# テスト環境は 2FA 不要で auto-NORMAL、staging では未設定でも動くケース有り。
-# prod では設定漏れ → 401 で発覚させる方針 (= fail-closed ではなく throw しない)。
-WEBULL_ACCESS_TOKEN=
 ALLOWED_SYMBOLS=SOXL,SOXS
 MAX_ORDER_NOTIONAL=100
 SYMBOL_MAX_NOTIONAL={"SOXL":200,"SOXS":150}
@@ -111,3 +103,12 @@ DASHBOARD_BASE_URL=
 ACCESS_DEV_BYPASS_USER=dev@local
 # CF_ACCESS_TEAM_DOMAIN=
 # CF_ACCESS_AUD=
+
+# Webull `x-access-token` (#21、append 規約)。token flow 別の supplemental auth:
+#   1. operator が Webull 公式ツールで token 発行 (PENDING 初期 status)
+#   2. Webull モバイルアプリで 2FA SMS verify (5 min 以内) → NORMAL 化
+#   3. その token 値を投入 (`wrangler secret put WEBULL_ACCESS_TOKEN --env=...`)
+#   4. 15 days inactivity で INVALID → 期限切れ監視 / 再投入は別 issue
+# テスト環境は 2FA 不要で auto-NORMAL、staging では未設定でも動くケース有り。
+# prod では設定漏れ → 401 で発覚させる方針 (= fail-closed ではなく throw しない)。
+WEBULL_ACCESS_TOKEN=

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Cron:
 | `WEBULL_TRADE_API_BASE` | trade API host override (#21)。未設定なら JP prod default (`https://api.webull.co.jp`)。UAT は ALB URL を投入 |
 | `WEBULL_QUOTES_API_BASE` | quotes API host override (#21)。未設定なら JP prod default (`https://data-api.webull.co.jp`)。UAT は ALB URL を投入 |
 | `WEBULL_EVENTS_API_BASE` | events API host override (#21、consumer 未実装)。未設定なら JP prod default (`https://events-api.webull.co.jp`) |
+| `WEBULL_ACCESS_TOKEN` | `x-access-token` ヘッダ値 (#21)。operator が Webull 公式ツールで 2FA 経由発行した token を投入。signature とは直交する supplemental auth。15 days inactivity で INVALID 化 (再発行 / 監視は follow-up issue で扱う) |
 | `WEBULL_GRPC_ENDPOINT` | bridge の gRPC 接続先 (非公開) |
 | `EVENT_INGEST_URL` | bridge 側から叩く Worker URL (`https://.../events/trade`) |
 | `EVENT_INGEST_SECRET` | `/events/trade` header |

--- a/docs/env-separation.md
+++ b/docs/env-separation.md
@@ -76,6 +76,15 @@ host 系 env var は **未設定なら JP prod default に fallback** する (�
 | quotes (snapshot / bars) | `data-api.webull.co.jp` | `WEBULL_QUOTES_API_BASE` |
 | events (consumer 未実装、SDK 定義のみ) | `events-api.webull.co.jp` | `WEBULL_EVENTS_API_BASE` |
 
+### `x-access-token` (#21、2FA supplemental auth)
+
+signature とは直交する 2FA-backed token。`WEBULL_ACCESS_TOKEN` env var に値を入れると各 client が `x-access-token` ヘッダを request に付与する。
+
+- **取得**: operator が Webull 公式ツールで token 発行 → モバイルアプリで 2FA SMS verify (5 min 以内) → status `NORMAL` 化した token 文字列を `wrangler secret put WEBULL_ACCESS_TOKEN --env=<env>` で投入
+- **テスト環境**: 2FA 不要で auto-`NORMAL`、staging では未設定でも動く可能性あり
+- **production**: 設定漏れだと 401 で発覚する設計 (fail-closed throw ではない、broker error で気付く)
+- **inactivity 15 日**: API call が 15 日途絶えると `INVALID` 化、再 verify 必要 → 期限切れ監視 / 自動再発行は別 issue (#21 follow-up) で扱う
+
 ### 4. DO namespace
 
 `durable_objects.bindings` は `class_name` ベース。env ごとに worker name が違うので Cloudflare が自動的に別 namespace を割り当てる (`namespace_id` 手動指定不要)。データ移行 / 共有が必要になったら明示的に `script_name` を切る事を検討する (現状不要)。

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -417,3 +417,20 @@ export interface Env {
   WEBULL_QUOTES_API_BASE?: string
   WEBULL_EVENTS_API_BASE?: string
 }
+
+
+// #21: Webull `x-access-token` flow (append 規約)。
+// signature + 2FA token の hybrid auth (developer.webull.co.jp/apis/docs/authentication/token):
+//   1. operator が Webull 公式ツールで token 発行 → PENDING
+//   2. Webull モバイルアプリで 2FA SMS verify (5 min 以内) → NORMAL 化
+//   3. その token 文字列を `wrangler secret put WEBULL_ACCESS_TOKEN --env=<env>` で投入
+//   4. 各 client が `x-access-token` ヘッダで request に付ける
+// token は signature の canonical string に **含めない** (SDK / docs 通り、x-version
+// と同じく supplemental ヘッダ扱い)。15 days inactivity で INVALID 化するので、
+// 期限切れ監視 / 再投入は別 issue で扱う (#21 follow-up)。テスト環境では token
+// auto-NORMAL なので staging では未設定でも動くが、prod では設定漏れ → 401。
+// 設定漏れ自体は fail-closed ではない (= signing だけで動く path もあるかもしれない
+// ので未設定でも client は作成成功) — 401 の broker error で発覚させる方針。
+export interface Env {
+  WEBULL_ACCESS_TOKEN?: string
+}

--- a/src/infrastructure/quotes/BarClient.ts
+++ b/src/infrastructure/quotes/BarClient.ts
@@ -55,6 +55,8 @@ export interface WebullBarClientEnv {
    * セットされてれば override。
    */
   WEBULL_QUOTES_API_BASE?: string
+  /** 2FA 発行 `x-access-token` (#21)。詳細は `WebullClientEnv.WEBULL_ACCESS_TOKEN`。 */
+  WEBULL_ACCESS_TOKEN?: string
   WEBULL_BARS_PATH?: string
 }
 
@@ -182,6 +184,7 @@ export function createWebullBarClient(
     auth: new WebullAuth({
       appKey: env.WEBULL_APP_KEY,
       appSecret: env.WEBULL_APP_SECRET,
+      accessToken: env.WEBULL_ACCESS_TOKEN,
     }),
     baseUrl,
     barsPath: env.WEBULL_BARS_PATH,

--- a/src/infrastructure/quotes/WebullQuoteClient.ts
+++ b/src/infrastructure/quotes/WebullQuoteClient.ts
@@ -30,6 +30,8 @@ export interface WebullQuoteClientEnv {
    * セットされてれば override。
    */
   WEBULL_QUOTES_API_BASE?: string
+  /** 2FA 発行 `x-access-token` (#21)。詳細は `WebullClientEnv.WEBULL_ACCESS_TOKEN`。 */
+  WEBULL_ACCESS_TOKEN?: string
   /**
    * Optional override for the snapshot endpoint path. Webull UAT endpoints are
    * not finalised for this POC, so the path is kept configurable per
@@ -189,6 +191,7 @@ export function createWebullQuoteClient(
     auth: new WebullAuth({
       appKey: env.WEBULL_APP_KEY,
       appSecret: env.WEBULL_APP_SECRET,
+      accessToken: env.WEBULL_ACCESS_TOKEN,
     }),
     baseUrl,
     quotePath: env.WEBULL_QUOTE_PATH,

--- a/src/infrastructure/webull/WebullAuth.ts
+++ b/src/infrastructure/webull/WebullAuth.ts
@@ -12,6 +12,13 @@ export interface WebullAuthConfig {
   appKey?: string
   appSecret?: string
   version?: string
+  /**
+   * 2FA 経由で発行された `x-access-token` 値 (#21)。token flow は signature と
+   * 直交する supplemental auth (developer.webull.co.jp/apis/docs/authentication/token)。
+   * 設定があれば `createHeaders()` が `x-access-token` を返却 headers に乗せるが、
+   * canonical string には含めない (= 署名対象外)。
+   */
+  accessToken?: string
 }
 
 export interface BuildSignedHeadersInput {
@@ -25,6 +32,8 @@ export interface BuildSignedHeadersInput {
   nonce?: string
   timestamp?: string
   version?: string
+  /** x-access-token (#21)。signing 対象外、設定があれば返却 headers に mix。 */
+  accessToken?: string
 }
 
 interface CanonicalStringInput {
@@ -46,8 +55,9 @@ export class WebullAuth {
     nonce,
     timestamp,
     version,
+    accessToken,
   }: Omit<BuildSignedHeadersInput, 'appKey' | 'appSecret'>): Promise<Record<string, string>> {
-    const { appKey, appSecret, version: configVersion } = this.config
+    const { appKey, appSecret, version: configVersion, accessToken: configToken } = this.config
 
     if (!appKey || !appSecret) {
       throw new Error('Missing Webull credentials')
@@ -64,6 +74,7 @@ export class WebullAuth {
       nonce,
       timestamp,
       version: version ?? configVersion,
+      accessToken: accessToken ?? configToken,
     })
   }
 }
@@ -79,6 +90,7 @@ export async function buildSignedHeaders({
   nonce = crypto.randomUUID(),
   timestamp = isoTimestampNoMillis(),
   version,
+  accessToken,
 }: BuildSignedHeadersInput): Promise<Record<string, string>> {
   const normalizedMethod = method.toUpperCase()
   if (normalizedMethod !== 'GET' && normalizedMethod !== 'POST') {
@@ -107,9 +119,14 @@ export async function buildSignedHeaders({
   const encodedString = urlEncodeCanonical(stringToSign)
   const signature = await hmacSha1Base64(appSecret, encodedString)
 
+  // x-access-token は signature と同じく supplemental ヘッダ扱い (canonical
+  // string に含めない)。trim 後が空文字なら未設定として扱う = whitespace-only な
+  // secret 投入事故で「token あるつもり」になるのを防ぐ。
+  const trimmedToken = accessToken?.trim()
   return {
     ...signingHeaders,
     ...(version === undefined ? {} : { 'x-version': version }),
+    ...(trimmedToken ? { 'x-access-token': trimmedToken } : {}),
     'x-signature': signature,
   }
 }

--- a/src/infrastructure/webull/WebullHttpClient.ts
+++ b/src/infrastructure/webull/WebullHttpClient.ts
@@ -23,6 +23,12 @@ export interface WebullClientEnv {
    */
   WEBULL_TRADE_API_BASE?: string
   /**
+   * 2FA 経由で発行された `x-access-token` 値 (#21)。設定時のみ `x-access-token`
+   * ヘッダを emit、signature には含めない。未設定でも client 自体は作れる
+   * (broker 側で 401 が出れば運用時に発覚する)。
+   */
+  WEBULL_ACCESS_TOKEN?: string
+  /**
    * JP CASH account ID. On the Webull JP tenant this is a multi-currency
    * cash account that holds BOTH JPY and USD positions (the probe confirmed
    * pre-existing AAPL / NVDA / MSFT positions alongside 1570 / 7011), so
@@ -461,6 +467,7 @@ export function createWebullHttpClient(
     auth: new WebullAuth({
       appKey: env.WEBULL_APP_KEY,
       appSecret: env.WEBULL_APP_SECRET,
+      accessToken: env.WEBULL_ACCESS_TOKEN,
     }),
     accountId: env.WEBULL_ACCOUNT_ID_JP_CASH,
     baseUrl,

--- a/test/infrastructure/webull/webullAuth.test.ts
+++ b/test/infrastructure/webull/webullAuth.test.ts
@@ -79,6 +79,43 @@ describe('WebullAuth helpers', () => {
     expect(withVersion['x-signature']).toBe(withoutVersion['x-signature'])
   })
 
+  it('emits x-access-token when accessToken is set, without affecting the signature', async () => {
+    // #21: token flow is supplemental to the HMAC-SHA1 scheme — the token must
+    // ride in `x-access-token` but not enter the canonical string. Compare
+    // signatures with/without the token to lock that behaviour.
+    const common = {
+      method: 'GET' as const,
+      path: '/account/profile',
+      appKey: 'app-key',
+      appSecret: 'app-secret',
+      host: 'api.sandbox.webull.hk',
+      nonce: 'nonce-1',
+      timestamp: '2026-04-18T12:30:45Z',
+    }
+
+    const withToken = await buildSignedHeaders({ ...common, accessToken: 'tok-abc' })
+    const withoutToken = await buildSignedHeaders({ ...common })
+
+    expect(withToken['x-access-token']).toBe('tok-abc')
+    expect(withoutToken['x-access-token']).toBeUndefined()
+    expect(withToken['x-signature']).toBe(withoutToken['x-signature'])
+  })
+
+  it('treats whitespace-only accessToken as unset (avoid silent "I set it" footgun)', async () => {
+    const common = {
+      method: 'GET' as const,
+      path: '/account/profile',
+      appKey: 'app-key',
+      appSecret: 'app-secret',
+      host: 'api.sandbox.webull.hk',
+      nonce: 'nonce-1',
+      timestamp: '2026-04-18T12:30:45Z',
+    }
+
+    const result = await buildSignedHeaders({ ...common, accessToken: '   ' })
+    expect(result['x-access-token']).toBeUndefined()
+  })
+
   it('matches the HMAC-SHA1 worked example from Webull docs', async () => {
     const encodedSignString =
       '%2Ftrade%2Fplace_order%26a1%3Dwebull%26a2%3D123%26a3%3Dxxx%26host%3Dapi.webull.com%26q1%3Dyyy%26x-app-key%3D776da210ab4a452795d74e726ebd74b6%26x-signature-algorithm%3DHMAC-SHA1%26x-signature-nonce%3D48ef5afed43d4d91ae514aaeafbc29ba%26x-signature-version%3D1.0%26x-timestamp%3D2022-01-04T03%3A55%3A31Z%26E296C96787E1A309691CEF3692F5EEDD'


### PR DESCRIPTION
## Summary
- Webull の \`x-access-token\` ヘッダ (developer.webull.co.jp/apis/docs/authentication/token) を env (\`WEBULL_ACCESS_TOKEN\`) 経由で全 client request に乗せられるよう plumbing 追加 (#21 follow-up)。
- HMAC-SHA1 signature とは直交する supplemental auth として扱い、**canonical string には含めない** (SDK composer の動作 + docs 上の "supplemental scheme" 記述に一致)。
- whitespace-only な secret 投入を「未設定」扱いにする regression を test で lock。

## なぜ
- \`/authentication/signature\` は既に \`WebullAuth\` で実装済 ✅
- \`/authentication/token\` は **未実装** だった。UAT は 2FA 不要で token が auto-\`NORMAL\` 化されるため staging では signing だけで動くが、JP **本番** は 2FA 経由で取得した有効 token が必須の可能性が高い (= 401 で発覚するブロッカー候補)
- 2FA フロー本体 (token 発行 endpoint / SMS verify) は operator が Webull 公式ツールで手動実施 → 取得した \`NORMAL\` token を \`wrangler secret put WEBULL_ACCESS_TOKEN\` で投入する運用
- 本 PR は **header plumbing のみ**。発行自動化 / 期限切れ監視 (15-day inactivity) は別 issue

## 実装方針
- \`WebullAuth\` constructor / \`buildSignedHeaders\` に \`accessToken?: string\` を追加。trim 後が空ならヘッダを emit しない
- \`createWebullHttpClient\` / \`createWebullQuoteClient\` / \`createWebullBarClient\` で \`env.WEBULL_ACCESS_TOKEN\` を thread
- env 未設定でも client 自体は生成成功 (= fail-closed throw しない)。UAT/staging が signing だけで動く構造を壊さないため。本番で 401 が出たら token 未投入が原因と判定可能
- canonical string への混入を防ぐため、test fixture で \`x-signature\` が token あり/なしで一致する事を assert

## Deploy 前提
- staging: 不要 (UAT は token auto-\`NORMAL\`、未設定でも動く)
- production: live trading 開始前に Webull 公式ツールで token 取得 → \`wrangler secret put WEBULL_ACCESS_TOKEN --env=production\` で投入

## Test plan
- [x] \`pnpm typecheck\` ✅
- [x] \`pnpm test\` (1087 tests pass、新 2 件追加) ✅
- [ ] staging deploy 後の \`/admin/broker/probe\` で挙動変化なし (token 未設定で従来通り 200)
- [ ] production deploy 前に \`WEBULL_ACCESS_TOKEN\` を secret 投入し、deploy 後の probe で 401 が出ない事を確認

## 別件 follow-up (本 PR scope 外)
- **HMAC algorithm**: SDK の \`is_not_upgrade_api_host\` 判定によると JP host (\`api.webull.co.jp\` / \`jp-openapi-alb.uat.webullbroker.com\` / \`data-api.webull.co.jp\`) は **HMAC-SHA256 + SHA256 body hash** が正解で、現実装の HMAC-SHA1 + MD5 と異なる。staging は HMAC-SHA1 で動いてるが prod で 401 が出る可能性あり。確認 + 必要なら switch を別 PR で。
- **Token 期限切れ監視**: 15-day inactivity を cron + 通知で track、警告通知後に operator が再 verify する運用フローを別 issue で
- **Token 自動 refresh**: 2FA SMS が絡むため fully-automated は不可。半自動化 (token 発行 helper script + 通知連動) を別 issue で検討

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Webull向けの追加認証トークン（x-access-token）を環境変数で設定できるようになりました。未設定時は本番で401を返す設計です。
* **ドキュメント**
  * トークン発行（2FA）、投入手順、15日無操作で無効化される挙動、テスト/ステージングの注意点をREADMEと運用資料に追記しました。
* **テスト**
  * トークンの有無・空白扱いに関する振る舞いを検証する単体テストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/323?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->