### PR TITLE
feat(webull): switch JP prod host to HMAC-SHA256 signing (#21 Phase B follow-up)

### DIFF
--- a/src/infrastructure/webull/WebullAuth.ts
+++ b/src/infrastructure/webull/WebullAuth.ts
@@ -1,5 +1,37 @@
-const WEBULL_SIGNATURE_ALGORITHM = 'HMAC-SHA1'
 const WEBULL_SIGNATURE_VERSION = '1.0'
+
+/**
+ * Webull SDK の `webull/core/utils/common.py::is_not_upgrade_api_host` と完全一致
+ * させた host 集合。これらの host だけが **HMAC-SHA1 + MD5 body** で signing
+ * (legacy / sandbox / 一部 UAT)、それ以外の host (JP の `api.webull.co.jp` 等
+ * production endpoint 含む) は **HMAC-SHA256 + SHA256 body** が要求される。
+ *
+ * 本番 JP host (`api.webull.co.jp`) を SHA1 で叩くと account/trade endpoint が
+ * `401 INVALID_TOKEN` で reject される事を staging probe で実証 (#21 Phase B
+ * follow-up)。SDK の挙動を忠実に移植する事で本番 broker と整合させる。
+ */
+export const HMAC_SHA1_HOSTS: ReadonlySet<string> = new Set([
+  'api.webull.com',
+  'events-api.webull.com',
+  'api.webull.hk',
+  'events-api.webull.hk',
+  'pre-openapi-us-alb.webullbroker.com',
+  'pre-openapi-us-events.webullbroker.com',
+  'pre-openapi-alb.webullbroker.com',
+  'pre-openapi-events.webullbroker.com',
+  'us-openapi-alb.uat.webullbroker.com',
+  'us-openapi-events.uat.webullbroker.com',
+  'hk-openapi.uat.webullbroker.com',
+  'hk-openapi-events-api.uat.webullbroker.com',
+  'api.sandbox.webull.hk',
+  'events-api.sandbox.webull.hk',
+])
+
+export type SignerAlgorithm = 'HMAC-SHA1' | 'HMAC-SHA256'
+
+export function pickSignerAlgorithm(host: string): SignerAlgorithm {
+  return HMAC_SHA1_HOSTS.has(host) ? 'HMAC-SHA1' : 'HMAC-SHA256'
+}
 
 type SignablePrimitive = string | number | boolean
 type SignableValue =
@@ -97,27 +129,39 @@ export async function buildSignedHeaders({
     throw new Error(`Unsupported Webull signing method: ${method}`)
   }
 
-  // The Python SDK (webullsdkcore.auth.composer.default_signature_composer) signs
-  // exactly these six headers + optional query/body, regardless of whether the
-  // request carries an x-version header. Including x-version in the canonical
-  // string makes Webull reject the signature as UNAUTHORIZED.
+  // SDK の `default_signature_composer` と同等の signing header 集合。x-version /
+  // x-signature / x-access-token は canonical string から除外 (含めると signature
+  // が UNAUTHORIZED で reject される)。signing algorithm は host base で
+  // HMAC-SHA1 / HMAC-SHA256 を自動選択 (SDK の `is_not_upgrade_api_host` ロジック
+  // を移植、#21 Phase B follow-up)。
+  const algorithm = pickSignerAlgorithm(host)
   const signingHeaders = {
     host,
     'x-app-key': appKey,
-    'x-signature-algorithm': WEBULL_SIGNATURE_ALGORITHM,
+    'x-signature-algorithm': algorithm,
     'x-signature-nonce': nonce,
     'x-signature-version': WEBULL_SIGNATURE_VERSION,
     'x-timestamp': timestamp,
   }
-  const bodyMd5 = body === undefined || body.length === 0 ? undefined : await md5UpperHex(body)
+  // body hash は algorithm と pair で決まる: HMAC-SHA1 → MD5 / HMAC-SHA256 → SHA256
+  // (SDK の `_get_body_string` 参照)。signing canonical の最後に hex-upper を入れる。
+  const bodyHash =
+    body === undefined || body.length === 0
+      ? undefined
+      : algorithm === 'HMAC-SHA256'
+        ? await sha256UpperHex(body)
+        : await md5UpperHex(body)
   const stringToSign = canonicalString({
     path,
     query,
     headers: signingHeaders,
-    bodyMd5,
+    bodyMd5: bodyHash,
   })
   const encodedString = urlEncodeCanonical(stringToSign)
-  const signature = await hmacSha1Base64(appSecret, encodedString)
+  const signature =
+    algorithm === 'HMAC-SHA256'
+      ? await hmacSha256Base64(appSecret, encodedString)
+      : await hmacSha1Base64(appSecret, encodedString)
 
   // x-access-token は signature と同じく supplemental ヘッダ扱い (canonical
   // string に含めない)。trim 後が空文字なら未設定として扱う = whitespace-only な
@@ -180,6 +224,32 @@ export async function hmacSha1Base64(secret: string, value: string): Promise<str
   )
   const signature = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(value))
   return toBase64(signature)
