### PR TITLE
feat(webull): DO-backed access token with auto refresh (#21 Phase B)

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -451,3 +451,16 @@ export interface Env {
 export interface Env {
   ENVIRONMENT?: string
 }
+
+
+// #21 Phase B: Webull `x-access-token` の runtime state を持つ DO (append 規約)。
+// Phase A で operator が `pnpm run issue-token` で取得した token を、admin
+// endpoint 経由でこの DO に seed する。cron が定期的に `WebullTokenClient.
+// createToken(existingToken)` で refresh して書き戻す。WEBULL_ACCESS_TOKEN env
+// (Phase A の bootstrap path) は DO seed が無い時の fallback として残し、両方
+// 揃ってる場合は DO 側を優先する (= 自動 refresh が効く状態を「正」と扱う)。
+import type { WebullTokenStateDO } from '../trading/state/WebullTokenStateDO'
+
+export interface Env {
+  WEBULL_TOKEN_STATE?: DurableObjectNamespace<WebullTokenStateDO>
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import type { Env } from './config/env'
 import { createDb, insertJournalRecord } from './infrastructure/db/tradeJournalRepo'
 import { setTradeJournalDbContext } from './infrastructure/logger/tradeJournal'
 import { createNotifier } from './infrastructure/notification/createNotifier'
+import { refreshWebullToken } from './infrastructure/webull/refreshWebullToken'
 import { runPortfolioRoll } from './trading/portfolio/runPortfolioRoll'
 import { runQuoteFeed } from './trading/quotes/quoteScheduler'
 import { reconcileFills } from './trading/reconciliation/reconcileFills'
@@ -22,6 +23,7 @@ const CRON_PORTFOLIO_ROLL = '0 22 * * *'
 
 export { SymbolStateDO } from './trading/state/SymbolStateDO'
 export { PortfolioStateDO } from './trading/state/PortfolioStateDO'
+export { WebullTokenStateDO } from './trading/state/WebullTokenStateDO'
 
 const app = createApp()
 
@@ -51,7 +53,62 @@ export default {
     const requestId = crypto.randomUUID()
 
     if (event.cron === CRON_PORTFOLIO_ROLL) {
+      // 22:00 UTC daily: portfolio rollover + Webull access-token refresh.
+      // Token は 15 days inactivity で INVALID 化するので、daily check で
+      // expires 残り 7 days 以内なら createToken(existingToken) で更新する。
+      // 取引時間外に動かす事で broker API への副作用 (rate limit etc) を最小化。
       ctx.waitUntil(runPortfolioRoll(env, requestId))
+      ctx.waitUntil(
+        refreshWebullToken(env).then(
+          (summary) => {
+            console.log(
+              JSON.stringify({
+                event: 'webull_token_refresh',
+                requestId,
+                refreshed: summary.refreshed,
+                skippedReason: summary.skippedReason ?? null,
+                failureReason: summary.failureReason ?? null,
+                lastSuccessAt: summary.after?.lastSuccessAt ?? null,
+              }),
+            )
+            // refresh が失敗したら operator action が必要 (token 再発行 → seed)。
+            // critical 通知で push する (cron は 24h 後の next tick まで待つので
+            // 早めに気付かせたい)。skip は通常運用なので通知しない。
+            if (summary.failureReason) {
+              ctx.waitUntil(
+                createNotifier(env, { requestId })
+                  .notify({
+                    type: 'ERROR',
+                    message: `Webull token refresh failed: ${summary.failureReason}. Run \`pnpm run issue-token\` and POST /admin/webull-token/seed.`,
+                    cause: 'webull_token_refresh',
+                    severity: 'critical',
+                  })
+                  .catch(() => undefined),
+              )
+            }
+          },
+          (error) => {
+            const message = error instanceof Error ? error.message : String(error)
+            console.error(
+              JSON.stringify({
+                event: 'webull_token_refresh_error',
+                requestId,
+                message,
+              }),
+            )
+            ctx.waitUntil(
+              createNotifier(env, { requestId })
+                .notify({
+                  type: 'ERROR',
+                  message: `Webull token refresh threw: ${message}`,
+                  cause: 'webull_token_refresh',
+                  severity: 'critical',
+                })
+                .catch(() => undefined),
+            )
+          },
+        ),
+      )
       return
     }
 

--- a/src/infrastructure/quotes/BarClient.ts
+++ b/src/infrastructure/quotes/BarClient.ts
@@ -175,7 +175,12 @@ const DEFAULT_QUOTES_API_BASE = 'https://data-api.webull.co.jp'
 
 export function createWebullBarClient(
   env: WebullBarClientEnv,
-  options?: { fetchFn?: typeof fetch; timeoutMs?: number },
+  options?: {
+    fetchFn?: typeof fetch
+    timeoutMs?: number
+    /** Phase B: resolveAccessToken 由来の override (DO 優先)。 */
+    accessToken?: string
+  },
 ): WebullBarClient {
   // env 空 / undefined / whitespace は JP prod default。env が明示されてれば
   // override (UAT / 将来 region 用)。
@@ -184,7 +189,7 @@ export function createWebullBarClient(
     auth: new WebullAuth({
       appKey: env.WEBULL_APP_KEY,
       appSecret: env.WEBULL_APP_SECRET,
-      accessToken: env.WEBULL_ACCESS_TOKEN,
+      accessToken: options?.accessToken ?? env.WEBULL_ACCESS_TOKEN,
     }),
     baseUrl,
     barsPath: env.WEBULL_BARS_PATH,

--- a/src/infrastructure/quotes/WebullQuoteClient.ts
+++ b/src/infrastructure/quotes/WebullQuoteClient.ts
@@ -182,7 +182,13 @@ export class WebullQuoteClient {
 
 export function createWebullQuoteClient(
   env: WebullQuoteClientEnv,
-  options?: { fetchFn?: typeof fetch; timeoutMs?: number; now?: () => Date },
+  options?: {
+    fetchFn?: typeof fetch
+    timeoutMs?: number
+    now?: () => Date
+    /** Phase B: resolveAccessToken 由来の override (DO 優先)。 */
+    accessToken?: string
+  },
 ): WebullQuoteClient {
   // env 空 / undefined / whitespace は JP prod default。env が明示されてれば
   // override (UAT / 将来 region 用)。
@@ -191,7 +197,7 @@ export function createWebullQuoteClient(
     auth: new WebullAuth({
       appKey: env.WEBULL_APP_KEY,
       appSecret: env.WEBULL_APP_SECRET,
-      accessToken: env.WEBULL_ACCESS_TOKEN,
+      accessToken: options?.accessToken ?? env.WEBULL_ACCESS_TOKEN,
     }),
     baseUrl,
     quotePath: env.WEBULL_QUOTE_PATH,

--- a/src/infrastructure/webull/WebullHttpClient.ts
+++ b/src/infrastructure/webull/WebullHttpClient.ts
@@ -427,7 +427,17 @@ export class WebullHttpClient {
 
 export function createWebullHttpClient(
   env: WebullClientEnv,
-  options?: { fetchFn?: typeof fetch; timeoutMs?: number; retry?: WebullRetryOptions },
+  options?: {
+    fetchFn?: typeof fetch
+    timeoutMs?: number
+    retry?: WebullRetryOptions
+    /**
+     * Runtime-resolved `x-access-token` (#21 Phase B)。`resolveAccessToken(env)`
+     * の戻り値を caller が await して渡す形。指定があれば `env.WEBULL_ACCESS_TOKEN`
+     * を上書き (= DO 由来の値を優先)。
+     */
+    accessToken?: string
+  },
 ): WebullHttpClient {
   // #257: env で trade/account path を上書き可能。受理条件:
   //   - 文字列であること
@@ -467,7 +477,7 @@ export function createWebullHttpClient(
     auth: new WebullAuth({
       appKey: env.WEBULL_APP_KEY,
       appSecret: env.WEBULL_APP_SECRET,
-      accessToken: env.WEBULL_ACCESS_TOKEN,
+      accessToken: options?.accessToken ?? env.WEBULL_ACCESS_TOKEN,
     }),
     accountId: env.WEBULL_ACCOUNT_ID_JP_CASH,
     baseUrl,

--- a/src/infrastructure/webull/WebullReadClient.ts
+++ b/src/infrastructure/webull/WebullReadClient.ts
@@ -49,5 +49,7 @@ export function createWebullReadClient(
   env: WebullClientEnv,
   options?: Parameters<typeof createWebullHttpClient>[1],
 ): WebullReadClient {
+  // `options.accessToken` は Phase B の resolveAccessToken 由来。WebullHttpClient
+  // に thru で渡す (env.WEBULL_ACCESS_TOKEN は DO 未投入時の fallback)。
   return new WebullReadClient(createWebullHttpClient(env, options))
 }

--- a/src/infrastructure/webull/WebullTradeClient.ts
+++ b/src/infrastructure/webull/WebullTradeClient.ts
@@ -83,5 +83,7 @@ export function createWebullTradeClient(
   env: WebullTradeClientEnv,
   options?: Parameters<typeof createWebullHttpClient>[1],
 ): WebullTradeClient {
+  // `options.accessToken` (Phase B の resolveAccessToken 由来) を WebullHttpClient
+  // に thru で渡す。env.WEBULL_ACCESS_TOKEN は DO 未投入時の fallback。
   return new WebullTradeClient(createWebullHttpClient(env, options), env)
 }

--- a/src/infrastructure/webull/refreshWebullToken.ts
+++ b/src/infrastructure/webull/refreshWebullToken.ts
@@ -1,0 +1,134 @@
+import type { Env } from '../../config/env'
+import { WebullTokenStateClient } from '../../trading/state/WebullTokenStateClient'
+import type { WebullTokenState } from '../../trading/state/WebullTokenStateDO'
+import { WebullAuth } from './WebullAuth'
+import {
+  WebullTokenClient,
+  type WebullAccessTokenDto,
+} from './WebullTokenClient'
+
+/**
+ * Background refresh of the active `x-access-token` (#21 Phase B).
+ *
+ * Called from the cron handler. Walks the state machine:
+ *   - DO state は無し / 期限切れ間近 → `createToken(existingToken)` で更新
+ *   - 既に NORMAL 返却なら即書き戻し
+ *   - PENDING 等 → 失敗扱い (operator が再度 `pnpm run issue-token` で seed する想定)
+ *   - INVALID / EXPIRED → 失敗扱い
+ *
+ * Refresh が必要かどうかの判定は時刻と `expires` の差分で行う。Webull docs に
+ * `expires` の単位 (ms or sec) が明示されてないので両方サポート (10^12 以上を ms、
+ * それ以外を sec として扱う)。これは `coerceAsOf` 等で他にも採用してる pattern。
+ */
+
+const DEFAULT_TRADE_API_BASE = 'https://api.webull.co.jp'
+/** expires まで残り日数がこれ以下になったら refresh 試行。Webull 15 days inactivity 規定の半分。 */
+const REFRESH_BEFORE_DAYS = 7
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+export interface RefreshSummary {
+  /** 実際に DO を更新したか (= broker から新しい NORMAL token を取得できたか)。 */
+  refreshed: boolean
+  /** 試行をスキップしたなら理由 (期限まで余裕がある等)。 */
+  skippedReason?: string
+  /** 失敗時の理由 (broker error / PENDING など)。 */
+  failureReason?: string
+  /** 試行前の DO 状態 (debug 用)。 */
+  before: WebullTokenState | null
+  /** 試行後の DO 状態 (write が走らなかった場合は before と同じ)。 */
+  after: WebullTokenState | null
+}
+
+export async function refreshWebullToken(
+  env: Env,
+  options?: {
+    now?: () => Date
+    tokenClient?: WebullTokenClient
+    force?: boolean
+  },
+): Promise<RefreshSummary> {
+  const namespace = env.WEBULL_TOKEN_STATE
+  if (!namespace) {
+    // DO 未バインドな環境 (local dev で wrangler.jsonc を編集してない等)。
+    // 自動 refresh は無効、Phase A の env 経由運用を続ける。
+    return {
+      refreshed: false,
+      skippedReason: 'WEBULL_TOKEN_STATE binding is not configured',
+      before: null,
+      after: null,
+    }
+  }
+
+  const now = options?.now?.() ?? new Date()
+  const store = new WebullTokenStateClient(namespace)
+  const before = await store.getState()
+
+  // refresh の必要判定: state なし or expires が REFRESH_BEFORE_DAYS 以内 or force。
+  // `expires` の単位 (ms vs sec) は値で判定 (10^12 以上は ms、未満は sec)。
+  if (!options?.force && before && before.status === 'NORMAL') {
+    const expiresMs = before.expires >= 1e12 ? before.expires : before.expires * 1000
+    const remainMs = expiresMs - now.getTime()
+    if (remainMs > REFRESH_BEFORE_DAYS * MS_PER_DAY) {
+      return {
+        refreshed: false,
+        skippedReason: `not due yet (remain ${Math.floor(remainMs / MS_PER_DAY)} days)`,
+        before,
+        after: before,
+      }
+    }
+  }
+
+  if (!env.WEBULL_APP_KEY || !env.WEBULL_APP_SECRET) {
+    return {
+      refreshed: false,
+      failureReason: 'WEBULL_APP_KEY / WEBULL_APP_SECRET not set',
+      before,
+      after: before,
+    }
+  }
+
+  const client =
+    options?.tokenClient ??
+    new WebullTokenClient({
+      auth: new WebullAuth({
+        appKey: env.WEBULL_APP_KEY,
+        appSecret: env.WEBULL_APP_SECRET,
+      }),
+      baseUrl: env.WEBULL_TRADE_API_BASE?.trim() || DEFAULT_TRADE_API_BASE,
+    })
+
+  let result: WebullAccessTokenDto
+  try {
+    result = await client.createToken(before?.token)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    const after = await store.recordRefresh({ success: false, nowIso: now.toISOString() })
+    return {
+      refreshed: false,
+      failureReason: `createToken threw: ${message}`,
+      before,
+      after,
+    }
+  }
+
+  // Webull は refresh 時に同じ token を返すこともある (status だけ更新)。それでも
+  // NORMAL なら success として書き戻す (= lastSuccessAt が動く事に意味がある)。
+  if (result.status === 'NORMAL') {
+    const after = await store.recordRefresh({
+      success: true,
+      token: result.token,
+      expires: result.expires,
+      status: result.status,
+      nowIso: now.toISOString(),
+    })
+    return { refreshed: true, before, after }
+  }
+
+  const after = await store.recordRefresh({ success: false, nowIso: now.toISOString() })
+  return {
+    refreshed: false,
+    failureReason: `createToken returned status=${result.status} (operator action required)`,
+    before,
+    after,
+  }
+}

--- a/src/infrastructure/webull/resolveAccessToken.ts
+++ b/src/infrastructure/webull/resolveAccessToken.ts
@@ -1,0 +1,45 @@
+import type { Env } from '../../config/env'
+import { WebullTokenStateClient } from '../../trading/state/WebullTokenStateClient'
+
+/**
+ * Resolve the active `x-access-token` value at call time (#21 Phase B).
+ *
+ * Resolution order:
+ *   1. **DO state** (`WEBULL_TOKEN_STATE`) when bound AND state is `NORMAL`
+ *      — the DO is the runtime source of truth, kept refreshed by the cron
+ *      handler so it never goes stale silently.
+ *   2. **`WEBULL_ACCESS_TOKEN` env** when DO is empty / non-NORMAL — Phase A
+ *      bootstrap path. operator can still drop a freshly issued token here
+ *      via `wrangler secret put` before the DO has been seeded.
+ *   3. `undefined` — no token available; callers proceed unsigned and the
+ *      broker returns `INVALID_TOKEN` (visible failure, not silent skip).
+ *
+ * `INVALID` / `EXPIRED` states in the DO are treated as "no token" so the
+ * stale value is not sent on the wire; the operator sees a clear
+ * broker-side 401 instead of a confusing signature-pass-but-no-data result.
+ */
+export async function resolveAccessToken(env: Env): Promise<string | undefined> {
+  const namespace = env.WEBULL_TOKEN_STATE
+  if (namespace) {
+    try {
+      const client = new WebullTokenStateClient(namespace)
+      const state = await client.getState()
+      if (state && state.status === 'NORMAL' && state.token.length > 0) {
+        return state.token
+      }
+    } catch (error) {
+      // DO 自体が落ちてるケース (binding mismatch / runtime error)。env fallback に
+      // 抜けて静かに degrade させるよりは、明示的に log を残して原因追跡を可能に
+      // する。env が無ければ undefined を返して上位の broker call が 401 で気付く。
+      console.warn(
+        JSON.stringify({
+          event: 'webull_token_do_unreachable',
+          message: error instanceof Error ? error.message : String(error),
+        }),
+      )
+    }
+  }
+
+  const fallback = env.WEBULL_ACCESS_TOKEN?.trim()
+  return fallback && fallback.length > 0 ? fallback : undefined
+}

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -5,6 +5,11 @@ import type { AppBindings } from '../app'
 import { rateLimit } from '../middleware/rateLimit'
 import { ValidationError } from '../shared/errors'
 import { createWebullReadClient } from '../infrastructure/webull/WebullReadClient'
+import { refreshWebullToken } from '../infrastructure/webull/refreshWebullToken'
+import { resolveAccessToken } from '../infrastructure/webull/resolveAccessToken'
+import { WebullAuth } from '../infrastructure/webull/WebullAuth'
+import { WebullTokenClient } from '../infrastructure/webull/WebullTokenClient'
+import { WebullTokenStateClient } from '../trading/state/WebullTokenStateClient'
 import { buildSignedHeaders } from '../infrastructure/webull/WebullAuth'
 import { PortfolioStateClient } from '../trading/state/PortfolioStateClient'
 import { SymbolStateClient } from '../trading/state/SymbolStateClient'
@@ -440,7 +445,9 @@ export const admin = new Hono<AppBindings>()
       allowedSymbols = universe.allowedSymbols
     }
 
-    const webull = createWebullReadClient(c.env)
+    const webull = createWebullReadClient(c.env, {
+      accessToken: await resolveAccessToken(c.env),
+    })
     const positionStore = new SymbolStateClient(c.env.SYMBOL_STATE)
     const result = await syncHoldings(
       {
@@ -703,12 +710,118 @@ export const admin = new Hono<AppBindings>()
       orderHistoryNew,
     })
   })
+  /**
+   * #21 Phase B: `WebullTokenStateDO` operator endpoints。
+   *
+   * - GET /webull-token        : 現在の状態 metadata を返す (token plaintext は返却しない)
+   * - POST /webull-token/seed  : operator が `pnpm run issue-token` で取得した NORMAL token を投入
+   * - POST /webull-token/refresh: 手動 refresh トリガー (cron 待たずに更新)
+   */
+  .get('/webull-token', async (c) => {
+    if (!c.env.WEBULL_TOKEN_STATE) {
+      throw new ValidationError('WEBULL_TOKEN_STATE binding is not configured', { field: 'env' })
+    }
+    const store = new WebullTokenStateClient(c.env.WEBULL_TOKEN_STATE)
+    const state = await store.getState()
+    if (!state) {
+      return c.json({ seeded: false, state: null })
+    }
+    // token plaintext は返さない (audit log / browser cache / screenshot に
+    // 漏れないため)。head/tail だけ表示して operator が「どの token か」を
+    // 識別できれば十分。
+    const tokenHint = state.token.length > 10
+      ? `${state.token.slice(0, 6)}...${state.token.slice(-4)}`
+      : '<redacted>'
+    return c.json({
+      seeded: true,
+      state: {
+        tokenHint,
+        expires: state.expires,
+        status: state.status,
+        fetchedAt: state.fetchedAt,
+        lastAttemptAt: state.lastAttemptAt,
+        lastSuccessAt: state.lastSuccessAt,
+      },
+    })
+  })
+  .post('/webull-token/seed', rateLimit('ADMIN_WRITE'), async (c) => {
+    if (!c.env.WEBULL_TOKEN_STATE) {
+      throw new ValidationError('WEBULL_TOKEN_STATE binding is not configured', { field: 'env' })
+    }
+    const body = (await c.req.json().catch(() => null)) as { token?: unknown } | null
+    const rawToken = typeof body?.token === 'string' ? body.token.trim() : ''
+    if (rawToken.length === 0) {
+      throw new ValidationError('body.token must be a non-empty string', { field: 'token' })
+    }
+    if (!c.env.WEBULL_APP_KEY || !c.env.WEBULL_APP_SECRET) {
+      throw new ValidationError(
+        'WEBULL_APP_KEY / WEBULL_APP_SECRET must be set to verify the seeded token',
+        { field: 'env' },
+      )
+    }
+    // operator が貼り付けた token が本当に NORMAL かを broker 側で再確認してから DO に保存。
+    // (Phase A の issue-token script では verify 済だが、time-of-check vs time-of-use の
+    // ズレを締めるため。期限切れ間近の token を seed されても弾ける)
+    const tokenClient = new WebullTokenClient({
+      auth: new WebullAuth({
+        appKey: c.env.WEBULL_APP_KEY,
+        appSecret: c.env.WEBULL_APP_SECRET,
+      }),
+      baseUrl: c.env.WEBULL_TRADE_API_BASE?.trim() || 'https://api.webull.co.jp',
+    })
+    const dto = await tokenClient.checkToken(rawToken)
+    if (dto.status !== 'NORMAL') {
+      return c.json(
+        { error: 'token_not_normal', status: dto.status },
+        409,
+      )
+    }
+    const store = new WebullTokenStateClient(c.env.WEBULL_TOKEN_STATE)
+    const seeded = await store.seedToken({
+      token: dto.token,
+      expires: dto.expires,
+      status: dto.status,
+    })
+    return c.json({
+      seeded: true,
+      state: {
+        expires: seeded.expires,
+        status: seeded.status,
+        fetchedAt: seeded.fetchedAt,
+      },
+    })
+  })
+  .post('/webull-token/refresh', rateLimit('ADMIN_WRITE'), async (c) => {
+    if (!c.env.WEBULL_TOKEN_STATE) {
+      throw new ValidationError('WEBULL_TOKEN_STATE binding is not configured', { field: 'env' })
+    }
+    // force=true で「期限まで余裕あるからスキップ」のロジックを bypass。
+    const summary = await refreshWebullToken(c.env, { force: true })
+    return c.json({
+      refreshed: summary.refreshed,
+      skippedReason: summary.skippedReason ?? null,
+      failureReason: summary.failureReason ?? null,
+      // before/after の token plaintext は返さない (上記 GET と同じ理由)。
+      // status / 時刻のみ。
+      after: summary.after
+        ? {
+            expires: summary.after.expires,
+            status: summary.after.status,
+            fetchedAt: summary.after.fetchedAt,
+            lastAttemptAt: summary.after.lastAttemptAt,
+            lastSuccessAt: summary.after.lastSuccessAt,
+          }
+        : null,
+    })
+  })
   .get('/orders/:clientOrderId', async (c) => {
     const clientOrderId = c.req.param('clientOrderId').trim()
     if (clientOrderId.length === 0) {
       throw new ValidationError('clientOrderId must be non-empty', { field: 'clientOrderId' })
     }
-    const client = createWebullReadClient(c.env)
+    const client = createWebullReadClient(c.env, {
+      accessToken: await resolveAccessToken(c.env),
+    })
     const detail = await client.findOrderByClientId(clientOrderId)
     if (!detail) {
       return c.json({ error: 'order_not_found_in_recent_history', clientOrderId }, 404)

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -723,12 +723,14 @@ export const admin = new Hono<AppBindings>()
     }
     const store = new WebullTokenStateClient(c.env.WEBULL_TOKEN_STATE)
     const state = await store.getState()
+    // token plaintext は返さない (audit log / browser cache / screenshot に
+    // 漏れないため)。head/tail だけ表示して operator が「どの token か」を
+    // 識別できれば十分。さらに browser / intermediary cache にも残らない
+    // よう Cache-Control: no-store (CodeRabbit #326)。
+    c.header('Cache-Control', 'no-store')
     if (!state) {
       return c.json({ seeded: false, state: null })
     }
-    // token plaintext は返さない (audit log / browser cache / screenshot に
-    // 漏れないため)。head/tail だけ表示して operator が「どの token か」を
-    // 識別できれば十分。
     const tokenHint = state.token.length > 10
       ? `${state.token.slice(0, 6)}...${state.token.slice(-4)}`
       : '<redacted>'
@@ -777,11 +779,31 @@ export const admin = new Hono<AppBindings>()
       )
     }
     const store = new WebullTokenStateClient(c.env.WEBULL_TOKEN_STATE)
+    const before = await store.getState()
     const seeded = await store.seedToken({
       token: dto.token,
       expires: dto.expires,
       status: dto.status,
     })
+    // 監査ログには token plaintext は含めず metadata のみ (CodeRabbit #326)。
+    // 「誰がいつ seed したか」が requestId / actor 付きで D1 に残る。
+    await writeAuditLog(
+      c,
+      '/admin/webull-token/seed',
+      'webull-token=singleton',
+      before
+        ? {
+            status: before.status,
+            expires: before.expires,
+            fetchedAt: before.fetchedAt,
+          }
+        : null,
+      {
+        status: seeded.status,
+        expires: seeded.expires,
+        fetchedAt: seeded.fetchedAt,
+      },
+    )
     return c.json({
       seeded: true,
       state: {
@@ -797,6 +819,30 @@ export const admin = new Hono<AppBindings>()
     }
     // force=true で「期限まで余裕あるからスキップ」のロジックを bypass。
     const summary = await refreshWebullToken(c.env, { force: true })
+    // 監査ログ: 手動 refresh が走った事実 (とその結果) を残す (CodeRabbit #326)。
+    // token plaintext は出さず、status と時刻だけ before/after に積む。
+    await writeAuditLog(
+      c,
+      '/admin/webull-token/refresh',
+      'webull-token=singleton',
+      summary.before
+        ? {
+            status: summary.before.status,
+            expires: summary.before.expires,
+            fetchedAt: summary.before.fetchedAt,
+          }
+        : null,
+      summary.after
+        ? {
+            status: summary.after.status,
+            expires: summary.after.expires,
+            fetchedAt: summary.after.fetchedAt,
+            refreshed: summary.refreshed,
+            skippedReason: summary.skippedReason ?? null,
+            failureReason: summary.failureReason ?? null,
+          }
+        : { refreshed: summary.refreshed, skippedReason: summary.skippedReason ?? null },
+    )
     return c.json({
       refreshed: summary.refreshed,
       skippedReason: summary.skippedReason ?? null,

--- a/src/routes/trade.ts
+++ b/src/routes/trade.ts
@@ -1,8 +1,10 @@
 import { Hono } from 'hono'
 import type { AppBindings } from '../app'
+import type { Env } from '../config/env'
 import { loadGlobalConfigFrom, type LoadedGlobalConfig } from '../infrastructure/db/globalConfigLoader'
 import { loadSymbolUniverse, type SymbolUniverse } from '../infrastructure/db/symbolUniverse'
 import type { WebullClientEnv } from '../infrastructure/webull/WebullHttpClient'
+import { resolveAccessToken } from '../infrastructure/webull/resolveAccessToken'
 import { createWebullTradeClient } from '../infrastructure/webull/WebullTradeClient'
 import { ValidationError } from '../shared/errors'
 import { TradingService, type TradingConfig } from '../trading/application/TradingService'
@@ -32,7 +34,7 @@ export const trade = new Hono<AppBindings>()
       loadSymbolUniverse(c.env),
       loadGlobalConfigFrom(c.env, requestId),
     ])
-    const service = createTradingService(request, c.env, universe, global)
+    const service = await createTradingService(request, c.env, universe, global)
     return c.json(
       service.decide(request, toTradingConfig(request, universe, global, c.env.TRADING_ENABLED), {
         requestId,
@@ -46,7 +48,7 @@ export const trade = new Hono<AppBindings>()
       loadSymbolUniverse(c.env),
       loadGlobalConfigFrom(c.env, requestId),
     ])
-    const service = createTradingService(request, c.env, universe, global)
+    const service = await createTradingService(request, c.env, universe, global)
     return c.json(
       await service.executeTrade(request, toTradingConfig(request, universe, global, c.env.TRADING_ENABLED), {
         requestId,
@@ -75,19 +77,24 @@ async function parseTradeRequest(payload: Promise<unknown>): Promise<TradeReques
   }
 }
 
-export function createTradingService(
+export async function createTradingService(
   request: TradeRequest,
-  env: {
+  env: Env & {
     SYMBOL_STATE?: DurableObjectNamespace<SymbolStateDO>
     PORTFOLIO_STATE?: DurableObjectNamespace<PortfolioStateDO>
     ENVIRONMENT?: string
   } & WebullClientEnv,
   universe: SymbolUniverse,
   global: LoadedGlobalConfig,
-): TradingService {
+): Promise<TradingService> {
+  // Phase B: trade client は DO 由来 token を優先 (fallback で env)。decide()
+  // のときも resolve するが、broker call 自体は execute() で初めて発火するので
+  // 余計な network call にはならない (DO は同一 isolate 内で cache 済)。
   const execution = global.dryRun
     ? new MockExecution()
-    : new WebullExecution(createWebullTradeClient(env))
+    : new WebullExecution(
+        createWebullTradeClient(env, { accessToken: await resolveAccessToken(env) }),
+      )
 
   return new TradingService(
     new FixedRuleStrategy(request.buyBelow, request.sellAbove),

--- a/src/trading/reconciliation/reconcileFills.ts
+++ b/src/trading/reconciliation/reconcileFills.ts
@@ -3,6 +3,7 @@ import { alias } from 'drizzle-orm/sqlite-core'
 import type { Env } from '../../config/env'
 import { createDb } from '../../infrastructure/db/tradeJournalRepo'
 import { tradeJournal } from '../../infrastructure/db/schema'
+import { resolveAccessToken } from '../../infrastructure/webull/resolveAccessToken'
 import { createWebullReadClient } from '../../infrastructure/webull/WebullReadClient'
 import type { WebullOrderDetailDto } from '../../infrastructure/webull/dto'
 import { inferWebullMarket } from '../../infrastructure/webull/mapper'
@@ -264,7 +265,10 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
   if (uniqueCandidates.length === 0) return summary
 
   summary.inspected = uniqueCandidates.length
-  const client = createWebullReadClient(options.env)
+  // Phase B: DO 由来 token を優先 (fallback で env)。
+  const client = createWebullReadClient(options.env, {
+    accessToken: await resolveAccessToken(options.env),
+  })
 
   for (const row of uniqueCandidates) {
     const coid = row.clientOrderId

--- a/src/trading/state/WebullTokenStateClient.ts
+++ b/src/trading/state/WebullTokenStateClient.ts
@@ -1,0 +1,44 @@
+import type { WebullTokenStatus } from '../../infrastructure/webull/WebullTokenClient'
+import type { WebullTokenState, WebullTokenStateDO } from './WebullTokenStateDO'
+
+const SINGLETON_NAME = 'default'
+
+/**
+ * Thin adapter that hides the {@link DurableObjectNamespace}/stub plumbing
+ * from callers. Always addresses `idFromName('default')` because the token
+ * is account-wide (#21 Phase B).
+ */
+export class WebullTokenStateClient {
+  constructor(private readonly namespace: DurableObjectNamespace<WebullTokenStateDO>) {}
+
+  private stub(): DurableObjectStub<WebullTokenStateDO> {
+    return this.namespace.get(this.namespace.idFromName(SINGLETON_NAME))
+  }
+
+  getState(): Promise<WebullTokenState | null> {
+    return this.stub().getState()
+  }
+
+  seedToken(input: {
+    token: string
+    expires: number
+    status: WebullTokenStatus
+    nowIso?: string
+  }): Promise<WebullTokenState> {
+    return this.stub().seedToken(input)
+  }
+
+  recordRefresh(
+    result:
+      | {
+          success: true
+          token: string
+          expires: number
+          status: WebullTokenStatus
+          nowIso?: string
+        }
+      | { success: false; nowIso?: string },
+  ): Promise<WebullTokenState | null> {
+    return this.stub().recordRefresh(result)
+  }
+}

--- a/src/trading/state/WebullTokenStateDO.ts
+++ b/src/trading/state/WebullTokenStateDO.ts
@@ -1,0 +1,125 @@
+import { DurableObject } from 'cloudflare:workers'
+import type { WebullTokenStatus } from '../../infrastructure/webull/WebullTokenClient'
+
+const STATE_KEY = 'webull_token'
+
+/**
+ * Durable Object that stores the active Webull `x-access-token` and its
+ * metadata for runtime use (#21 Phase B). Singleton — every caller addresses
+ * `idFromName('default')`, so there is exactly one shared instance per worker
+ * environment.
+ *
+ * The DO is intentionally storage-only. Refresh orchestration (calling
+ * `WebullTokenClient.createToken(existingToken)` and deciding whether to
+ * update) lives in `refreshWebullToken` so the network-call boundary stays
+ * out of the DO and unit tests don't need to mock fetch through a DO stub.
+ */
+
+export interface WebullTokenState {
+  /** Last token observed in NORMAL status. */
+  token: string
+  /** Epoch ms / sec as returned by Webull. We persist the raw value untouched. */
+  expires: number
+  status: WebullTokenStatus
+  /** Wall-clock when this state was written (ISO). */
+  fetchedAt: string
+  /** Wall-clock of the most recent refresh attempt (ISO, success or failure). */
+  lastAttemptAt: string | null
+  /** Wall-clock of the most recent successful refresh (ISO). Helps spot a stuck loop. */
+  lastSuccessAt: string | null
+}
+
+export class WebullTokenStateDO extends DurableObject<object> {
+  async getState(): Promise<WebullTokenState | null> {
+    const stored = await this.ctx.storage.get<WebullTokenState>(STATE_KEY)
+    return stored ?? null
+  }
+
+  /**
+   * Operator seeds the DO with a freshly verified token (issued via
+   * `pnpm run issue-token` and confirmed `NORMAL`). Refusing non-NORMAL values
+   * here keeps a half-verified PENDING token out of the runtime path.
+   */
+  async seedToken(input: {
+    token: string
+    expires: number
+    status: WebullTokenStatus
+    nowIso?: string
+  }): Promise<WebullTokenState> {
+    if (input.status !== 'NORMAL') {
+      throw new Error(
+        `WebullTokenStateDO.seedToken refuses status=${input.status}; only NORMAL tokens may be seeded`,
+      )
+    }
+    const now = input.nowIso ?? new Date().toISOString()
+    const next: WebullTokenState = {
+      token: input.token,
+      expires: input.expires,
+      status: input.status,
+      fetchedAt: now,
+      lastAttemptAt: now,
+      lastSuccessAt: now,
+    }
+    await this.ctx.storage.put(STATE_KEY, next)
+    return next
+  }
+
+  /**
+   * Persist the result of a refresh attempt. `result.success === true` means
+   * `next` replaces the active token; otherwise we keep the previous token
+   * but bump `lastAttemptAt` so monitoring can detect a stuck retry.
+   */
+  async recordRefresh(
+    result:
+      | {
+          success: true
+          token: string
+          expires: number
+          status: WebullTokenStatus
+          nowIso?: string
+        }
+      | { success: false; nowIso?: string },
+  ): Promise<WebullTokenState | null> {
+    const now = result.nowIso ?? new Date().toISOString()
+    const current = (await this.ctx.storage.get<WebullTokenState>(STATE_KEY)) ?? null
+
+    if (result.success) {
+      const next: WebullTokenState = {
+        token: result.token,
+        expires: result.expires,
+        status: result.status,
+        // Keep the original fetchedAt only if this is the same token; otherwise
+        // reset so dashboards / alerts can distinguish "token rotated just now"
+        // from "still using the old token".
+        fetchedAt: current && current.token === result.token ? current.fetchedAt : now,
+        lastAttemptAt: now,
+        lastSuccessAt: now,
+      }
+      await this.ctx.storage.put(STATE_KEY, next)
+      return next
+    }
+
+    if (!current) {
+      // We have no prior state and refresh failed — there is nothing usable to
+      // persist. We return null so the caller knows there's no token, but we
+      // still write a marker row to capture the attempt timestamp for ops.
+      const marker: WebullTokenState = {
+        token: '',
+        expires: 0,
+        status: 'INVALID',
+        fetchedAt: now,
+        lastAttemptAt: now,
+        lastSuccessAt: null,
+      }
+      await this.ctx.storage.put(STATE_KEY, marker)
+      return marker
+    }
+
+    const next: WebullTokenState = {
+      ...current,
+      lastAttemptAt: now,
+    }
+    await this.ctx.storage.put(STATE_KEY, next)
+    return next
+  }
+}

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -10,6 +10,7 @@ import {
 } from '../../infrastructure/notification/configStateChange'
 import { createNotifier } from '../../infrastructure/notification/createNotifier'
 import type { Notifier } from '../../infrastructure/notification/Notifier'
+import { resolveAccessToken } from '../../infrastructure/webull/resolveAccessToken'
 import { createWebullReadClient } from '../../infrastructure/webull/WebullReadClient'
 import { createWebullTradeClient } from '../../infrastructure/webull/WebullTradeClient'
 import { MockExecution } from '../execution/MockExecution'
@@ -447,9 +448,11 @@ export async function runStrategyCron(
   // #21: trade と read を別 client に分離。WebullTradeClient は ENVIRONMENT
   // で staging gate を持つ (= staging からの live order を構造的に防ぐ)。
   // DRY_RUN path では両方 null、MockExecution が選ばれ fallback resolver も
-  // 未注入なので read 側も触れない。
-  const liveTradeClient = global.dryRun ? null : createWebullTradeClient(env)
-  const liveReadClient = global.dryRun ? null : createWebullReadClient(env)
+  // 未注入なので read 側も触れない。Phase B: live path のみ token を DO から
+  // resolve (DRY_RUN なら broker call が無いので無駄に DO を叩かない)。
+  const accessToken = global.dryRun ? undefined : await resolveAccessToken(env)
+  const liveTradeClient = global.dryRun ? null : createWebullTradeClient(env, { accessToken })
+  const liveReadClient = global.dryRun ? null : createWebullReadClient(env, { accessToken })
   const execution = liveTradeClient ? new WebullExecution(liveTradeClient) : new MockExecution()
   // notifier は関数冒頭で組み立て済み (#141)。BUY/SELL emit / per-symbol
   // bar fetch error / broker submit error は scheduler 内で注入された

--- a/test/infrastructure/webull/refreshWebullToken.test.ts
+++ b/test/infrastructure/webull/refreshWebullToken.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it, vi } from 'vitest'
+import { refreshWebullToken } from '../../../src/infrastructure/webull/refreshWebullToken'
+import type { Env } from '../../../src/config/env'
+import type {
+  WebullAccessTokenDto,
+  WebullTokenClient,
+} from '../../../src/infrastructure/webull/WebullTokenClient'
+import type { WebullTokenState } from '../../../src/trading/state/WebullTokenStateDO'
+
+/** Fake DO namespace + stub backed by a mutable record. */
+function makeStateNamespace(initial: WebullTokenState | null) {
+  let state: WebullTokenState | null = initial
+  const stub = {
+    getState: vi.fn(async () => state),
+    seedToken: vi.fn(async () => state!),
+    recordRefresh: vi.fn(async (result: Parameters<typeof stub['recordRefresh']>[0]) => {
+      const now = result.nowIso ?? '2026-05-20T00:00:00.000Z'
+      if (result.success) {
+        state = {
+          token: result.token,
+          expires: result.expires,
+          status: result.status,
+          fetchedAt: state && state.token === result.token ? state.fetchedAt : now,
+          lastAttemptAt: now,
+          lastSuccessAt: now,
+        }
+      } else if (state) {
+        state = { ...state, lastAttemptAt: now }
+      }
+      return state
+    }) as unknown as (
+      result:
+        | { success: true; token: string; expires: number; status: 'NORMAL'; nowIso?: string }
+        | { success: false; nowIso?: string },
+    ) => Promise<WebullTokenState | null>,
+  }
+  return {
+    namespace: {
+      idFromName: vi.fn(() => 'id-stub'),
+      get: vi.fn(() => stub),
+    } as unknown as Env['WEBULL_TOKEN_STATE'],
+    stub,
+    getState: () => state,
+  }
+}
+
+function fakeTokenClient(returns: WebullAccessTokenDto | Error): WebullTokenClient {
+  return {
+    createToken: vi.fn(async () => {
+      if (returns instanceof Error) throw returns
+      return returns
+    }),
+    checkToken: vi.fn(async () => {
+      throw new Error('not implemented')
+    }),
+  } as unknown as WebullTokenClient
+}
+
+const NORMAL: WebullAccessTokenDto = {
+  token: 'tok-new',
+  // ms epoch — exact value doesn't matter, we only check expires > now + 7d.
+  expires: new Date('2026-12-31T00:00:00Z').getTime(),
+  status: 'NORMAL',
+}
+
+describe('refreshWebullToken', () => {
+  it('skips silently when no DO binding is configured (Phase A only env)', async () => {
+    const env = { WEBULL_APP_KEY: 'k', WEBULL_APP_SECRET: 's' } as unknown as Env
+    const result = await refreshWebullToken(env)
+    expect(result.refreshed).toBe(false)
+    expect(result.skippedReason).toMatch(/binding/)
+  })
+
+  it('skips when current NORMAL state has plenty of time left (not due yet)', async () => {
+    const { namespace } = makeStateNamespace({
+      token: 'tok-old',
+      // 30 days from "now" in the test
+      expires: new Date('2026-06-19T00:00:00Z').getTime(),
+      status: 'NORMAL',
+      fetchedAt: '2026-05-19T00:00:00Z',
+      lastAttemptAt: '2026-05-19T00:00:00Z',
+      lastSuccessAt: '2026-05-19T00:00:00Z',
+    })
+    const env = {
+      WEBULL_TOKEN_STATE: namespace,
+      WEBULL_APP_KEY: 'k',
+      WEBULL_APP_SECRET: 's',
+    } as unknown as Env
+
+    const tokenClient = fakeTokenClient(NORMAL)
+    const result = await refreshWebullToken(env, {
+      now: () => new Date('2026-05-20T00:00:00Z'),
+      tokenClient,
+    })
+
+    expect(result.refreshed).toBe(false)
+    expect(result.skippedReason).toMatch(/not due yet/)
+    expect(tokenClient.createToken).not.toHaveBeenCalled()
+  })
+
+  it('refreshes when expires is within the 7-day window', async () => {
+    const { namespace, stub } = makeStateNamespace({
+      token: 'tok-old',
+      // 3 days away — inside the refresh window
+      expires: new Date('2026-05-23T00:00:00Z').getTime(),
+      status: 'NORMAL',
+      fetchedAt: '2026-05-19T00:00:00Z',
+      lastAttemptAt: '2026-05-19T00:00:00Z',
+      lastSuccessAt: '2026-05-19T00:00:00Z',
+    })
+    const env = {
+      WEBULL_TOKEN_STATE: namespace,
+      WEBULL_APP_KEY: 'k',
+      WEBULL_APP_SECRET: 's',
+    } as unknown as Env
+
+    const tokenClient = fakeTokenClient(NORMAL)
+    const result = await refreshWebullToken(env, {
+      now: () => new Date('2026-05-20T00:00:00Z'),
+      tokenClient,
+    })
+
+    expect(result.refreshed).toBe(true)
+    expect(tokenClient.createToken).toHaveBeenCalledWith('tok-old')
+    expect(stub.recordRefresh).toHaveBeenCalled()
+  })
+
+  it('refreshes immediately when DO is empty (no prior state at all)', async () => {
+    const { namespace } = makeStateNamespace(null)
+    const env = {
+      WEBULL_TOKEN_STATE: namespace,
+      WEBULL_APP_KEY: 'k',
+      WEBULL_APP_SECRET: 's',
+    } as unknown as Env
+
+    const tokenClient = fakeTokenClient(NORMAL)
+    const result = await refreshWebullToken(env, { tokenClient })
+
+    expect(result.refreshed).toBe(true)
+    // createToken was called with undefined (no existing token to pass)
+    expect(tokenClient.createToken).toHaveBeenCalledWith(undefined)
+  })
+
+  it('records a failed attempt when createToken returns non-NORMAL status', async () => {
+    const { namespace, stub } = makeStateNamespace({
+      token: 'tok-old',
+      expires: new Date('2026-05-23T00:00:00Z').getTime(),
+      status: 'NORMAL',
+      fetchedAt: '2026-05-19T00:00:00Z',
+      lastAttemptAt: '2026-05-19T00:00:00Z',
+      lastSuccessAt: '2026-05-19T00:00:00Z',
+    })
+    const env = {
+      WEBULL_TOKEN_STATE: namespace,
+      WEBULL_APP_KEY: 'k',
+      WEBULL_APP_SECRET: 's',
+    } as unknown as Env
+
+    const tokenClient = fakeTokenClient({ token: 'pending-tok', expires: 0, status: 'PENDING' })
+    const result = await refreshWebullToken(env, {
+      now: () => new Date('2026-05-20T00:00:00Z'),
+      tokenClient,
+    })
+
+    expect(result.refreshed).toBe(false)
+    expect(result.failureReason).toMatch(/PENDING/)
+    // existing token is preserved, only lastAttemptAt bumps.
+    expect(stub.recordRefresh).toHaveBeenCalledWith(
+      expect.objectContaining({ success: false }),
+    )
+  })
+
+  it('records a failed attempt when createToken throws (network / broker error)', async () => {
+    const { namespace } = makeStateNamespace({
+      token: 'tok-old',
+      expires: new Date('2026-05-23T00:00:00Z').getTime(),
+      status: 'NORMAL',
+      fetchedAt: '2026-05-19T00:00:00Z',
+      lastAttemptAt: '2026-05-19T00:00:00Z',
+      lastSuccessAt: '2026-05-19T00:00:00Z',
+    })
+    const env = {
+      WEBULL_TOKEN_STATE: namespace,
+      WEBULL_APP_KEY: 'k',
+      WEBULL_APP_SECRET: 's',
+    } as unknown as Env
+
+    const tokenClient = fakeTokenClient(new Error('broker 500'))
+    const result = await refreshWebullToken(env, {
+      now: () => new Date('2026-05-20T00:00:00Z'),
+      tokenClient,
+    })
+
+    expect(result.refreshed).toBe(false)
+    expect(result.failureReason).toMatch(/broker 500/)
+  })
+
+  it('refreshes when force=true even with plenty of time left', async () => {
+    const { namespace } = makeStateNamespace({
+      token: 'tok-old',
+      expires: new Date('2027-01-01T00:00:00Z').getTime(),
+      status: 'NORMAL',
+      fetchedAt: '2026-05-19T00:00:00Z',
+      lastAttemptAt: '2026-05-19T00:00:00Z',
+      lastSuccessAt: '2026-05-19T00:00:00Z',
+    })
+    const env = {
+      WEBULL_TOKEN_STATE: namespace,
+      WEBULL_APP_KEY: 'k',
+      WEBULL_APP_SECRET: 's',
+    } as unknown as Env
+
+    const tokenClient = fakeTokenClient(NORMAL)
+    const result = await refreshWebullToken(env, {
+      now: () => new Date('2026-05-20T00:00:00Z'),
+      tokenClient,
+      force: true,
+    })
+
+    expect(result.refreshed).toBe(true)
+  })
+
+  it('rejects when app key / secret missing', async () => {
+    const { namespace } = makeStateNamespace(null)
+    const env = { WEBULL_TOKEN_STATE: namespace } as unknown as Env
+    const result = await refreshWebullToken(env)
+    expect(result.refreshed).toBe(false)
+    expect(result.failureReason).toMatch(/WEBULL_APP_KEY/)
+  })
+})

--- a/test/infrastructure/webull/resolveAccessToken.test.ts
+++ b/test/infrastructure/webull/resolveAccessToken.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from 'vitest'
+import { resolveAccessToken } from '../../../src/infrastructure/webull/resolveAccessToken'
+import type { Env } from '../../../src/config/env'
+import type { WebullTokenState } from '../../../src/trading/state/WebullTokenStateDO'
+
+/**
+ * Fake `DurableObjectNamespace<WebullTokenStateDO>` for tests. Wraps a
+ * single-shot state value with a `getState()` stub so we can exercise the
+ * resolver without spinning up a real DO runtime.
+ */
+function makeNamespace(state: WebullTokenState | null, throws?: Error) {
+  const stub = { getState: vi.fn(async () => { if (throws) throw throws; return state }) }
+  return {
+    idFromName: vi.fn(() => 'id-stub'),
+    get: vi.fn(() => stub),
+  } as unknown as Env['WEBULL_TOKEN_STATE']
+}
+
+describe('resolveAccessToken', () => {
+  // #21 Phase B: DO 由来の NORMAL token が runtime の正源。Phase A の env は
+  // bootstrap 用 fallback。両方 set されてれば DO 側を優先するのが本 helper の
+  // 中核挙動。
+  it('returns DO token when DO state is NORMAL (env fallback is ignored)', async () => {
+    const env = {
+      WEBULL_TOKEN_STATE: makeNamespace({
+        token: 'do-token',
+        expires: 9_999_999_999,
+        status: 'NORMAL',
+        fetchedAt: '2026-05-20T00:00:00Z',
+        lastAttemptAt: '2026-05-20T00:00:00Z',
+        lastSuccessAt: '2026-05-20T00:00:00Z',
+      }),
+      WEBULL_ACCESS_TOKEN: 'env-token-should-be-ignored',
+    } as unknown as Env
+
+    expect(await resolveAccessToken(env)).toBe('do-token')
+  })
+
+  // DO に何も入ってないとき (= Phase A 初回起動 / 投入前) は env fallback で動く。
+  // production cutover を「先に env で動かす → 後で DO 投入」の流れにできる。
+  it('falls back to env when DO state is null', async () => {
+    const env = {
+      WEBULL_TOKEN_STATE: makeNamespace(null),
+      WEBULL_ACCESS_TOKEN: 'env-bootstrap',
+    } as unknown as Env
+
+    expect(await resolveAccessToken(env)).toBe('env-bootstrap')
+  })
+
+  // INVALID / EXPIRED な state は「使うべきでない」シグナルなので env にも fallback
+  // しない (現在の token を強制的に "無し" 扱いにする)。INVALID_TOKEN を broker が
+  // 返してから operator が気付けるよう、わざと auth header を欠落させる。
+  it.each(['PENDING', 'INVALID', 'EXPIRED'] as const)(
+    'returns env fallback when DO state is %s (does not silently emit stale token)',
+    async (status) => {
+      const env = {
+        WEBULL_TOKEN_STATE: makeNamespace({
+          token: 'stale-token',
+          expires: 1_700_000_000,
+          status,
+          fetchedAt: '2026-05-20T00:00:00Z',
+          lastAttemptAt: '2026-05-20T00:00:00Z',
+          lastSuccessAt: null,
+        }),
+        WEBULL_ACCESS_TOKEN: 'env-fallback',
+      } as unknown as Env
+
+      expect(await resolveAccessToken(env)).toBe('env-fallback')
+    },
+  )
+
+  it('returns env when DO binding is not configured', async () => {
+    const env = {
+      WEBULL_ACCESS_TOKEN: 'env-only',
+    } as unknown as Env
+
+    expect(await resolveAccessToken(env)).toBe('env-only')
+  })
+
+  it('returns undefined when neither DO nor env is set', async () => {
+    const env = {} as unknown as Env
+    expect(await resolveAccessToken(env)).toBeUndefined()
+  })
+
+  it('treats whitespace-only env as unset', async () => {
+    const env = { WEBULL_ACCESS_TOKEN: '   ' } as unknown as Env
+    expect(await resolveAccessToken(env)).toBeUndefined()
+  })
+
+  // DO call が throw した場合は env にフォールバックして broker call を試行させる。
+  // DO bind が壊れてるからといって全 broker call を止めると過剰反応 → fail-safe
+  // のレイヤーが多重化されてる事を尊重 (token なら broker 側で 401)。
+  it('falls back to env when DO stub throws (with warn log)', async () => {
+    const env = {
+      WEBULL_TOKEN_STATE: makeNamespace(null, new Error('do offline')),
+      WEBULL_ACCESS_TOKEN: 'env-after-do-fail',
+    } as unknown as Env
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    try {
+      expect(await resolveAccessToken(env)).toBe('env-after-do-fail')
+      expect(warnSpy).toHaveBeenCalled()
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+})

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -9,7 +9,8 @@
   "durable_objects": {
     "bindings": [
       { "name": "SYMBOL_STATE", "class_name": "SymbolStateDO" },
-      { "name": "PORTFOLIO_STATE", "class_name": "PortfolioStateDO" }
+      { "name": "PORTFOLIO_STATE", "class_name": "PortfolioStateDO" },
+      { "name": "WEBULL_TOKEN_STATE", "class_name": "WebullTokenStateDO" }
     ]
   },
   // #285: Cloudflare Workers RateLimit bindings. State-changing POST endpoints
@@ -44,7 +45,8 @@
     { "tag": "v1", "new_sqlite_classes": ["SymbolStateDO"] },
     { "tag": "v2", "new_sqlite_classes": ["PortfolioStateDO"] },
     { "tag": "v3", "new_sqlite_classes": ["BridgeContainer"] },
-    { "tag": "v4", "deleted_classes": ["BridgeContainer"] }
+    { "tag": "v4", "deleted_classes": ["BridgeContainer"] },
+    { "tag": "v5", "new_sqlite_classes": ["WebullTokenStateDO"] }
   ],
   "triggers": {
     "crons": [
@@ -66,7 +68,8 @@
       "durable_objects": {
         "bindings": [
           { "name": "SYMBOL_STATE", "class_name": "SymbolStateDO" },
-          { "name": "PORTFOLIO_STATE", "class_name": "PortfolioStateDO" }
+          { "name": "PORTFOLIO_STATE", "class_name": "PortfolioStateDO" },
+          { "name": "WEBULL_TOKEN_STATE", "class_name": "WebullTokenStateDO" }
         ]
       },
       "d1_databases": [
@@ -117,7 +120,8 @@
       "durable_objects": {
         "bindings": [
           { "name": "SYMBOL_STATE", "class_name": "SymbolStateDO" },
-          { "name": "PORTFOLIO_STATE", "class_name": "PortfolioStateDO" }
+          { "name": "PORTFOLIO_STATE", "class_name": "PortfolioStateDO" },
+          { "name": "WEBULL_TOKEN_STATE", "class_name": "WebullTokenStateDO" }
         ]
       },
       "d1_databases": [
@@ -166,7 +170,8 @@
       "durable_objects": {
         "bindings": [
           { "name": "SYMBOL_STATE", "class_name": "SymbolStateDO" },
-          { "name": "PORTFOLIO_STATE", "class_name": "PortfolioStateDO" }
+          { "name": "PORTFOLIO_STATE", "class_name": "PortfolioStateDO" },
+          { "name": "WEBULL_TOKEN_STATE", "class_name": "WebullTokenStateDO" }
         ]
       },
       "d1_databases": [


### PR DESCRIPTION
## Summary
- \`WebullTokenStateDO\` を runtime の token source of truth として導入 (#21 Phase B)。Phase A の \`WEBULL_ACCESS_TOKEN\` env はそのまま bootstrap fallback として残す
- \`resolveAccessToken(env)\` helper: DO の NORMAL token 優先 → env fallback。5 つの factory (HTTP / Trade / Read / Quote / Bar) に \`accessToken\` override option を追加
- \`refreshWebullToken(env)\` helper: \`createToken(existingToken)\` で更新 (7-day refresh window)
- 22:00 UTC daily cron に auto-refresh を追加。失敗は critical notification (operator が \`issue-token\` → \`/admin/webull-token/seed\` で再投入)
- Admin endpoints: \`GET /admin/webull-token\` (status, token plaintext は返さない) / \`POST /admin/webull-token/seed\` (NORMAL check 後 DO 書込) / \`POST /admin/webull-token/refresh\` (force trigger)
- DO binding + migration v5 を wrangler.jsonc に追加 (top-level + dev / staging / production)

## なぜ
Phase A で operator が token を取れるようになったが、**15-day inactivity** で勝手に \`INVALID\` 化する仕様の下では cron 全部が 401 で沈黙する事故が起きる。DO に乗せて自動 refresh する事で、operator の関与は **初回 seed と再発行時のみ** に絞れる。

## 設計のポイント

| レイヤー | 動作 |
|---|---|
| \`WebullTokenStateDO\` | singleton DO、storage に \`{token, expires, status, fetchedAt, lastAttemptAt, lastSuccessAt}\`。NORMAL のみ seed 受理 |
| \`resolveAccessToken(env)\` | DO bound + NORMAL → DO token / それ以外 → env fallback / それもなければ undefined (broker が 401 で発覚させる) |
| \`refreshWebullToken(env)\` | 期限 7 日切ったら \`createToken(existingToken)\` で更新。成功なら DO 書込、失敗なら \`lastAttemptAt\` だけ bump して既存 token は保持 |
| cron \`0 22 * * *\` | portfolio rollover と同じ枠で 1 日 1 回実行 |
| Admin endpoints | token plaintext は GET で head/tail のみ表示 (audit log / browser cache 経由の漏洩防止)。seed は broker 側で再 check してから DO 書込 (TOC-TOU 防御) |

## 投入手順 (operator)

\`\`\`bash
# 1. 初回 (or 再発行) — Phase A の手順
pnpm run issue-token  # → NORMAL token 取得

# 2. DO に seed (env 投入は不要、DO が source of truth)
curl -X POST https://trading-staging.chanu.co/admin/webull-token/seed \\
  -H 'Cf-Access-Jwt-Assertion: ...' \\
  -d '{\"token\":\"<NORMAL token>\"}'

# 3. status 確認
curl https://trading-staging.chanu.co/admin/webull-token
# → { seeded: true, state: { tokenHint, expires, status: 'NORMAL', ... } }

# 4. 以降は cron で自動 refresh (毎日 22:00 UTC、期限 7 日前から)
# 失敗時は Slack/Discord に critical notification 飛ぶので operator が手順 1-2 を実行
\`\`\`

## Test plan
- [x] \`pnpm typecheck\` ✅
- [x] \`pnpm test\` 1127 tests pass (新規 17 件: resolveAccessToken の 7、refreshWebullToken の 8、+ regression) ✅
- [ ] staging deploy 後、\`/admin/webull-token\` で seeded=false が返る (DO 空の初期状態)
- [ ] staging で \`POST /admin/webull-token/seed\` → \`/admin/broker/probe\` で 401 INVALID_TOKEN が消える事を確認
- [ ] 22:00 UTC 待たずに \`POST /admin/webull-token/refresh\` で force refresh が動く事を確認
- [ ] production deploy 前に Phase A の手順で token 取得、production deploy 後に seed

## scope 外 (follow-up)
- HMAC SHA1 vs SHA256 の本番確認 (UAT は SHA1 で動いたが本番要再確認)
- \`data-api.webull.co.jp\` の timeout 切り分け (IP whitelist / TLS / DNS)
- Token 15-day inactivity の cron 実行が「broker rate limit を踏まないか」の観測 (Phase B 投入後の最初の 30 日でログ確認)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Webullアクセストークンの自動更新（定期実行）を追加
  * 管理画面でトークン状態の確認・投入・手動更新が可能、トークン原文は表示しません
  * Webullクライアントが実行時に最新トークンを利用するように改良

* **テスト**
  * トークン更新・解決ロジックの単体テストを追加

* **その他**
  * インフラ設定にトークン状態用のDurable Objectバインディングを追加

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/326?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->