### PR TITLE
feat(admin): surface accessToken source in broker probe response (#21 Phase B follow-up)

### DIFF
--- a/src/infrastructure/webull/resolveAccessToken.ts
+++ b/src/infrastructure/webull/resolveAccessToken.ts
@@ -1,5 +1,35 @@
 import type { Env } from '../../config/env'
 import { WebullTokenStateClient } from '../../trading/state/WebullTokenStateClient'
+import type { WebullTokenStatus } from './WebullTokenClient'
+
+/**
+ * どの経路で token を引いたかの診断ラベル (probe / log 用)。token 値そのものは
+ * 漏らさず、source だけ surface する事で「DO 由来 NORMAL を送ってるのに broker
+ * が reject」「そもそも token が undefined」を切り分ける。
+ */
+export type AccessTokenSource =
+  /** DO NORMAL token を使った (正常な production path)。 */
+  | 'do_normal'
+  /** DO に state はあるが NORMAL じゃない (PENDING/INVALID/EXPIRED) → env fallback or none。 */
+  | 'do_non_normal'
+  /** DO は bound だが state が null (seed されてない) → env fallback or none。 */
+  | 'do_empty'
+  /** DO 読込で throw → env fallback or none。 */
+  | 'do_error'
+  /** DO 未 bind → env fallback or none。 */
+  | 'do_unbound'
+  /** env.WEBULL_ACCESS_TOKEN を使った (Phase A bootstrap)。 */
+  | 'env'
+  /** どこからも取れなかった (header 欠落、broker が 401 INVALID_TOKEN で reject される)。 */
+  | 'none'
+
+export interface ResolvedAccessToken {
+  token: string | undefined
+  /** どの source から取得 (してない場合は理由を含む)。 */
+  source: AccessTokenSource
+  /** DO 読込が試みられた場合の生 status (debug 用、token 値ではない)。 */
+  doStatus?: WebullTokenStatus | null
+}
 
 /**
  * Resolve the active `x-access-token` value at call time (#21 Phase B).
@@ -19,13 +49,31 @@ import { WebullTokenStateClient } from '../../trading/state/WebullTokenStateClie
  * broker-side 401 instead of a confusing signature-pass-but-no-data result.
  */
 export async function resolveAccessToken(env: Env): Promise<string | undefined> {
+  return (await resolveAccessTokenWithSource(env)).token
+}
+
+/**
+ * Same lookup logic as {@link resolveAccessToken}, but returns the source path
+ * so callers (e.g. `/admin/broker/probe`) can surface "which source did we use,
+ * and was the token loaded at all" for debugging without leaking the token
+ * value itself.
+ */
+export async function resolveAccessTokenWithSource(env: Env): Promise<ResolvedAccessToken> {
   const namespace = env.WEBULL_TOKEN_STATE
+  let doResolution: { source: AccessTokenSource; doStatus?: WebullTokenStatus | null } = {
+    source: 'do_unbound',
+  }
+
   if (namespace) {
     try {
       const client = new WebullTokenStateClient(namespace)
       const state = await client.getState()
-      if (state && state.status === 'NORMAL' && state.token.length > 0) {
-        return state.token
+      if (state === null) {
+        doResolution = { source: 'do_empty', doStatus: null }
+      } else if (state.status === 'NORMAL' && state.token.length > 0) {
+        return { token: state.token, source: 'do_normal', doStatus: state.status }
+      } else {
+        doResolution = { source: 'do_non_normal', doStatus: state.status }
       }
     } catch (error) {
       // DO 自体が落ちてるケース (binding mismatch / runtime error)。env fallback に
@@ -37,9 +85,13 @@ export async function resolveAccessToken(env: Env): Promise<string | undefined> 
           message: error instanceof Error ? error.message : String(error),
         }),
       )
+      doResolution = { source: 'do_error' }
     }
   }
 
   const fallback = env.WEBULL_ACCESS_TOKEN?.trim()
-  return fallback && fallback.length > 0 ? fallback : undefined
+  if (fallback && fallback.length > 0) {
+    return { token: fallback, source: 'env', doStatus: doResolution.doStatus }
+  }
+  return { token: undefined, source: doResolution.source, doStatus: doResolution.doStatus }
 }

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -6,7 +6,10 @@ import { rateLimit } from '../middleware/rateLimit'
 import { ValidationError } from '../shared/errors'
 import { createWebullReadClient } from '../infrastructure/webull/WebullReadClient'
 import { refreshWebullToken } from '../infrastructure/webull/refreshWebullToken'
-import { resolveAccessToken } from '../infrastructure/webull/resolveAccessToken'
+import {
+  resolveAccessToken,
+  resolveAccessTokenWithSource,
+} from '../infrastructure/webull/resolveAccessToken'
 import { WebullAuth } from '../infrastructure/webull/WebullAuth'
 import { WebullTokenClient } from '../infrastructure/webull/WebullTokenClient'
 import { WebullTokenStateClient } from '../trading/state/WebullTokenStateClient'
