### PR TITLE
feat(dashboard): auto-extract Webull token from pasted issue-token output (#21 Phase B follow-up)

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -912,10 +912,22 @@ export const dashboard = new Hono<DashboardBindings>()
       return c.redirect('/dashboard/webull-token?error=WEBULL_APP_KEY+%2F+WEBULL_APP_SECRET+missing', 303)
     }
     const form = await c.req.formData()
-    const rawToken = (form.get('token')?.toString() ?? '').trim()
-    if (rawToken.length === 0) {
+    const rawPaste = (form.get('token')?.toString() ?? '').trim()
+    if (rawPaste.length === 0) {
       return c.redirect('/dashboard/webull-token?error=token+is+required', 303)
     }
+    // issue-token script の出力丸ごと貼り付けても OK にする。stderr の
+    // diagnostic ("[issue-token] ...") や wrangler suggest 行 ("pnpm wrangler
+    // ...") を strip、残った 1 行が NORMAL token。複数行残ったら曖昧として
+    // error にする (operator に何を貼ったか判別させる)。
+    const extraction = extractTokenFromPaste(rawPaste)
+    if (!extraction.ok) {
+      return c.redirect(
+        `/dashboard/webull-token?error=${encodeURIComponent(extraction.error)}`,
+        303,
+      )
+    }
+    const rawToken = extraction.token
     const tokenClient = new WebullTokenClient({
       auth: new WebullAuth({
         appKey: c.env.WEBULL_APP_KEY,
@@ -1018,6 +1030,48 @@ function messageOf(error: unknown): string {
 }
 
 /**
+ * `pnpm run issue-token` の出力から実 token (NORMAL の stdout 行) を抽出する。
+ *
+ * operator が terminal の出力丸ごと貼ったケースに耐性をつけるため:
+ *   - `[issue-token] ...` 始まりの diagnostic は捨てる
+ *   - wrangler instruction (`pnpm wrangler ...`, `(paste the value...)`) は捨てる
+ *   - 空行 / whitespace-only は捨てる
+ *   - 残った 1 行 = NORMAL token
+ *
+ * 複数行残った場合は何が token か判別不能として error。operator は不要行を
+ * 削って再 submit する。
+ *
+ * exported for testing。
+ */
+export function extractTokenFromPaste(raw: string):
+  | { ok: true; token: string }
+  | { ok: false; error: string } {
+  const candidates = raw
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .filter((line) => !line.startsWith('[issue-token]'))
+    .filter((line) => !line.startsWith('pnpm '))
+    .filter((line) => !line.startsWith('(paste'))
+  if (candidates.length === 0) {
+    return {
+      ok: false,
+      error:
+        'token line not found — did the issue-token flow finish with status=NORMAL? (the PENDING summary like "0197...7689" is NOT the actual token)',
+    }
+  }
+  if (candidates.length > 1) {
+    // 余分な行が残ってる: operator に何を貼ってるか伝えるため head 部分を含める。
+    const preview = candidates.map((c) => c.slice(0, 32)).join(' | ')
+    return {
+      ok: false,
+      error: `expected 1 token line, found ${candidates.length}: ${preview}`,
+    }
+  }
+  return { ok: true, token: candidates[0]! }
+}
+
+/**
  * #21 Phase B follow-up: Webull token 管理 UI の HTML body。token plaintext は
  * 一切埋め込まない (tokenHint だけ)。notice / error は redirect 後の query string
  * 経由で受け取る (PRG パターン)。
@@ -1050,14 +1104,33 @@ function renderWebullTokenBody(args: {
   ${stateSection}
 
   <h2>新規 seed (or 上書き)</h2>
+  <details style="margin-bottom:8px">
+    <summary style="cursor:pointer;color:#555">📋 何を貼ればいい？</summary>
+    <div style="padding:8px 0 0 16px;color:#555;font-size:13px;line-height:1.6">
+      <p><code>pnpm run issue-token</code> を最後まで完了させる (status=NORMAL になる) と、
+      stdout の <strong>最後の 1 行</strong> に長い英数字の token が出力されます。<br>
+      diagnostic ログ (<code>[issue-token] ...</code> で始まる行) を含めて全文貼り付けても OK
+      — server-side で token 行だけ自動抽出します。</p>
+      <p>⚠ ログ内の <code>received: 0197e6...7689</code> のような <strong>"..." 入りの短い文字列は
+      実 token ではなく表示用の省略形</strong> です。2FA verify を完了するまで実 token は
+      出力されません。</p>
+      <p>例 (NORMAL 化したときの末尾出力):</p>
+      <pre style="background:#f6f8fa;padding:8px;border-radius:4px;overflow:auto;font-size:12px">[issue-token] poll (60s elapsed): 0197e6...7689 (status=NORMAL)
+[issue-token] NORMAL token acquired. Inject via:
+  pnpm wrangler secret put WEBULL_ACCESS_TOKEN --env=&lt;dev|staging|production&gt;
+  (paste the value printed below)
+
+0197e6abcd1234567890fedcba9876543210...   ← この長い行が実 token</pre>
+    </div>
+  </details>
   <form method="post" action="/dashboard/webull-token/seed" style="display:flex;flex-direction:column;gap:8px;max-width:720px">
-    <label for="token" style="font-weight:bold">token 文字列 (NORMAL のみ受理):</label>
-    <textarea id="token" name="token" rows="3" required
-      placeholder="pnpm run issue-token の stdout を丸ごと貼り付け"
+    <label for="token" style="font-weight:bold">issue-token の出力を貼り付け (丸ごとで OK):</label>
+    <textarea id="token" name="token" rows="6" required
+      placeholder="例:&#10;[issue-token] NORMAL token acquired. Inject via:&#10;  pnpm wrangler secret put WEBULL_ACCESS_TOKEN --env=production&#10;&#10;0197e6abcd1234567890fedcba9876543210..."
       style="font-family:ui-monospace,monospace;padding:6px;border:1px solid #ccc;border-radius:4px"
     ></textarea>
     <button type="submit" style="padding:8px 16px;background:#28a;color:#fff;border:none;border-radius:4px;cursor:pointer;align-self:flex-start">
-      seed (broker で再 verify 後に DO 書込)
+      seed (token 行を自動抽出 → broker で再 verify → DO 書込)
     </button>
   </form>
 

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1061,11 +1061,12 @@ export function extractTokenFromPaste(raw: string):
     }
   }
   if (candidates.length > 1) {
-    // 余分な行が残ってる: operator に何を貼ってるか伝えるため head 部分を含める。
-    const preview = candidates.map((c) => c.slice(0, 32)).join(' | ')
+    // 候補プレビューを URL に含めると token 断片が browser 履歴 / access log に
+    // 漏れる (CodeRabbit #328)。件数のみ返して、operator は form 側で
+    // 不要行を削って再 submit する。
     return {
       ok: false,
-      error: `expected 1 token line, found ${candidates.length}: ${preview}`,
+      error: `expected 1 token line, found ${candidates.length}. remove non-token lines and retry`,
     }
   }
   return { ok: true, token: candidates[0]! }
@@ -1115,18 +1116,18 @@ function renderWebullTokenBody(args: {
       実 token ではなく表示用の省略形</strong> です。2FA verify を完了するまで実 token は
       出力されません。</p>
       <p>例 (NORMAL 化したときの末尾出力):</p>
-      <pre style="background:#f6f8fa;padding:8px;border-radius:4px;overflow:auto;font-size:12px">[issue-token] poll (60s elapsed): 0197e6...7689 (status=NORMAL)
+      <pre style="background:#f6f8fa;padding:8px;border-radius:4px;overflow:auto;font-size:12px">[issue-token] poll (60s elapsed): xxxxxx...yyyy (status=NORMAL)
 [issue-token] NORMAL token acquired. Inject via:
   pnpm wrangler secret put WEBULL_ACCESS_TOKEN --env=&lt;dev|staging|production&gt;
   (paste the value printed below)
 
-0197e6abcd1234567890fedcba9876543210...   ← この長い行が実 token</pre>
+&lt;long alphanumeric NORMAL token string&gt;   ← この行が実 token</pre>
     </div>
   </details>
   <form method="post" action="/dashboard/webull-token/seed" style="display:flex;flex-direction:column;gap:8px;max-width:720px">
     <label for="token" style="font-weight:bold">issue-token の出力を貼り付け (丸ごとで OK):</label>
     <textarea id="token" name="token" rows="6" required
-      placeholder="例:&#10;[issue-token] NORMAL token acquired. Inject via:&#10;  pnpm wrangler secret put WEBULL_ACCESS_TOKEN --env=production&#10;&#10;0197e6abcd1234567890fedcba9876543210..."
+      placeholder="例:&#10;[issue-token] NORMAL token acquired. Inject via:&#10;  pnpm wrangler secret put WEBULL_ACCESS_TOKEN --env=production&#10;&#10;<long alphanumeric NORMAL token string>"
       style="font-family:ui-monospace,monospace;padding:6px;border:1px solid #ccc;border-radius:4px"
     ></textarea>
     <button type="submit" style="padding:8px 16px;background:#28a;color:#fff;border:none;border-radius:4px;cursor:pointer;align-self:flex-start">

--- a/test/routes/dashboardWebullTokenExtract.test.ts
+++ b/test/routes/dashboardWebullTokenExtract.test.ts
@@ -3,36 +3,37 @@ import { extractTokenFromPaste } from '../../src/routes/dashboard'
 
 describe('extractTokenFromPaste (#21 Phase B follow-up)', () => {
   // happy path: operator が token 文字列だけ貼った
+  // ダミー値 (`test_token_*`) を使う事で secret scanner ノイズを避ける (CodeRabbit #328)
   it('returns the token when only the token line is pasted', () => {
-    const result = extractTokenFromPaste('0197e6abcd1234567890fedcba9876543210')
-    expect(result).toEqual({ ok: true, token: '0197e6abcd1234567890fedcba9876543210' })
+    const result = extractTokenFromPaste('test_token_normal_single_line')
+    expect(result).toEqual({ ok: true, token: 'test_token_normal_single_line' })
   })
 
   // 出力丸ごと貼り付け: issue-token script の典型的な NORMAL 化時の出力
   it('strips [issue-token] diagnostic lines and wrangler instruction bullets', () => {
     const paste = `[issue-token] base URL: https://api.webull.co.jp
 [issue-token] step 1/3: POST /openapi/auth/token/create
-[issue-token] received: 0197e6...7689 (expires=1779286627791, status=PENDING)
+[issue-token] received: xxxxxx...yyyy (expires=1779286627791, status=PENDING)
 [issue-token] step 2/3: open Webull mobile app and complete 2FA SMS verify (5 min).
 [issue-token] step 3/3: polling /openapi/auth/token/check every 30s (timeout 300s)...
-[issue-token] poll (30s elapsed): 0197e6...7689 (expires=..., status=PENDING)
-[issue-token] poll (60s elapsed): 0197e6...7689 (expires=..., status=NORMAL)
+[issue-token] poll (30s elapsed): xxxxxx...yyyy (expires=..., status=PENDING)
+[issue-token] poll (60s elapsed): xxxxxx...yyyy (expires=..., status=NORMAL)
 [issue-token] NORMAL token acquired. Inject via:
   pnpm wrangler secret put WEBULL_ACCESS_TOKEN --env=<dev|staging|production>
   (paste the value printed below)
 
-0197e6abcd1234567890fedcba9876543210ffaabbccddeeff7689`
+test_token_normal_full_output_paste`
     const result = extractTokenFromPaste(paste)
     expect(result).toEqual({
       ok: true,
-      token: '0197e6abcd1234567890fedcba9876543210ffaabbccddeeff7689',
+      token: 'test_token_normal_full_output_paste',
     })
   })
 
   it('trims whitespace and CRLF line endings', () => {
-    const paste = '  \r\n[issue-token] foo\r\n  0197e6abcd1234567890fedcba9876543210  \r\n  \r\n'
+    const paste = '  \r\n[issue-token] foo\r\n  test_token_with_crlf  \r\n  \r\n'
     const result = extractTokenFromPaste(paste)
-    expect(result).toEqual({ ok: true, token: '0197e6abcd1234567890fedcba9876543210' })
+    expect(result).toEqual({ ok: true, token: 'test_token_with_crlf' })
   })
 
   // negative: empty / whitespace-only
@@ -57,15 +58,18 @@ describe('extractTokenFromPaste (#21 Phase B follow-up)', () => {
   })
 
   // negative: 2 つ以上の non-diagnostic 行 — 何が token か曖昧
+  // 候補プレビューは URL に乗らない (CodeRabbit #328): 件数だけ返す。
   it('errors when multiple candidate lines remain (ambiguous)', () => {
     const paste = `[issue-token] foo
-abc123def456ghi
-xyz789jkl012mno`
+test_candidate_first
+test_candidate_second`
     const result = extractTokenFromPaste(paste)
     expect(result.ok).toBe(false)
     if (!result.ok) {
       expect(result.error).toMatch(/expected 1 token line/)
-      expect(result.error).toMatch(/abc123def456ghi/)
+      // raw candidate 文字列は error に含めない (URL 履歴に漏らさない)
+      expect(result.error).not.toMatch(/test_candidate/)
+      expect(result.error).toMatch(/remove non-token lines/)
     }
   })
 })

--- a/test/routes/dashboardWebullTokenExtract.test.ts
+++ b/test/routes/dashboardWebullTokenExtract.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import { extractTokenFromPaste } from '../../src/routes/dashboard'
+
+describe('extractTokenFromPaste (#21 Phase B follow-up)', () => {
+  // happy path: operator が token 文字列だけ貼った
+  it('returns the token when only the token line is pasted', () => {
+    const result = extractTokenFromPaste('0197e6abcd1234567890fedcba9876543210')
+    expect(result).toEqual({ ok: true, token: '0197e6abcd1234567890fedcba9876543210' })
+  })
+
+  // 出力丸ごと貼り付け: issue-token script の典型的な NORMAL 化時の出力
+  it('strips [issue-token] diagnostic lines and wrangler instruction bullets', () => {
+    const paste = `[issue-token] base URL: https://api.webull.co.jp
+[issue-token] step 1/3: POST /openapi/auth/token/create
+[issue-token] received: 0197e6...7689 (expires=1779286627791, status=PENDING)
+[issue-token] step 2/3: open Webull mobile app and complete 2FA SMS verify (5 min).
+[issue-token] step 3/3: polling /openapi/auth/token/check every 30s (timeout 300s)...
+[issue-token] poll (30s elapsed): 0197e6...7689 (expires=..., status=PENDING)
+[issue-token] poll (60s elapsed): 0197e6...7689 (expires=..., status=NORMAL)
+[issue-token] NORMAL token acquired. Inject via:
+  pnpm wrangler secret put WEBULL_ACCESS_TOKEN --env=<dev|staging|production>
+  (paste the value printed below)
+
+0197e6abcd1234567890fedcba9876543210ffaabbccddeeff7689`
+    const result = extractTokenFromPaste(paste)
+    expect(result).toEqual({
+      ok: true,
+      token: '0197e6abcd1234567890fedcba9876543210ffaabbccddeeff7689',
+    })
+  })
+
+  it('trims whitespace and CRLF line endings', () => {
+    const paste = '  \r\n[issue-token] foo\r\n  0197e6abcd1234567890fedcba9876543210  \r\n  \r\n'
+    const result = extractTokenFromPaste(paste)
+    expect(result).toEqual({ ok: true, token: '0197e6abcd1234567890fedcba9876543210' })
+  })
+
+  // negative: empty / whitespace-only
+  it('errors when nothing meaningful is pasted', () => {
+    const result = extractTokenFromPaste('  \n\n\n  ')
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toMatch(/not found/)
+  })
+
+  // negative: only diagnostic lines (operator copied output before NORMAL)
+  it('errors when only diagnostic lines are present (operator Ctrl+C\'d before NORMAL)', () => {
+    const paste = `[issue-token] base URL: ...
+[issue-token] step 1/3: ...
+[issue-token] received: xxx...yyy (status=PENDING)`
+    const result = extractTokenFromPaste(paste)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toMatch(/not found/)
+      // operator が "..." 入りの summary を貼ってる事故への hint も入る
+      expect(result.error).toMatch(/PENDING summary/)
+    }
+  })
+
+  // negative: 2 つ以上の non-diagnostic 行 — 何が token か曖昧
+  it('errors when multiple candidate lines remain (ambiguous)', () => {
+    const paste = `[issue-token] foo
+abc123def456ghi
+xyz789jkl012mno`
+    const result = extractTokenFromPaste(paste)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toMatch(/expected 1 token line/)
+      expect(result.error).toMatch(/abc123def456ghi/)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- \`/dashboard/webull-token\` の seed form を **issue-token の出力丸ごと貼り付け OK** に変更
- \`extractTokenFromPaste()\` helper を追加: \`[issue-token] ...\` 行と wrangler instruction 行を strip、残った 1 行を token として返す
- 失敗系 (token 行 0 件 / 複数件) は label 付きで \`?error=\` 経由で表示、500 で落とさない
- 「何を貼ればいいか」の inline 説明を \`<details>\` で展開可能に追加、placeholder も「実 token はこんな形式」の例に変更

## なぜ
PR #327 の form の最初の実用で操作者が **summary 表示の \`0197e6...7689\` を実 token と誤認して貼り付け** → broker が INVALID で reject → 何が悪いのか分からない、という UX 事故が発生。

原因:
1. terminal の出力で stderr (diagnostic) と stdout (実 token) が混在してて区別困難
2. 既存 form の placeholder が "stdout を丸ごと" だったが、実際の terminal output では分離不能
3. \`[issue-token] received: 0197e6...7689\` は表示用の masked summary (head 6 + 末尾 4 + "..." 連結) で、実 token じゃないが文字列としては token 風に見える

## 設計

### \`extractTokenFromPaste(raw: string)\` の動作

入力例:
\`\`\`
[issue-token] base URL: https://api.webull.co.jp
[issue-token] step 1/3: POST /openapi/auth/token/create
[issue-token] received: 0197e6...7689 (expires=..., status=PENDING)
[issue-token] poll (30s elapsed): ... (status=NORMAL)
[issue-token] NORMAL token acquired. Inject via:
  pnpm wrangler secret put WEBULL_ACCESS_TOKEN --env=production
  (paste the value printed below)

0197e6abcd1234567890fedcba9876543210ffaabbccddeeff7689
\`\`\`

処理:
1. CRLF 含めて行分割
2. 各行 trim
3. 空行を捨てる
4. \`[issue-token]\` で始まる行を捨てる
5. \`pnpm \` で始まる行を捨てる
6. \`(paste\` で始まる行を捨てる
7. 残り 1 行 = token、 ≠ 1 行はエラー

### Error UX
- 候補 0: "did the issue-token flow finish with status=NORMAL? (the PENDING summary like \"0197...7689\" is NOT the actual token)" — 一番起きやすい誤操作への具体的 hint
- 候補 2+: head 32 文字ずつを preview にして「何を貼ったか」を operator に見せる

## Test plan
- [x] \`pnpm typecheck\` ✅
- [x] \`pnpm test\` 1133 tests pass (新規 6 件: extract 正常 / CRLF / 空 / PENDING summary / 多数候補) ✅
- [ ] staging deploy 後、issue-token の出力丸ごとを form に貼り付け → seed 成功確認
- [ ] わざと PENDING 中の \`0197e6...7689\` summary を貼り付け → 候補 0 件の error メッセージ確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * トークンシード入力を拡張し、コマンド出力などの全文を貼り付けるだけでサーバー側が自動抽出して正しいトークン行を再検証します。抽出失敗時はエラーメッセージ付きでリダイレクトされ、UIの説明とプレースホルダ・ボタン文言も更新しました。

* **Tests**
  * 貼り付けからのトークン抽出と各種エラー判定を検証する包括的なテストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/328?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->