### PR TITLE
feat(webull): split read / trade clients with ENVIRONMENT gate (#21)

### DIFF
--- a/scripts/list-webull-accounts.ts
+++ b/scripts/list-webull-accounts.ts
@@ -12,7 +12,7 @@
  * Copy the account_id into `.dev.vars` as WEBULL_ACCOUNT_ID.
  */
 
-import { createWebullHttpClient } from '../src/infrastructure/webull/WebullHttpClient'
+import { createWebullReadClient } from '../src/infrastructure/webull/WebullReadClient'
 
 const appKey = process.env.WEBULL_APP_KEY
 const appSecret = process.env.WEBULL_APP_SECRET
@@ -22,7 +22,7 @@ if (!appKey || !appSecret) {
   process.exit(1)
 }
 
-const client = createWebullHttpClient({
+const client = createWebullReadClient({
   WEBULL_APP_KEY: appKey,
   WEBULL_APP_SECRET: appSecret,
   WEBULL_TRADE_API_BASE: process.env.WEBULL_TRADE_API_BASE,

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -419,6 +419,23 @@ export interface Env {
 }
 
 
+// Cross-cutting: deploy 環境ラベル (append 規約)。`wrangler.jsonc::env.<env>.vars`
+// で各 env に **hardcode** される (= deploy artifact に焼き込まれる)。secret では
+// 上書きされ得るが、その時点で operator が意図してる行為とみなす (= 偶発事故
+// 防止が主目的、悪意ある書換は防げない)。`WebullTradeClient` で
+// `ENVIRONMENT === 'staging'` を検知して staging からの live order を絶対に出さ
+// ないために使う (Webull JP は 1 user = 1 app の制約で staging/prod で API key
+// 分離できないため、コード側で trade を gate する必要がある)。
+//   - dev:        'dev'        (wrangler.jsonc env.dev.vars)
+//   - staging:    'staging'    (wrangler.jsonc env.staging.vars)
+//   - production: 'production' (wrangler.jsonc env.production.vars)
+// 'production' は省略可だが、明示することで「staging gate を抜けたら本番」
+// という意図が読みやすくなる。
+export interface Env {
+  ENVIRONMENT?: string
+}
+
+
 // #21: Webull `x-access-token` flow (append 規約)。
 // signature + 2FA token の hybrid auth (developer.webull.co.jp/apis/docs/authentication/token):
 //   1. operator が Webull 公式ツールで token 発行 → PENDING

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -419,23 +419,6 @@ export interface Env {
 }
 
 
-// Cross-cutting: deploy 環境ラベル (append 規約)。`wrangler.jsonc::env.<env>.vars`
-// で各 env に **hardcode** される (= deploy artifact に焼き込まれる)。secret では
-// 上書きされ得るが、その時点で operator が意図してる行為とみなす (= 偶発事故
-// 防止が主目的、悪意ある書換は防げない)。`WebullTradeClient` で
-// `ENVIRONMENT === 'staging'` を検知して staging からの live order を絶対に出さ
-// ないために使う (Webull JP は 1 user = 1 app の制約で staging/prod で API key
-// 分離できないため、コード側で trade を gate する必要がある)。
-//   - dev:        'dev'        (wrangler.jsonc env.dev.vars)
-//   - staging:    'staging'    (wrangler.jsonc env.staging.vars)
-//   - production: 'production' (wrangler.jsonc env.production.vars)
-// 'production' は省略可だが、明示することで「staging gate を抜けたら本番」
-// という意図が読みやすくなる。
-export interface Env {
-  ENVIRONMENT?: string
-}
-
-
 // #21: Webull `x-access-token` flow (append 規約)。
 // signature + 2FA token の hybrid auth (developer.webull.co.jp/apis/docs/authentication/token):
 //   1. operator が Webull 公式ツールで token 発行 → PENDING
@@ -450,4 +433,21 @@ export interface Env {
 // ので未設定でも client は作成成功) — 401 の broker error で発覚させる方針。
 export interface Env {
   WEBULL_ACCESS_TOKEN?: string
+}
+
+
+// Cross-cutting: deploy 環境ラベル (append 規約)。`wrangler.jsonc::env.<env>.vars`
+// で各 env に **hardcode** される (= deploy artifact に焼き込まれる)。secret では
+// 上書きされ得るが、その時点で operator が意図してる行為とみなす (= 偶発事故
+// 防止が主目的、悪意ある書換は防げない)。`WebullTradeClient` で
+// `ENVIRONMENT === 'staging'` を検知して staging からの live order を絶対に出さ
+// ないために使う (Webull JP は 1 user = 1 app の制約で staging/prod で API key
+// 分離できないため、コード側で trade を gate する必要がある)。
+//   - dev:        'dev'        (wrangler.jsonc env.dev.vars)
+//   - staging:    'staging'    (wrangler.jsonc env.staging.vars)
+//   - production: 'production' (wrangler.jsonc env.production.vars)
+// 'production' は省略可だが、明示することで「staging gate を抜けたら本番」
+// という意図が読みやすくなる。
+export interface Env {
+  ENVIRONMENT?: string
 }

--- a/src/infrastructure/webull/WebullReadClient.ts
+++ b/src/infrastructure/webull/WebullReadClient.ts
@@ -1,0 +1,53 @@
+import {
+  createWebullHttpClient,
+  type WebullClientEnv,
+  type WebullHttpClient,
+} from './WebullHttpClient'
+import type {
+  WebullAccountDto,
+  WebullOrderDetailDto,
+  WebullPositionDto,
+  WebullSubscriptionDto,
+} from './dto'
+
+/**
+ * Read-only facade over {@link WebullHttpClient} (#21)。trade API への access を
+ * `WebullTradeClient` に一本化する設計の片割れで、こちらは副作用のない GET 系
+ * (positions / orders history / account profile / subscriptions) のみを expose。
+ * `placeOrder` は型レベルで触れない (= read 用途のコードが誤って write を呼ぶ
+ * 事故を防ぐ。Webull JP の 1 user = 1 app 制約で staging/prod が同じ API key を
+ * 共有するため、コード側の type system で write を gate する)。
+ */
+export class WebullReadClient {
+  constructor(private readonly http: WebullHttpClient) {}
+
+  listSubscriptions(): Promise<WebullSubscriptionDto[]> {
+    return this.http.listSubscriptions()
+  }
+
+  getAccount(): Promise<WebullAccountDto> {
+    return this.http.getAccount()
+  }
+
+  findOrderByClientId(
+    clientOrderId: string,
+    pageSize?: number,
+  ): Promise<WebullOrderDetailDto | undefined> {
+    return this.http.findOrderByClientId(clientOrderId, pageSize)
+  }
+
+  getPositions(): Promise<WebullPositionDto[]> {
+    return this.http.getPositions()
+  }
+
+  getAvailableQtyForSymbol(symbol: string): Promise<number | null> {
+    return this.http.getAvailableQtyForSymbol(symbol)
+  }
+}
+
+export function createWebullReadClient(
+  env: WebullClientEnv,
+  options?: Parameters<typeof createWebullHttpClient>[1],
+): WebullReadClient {
+  return new WebullReadClient(createWebullHttpClient(env, options))
+}

--- a/src/infrastructure/webull/WebullTradeClient.ts
+++ b/src/infrastructure/webull/WebullTradeClient.ts
@@ -1,0 +1,87 @@
+import type { OrderIntent } from '../../trading/domain/OrderIntent'
+import {
+  createWebullHttpClient,
+  type WebullClientEnv,
+  type WebullHttpClient,
+} from './WebullHttpClient'
+import type { WebullPlaceOrderResponseDto } from './dto'
+
+/**
+ * `WebullTradeClient` への入力 env (#21)。`ENVIRONMENT` が `'production'` 以外
+ * (`'staging'` / `'dev'` / undefined / 任意文字列) のとき、constructor 時点で
+ * trade を **構造的に disable** する。Webull JP は 1 user = 1 app の制約で
+ * staging/prod が同じ API key を共有するため、env 識別ラベルでコード側に gate を
+ * 入れて staging からの live order を絶対に出さない設計 (3 重防御の中核)。
+ *
+ * `ENVIRONMENT` は `wrangler.jsonc::env.<env>.vars` で deploy artifact に焼かれる。
+ * secret で override される可能性はあるが、その時点で operator の明示的な行為
+ * とみなす (= 偶発事故の防止が主目的)。
+ */
+export interface WebullTradeClientEnv extends WebullClientEnv {
+  ENVIRONMENT?: string
+}
+
+/**
+ * Thrown when `WebullTradeClient.placeOrder` is invoked in a non-production
+ * environment (staging / dev / unset). Distinct from {@link BrokerRequestError}
+ * so logs can distinguish "broker rejected the trade" from "our gate stopped
+ * the trade before it reached the broker".
+ */
+export class TradeDisabledError extends Error {
+  constructor(reason: string) {
+    super(`WebullTradeClient: placeOrder disabled — ${reason}`)
+    this.name = 'TradeDisabledError'
+  }
+}
+
+/**
+ * Write-only facade over {@link WebullHttpClient} (#21)。read 系 (`getPositions`
+ * 等) は触れない。`placeOrder` は constructor 時に判定された staging gate を経由
+ * してから broker に届く。
+ */
+export class WebullTradeClient {
+  /**
+   * Reason for blocking trades, or `null` if production. `null` 以外なら
+   * `placeOrder` は必ず `TradeDisabledError` を throw する。
+   */
+  private readonly disabledReason: string | null
+
+  constructor(
+    private readonly http: Pick<WebullHttpClient, 'placeOrder'>,
+    env: { ENVIRONMENT?: string },
+  ) {
+    const label = (env.ENVIRONMENT ?? '').trim()
+    if (label === 'production') {
+      this.disabledReason = null
+    } else if (label.length === 0) {
+      // 未設定 = wrangler.jsonc::env.<env>.vars が外れた / local dev の暴発を防ぐ。
+      // production を deploy するときは必ず 'production' が設定されてるはず。
+      this.disabledReason = 'ENVIRONMENT is not set (expected "production" for live trades)'
+    } else {
+      this.disabledReason = `ENVIRONMENT="${label}" (expected "production" for live trades)`
+    }
+  }
+
+  /** `placeOrder` を呼ばずに gate の現状を運用ログに残したいときの read 用。 */
+  get isLiveTradingEnabled(): boolean {
+    return this.disabledReason === null
+  }
+
+  async placeOrder(intent: OrderIntent): Promise<WebullPlaceOrderResponseDto> {
+    if (this.disabledReason !== null) {
+      // strategy cron は ENVIRONMENT=staging のとき MockExecution に流す path
+      // で staging を防ぐが、admin route や script から `placeOrder` が呼ばれる
+      // とその上位 gate を経由しない。ここで throw する事で「想定外の call site
+      // から live order が出る」事故を抑える。
+      throw new TradeDisabledError(this.disabledReason)
+    }
+    return this.http.placeOrder(intent)
+  }
+}
+
+export function createWebullTradeClient(
+  env: WebullTradeClientEnv,
+  options?: Parameters<typeof createWebullHttpClient>[1],
+): WebullTradeClient {
+  return new WebullTradeClient(createWebullHttpClient(env, options), env)
+}

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -4,7 +4,7 @@ import type { Context } from 'hono'
 import type { AppBindings } from '../app'
 import { rateLimit } from '../middleware/rateLimit'
 import { ValidationError } from '../shared/errors'
-import { createWebullHttpClient } from '../infrastructure/webull/WebullHttpClient'
+import { createWebullReadClient } from '../infrastructure/webull/WebullReadClient'
 import { buildSignedHeaders } from '../infrastructure/webull/WebullAuth'
 import { PortfolioStateClient } from '../trading/state/PortfolioStateClient'
 import { SymbolStateClient } from '../trading/state/SymbolStateClient'
@@ -440,7 +440,7 @@ export const admin = new Hono<AppBindings>()
       allowedSymbols = universe.allowedSymbols
     }
 
-    const webull = createWebullHttpClient(c.env)
+    const webull = createWebullReadClient(c.env)
     const positionStore = new SymbolStateClient(c.env.SYMBOL_STATE)
     const result = await syncHoldings(
       {
@@ -708,7 +708,7 @@ export const admin = new Hono<AppBindings>()
     if (clientOrderId.length === 0) {
       throw new ValidationError('clientOrderId must be non-empty', { field: 'clientOrderId' })
     }
-    const client = createWebullHttpClient(c.env)
+    const client = createWebullReadClient(c.env)
     const detail = await client.findOrderByClientId(clientOrderId)
     if (!detail) {
       return c.json({ error: 'order_not_found_in_recent_history', clientOrderId }, 404)

--- a/src/routes/trade.ts
+++ b/src/routes/trade.ts
@@ -2,7 +2,8 @@ import { Hono } from 'hono'
 import type { AppBindings } from '../app'
 import { loadGlobalConfigFrom, type LoadedGlobalConfig } from '../infrastructure/db/globalConfigLoader'
 import { loadSymbolUniverse, type SymbolUniverse } from '../infrastructure/db/symbolUniverse'
-import { createWebullHttpClient, type WebullClientEnv } from '../infrastructure/webull/WebullHttpClient'
+import type { WebullClientEnv } from '../infrastructure/webull/WebullHttpClient'
+import { createWebullTradeClient } from '../infrastructure/webull/WebullTradeClient'
 import { ValidationError } from '../shared/errors'
 import { TradingService, type TradingConfig } from '../trading/application/TradingService'
 import { MockExecution } from '../trading/execution/MockExecution'
@@ -79,13 +80,14 @@ export function createTradingService(
   env: {
     SYMBOL_STATE?: DurableObjectNamespace<SymbolStateDO>
     PORTFOLIO_STATE?: DurableObjectNamespace<PortfolioStateDO>
+    ENVIRONMENT?: string
   } & WebullClientEnv,
   universe: SymbolUniverse,
   global: LoadedGlobalConfig,
 ): TradingService {
   const execution = global.dryRun
     ? new MockExecution()
-    : new WebullExecution(createWebullHttpClient(env))
+    : new WebullExecution(createWebullTradeClient(env))
 
   return new TradingService(
     new FixedRuleStrategy(request.buyBelow, request.sellAbove),

--- a/src/trading/execution/WebullExecution.ts
+++ b/src/trading/execution/WebullExecution.ts
@@ -1,12 +1,15 @@
 import { toExecutionResult } from '../../infrastructure/webull/mapper'
-import type { WebullHttpClient } from '../../infrastructure/webull/WebullHttpClient'
+import type { WebullTradeClient } from '../../infrastructure/webull/WebullTradeClient'
 import { BrokerRequestError } from '../../shared/errors'
 import type { ExecutionResult } from '../domain/ExecutionResult'
 import type { OrderIntent } from '../domain/OrderIntent'
 import type { Execution } from './Execution'
 
 export class WebullExecution implements Execution {
-  constructor(private readonly client: Pick<WebullHttpClient, 'placeOrder'>) {}
+  // #21: `WebullTradeClient` 経由でしか trade API に触れない。staging からの
+  // 誤発注は client constructor で disable されているため、ここに来た時点で
+  // production deploy + ENVIRONMENT=production の不変条件が満たされている。
+  constructor(private readonly client: Pick<WebullTradeClient, 'placeOrder'>) {}
 
   async execute(intent: OrderIntent): Promise<ExecutionResult> {
     try {

--- a/src/trading/execution/WebullExecution.ts
+++ b/src/trading/execution/WebullExecution.ts
@@ -1,5 +1,8 @@
 import { toExecutionResult } from '../../infrastructure/webull/mapper'
-import type { WebullTradeClient } from '../../infrastructure/webull/WebullTradeClient'
+import {
+  TradeDisabledError,
+  type WebullTradeClient,
+} from '../../infrastructure/webull/WebullTradeClient'
 import { BrokerRequestError } from '../../shared/errors'
 import type { ExecutionResult } from '../domain/ExecutionResult'
 import type { OrderIntent } from '../domain/OrderIntent'
@@ -19,7 +22,10 @@ export class WebullExecution implements Execution {
       // Preserve the upstream broker error when it's already a
       // BrokerRequestError (status + class). Rethrow as-is so callers see
       // the real 4xx/5xx status classification from brokerErrorForStatus.
-      if (error instanceof BrokerRequestError) {
+      // TradeDisabledError は broker に到達してない (= ENVIRONMENT gate で止めた)
+      // 状態を表すので、broker error として log に乗ると "broker rejected" と誤読
+      // される。原クラスのまま再送出して両者を分離する。
+      if (error instanceof BrokerRequestError || error instanceof TradeDisabledError) {
         throw error
       }
       const detail = error instanceof Error ? error.message : String(error)

--- a/src/trading/reconciliation/reconcileFills.ts
+++ b/src/trading/reconciliation/reconcileFills.ts
@@ -3,7 +3,7 @@ import { alias } from 'drizzle-orm/sqlite-core'
 import type { Env } from '../../config/env'
 import { createDb } from '../../infrastructure/db/tradeJournalRepo'
 import { tradeJournal } from '../../infrastructure/db/schema'
-import { createWebullHttpClient } from '../../infrastructure/webull/WebullHttpClient'
+import { createWebullReadClient } from '../../infrastructure/webull/WebullReadClient'
 import type { WebullOrderDetailDto } from '../../infrastructure/webull/dto'
 import { inferWebullMarket } from '../../infrastructure/webull/mapper'
 import { inferTradingMarket, nextTradingDay } from '../domain/tradingCalendar'
@@ -264,7 +264,7 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
   if (uniqueCandidates.length === 0) return summary
 
   summary.inspected = uniqueCandidates.length
-  const client = createWebullHttpClient(options.env)
+  const client = createWebullReadClient(options.env)
 
   for (const row of uniqueCandidates) {
     const coid = row.clientOrderId

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -10,7 +10,8 @@ import {
 } from '../../infrastructure/notification/configStateChange'
 import { createNotifier } from '../../infrastructure/notification/createNotifier'
 import type { Notifier } from '../../infrastructure/notification/Notifier'
-import { createWebullHttpClient } from '../../infrastructure/webull/WebullHttpClient'
+import { createWebullReadClient } from '../../infrastructure/webull/WebullReadClient'
+import { createWebullTradeClient } from '../../infrastructure/webull/WebullTradeClient'
 import { MockExecution } from '../execution/MockExecution'
 import { WebullExecution } from '../execution/WebullExecution'
 import { PortfolioStateClient } from '../state/PortfolioStateClient'
@@ -443,12 +444,13 @@ export async function runStrategyCron(
   const scaledRiskPerTradePct = global.riskBasePerTradePct * ddScale.scale
 
   const positionStore = new SymbolStateClient(env.SYMBOL_STATE)
-  // Single Webull client instance shared between WebullExecution (order
-  // submit) and the SELL_QTY_EXCEED fallback (positions read). DRY_RUN
-  // path constructs nothing live — fallback resolver is also undefined so
-  // MockExecution can never trip the fallback retry path.
-  const liveWebullClient = global.dryRun ? null : createWebullHttpClient(env)
-  const execution = liveWebullClient ? new WebullExecution(liveWebullClient) : new MockExecution()
+  // #21: trade と read を別 client に分離。WebullTradeClient は ENVIRONMENT
+  // で staging gate を持つ (= staging からの live order を構造的に防ぐ)。
+  // DRY_RUN path では両方 null、MockExecution が選ばれ fallback resolver も
+  // 未注入なので read 側も触れない。
+  const liveTradeClient = global.dryRun ? null : createWebullTradeClient(env)
+  const liveReadClient = global.dryRun ? null : createWebullReadClient(env)
+  const execution = liveTradeClient ? new WebullExecution(liveTradeClient) : new MockExecution()
   // notifier は関数冒頭で組み立て済み (#141)。BUY/SELL emit / per-symbol
   // bar fetch error / broker submit error は scheduler 内で注入された
   // notifier を使う (#199 経路のまま)。
@@ -586,11 +588,11 @@ export async function runStrategyCron(
       // (`WebullHttpClient.getAvailableQtyForSymbol`) に閉じている。
       // resolver 側で例外を握り潰さず、scheduler 側 (`tryFallbackSell`) が
       // null fallback して元の SELL_QTY_EXCEED エラーを再 throw する。
-      ...(liveWebullClient
+      ...(liveReadClient
         ? {
             sellFallback: {
               getAvailableQty: (symbol: string) =>
-                liveWebullClient.getAvailableQtyForSymbol(symbol),
+                liveReadClient.getAvailableQtyForSymbol(symbol),
             },
           }
         : {}),

--- a/test/infrastructure/webull/webullReadClient.test.ts
+++ b/test/infrastructure/webull/webullReadClient.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest'
+import { WebullReadClient } from '../../../src/infrastructure/webull/WebullReadClient'
+import type {
+  WebullAccountDto,
+  WebullPositionDto,
+} from '../../../src/infrastructure/webull/dto'
+
+describe('WebullReadClient', () => {
+  // #21: read facade は HTTP client への単純な passthrough。重要なのは
+  // **write メソッドが型にも実装にも存在しない** こと。コードレビューで
+  // この test を見て「placeOrder が無い」が一目で分かるよう、明示的に確認。
+  it('exposes only the read methods and does not expose placeOrder', () => {
+    const dummy = {
+      listSubscriptions: vi.fn(),
+      getAccount: vi.fn(),
+      findOrderByClientId: vi.fn(),
+      getPositions: vi.fn(),
+      getAvailableQtyForSymbol: vi.fn(),
+    }
+    const client = new WebullReadClient(
+      dummy as unknown as ConstructorParameters<typeof WebullReadClient>[0],
+    )
+
+    expect(typeof client.listSubscriptions).toBe('function')
+    expect(typeof client.getAccount).toBe('function')
+    expect(typeof client.findOrderByClientId).toBe('function')
+    expect(typeof client.getPositions).toBe('function')
+    expect(typeof client.getAvailableQtyForSymbol).toBe('function')
+
+    expect('placeOrder' in client).toBe(false)
+  })
+
+  // Forwarding sanity: getPositions must hit the underlying client. Without
+  // this the facade could be a no-op and tests of consumers would still pass
+  // against mocks.
+  it('forwards getPositions to the underlying http client', async () => {
+    const positions: WebullPositionDto[] = [
+      { symbol: 'AAPL', available_quantity: '5' } as WebullPositionDto,
+    ]
+    const dummy = {
+      listSubscriptions: vi.fn(),
+      getAccount: vi.fn(),
+      findOrderByClientId: vi.fn(),
+      getPositions: vi.fn(async () => positions),
+      getAvailableQtyForSymbol: vi.fn(),
+    }
+    const client = new WebullReadClient(
+      dummy as unknown as ConstructorParameters<typeof WebullReadClient>[0],
+    )
+
+    const result = await client.getPositions()
+    expect(result).toBe(positions)
+    expect(dummy.getPositions).toHaveBeenCalledTimes(1)
+  })
+
+  it('forwards getAccount to the underlying http client', async () => {
+    const account: WebullAccountDto = { account_id: 'acct-1' } as WebullAccountDto
+    const dummy = {
+      listSubscriptions: vi.fn(),
+      getAccount: vi.fn(async () => account),
+      findOrderByClientId: vi.fn(),
+      getPositions: vi.fn(),
+      getAvailableQtyForSymbol: vi.fn(),
+    }
+    const client = new WebullReadClient(
+      dummy as unknown as ConstructorParameters<typeof WebullReadClient>[0],
+    )
+
+    const result = await client.getAccount()
+    expect(result).toBe(account)
+    expect(dummy.getAccount).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/infrastructure/webull/webullTradeClient.test.ts
+++ b/test/infrastructure/webull/webullTradeClient.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  TradeDisabledError,
+  WebullTradeClient,
+} from '../../../src/infrastructure/webull/WebullTradeClient'
+import type { OrderIntent } from '../../../src/trading/domain/OrderIntent'
+import type { WebullPlaceOrderResponseDto } from '../../../src/infrastructure/webull/dto'
+
+const intent: OrderIntent = {
+  symbol: 'AAPL',
+  side: 'BUY',
+  quantity: 1,
+  price: 200,
+  notional: 200,
+  clientOrderId: 'test-coid-1',
+}
+
+const okResponse: WebullPlaceOrderResponseDto = { order_id: 'ord-1' }
+
+function fakeHttp(): { placeOrder: ReturnType<typeof vi.fn> } {
+  return { placeOrder: vi.fn(async () => okResponse) }
+}
+
+describe('WebullTradeClient', () => {
+  // #21: live trade を produce してよいのは ENVIRONMENT='production' のときだけ。
+  // wrangler.jsonc::env.production.vars でハードコードされている前提。
+  it('forwards placeOrder to the underlying client when ENVIRONMENT="production"', async () => {
+    const http = fakeHttp()
+    const client = new WebullTradeClient(http, { ENVIRONMENT: 'production' })
+    expect(client.isLiveTradingEnabled).toBe(true)
+
+    const result = await client.placeOrder(intent)
+
+    expect(result).toEqual(okResponse)
+    expect(http.placeOrder).toHaveBeenCalledTimes(1)
+    expect(http.placeOrder).toHaveBeenCalledWith(intent)
+  })
+
+  // staging / dev / unset / 任意文字列 → すべて fail-safe で reject。
+  // Webull JP は 1 user = 1 app なので staging と production で同じ API key を
+  // 共有する。コード側で broker に届く前に止めるのが防御の最後の砦。
+  it.each([
+    ['staging', 'staging'],
+    ['dev', 'dev'],
+    ['undefined', undefined],
+    ['empty', ''],
+    ['whitespace-only', '   '],
+    ['unexpected-value', 'preview'],
+  ])(
+    'rejects placeOrder with TradeDisabledError when ENVIRONMENT is %s',
+    async (_label, value) => {
+      const http = fakeHttp()
+      const client = new WebullTradeClient(http, { ENVIRONMENT: value })
+      expect(client.isLiveTradingEnabled).toBe(false)
+
+      await expect(client.placeOrder(intent)).rejects.toBeInstanceOf(TradeDisabledError)
+      // The underlying http.placeOrder must NEVER be called — that's the whole
+      // point of this gate. Verifying it stays at zero is the load-bearing
+      // assertion of this test file.
+      expect(http.placeOrder).not.toHaveBeenCalled()
+    },
+  )
+
+  it('TradeDisabledError messages include the offending ENVIRONMENT for log clarity', async () => {
+    const http = fakeHttp()
+    const client = new WebullTradeClient(http, { ENVIRONMENT: 'staging' })
+
+    await expect(client.placeOrder(intent)).rejects.toThrow(/staging/)
+  })
+
+  it('treats whitespace-only ENVIRONMENT as unset (does not interpret as "production")', async () => {
+    // operator が wrangler.jsonc を空文字で上書き / secret で whitespace を入れた
+    // などのエッジで本番扱いされない事を locked。
+    const http = fakeHttp()
+    const client = new WebullTradeClient(http, { ENVIRONMENT: '  production  ' })
+    // 注意: trim 後の比較で 'production' と一致するので live を許可する。これは
+    // wrangler secret put で誤って前後 space を入れた事故をフォローする意図。
+    expect(client.isLiveTradingEnabled).toBe(true)
+
+    await client.placeOrder(intent)
+    expect(http.placeOrder).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/routes/trade.test.ts
+++ b/test/routes/trade.test.ts
@@ -165,6 +165,9 @@ describe('trade routes', () => {
       },
       {
         ...env,
+        // #21: WebullTradeClient は ENVIRONMENT='production' 以外を fail-safe
+        // で拒否する。LIVE 経路の test ではこのラベルが必須。
+        ENVIRONMENT: 'production',
         WEBULL_APP_KEY: 'app-key',
         WEBULL_APP_SECRET: 'app-secret',
         WEBULL_TRADE_API_BASE: 'https://broker.example.test',

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -58,6 +58,11 @@
     // --env still uses the top-level config (local miniflare + local SQLite).
     "dev": {
       "name": "webull-trading-dev",
+      "vars": {
+        // #21: live trade を gate するため env を識別するラベル。`WebullTradeClient`
+        // が `ENVIRONMENT !== 'production'` のとき placeOrder を throw する。
+        "ENVIRONMENT": "dev"
+      },
       "durable_objects": {
         "bindings": [
           { "name": "SYMBOL_STATE", "class_name": "SymbolStateDO" },
@@ -99,6 +104,13 @@
     },
     "staging": {
       "name": "webull-trading-staging",
+      "vars": {
+        // #21: live trade を gate するため env を識別するラベル。Webull JP は
+        // 1 user = 1 app の制約で staging/prod で API key 分離できないため、コード
+        // 側で staging からの live order を絶対に止める。`WebullTradeClient` が
+        // 'staging' を検知すると placeOrder で throw。
+        "ENVIRONMENT": "staging"
+      },
       "routes": [
         { "pattern": "trading-staging.chanu.co", "custom_domain": true }
       ],
@@ -143,6 +155,11 @@
     },
     "production": {
       "name": "webull-trading-production",
+      "vars": {
+        // #21: `WebullTradeClient` の trade gate を通すラベル。'production' のときだけ
+        // placeOrder が実行可能。他の値 (staging / dev / 未設定) は強制 DRY_RUN。
+        "ENVIRONMENT": "production"
+      },
       "routes": [
         { "pattern": "trading.chanu.co", "custom_domain": true }
       ],


### PR DESCRIPTION
## Summary
- Webull JP の **1 user = 1 app 制約** で staging / production が同じ API key を共有する状況に対応。trade API への access を **`WebullTradeClient` 経由のみに型レベルで強制** し、`ENVIRONMENT === 'production'` のときだけ `placeOrder` を許可 (fail-safe gate)。
- `WebullHttpClient` を 2 つの facade に分割:
  - `WebullReadClient` — positions / orders history / account profile / subscriptions / availableQtyForSymbol (副作用なし)
  - `WebullTradeClient` — placeOrder のみ + `TradeDisabledError` で staging からの呼び出しを reject
- `wrangler.jsonc::env.<env>.vars.ENVIRONMENT` を **deploy artifact に hardcode** (dev / staging / production)。secret で上書き可能だが、その時点で operator の明示行為とみなす (= 偶発事故防止が主目的)。

## なぜ
Webull JP は 1 user = 1 OpenAPI app しか作れず、scope (trade + quotes) も固定で複数 app 作成不可。staging / dev / production の API key が同じになるため、code 側で安全策を入れる必要がある。

これまでの DRY_RUN / TRADING_ENABLED は env / secret 経由なので、operator が staging に間違って \`DRY_RUN=false\` を投入したら即発注リスクだった。今 PR の \`WebullTradeClient\` は **型 + 実装 + deploy artifact** の 3 重防御で「staging が live order を出す」事故を構造的に防ぐ。

## 設計哲学: fail-safe (フェイルセーフ)
- ENVIRONMENT が misconfig / unset → \`placeOrder\` は throw、取引止まる
- 取引止まる損失は限定的・回復可能 (5min cron 1 回 skip → 再 deploy で復旧)
- 誤発注の損失は永続的 (実マネー流出 / reversal 不能 / 法務リスク)
- 非対称リスクには「安全側に倒す」(CLAUDE.md 方針)

## 変更ファイル
- 新規: \`src/infrastructure/webull/WebullReadClient.ts\` / \`src/infrastructure/webull/WebullTradeClient.ts\`
- 新規 test: \`test/infrastructure/webull/webullReadClient.test.ts\` (3 件) / \`test/infrastructure/webull/webullTradeClient.test.ts\` (9 件)
- \`src/config/env.ts\` — \`ENVIRONMENT?: string\` declare (末尾 append)
- \`wrangler.jsonc\` — \`env.dev/staging/production.vars.ENVIRONMENT\` を hardcode
- \`src/trading/execution/WebullExecution.ts\` — \`WebullTradeClient\` を受け取る
- 5 caller の書き換え:
  - \`src/routes/admin.ts\` — \`createWebullReadClient\` (probe + orders/:clientOrderId, どちらも read)
  - \`src/routes/trade.ts\` — \`createWebullTradeClient\` (LIVE 経路)
  - \`src/trading/strategy/runStrategyCron.ts\` — trade + read 両方 (LIVE 経路の placeOrder + SELL_QTY_EXCEED fallback の read)
  - \`src/trading/reconciliation/reconcileFills.ts\` — \`createWebullReadClient\`
  - \`scripts/list-webull-accounts.ts\` — \`createWebullReadClient\`
- \`test/routes/trade.test.ts\` — LIVE 経路 test に \`ENVIRONMENT: 'production'\` を明示

## Deploy 前提
- staging / dev: 何もしなくて OK (\`wrangler.jsonc::env.staging.vars.ENVIRONMENT = "staging"\` が deploy artifact に焼かれる → \`WebullTradeClient\` が staging gate を有効化)
- production: 同じく \`env.production.vars.ENVIRONMENT = "production"\` が焼かれる → trade gate 解除

## Test plan
- [x] \`pnpm typecheck\` ✅
- [x] \`pnpm test\` 1099 tests pass (新規 12 件) ✅
- [ ] staging deploy 後に \`/admin/broker/probe\` で従来通り 200 が返る (read 経路は不変)
- [ ] staging で \`/trade/execute\` を叩いて \`TradeDisabledError\` で reject される事を確認 (= staging gate が効いてる証明)
- [ ] production deploy 前に \`/admin/broker/probe\` で trade host を確認、production deploy 後に同 probe で live 経路が動く

## scope 外 (follow-up)
- HMAC algorithm (SHA1 vs SHA256) の本番確認
- Token 15-day inactivity 監視
- ENVIRONMENT unset を staging 扱いにする「いっそ unset = safer」の選択 (現状は unset = throw、これは最も保守的)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 本番環境のみで実行される取引の有効化制御を導入（非本番環境では発注を拒否）

* **改善**
  * 読取操作と取引操作を明確に分離し、読み取り系の処理は読み取り専用経路で実行
  * 運用環境ラベル（ENVIRONMENT）により環境ごとの挙動を明確化

* **テスト**
  * 読取／取引それぞれの挙動を検証するテストを追加

* **雑務**
  * デプロイ設定に環境ラベルを追加

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/324?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->