### PR TITLE
fix(admin): pass resolved x-access-token to broker probe (#21 Phase B follow-up)

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -543,6 +543,12 @@ export const admin = new Hono<AppBindings>()
       )
     }
 
+    // #21 Phase B: DO or env 由来の `x-access-token` を resolve。NORMAL token が
+    // あれば全 probe call に乗せる (none なら省略、broker が 401 で発覚する)。
+    // この probe は client factory を経由せず buildSignedHeaders を直接呼んでた
+    // ため Phase B 直後は seed しても 401 が消えないバグだった (PR #328 follow-up)。
+    const accessToken = await resolveAccessToken(c.env)
+
     // 全 phase で同じキーを返す uniform shape (CodeRabbit #243)。jq / curl から
     // 結果を比較・集計するときに「auth phase だけキーが少ない」状況を避ける。
     // 値が無い場合は null を入れ、`error` は response phase では null にする。
@@ -581,6 +587,7 @@ export const admin = new Hono<AppBindings>()
           appKey,
           appSecret,
           version: args.version,
+          accessToken,
         })
       } catch (e) {
         return {

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1518,12 +1518,13 @@ function brokerProbeBody(args: {
   // 1570=JP_ETF、US は SOXL/SOXS/SPY/QQQ=US_ETF それ以外=US_STOCK)。
   const universeLinks = renderUniverseLinks(args.universe)
   return `<p class="muted" style="font-size:12px">
-  Webull broker (現状: JP UAT <code>jp-openapi-alb.uat.webullbroker.com</code>) に
-  <code>/openapi/market-data/stock/snapshot</code> + <code>/openapi/account/positions</code>
-  を直接 fetch して raw レスポンスを表示します。click した銘柄について broker に
-  quote を問合せて生応答 (status / error_code / request_id) が見えます。任意の
-  symbol / category で叩きたい場合は <code>curl /admin/broker/probe?symbol=X&amp;category=Y</code>
-  を直接実行してください。
+  Webull broker (host は <code>WEBULL_TRADE_API_BASE</code> / <code>WEBULL_QUOTES_API_BASE</code> から決定、
+  未設定なら JP prod default) に <code>/openapi/market-data/stock/snapshot</code> +
+  <code>/openapi/account/positions</code> を直接 fetch して raw レスポンスを表示します。
+  click した銘柄について broker に quote を問合せて生応答 (status / error_code / request_id)
+  が見えます。実際に使われた host は meta セクションの <code>sandbox.trade</code> /
+  <code>sandbox.quotes</code> で確認可。任意の symbol / category で叩きたい場合は
+  <code>curl /admin/broker/probe?symbol=X&amp;category=Y</code> を直接実行してください。
 </p>
 <div style="display:flex;gap:14px;align-items:center;margin-bottom:12px">
   <span class="muted" id="probe-status" style="font-size:12px">読み込み中...</span>


### PR DESCRIPTION
## Summary
- \`/admin/broker/probe\` の signing path に \`resolveAccessToken()\` を組み込む。Phase B で DO seed 済の NORMAL token が **probe では使われてなかった** バグ修正
- \`/dashboard/broker-probe\` の intro 説明文 (UAT-only 表記) を host 分離後の表現に更新

## なぜ
PR #326 merge + PR #327/#328 で UI 完成、operator が `/dashboard/webull-token` から NORMAL token を seed → DO に \`status: NORMAL\` で投入成功 ✅、しかし \`/admin/broker/probe\` を叩くと:

\`\`\`
positions: status=401 INVALID_TOKEN
positionsNew: status=401 INVALID_TOKEN
orderHistoryOld: status=401 INVALID_TOKEN
orderHistoryNew: status=401 INVALID_TOKEN
\`\`\`

## 原因
probe handler は client factory (\`createWebullReadClient\` 等) を経由せず、\`buildSignedHeaders\` を **直接** 呼んでた:

\`\`\`ts
// BEFORE
headers = await buildSignedHeaders({
  method, path, query, host, appKey, appSecret, version,
  // ↑ accessToken 渡してない
})
\`\`\`

Phase B (PR #326) で \`resolveAccessToken\` + DO 経路を入れたが、それは factory 経由 (\`createWebullTradeClient\` etc.) のコードパスに limited。直接 \`buildSignedHeaders\` を叩いてた probe はカバー外。

## 修正
\`probeOnce\` 呼び出し前に \`resolveAccessToken(c.env)\` を await → 全 probe call の \`buildSignedHeaders\` に \`accessToken\` を渡す。precedence は他の経路と同じ (DO NORMAL → env fallback → undefined)。

## Test plan
- [x] \`pnpm typecheck\` ✅
- [x] \`pnpm test\` 1133 tests pass (新規 test なし — resolveAccessToken の coverage は既存、probe は integration 寄りで unit test 困難) ✅
- [ ] staging deploy 後、既に DO に NORMAL token が入った状態で /admin/broker/probe を叩いて positions / orders が **200** で返ることを確認
- [ ] quote endpoint は本 PR の影響範囲外 (\`data-api.webull.co.jp\` 10s timeout は別件、IP whitelist / TLS / DNS 切り分け要)

## scope 外
- quote endpoint timeout 切り分け
- HMAC SHA1 vs SHA256 検証

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * Webull ブローカープローブの認証エラーを解決しました。

* **改善**
  * ダッシュボードのブローカープローブ説明を更新し、実際に使用されるホスト情報をより正確に表示するようにしました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/329?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->