@@ -546,8 +549,11 @@ export const admin = new Hono<AppBindings>()
     // #21 Phase B: DO or env 由来の `x-access-token` を resolve。NORMAL token が
     // あれば全 probe call に乗せる (none なら省略、broker が 401 で発覚する)。
     // この probe は client factory を経由せず buildSignedHeaders を直接呼んでた
-    // ため Phase B 直後は seed しても 401 が消えないバグだった (PR #328 follow-up)。
-    const accessToken = await resolveAccessToken(c.env)
+    // ため Phase B 直後は seed しても 401 が消えないバグだった (PR #329)。
+    // 診断ラベル (source / length) を probe response に乗せて「token が乗ったが
+    // broker が reject」と「そもそも token が未配信」を切り分け可能にする。
+    const tokenResolved = await resolveAccessTokenWithSource(c.env)
+    const accessToken = tokenResolved.token
 
     // 全 phase で同じキーを返す uniform shape (CodeRabbit #243)。jq / curl から
     // 結果を比較・集計するときに「auth phase だけキーが少ない」状況を避ける。
@@ -707,6 +713,15 @@ export const admin = new Hono<AppBindings>()
       timestamp: new Date().toISOString(),
       sandbox: { trade: baseUrl, quotes: quotesBaseUrl },
       input: { symbol, category, accountIdConfigured: accountId.length > 0 },
+      // #21 token diagnostic: source ('do_normal' なら DO 由来 NORMAL token を
+      // 使った正常 path / 'env' は Phase A fallback / 'none' は token なし
+      // = broker は INVALID_TOKEN を返す)。length は値の長さだけで plaintext は
+      // 出さない (browser cache / log 経由の漏洩防止)。
+      accessToken: {
+        source: tokenResolved.source,
+        length: accessToken?.length ?? 0,
+        doStatus: tokenResolved.doStatus ?? null,
+      },
       quote: quoteResult,
       // 後方互換: dashboard UI が `positions` を保有銘柄リスト描画に使うので
       // 旧 path 結果を従来通り返す。


### PR DESCRIPTION
## Summary
- \`/admin/broker/probe\` response の meta に **\`accessToken: { source, length, doStatus }\`** を追加
- source ラベルで「DO 由来 NORMAL を送ってる」「env 由来」「そもそも token なし」を 1 リクエストで切り分け
- token plaintext は出さず length のみ surface (browser cache / log への漏洩防止)

## なぜ
PR #329 で probe が \`resolveAccessToken\` を経由するように修正したが、deploy 後も依然 \`401 INVALID_TOKEN\` が継続。response からは「token が実際に送られたか」が判別不能だった。

切り分けたい 2 ケース:
1. **token は送られてるが broker が reject** → 別原因 (HMAC algo / account binding / expiry / ...)
2. **token が undefined** → \`resolveAccessToken\` の挙動不良 / DO 経路の欠落 / env fallback への意図せざる流入 etc.

## 実装
\`resolveAccessTokenWithSource(env)\` を新設、source enum 付きの結果を返す:

| source | 意味 |
|---|---|
| \`do_normal\` | DO に NORMAL token がある (正常) |
| \`do_empty\` | DO は bound だが state が null (まだ seed されてない) |
| \`do_non_normal\` | DO state はあるが PENDING/INVALID/EXPIRED |
| \`do_error\` | DO 読込で throw |
| \`do_unbound\` | DO binding 自体が無い |
| \`env\` | env.WEBULL_ACCESS_TOKEN を使った (Phase A bootstrap) |
| \`none\` | どこからも取れず token なしで broker に投げた |

\`resolveAccessToken\` は thin wrapper として残し、既存 caller 影響なし。

probe response shape:
\`\`\`json
{
  "timestamp": "...",
  "sandbox": {...},
  "input": {...},
  "accessToken": {
    "source": "do_normal",
    "length": 64,
    "doStatus": "NORMAL"
  },
  "quote": {...},
  ...
}
\`\`\`

## 期待される運用
deploy → probe を再実行 → meta の \`accessToken.source\` を確認:
- \`source: "do_normal"\` + \`length: > 0\` で **broker が 401** → token は送ってるが broker reject (HMAC algo or token 自体の問題、別途調査)
- \`source: "none" / "do_empty"\` で **broker が 401** → token が乗ってない、resolveAccessToken の経路を再確認

## Test plan
- [x] \`pnpm typecheck\` ✅
- [x] \`pnpm test\` 1133 tests pass ✅
- [ ] staging deploy 後 probe を再実行、\`accessToken\` field を確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Webullブローカー診断エンドポイントで、アクセストークンの取得元情報とステータス詳細が提供されるようになりました。

* **改善**
  * トークン解決プロセスが改善され、複数の取得経路における詳細なステータス情報をトラッキングできるようになりました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/330?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->