+}
+
+/**
+ * HMAC-SHA256 + base64 — JP 本番 host (SDK 上で `is_not_upgrade_api_host` が true)
+ * の signing 用。secret は `<app_secret>&` の trailing `&` 付き (SHA1 と共通)。
+ */
+export async function hmacSha256Base64(secret: string, value: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(`${secret}&`),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  )
+  const signature = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(value))
+  return toBase64(signature)
+}
+
+/**
+ * SHA-256 hex (大文字)。SDK の `sha256_hex(content).upper()` と等価。HMAC-SHA256
+ * 経路の body hash 用 (HMAC-SHA1 経路は MD5 を使う、`md5UpperHex` 参照)。
+ */
+export async function sha256UpperHex(value: string): Promise<string> {
+  const input = new TextEncoder().encode(value)
+  const digest = await crypto.subtle.digest('SHA-256', input)
+  return toHex(digest).toUpperCase()
 }
 
 export async function md5UpperHex(value: string): Promise<string> {

--- a/test/infrastructure/webull/webullAuth.test.ts
+++ b/test/infrastructure/webull/webullAuth.test.ts
@@ -3,7 +3,10 @@ import {
   buildSignedHeaders,
   canonicalString,
   hmacSha1Base64,
+  hmacSha256Base64,
   md5UpperHex,
+  pickSignerAlgorithm,
+  sha256UpperHex,
   urlEncodeCanonical,
 } from '../../../src/infrastructure/webull/WebullAuth'
 
@@ -114,6 +117,111 @@ describe('WebullAuth helpers', () => {
 
     const result = await buildSignedHeaders({ ...common, accessToken: '   ' })
     expect(result['x-access-token']).toBeUndefined()
+  })
+
+  // #21 Phase B follow-up: SDK の `is_not_upgrade_api_host` ロジックに沿った host
+  // base のアルゴ選択。JP 本番 host (`api.webull.co.jp` 等) が SHA1 で signing
+  // されると broker が `401 INVALID_TOKEN` で reject する事を staging probe で実証
+  // したため、SDK と同じ挙動に固定する。
+  describe('pickSignerAlgorithm (host-based selection)', () => {
+    it.each([
+      'api.webull.com',
+      'api.webull.hk',
+      'api.sandbox.webull.hk',
+      'us-openapi-alb.uat.webullbroker.com',
+      'hk-openapi.uat.webullbroker.com',
+    ])('uses HMAC-SHA1 for upgrade_hosts member %s', (host) => {
+      expect(pickSignerAlgorithm(host)).toBe('HMAC-SHA1')
+    })
+
+    it.each([
+      // JP 本番 (主目的)
+      'api.webull.co.jp',
+      'data-api.webull.co.jp',
+      'events-api.webull.co.jp',
+      // JP UAT (SDK 定義上は SHA256 host だが、broker 自体は SHA1 も受理してる
+      // (実機 staging probe で確認)。SDK 仕様に従って SHA256 にする方が安全。)
+      'jp-openapi-alb.uat.webullbroker.com',
+      // 未知の host も default で SHA256 (新 region 等が追加されても fail-safe)
+      'api.webull.example.com',
+    ])('uses HMAC-SHA256 for non-upgrade host %s', (host) => {
+      expect(pickSignerAlgorithm(host)).toBe('HMAC-SHA256')
+    })
+  })
+
+  it('buildSignedHeaders emits x-signature-algorithm=HMAC-SHA256 for JP prod host', async () => {
+    const headers = await buildSignedHeaders({
+      method: 'GET',
+      path: '/openapi/account/positions',
+      query: { account_id: 'acct-1' },
+      appKey: 'app-key',
+      appSecret: 'app-secret',
+      host: 'api.webull.co.jp',
+      nonce: 'nonce-1',
+      timestamp: '2026-05-20T00:00:00Z',
+    })
+    expect(headers['x-signature-algorithm']).toBe('HMAC-SHA256')
+  })
+
+  it('buildSignedHeaders emits x-signature-algorithm=HMAC-SHA1 for UAT HK host', async () => {
+    const headers = await buildSignedHeaders({
+      method: 'GET',
+      path: '/openapi/account/positions',
+      query: { account_id: 'acct-1' },
+      appKey: 'app-key',
+      appSecret: 'app-secret',
+      host: 'api.sandbox.webull.hk',
+      nonce: 'nonce-1',
+      timestamp: '2026-05-20T00:00:00Z',
+    })
+    expect(headers['x-signature-algorithm']).toBe('HMAC-SHA1')
+  })
+
+  it('SHA256 path uses SHA256 body hash (not MD5) in the canonical string', async () => {
+    // Sign with JP prod host (SHA256) and a body. Then re-create the canonical
+    // string with the same body's SHA256 hex and confirm the signature matches
+    // a manual HMAC-SHA256 over that canonical. SHA1 + MD5 must NOT produce the
+    // same value (i.e. the algorithm switch is taking effect).
+    const body = '{"a":1}'
+    const headers = await buildSignedHeaders({
+      method: 'POST',
+      path: '/openapi/trade/order/place',
+      body,
+      appKey: 'app-key',
+      appSecret: 'app-secret',
+      host: 'api.webull.co.jp',
+      nonce: 'nonce-1',
+      timestamp: '2026-05-20T00:00:00Z',
+    })
+    expect(headers['x-signature-algorithm']).toBe('HMAC-SHA256')
+
+    // 再現テスト: signing canonical を組み立てて HMAC-SHA256 で署名 → 一致確認。
+    const bodyHash = await sha256UpperHex(body)
+    const canonical = canonicalString({
+      path: '/openapi/trade/order/place',
+      headers: {
+        host: 'api.webull.co.jp',
+        'x-app-key': 'app-key',
+        'x-signature-algorithm': 'HMAC-SHA256',
+        'x-signature-nonce': 'nonce-1',
+        'x-signature-version': '1.0',
+        'x-timestamp': '2026-05-20T00:00:00Z',
+      },
+      bodyMd5: bodyHash,
+    })
+    const expected = await hmacSha256Base64('app-secret', urlEncodeCanonical(canonical))
+    expect(headers['x-signature']).toBe(expected)
+
+    // SHA1 で同じ canonical を署名すると **異なる値** になる事を確認 = 切替が effective。
+    const sha1Sig = await hmacSha1Base64('app-secret', urlEncodeCanonical(canonical))
+    expect(headers['x-signature']).not.toBe(sha1Sig)
+  })
+
+  it('sha256UpperHex matches a known SHA-256 vector', async () => {
+    // SHA-256 of "abc" = ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+    await expect(sha256UpperHex('abc')).resolves.toBe(
+      'BA7816BF8F01CFEA414140DE5DAE2223B00361A396177A9CB410FF61F20015AD',
+    )
   })
 
   it('matches the HMAC-SHA1 worked example from Webull docs', async () => {

--- a/test/infrastructure/webull/webullHttpClient.test.ts
+++ b/test/infrastructure/webull/webullHttpClient.test.ts
@@ -105,7 +105,10 @@ describe('WebullHttpClient', () => {
       'Content-Type': 'application/json',
       host: 'broker.example.test',
       'x-app-key': 'app-key',
-      'x-signature-algorithm': 'HMAC-SHA1',
+      // host が SDK の upgrade_hosts に含まれない場合は HMAC-SHA256 (#21 Phase B
+      // follow-up)。`broker.example.test` は fake host なので default の SHA256
+      // 経路に乗る。本物の prod (api.webull.co.jp) も同じく SHA256。
+      'x-signature-algorithm': 'HMAC-SHA256',
       'x-signature-version': '1.0',
       'x-signature-nonce': expect.any(String),
       'x-timestamp': expect.any(String),


### PR DESCRIPTION
## Summary
- Webull SDK の \`is_not_upgrade_api_host\` ロジックを移植して **host base で HMAC-SHA1 / HMAC-SHA256 を自動選択**
- JP 本番 host (\`api.webull.co.jp\` / \`data-api.webull.co.jp\` / \`events-api.webull.co.jp\`) は SDK 定義どおり **HMAC-SHA256 + SHA256 body hash**
- legacy / sandbox / US 系 host は引き続き HMAC-SHA1 + MD5 body
- \`pickSignerAlgorithm(host)\` / \`hmacSha256Base64()\` / \`sha256UpperHex()\` を export

## なぜ
staging probe で原因が確定:

\`\`\`json
"accessToken": {
  "source": "do_normal",
  "length": 32,
  "doStatus": "NORMAL"
}
\`\`\`

token は乗ってる (PR #330 の diagnostic で確認) → broker が active reject。

Webull SDK の host 分類 (\`webull/core/utils/common.py::is_not_upgrade_api_host\`) では JP 本番 host は **HMAC-SHA256 必須** に分類されてる。我々の実装は常に HMAC-SHA1 だったため、UAT (寛容モード) では 200 が返るが本番では \`401 INVALID_TOKEN\` で reject されてた。

実機根拠:
- \`pnpm run issue-token\` (= \`/openapi/auth/token/create\` を SHA1 で叩く) → 200 NORMAL token 取得 ✅ (= SHA1 が完全に拒否される訳ではない)
- DO に NORMAL token 投入後 \`/openapi/account/positions\` を SHA1 で叩く → \`401 INVALID_TOKEN\` ❌
- → endpoint 別に SHA256 強制度が違うが、account/trade endpoint は SHA256 必須

## 実装

\`\`\`ts
export const HMAC_SHA1_HOSTS = new Set([
  'api.webull.com', 'events-api.webull.com',
  'api.webull.hk', 'events-api.webull.hk',
  'pre-openapi-us-alb.webullbroker.com', 'pre-openapi-us-events.webullbroker.com',
  'pre-openapi-alb.webullbroker.com', 'pre-openapi-events.webullbroker.com',
  'us-openapi-alb.uat.webullbroker.com', 'us-openapi-events.uat.webullbroker.com',
  'hk-openapi.uat.webullbroker.com', 'hk-openapi-events-api.uat.webullbroker.com',
  'api.sandbox.webull.hk', 'events-api.sandbox.webull.hk',
])

export function pickSignerAlgorithm(host: string): 'HMAC-SHA1' | 'HMAC-SHA256' {
  return HMAC_SHA1_HOSTS.has(host) ? 'HMAC-SHA1' : 'HMAC-SHA256'
}
\`\`\`

- algorithm header (\`x-signature-algorithm\`) も derived value に変更
- body hash も algorithm と pair: SHA1 → MD5 / SHA256 → SHA256
- 未知 host (新 region / typo) は default で SHA256 (fail-safe: 新 region は SHA256 path に乗る可能性が高い)

## Test plan
- [x] \`pnpm typecheck\` ✅
- [x] \`pnpm test\` 1147 tests pass (新規 14 件: host base 選択 / SHA256 algorithm 出力 / body hash 切替 / SHA-256 known vector) ✅
- [ ] staging deploy 後 \`/admin/broker/probe?symbol=AAPL&category=US_STOCK\` で \`positions\` / \`positionsNew\` / \`orderHistoryOld\` / \`orderHistoryNew\` が **200** で返ることを確認 ← 本 PR の最終 acceptance
- [ ] \`accessToken.source: do_normal\` が引き続き出ることを確認 (token 経路への regression なし)

## scope 外
- \`data-api.webull.co.jp\` の 10s timeout (本 PR とは独立、IP whitelist / TLS / DNS の切り分け要)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * Webull 認証の署名アルゴリズムがリクエスト先ホストに応じて自動選択されるようになりました。複数のサーバー環境に対応し、認証処理の安定性と互換性が向上します。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/331?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->