### PR TITLE
feat(webull): operator-driven x-access-token issuance (#21 Phase A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Cron:
 | `WEBULL_TRADE_API_BASE` | trade API host override (#21)。未設定なら JP prod default (`https://api.webull.co.jp`)。UAT は ALB URL を投入 |
 | `WEBULL_QUOTES_API_BASE` | quotes API host override (#21)。未設定なら JP prod default (`https://data-api.webull.co.jp`)。UAT は ALB URL を投入 |
 | `WEBULL_EVENTS_API_BASE` | events API host override (#21、consumer 未実装)。未設定なら JP prod default (`https://events-api.webull.co.jp`) |
-| `WEBULL_ACCESS_TOKEN` | `x-access-token` ヘッダ値 (#21)。operator が Webull 公式ツールで 2FA 経由発行した token を投入。signature とは直交する supplemental auth。15 days inactivity で INVALID 化 (再発行 / 監視は follow-up issue で扱う) |
+| `WEBULL_ACCESS_TOKEN` | `x-access-token` ヘッダ値 (#21)。signature とは直交する supplemental auth、JP 本番では必須。`pnpm run issue-token` で発行 + 2FA verify して取得する (下記参照)。15 days inactivity で INVALID 化 (自動 refresh は #21 Phase B で扱う) |
 | `WEBULL_GRPC_ENDPOINT` | bridge の gRPC 接続先 (非公開) |
 | `EVENT_INGEST_URL` | bridge 側から叩く Worker URL (`https://.../events/trade`) |
 | `EVENT_INGEST_SECRET` | `/events/trade` header |
@@ -194,6 +194,32 @@ WEBULL_APP_KEY=... WEBULL_APP_SECRET=... \
 WEBULL_TRADE_API_BASE=https://jp-openapi-alb.uat.webullbroker.com \
   pnpm run accounts
 ```
+
+### Webull `x-access-token` を発行する (#21)
+
+JP 本番では signature に加えて 2FA-backed `x-access-token` が必須。`pnpm run issue-token` が `/openapi/auth/token/create` を叩いて PENDING token を発行し、operator が Webull モバイルアプリで 2FA SMS verify を完了するのを poll で待ち、NORMAL になった token を stdout に出力する。
+
+```bash
+# 1. Operator script を起動
+WEBULL_APP_KEY="$(op read 'op://Personal/WEBULL_APP_KEY/credential')" \
+WEBULL_APP_SECRET="$(op read 'op://Personal/WEBULL_APP_SECRET/credential')" \
+  pnpm run issue-token
+
+# 2. ログに表示された PENDING token を確認し、Webull モバイルアプリで 5 分以内に
+#    2FA SMS verify を完了する。script は 30 秒毎に check_token を poll する。
+
+# 3. status=NORMAL になると stdout に token 文字列だけが出力されるので、
+#    そのまま wrangler に流し込める:
+pnpm wrangler secret put WEBULL_ACCESS_TOKEN --env=production
+# (上で出力された token 文字列を貼り付ける)
+
+# refresh (既存 token を引き継いで更新したい場合):
+WEBULL_APP_KEY=... WEBULL_APP_SECRET=... \
+WEBULL_EXISTING_TOKEN=<old token> \
+  pnpm run issue-token
+```
+
+15 days inactivity で `INVALID` 化する。手動再発行は同じ手順、自動 refresh は #21 Phase B (DO ベース) で扱う。
 
 ## D1 セットアップ (初回のみ)
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
-    "accounts": "tsx scripts/list-webull-accounts.ts"
+    "accounts": "tsx scripts/list-webull-accounts.ts",
+    "issue-token": "tsx scripts/issue-webull-token.ts"
   },
   "dependencies": {
     "drizzle-orm": "^0.45.2",

--- a/scripts/issue-webull-token.ts
+++ b/scripts/issue-webull-token.ts
@@ -1,0 +1,129 @@
+/**
+ * Operator-driven `x-access-token` 取得 script (#21 Phase A)。
+ *
+ * Webull JP の本番 OpenAPI endpoint は signature + 2FA-backed token の hybrid
+ * auth を要求する。token は dev portal の UI から取れず、API 経由でのみ発行
+ * できるため、本 script で取得して `wrangler secret put` で投入する運用。
+ *
+ * Usage:
+ *   pnpm run issue-token
+ *
+ * 必要な env:
+ *   WEBULL_APP_KEY=<app key>
+ *   WEBULL_APP_SECRET=<app secret>
+ *   (optional) WEBULL_TRADE_API_BASE=<UAT ALB URL>  ※ 未設定なら本番 host
+ *   (optional) WEBULL_EXISTING_TOKEN=<previous token to refresh>
+ *
+ * 流れ:
+ *   1. POST /openapi/auth/token/create — PENDING token を取得
+ *   2. operator が Webull モバイルアプリで 5 分以内に 2FA SMS verify
+ *   3. POST /openapi/auth/token/check を 30s 毎に poll、status が NORMAL に
+ *      なったら確定
+ *   4. 取得 token を console に表示 + `wrangler secret put` コマンドを suggest
+ */
+
+import { WebullAuth } from '../src/infrastructure/webull/WebullAuth'
+import {
+  WebullTokenClient,
+  type WebullAccessTokenDto,
+} from '../src/infrastructure/webull/WebullTokenClient'
+
+const DEFAULT_BASE_URL = 'https://api.webull.co.jp'
+const POLL_INTERVAL_MS = 30_000
+const POLL_TIMEOUT_MS = 5 * 60_000
+
+const appKey = process.env.WEBULL_APP_KEY
+const appSecret = process.env.WEBULL_APP_SECRET
+const baseUrl = process.env.WEBULL_TRADE_API_BASE?.trim() || DEFAULT_BASE_URL
+const existingToken = process.env.WEBULL_EXISTING_TOKEN?.trim() || undefined
+
+if (!appKey || !appSecret) {
+  console.error('Set WEBULL_APP_KEY and WEBULL_APP_SECRET in the environment first.')
+  process.exit(1)
+}
+
+function summarize(token: WebullAccessTokenDto): string {
+  // Show only the head + tail of the token so operator can correlate without
+  // accidentally pasting the secret into chat / screenshots.
+  const head = token.token.slice(0, 6)
+  const tail = token.token.slice(-4)
+  return `${head}...${tail} (expires=${token.expires}, status=${token.status})`
+}
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function main(): Promise<void> {
+  console.error(`[issue-token] base URL: ${baseUrl}`)
+  if (existingToken) {
+    console.error('[issue-token] refreshing existing token via WEBULL_EXISTING_TOKEN.')
+  }
+
+  const auth = new WebullAuth({ appKey, appSecret })
+  const client = new WebullTokenClient({ auth, baseUrl })
+
+  console.error('[issue-token] step 1/3: POST /openapi/auth/token/create')
+  const initial = await client.createToken(existingToken)
+  console.error(`[issue-token] received: ${summarize(initial)}`)
+
+  if (initial.status === 'NORMAL') {
+    // Test env (UAT) は 2FA 不要で auto-NORMAL なケースがある。即時利用可。
+    printResult(initial)
+    return
+  }
+
+  if (initial.status === 'INVALID' || initial.status === 'EXPIRED') {
+    console.error(`[issue-token] token returned with terminal status ${initial.status}. Aborting.`)
+    process.exit(2)
+  }
+
+  console.error('[issue-token] step 2/3: open Webull mobile app and complete 2FA SMS verify (5 min).')
+  console.error(
+    `[issue-token] step 3/3: polling /openapi/auth/token/check every ${POLL_INTERVAL_MS / 1000}s ` +
+      `(timeout ${POLL_TIMEOUT_MS / 1000}s)...`,
+  )
+
+  const startedAt = Date.now()
+  let latest = initial
+  while (Date.now() - startedAt < POLL_TIMEOUT_MS) {
+    await sleep(POLL_INTERVAL_MS)
+    latest = await client.checkToken(initial.token)
+    const elapsedSec = Math.floor((Date.now() - startedAt) / 1000)
+    console.error(`[issue-token] poll (${elapsedSec}s elapsed): ${summarize(latest)}`)
+
+    if (latest.status === 'NORMAL') {
+      printResult(latest)
+      return
+    }
+    if (latest.status === 'INVALID' || latest.status === 'EXPIRED') {
+      console.error(`[issue-token] poll terminated with status ${latest.status}. Aborting.`)
+      process.exit(3)
+    }
+  }
+
+  console.error(
+    `[issue-token] poll exceeded ${POLL_TIMEOUT_MS / 1000}s without NORMAL status. ` +
+      'Re-run after completing 2FA in the Webull mobile app.',
+  )
+  process.exit(4)
+}
+
+function printResult(token: WebullAccessTokenDto): void {
+  // Token 文字列自体は stdout に出して redirect / pipe しやすくする。
+  // 周辺メタデータは stderr。これで `pnpm run issue-token > .token` のように
+  // file に流せる。
+  console.error('[issue-token] NORMAL token acquired. Inject via:')
+  console.error('  pnpm wrangler secret put WEBULL_ACCESS_TOKEN --env=<dev|staging|production>')
+  console.error('  (paste the value printed below)')
+  console.error('')
+  console.log(token.token)
+}
+
+main().catch((error) => {
+  console.error(`[issue-token] failed: ${error instanceof Error ? error.message : String(error)}`)
+  if (error instanceof Error && error.stack) {
+    console.error(error.stack)
+  }
+  process.exit(1)
+})

--- a/src/infrastructure/webull/WebullTokenClient.ts
+++ b/src/infrastructure/webull/WebullTokenClient.ts
@@ -155,8 +155,17 @@ function normalizeAccessToken(json: unknown, path: string): WebullAccessTokenDto
   const expires = typeof obj.expires === 'number' ? obj.expires : Number(obj.expires)
   const statusRaw = typeof obj.status === 'string' ? obj.status : null
   if (!token || !Number.isFinite(expires) || statusRaw === null) {
+    // Mask the token in error output. raw token を JSON.stringify でログ /
+    // スタックに残すと、認証情報がエラー解析チャネルに漏れる (CodeRabbit
+    // #325 review)。
+    const masked: Record<string, unknown> = { ...obj }
+    if (typeof obj.token === 'string' && obj.token.length > 10) {
+      masked.token = `${obj.token.slice(0, 6)}...${obj.token.slice(-4)}`
+    } else if (typeof obj.token === 'string') {
+      masked.token = '<redacted>'
+    }
     throw new BrokerRequestError(
-      `Webull token response missing token/expires/status: ${JSON.stringify(obj)}`,
+      `Webull token response missing token/expires/status: ${JSON.stringify(masked)}`,
       `POST ${path}`,
     )
   }

--- a/src/infrastructure/webull/WebullTokenClient.ts
+++ b/src/infrastructure/webull/WebullTokenClient.ts
@@ -1,0 +1,175 @@
+import { BrokerRequestError, brokerErrorForStatus } from '../../shared/errors'
+import { WebullAuth } from './WebullAuth'
+
+/**
+ * Webull の `x-access-token` 発行フロー (#21)。
+ *
+ * - `createToken(existingToken?)` → `POST /openapi/auth/token/create` v2、
+ *   返却された token (通常 status=PENDING) を operator が Webull モバイルアプリで
+ *   2FA SMS verify するまで使えない。
+ * - `checkToken(token)` → `POST /openapi/auth/token/check` v2、status を poll
+ *   して NORMAL になったかを確認する。
+ *
+ * Operator script (`scripts/issue-webull-token.ts`) が createToken → poll
+ * checkToken → 取得 token を `wrangler secret put WEBULL_ACCESS_TOKEN` で投入、
+ * という流れで使う。Worker runtime からの自動 refresh (Phase B / #21 follow-up) では
+ * 同 class を Durable Object 経由で呼び出す予定。
+ */
+
+/** Webull docs / SDK enum 定義より (PENDING=0 / NORMAL=1 / INVALID=2 / EXPIRED=3)。 */
+export type WebullTokenStatus = 'PENDING' | 'NORMAL' | 'INVALID' | 'EXPIRED'
+
+export interface WebullAccessTokenDto {
+  /** token 文字列。`x-access-token` ヘッダにそのまま乗せる値。 */
+  token: string
+  /** epoch ms (or seconds — Webull docs では明示なし)。SDK は数値として保持。 */
+  expires: number
+  status: WebullTokenStatus
+}
+
+export interface WebullTokenClientOptions {
+  auth: WebullAuth
+  /** 通常 `api.webull.co.jp` (本番) または UAT ALB URL。trade host と同じ。 */
+  baseUrl: string
+  /** Default 10s。create / check のレスポンスは速いはず。 */
+  timeoutMs?: number
+  fetchFn?: typeof fetch
+}
+
+const CREATE_PATH = '/openapi/auth/token/create'
+const CHECK_PATH = '/openapi/auth/token/check'
+/**
+ * Webull は token endpoint だけ x-version=v2 を要求する (SDK 実装より)。
+ * 既存の `WebullHttpClient.tradeVersion` (default v1) とは別軸。
+ */
+const TOKEN_VERSION = 'v2'
+
+export class WebullTokenClient {
+  private readonly baseUrl: string
+  private readonly timeoutMs: number
+  private readonly fetchFn: typeof fetch
+
+  constructor(private readonly options: WebullTokenClientOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/+$/, '')
+    this.timeoutMs = options.timeoutMs ?? 10_000
+    this.fetchFn = options.fetchFn ?? fetch.bind(globalThis)
+  }
+
+  /**
+   * 新規 token 発行 (`existingToken` 渡すと refresh) 。返却された status が
+   * `NORMAL` ならそのまま使える (test env 等)、`PENDING` なら operator が
+   * モバイルアプリで verify する必要があり、その後 `checkToken` で確認する。
+   */
+  createToken(existingToken?: string): Promise<WebullAccessTokenDto> {
+    // SDK の CreateTokenRequest は token があれば body に含める、無ければ空 body。
+    // 空 body だと body MD5 は計算しない (signing 上 body 部分が省略される)。
+    const body = existingToken ? { token: existingToken } : undefined
+    return this.requestToken(CREATE_PATH, body)
+  }
+
+  /** 既存 token の現在 status を取得 (poll 用)。 */
+  checkToken(token: string): Promise<WebullAccessTokenDto> {
+    return this.requestToken(CHECK_PATH, { token })
+  }
+
+  private async requestToken(
+    path: string,
+    body: { token?: string } | undefined,
+  ): Promise<WebullAccessTokenDto> {
+    const payload = body === undefined ? undefined : JSON.stringify(body)
+    const url = new URL(path, `${this.baseUrl}/`)
+
+    let authHeaders: Record<string, string>
+    try {
+      authHeaders = await this.options.auth.createHeaders({
+        method: 'POST',
+        path: url.pathname,
+        body: payload,
+        host: url.host,
+        version: TOKEN_VERSION,
+      })
+    } catch (error) {
+      throw new BrokerRequestError(
+        `Webull token auth failed: ${error instanceof Error ? error.message : String(error)}`,
+        `POST ${path}`,
+        { cause: error instanceof Error ? error : undefined },
+      )
+    }
+
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs)
+    let response: Response
+    try {
+      response = await this.fetchFn(url.href, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          ...(payload === undefined ? {} : { 'Content-Type': 'application/json' }),
+          ...authHeaders,
+        },
+        body: payload,
+        signal: controller.signal,
+      })
+    } catch (error) {
+      throw new BrokerRequestError(
+        `Webull token fetch failed: ${error instanceof Error ? error.message : String(error)}`,
+        `POST ${path}`,
+        { cause: error instanceof Error ? error : undefined },
+      )
+    } finally {
+      clearTimeout(timeoutId)
+    }
+
+    if (!response.ok) {
+      throw brokerErrorForStatus(
+        response.status,
+        `Webull token request failed with status ${response.status}`,
+        `POST ${path}`,
+      )
+    }
+
+    let json: unknown
+    try {
+      json = await response.json()
+    } catch (error) {
+      throw new BrokerRequestError(
+        `Webull token response parse failed: ${error instanceof Error ? error.message : String(error)}`,
+        `POST ${path}`,
+        { cause: error instanceof Error ? error : undefined },
+      )
+    }
+
+    return normalizeAccessToken(json, path)
+  }
+}
+
+function normalizeAccessToken(json: unknown, path: string): WebullAccessTokenDto {
+  if (typeof json !== 'object' || json === null) {
+    throw new BrokerRequestError(
+      `Webull token response is not an object`,
+      `POST ${path}`,
+    )
+  }
+  const obj = json as Record<string, unknown>
+  const token = typeof obj.token === 'string' ? obj.token : null
+  const expires = typeof obj.expires === 'number' ? obj.expires : Number(obj.expires)
+  const statusRaw = typeof obj.status === 'string' ? obj.status : null
+  if (!token || !Number.isFinite(expires) || statusRaw === null) {
+    throw new BrokerRequestError(
+      `Webull token response missing token/expires/status: ${JSON.stringify(obj)}`,
+      `POST ${path}`,
+    )
+  }
+  if (
+    statusRaw !== 'PENDING' &&
+    statusRaw !== 'NORMAL' &&
+    statusRaw !== 'INVALID' &&
+    statusRaw !== 'EXPIRED'
+  ) {
+    throw new BrokerRequestError(
+      `Webull token returned unknown status '${statusRaw}'`,
+      `POST ${path}`,
+    )
+  }
+  return { token, expires, status: statusRaw }
+}

--- a/test/infrastructure/webull/webullTokenClient.test.ts
+++ b/test/infrastructure/webull/webullTokenClient.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from 'vitest'
+import { WebullAuth } from '../../../src/infrastructure/webull/WebullAuth'
+import { WebullTokenClient } from '../../../src/infrastructure/webull/WebullTokenClient'
+
+const auth = new WebullAuth({ appKey: 'ak', appSecret: 'sk' })
+
+function mockJson(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('WebullTokenClient.createToken', () => {
+  // #21: token endpoint は v2 固定 (SDK 実装より)。Webull は version mismatch を
+  // signature reject で返してくるので、ここの version drift を必ず lock する。
+  it('POSTs /openapi/auth/token/create with x-version: v2 (no body when no existing token)', async () => {
+    let capturedUrl: URL | undefined
+    let capturedHeaders: Headers | undefined
+    let capturedBody: string | null = null
+    let capturedMethod: string | undefined
+    const fetchFn = vi.fn(async (input: Request | string | URL, init?: RequestInit) => {
+      const urlStr = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      capturedUrl = new URL(urlStr)
+      capturedMethod = init?.method
+      capturedHeaders = new Headers(init?.headers)
+      capturedBody = init?.body ? String(init.body) : null
+      return mockJson({ token: 'tok-1', expires: 1700000000, status: 'PENDING' })
+    }) as unknown as typeof fetch
+
+    const client = new WebullTokenClient({
+      auth,
+      baseUrl: 'https://api.example.test',
+      fetchFn,
+    })
+    const result = await client.createToken()
+
+    expect(capturedMethod).toBe('POST')
+    expect(capturedUrl?.pathname).toBe('/openapi/auth/token/create')
+    expect(capturedHeaders?.get('x-version')).toBe('v2')
+    // SDK の CreateTokenRequest: token 未指定なら body params が空のまま。
+    // ここで `{}` を送ると body MD5 が canonical に混ざってしまうので、
+    // `undefined` を保ってるか locked する (signing への影響あり)。
+    expect(capturedBody).toBeNull()
+    expect(result).toEqual({ token: 'tok-1', expires: 1700000000, status: 'PENDING' })
+  })
+
+  // refresh path: existing token を渡すと body に乗る。check_token と区別するため
+  // body shape を locked。
+  it('includes the existing token in the body when refreshing', async () => {
+    let capturedBody: string | null = null
+    const fetchFn = vi.fn(async (_input: Request | string | URL, init?: RequestInit) => {
+      capturedBody = init?.body ? String(init.body) : null
+      return mockJson({ token: 'tok-2', expires: 1700000000, status: 'NORMAL' })
+    }) as unknown as typeof fetch
+
+    const client = new WebullTokenClient({
+      auth,
+      baseUrl: 'https://api.example.test',
+      fetchFn,
+    })
+    await client.createToken('tok-old')
+
+    expect(capturedBody).toBe(JSON.stringify({ token: 'tok-old' }))
+  })
+
+  it('parses { token, expires, status } and exposes NORMAL/PENDING/INVALID/EXPIRED', async () => {
+    const fetchFn = vi.fn(async () =>
+      mockJson({ token: 'tok-3', expires: 9999999999, status: 'NORMAL' }),
+    ) as unknown as typeof fetch
+    const client = new WebullTokenClient({ auth, baseUrl: 'https://api.example.test', fetchFn })
+    const result = await client.createToken()
+    expect(result.status).toBe('NORMAL')
+  })
+
+  it('throws BrokerRequestError on non-2xx', async () => {
+    const fetchFn = vi.fn(async () => mockJson({ error: 'bad' }, 401)) as unknown as typeof fetch
+    const client = new WebullTokenClient({ auth, baseUrl: 'https://api.example.test', fetchFn })
+    await expect(client.createToken()).rejects.toThrow(/401/)
+  })
+
+  it('throws when response is missing required fields', async () => {
+    const fetchFn = vi.fn(async () =>
+      mockJson({ token: 'tok-no-status', expires: 1700000000 }),
+    ) as unknown as typeof fetch
+    const client = new WebullTokenClient({ auth, baseUrl: 'https://api.example.test', fetchFn })
+    await expect(client.createToken()).rejects.toThrow(/token\/expires\/status/)
+  })
+
+  it('throws when status string is unrecognised (e.g. typo or new value)', async () => {
+    const fetchFn = vi.fn(async () =>
+      mockJson({ token: 'tok-x', expires: 1700000000, status: 'WHATEVER' }),
+    ) as unknown as typeof fetch
+    const client = new WebullTokenClient({ auth, baseUrl: 'https://api.example.test', fetchFn })
+    await expect(client.createToken()).rejects.toThrow(/unknown status/)
+  })
+})
+
+describe('WebullTokenClient.checkToken', () => {
+  it('POSTs /openapi/auth/token/check with { token } body', async () => {
+    let capturedUrl: URL | undefined
+    let capturedBody: string | null = null
+    const fetchFn = vi.fn(async (input: Request | string | URL, init?: RequestInit) => {
+      const urlStr = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      capturedUrl = new URL(urlStr)
+      capturedBody = init?.body ? String(init.body) : null
+      return mockJson({ token: 'tok-y', expires: 1700000000, status: 'NORMAL' })
+    }) as unknown as typeof fetch
+
+    const client = new WebullTokenClient({
+      auth,
+      baseUrl: 'https://api.example.test',
+      fetchFn,
+    })
+    const result = await client.checkToken('tok-y')
+
+    expect(capturedUrl?.pathname).toBe('/openapi/auth/token/check')
+    expect(capturedBody).toBe(JSON.stringify({ token: 'tok-y' }))
+    expect(result.status).toBe('NORMAL')
+  })
+
+  // Status は string enum で 4 値しかない。typo / unknown は throw する事を locked。
+  it.each(['PENDING', 'NORMAL', 'INVALID', 'EXPIRED'] as const)(
+    'accepts status=%s',
+    async (status) => {
+      const fetchFn = vi.fn(async () =>
+        mockJson({ token: 'tok-z', expires: 1700000000, status }),
+      ) as unknown as typeof fetch
+      const client = new WebullTokenClient({ auth, baseUrl: 'https://api.example.test', fetchFn })
+      const result = await client.checkToken('tok-z')
+      expect(result.status).toBe(status)
+    },
+  )
+})


### PR DESCRIPTION
## Summary
- Webull JP の `x-access-token` を operator が **CLI から発行** できる仕組みを実装 (#21 Phase A)
- `WebullTokenClient` — `/openapi/auth/token/create` と `/openapi/auth/token/check` を v2 で POST する HTTP wrapper
- `scripts/issue-webull-token.ts` — operator が \`pnpm run issue-token\` で create → 2FA verify (モバイルアプリ) → poll check → NORMAL token 取得まで通せる対話型 CLI
- Phase A は **operator-driven (= 人手で 2FA verify する半自動)**。Worker runtime からの auto-refresh (Phase B、DO ベース) は別 PR

## なぜ
[PR #323](https://github.com/ochanuco/webull-trading/pull/323) は \`WEBULL_ACCESS_TOKEN\` env passthrough を実装したが、**token を取得する手段** が未実装だった。Webull JP は token を dev portal の UI ではなく API call (\`POST /openapi/auth/token/create\`) で発行する仕様で、2FA SMS verify が絡むため fully automated は不可。

staging を本番 URL に向けて probe したら \`positions\` 系で **401 \`INVALID_TOKEN\`** が出てて、これが本 PR が解決する直接の症状。

## 実装
- **`WebullTokenClient.createToken(existingToken?)`**: 空 body or \`{ token }\` を POST。response から \`{ token, expires, status }\` を validate して返す
- **`WebullTokenClient.checkToken(token)`**: \`{ token }\` を POST、現在の status を取得
- **`scripts/issue-webull-token.ts`**: 30 秒間隔で check_token を 5 分間 poll、\`NORMAL\` 化したら stdout に token のみ出力 (\`> file\` で pipe しやすい)、メタ情報は stderr に分離
- status enum \`PENDING\` / \`NORMAL\` / \`INVALID\` / \`EXPIRED\` のみ受理 (unknown は throw、Webull が enum 追加したら locked test が落ちて気付ける)

## 使い方 (運用)

\`\`\`bash
# 1. 発行 + 2FA verify
WEBULL_APP_KEY="..." WEBULL_APP_SECRET="..." pnpm run issue-token
# → "Token issued (PENDING): tok-abc...xyz"
# → Webull モバイルアプリで 5 分以内に SMS verify
# → 30s 毎に poll、NORMAL になると stdout に token のみ出力

# 2. wrangler に流し込み
pnpm wrangler secret put WEBULL_ACCESS_TOKEN --env=production
# (上で出力された token 文字列を貼り付け)

# refresh: WEBULL_EXISTING_TOKEN=<old> pnpm run issue-token
\`\`\`

## Test plan
- [x] \`pnpm typecheck\` ✅
- [x] \`pnpm test\` 1110 tests pass (新規 11 件: createToken / checkToken の path / version / body / response parse / error 系) ✅
- [ ] staging で実機 \`pnpm run issue-token\` 実行 → 2FA verify → NORMAL token 取得 → \`wrangler secret put --env=staging\`
- [ ] staging probe で \`positions\` / \`orders\` の 401 INVALID_TOKEN が解消し 200 が返る事を確認

## scope 外 (Phase B / follow-up)
- **DO ベース auto-refresh** — token を Durable Object に保存、cron で expire 前 (e.g. 12 day mark) に \`createToken(existingToken)\` で refresh、失敗時は通知 + 取引停止 (fail-safe)
- 別 issue or PR で実装、本 PR の \`WebullTokenClient\` を共有 infrastructure として再利用
- (別件) \`data-api.webull.co.jp\` の timeout (staging probe で観測) — IP whitelist / TLS / DNS 切り分けが必要

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 変更内容

* **新機能**
  * トークン発行コマンド `pnpm run issue-token` を追加し、運用者向けのトークン取得を自動化（トークンを stdout に出力、シークレット登録案内を表示）

* **ドキュメント**
  * README の Secrets に JP 本番での 2FA 必須や supplemental auth（x-access-token）と signature の関係、発行・更新手順（実行例）を追記・整理

* **テスト**
  * トークン発行／照合ロジックの包括的なテストを追加

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/325?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->