### PR TITLE
fix(webull): switch signing algorithm by x-version, not host (#21 Phase B follow-up)

### DIFF
--- a/src/infrastructure/webull/WebullAuth.ts
+++ b/src/infrastructure/webull/WebullAuth.ts
@@ -1,36 +1,26 @@
 const WEBULL_SIGNATURE_VERSION = '1.0'
 
-/**
- * Webull SDK の `webull/core/utils/common.py::is_not_upgrade_api_host` と完全一致
- * させた host 集合。これらの host だけが **HMAC-SHA1 + MD5 body** で signing
- * (legacy / sandbox / 一部 UAT)、それ以外の host (JP の `api.webull.co.jp` 等
- * production endpoint 含む) は **HMAC-SHA256 + SHA256 body** が要求される。
- *
- * 本番 JP host (`api.webull.co.jp`) を SHA1 で叩くと account/trade endpoint が
- * `401 INVALID_TOKEN` で reject される事を staging probe で実証 (#21 Phase B
- * follow-up)。SDK の挙動を忠実に移植する事で本番 broker と整合させる。
- */
-export const HMAC_SHA1_HOSTS: ReadonlySet<string> = new Set([
-  'api.webull.com',
-  'events-api.webull.com',
-  'api.webull.hk',
-  'events-api.webull.hk',
-  'pre-openapi-us-alb.webullbroker.com',
-  'pre-openapi-us-events.webullbroker.com',
-  'pre-openapi-alb.webullbroker.com',
-  'pre-openapi-events.webullbroker.com',
-  'us-openapi-alb.uat.webullbroker.com',
-  'us-openapi-events.uat.webullbroker.com',
-  'hk-openapi.uat.webullbroker.com',
-  'hk-openapi-events-api.uat.webullbroker.com',
-  'api.sandbox.webull.hk',
-  'events-api.sandbox.webull.hk',
-])
-
 export type SignerAlgorithm = 'HMAC-SHA1' | 'HMAC-SHA256'
 
-export function pickSignerAlgorithm(host: string): SignerAlgorithm {
-  return HMAC_SHA1_HOSTS.has(host) ? 'HMAC-SHA1' : 'HMAC-SHA256'
+/**
+ * Webull の signing algorithm は **x-version (= API version) を見て決まる**
+ * 事を JP 本番 probe で実証 (#21 Phase B follow-up):
+ *
+ *   - v1 endpoint (`/openapi/account/*`) + SHA256 → 401 `SIGNATURE_ALGORITHM_NOT_SUPPORTED`
+ *   - v2 endpoint (`/openapi/assets/*` / `/openapi/trade/*`) + SHA256 → signing 通過
+ *     (broker は SHA256 を受理。別 layer で INVALID_TOKEN になる事はあるがそれは
+ *      signature の問題ではない)
+ *
+ * Webull SDK は host base で switch する実装になってるが、SDK は host ごとに
+ * 「使う endpoint version」を間接的に固定してるだけで、実態は version base。
+ * 我々のコードは v1 / v2 両 path を probe / drift 比較するため、host base だと
+ * v1 + 新 host で SHA256 を送って `SIGNATURE_ALGORITHM_NOT_SUPPORTED` になる
+ * (PR #331 で踏んだバグ)。version base に切替えてこれを解消。
+ *
+ * version 未指定 (legacy caller) は SHA1 default (= v1 互換)。
+ */
+export function pickSignerAlgorithm(version: string | undefined): SignerAlgorithm {
+  return version === 'v2' ? 'HMAC-SHA256' : 'HMAC-SHA1'
 }
 
 type SignablePrimitive = string | number | boolean
@@ -131,10 +121,11 @@ export async function buildSignedHeaders({
 
   // SDK の `default_signature_composer` と同等の signing header 集合。x-version /
   // x-signature / x-access-token は canonical string から除外 (含めると signature
-  // が UNAUTHORIZED で reject される)。signing algorithm は host base で
-  // HMAC-SHA1 / HMAC-SHA256 を自動選択 (SDK の `is_not_upgrade_api_host` ロジック
-  // を移植、#21 Phase B follow-up)。
-  const algorithm = pickSignerAlgorithm(host)
+  // が UNAUTHORIZED で reject される)。signing algorithm は **x-version base**
+  // で HMAC-SHA1 / HMAC-SHA256 を自動選択 (#21 Phase B follow-up、JP 本番 probe
+  // で v1=SHA1 / v2=SHA256 必須が判明)。host base ではない (SDK の host-based
+  // 実装は SDK 自身が version を間接固定してたから動いてただけ)。
+  const algorithm = pickSignerAlgorithm(version)
   const signingHeaders = {
     host,
     'x-app-key': appKey,

--- a/test/infrastructure/webull/webullAuth.test.ts
+++ b/test/infrastructure/webull/webullAuth.test.ts
@@ -119,37 +119,47 @@ describe('WebullAuth helpers', () => {
     expect(result['x-access-token']).toBeUndefined()
   })
 
-  // #21 Phase B follow-up: SDK の `is_not_upgrade_api_host` ロジックに沿った host
-  // base のアルゴ選択。JP 本番 host (`api.webull.co.jp` 等) が SHA1 で signing
-  // されると broker が `401 INVALID_TOKEN` で reject する事を staging probe で実証
-  // したため、SDK と同じ挙動に固定する。
-  describe('pickSignerAlgorithm (host-based selection)', () => {
-    it.each([
-      'api.webull.com',
-      'api.webull.hk',
-      'api.sandbox.webull.hk',
-      'us-openapi-alb.uat.webullbroker.com',
-      'hk-openapi.uat.webullbroker.com',
-    ])('uses HMAC-SHA1 for upgrade_hosts member %s', (host) => {
-      expect(pickSignerAlgorithm(host)).toBe('HMAC-SHA1')
+  // #21 Phase B follow-up: signing algorithm の選択は **x-version base** で行う
+  // (JP 本番 probe で v1 endpoint + SHA256 が `SIGNATURE_ALGORITHM_NOT_SUPPORTED`
+  // で reject される事を実証)。SDK は host base 実装だが、それは host ごとに
+  // 「使う endpoint version」を固定してた副次効果で動いてただけ。
+  describe('pickSignerAlgorithm (version-based selection)', () => {
+    it('uses HMAC-SHA1 for v1 (or unspecified) endpoint', () => {
+      expect(pickSignerAlgorithm('v1')).toBe('HMAC-SHA1')
+      expect(pickSignerAlgorithm(undefined)).toBe('HMAC-SHA1')
     })
 
-    it.each([
-      // JP 本番 (主目的)
-      'api.webull.co.jp',
-      'data-api.webull.co.jp',
-      'events-api.webull.co.jp',
-      // JP UAT (SDK 定義上は SHA256 host だが、broker 自体は SHA1 も受理してる
-      // (実機 staging probe で確認)。SDK 仕様に従って SHA256 にする方が安全。)
-      'jp-openapi-alb.uat.webullbroker.com',
-      // 未知の host も default で SHA256 (新 region 等が追加されても fail-safe)
-      'api.webull.example.com',
-    ])('uses HMAC-SHA256 for non-upgrade host %s', (host) => {
-      expect(pickSignerAlgorithm(host)).toBe('HMAC-SHA256')
+    it('uses HMAC-SHA256 for v2 endpoint', () => {
+      expect(pickSignerAlgorithm('v2')).toBe('HMAC-SHA256')
+    })
+
+    // 想定外の値は安全側で SHA1 にする (broker が v1 として扱えば許容、v2 として
+    // 扱えば signature の前段で reject なので fail-fast)。
+    it('falls back to HMAC-SHA1 for unknown version values', () => {
+      expect(pickSignerAlgorithm('v3-future')).toBe('HMAC-SHA1')
+      expect(pickSignerAlgorithm('')).toBe('HMAC-SHA1')
     })
   })
 
-  it('buildSignedHeaders emits x-signature-algorithm=HMAC-SHA256 for JP prod host', async () => {
+  it('buildSignedHeaders emits x-signature-algorithm=HMAC-SHA256 for v2 endpoint', async () => {
+    const headers = await buildSignedHeaders({
+      method: 'GET',
+      path: '/openapi/assets/positions',
+      query: { account_id: 'acct-1' },
+      appKey: 'app-key',
+      appSecret: 'app-secret',
+      host: 'api.webull.co.jp',
+      nonce: 'nonce-1',
+      timestamp: '2026-05-20T00:00:00Z',
+      version: 'v2',
+    })
+    expect(headers['x-signature-algorithm']).toBe('HMAC-SHA256')
+  })
+
+  it('buildSignedHeaders emits x-signature-algorithm=HMAC-SHA1 for v1 endpoint (even on JP prod host)', async () => {
+    // 同じ host (api.webull.co.jp) でも v1 endpoint なら SHA1 を使う。
+    // JP 本番 probe で v1+SHA256 → SIGNATURE_ALGORITHM_NOT_SUPPORTED だった事の
+    // regression lock。
     const headers = await buildSignedHeaders({
       method: 'GET',
       path: '/openapi/account/positions',
@@ -159,29 +169,14 @@ describe('WebullAuth helpers', () => {
       host: 'api.webull.co.jp',
       nonce: 'nonce-1',
       timestamp: '2026-05-20T00:00:00Z',
-    })
-    expect(headers['x-signature-algorithm']).toBe('HMAC-SHA256')
-  })
-
-  it('buildSignedHeaders emits x-signature-algorithm=HMAC-SHA1 for UAT HK host', async () => {
-    const headers = await buildSignedHeaders({
-      method: 'GET',
-      path: '/openapi/account/positions',
-      query: { account_id: 'acct-1' },
-      appKey: 'app-key',
-      appSecret: 'app-secret',
-      host: 'api.sandbox.webull.hk',
-      nonce: 'nonce-1',
-      timestamp: '2026-05-20T00:00:00Z',
+      version: 'v1',
     })
     expect(headers['x-signature-algorithm']).toBe('HMAC-SHA1')
   })
 
-  it('SHA256 path uses SHA256 body hash (not MD5) in the canonical string', async () => {
-    // Sign with JP prod host (SHA256) and a body. Then re-create the canonical
-    // string with the same body's SHA256 hex and confirm the signature matches
-    // a manual HMAC-SHA256 over that canonical. SHA1 + MD5 must NOT produce the
-    // same value (i.e. the algorithm switch is taking effect).
+  it('SHA256 path (v2) uses SHA256 body hash (not MD5) in the canonical string', async () => {
+    // v2 endpoint + body で SHA256 経路を踏み、canonical/signature が SHA256 で
+    // 組まれてる事を確認。SHA1 と比較して異なる値になる = 切替が effective。
     const body = '{"a":1}'
     const headers = await buildSignedHeaders({
       method: 'POST',
@@ -192,10 +187,10 @@ describe('WebullAuth helpers', () => {
       host: 'api.webull.co.jp',
       nonce: 'nonce-1',
       timestamp: '2026-05-20T00:00:00Z',
+      version: 'v2',
     })
     expect(headers['x-signature-algorithm']).toBe('HMAC-SHA256')
 
-    // 再現テスト: signing canonical を組み立てて HMAC-SHA256 で署名 → 一致確認。
     const bodyHash = await sha256UpperHex(body)
     const canonical = canonicalString({
       path: '/openapi/trade/order/place',
@@ -212,7 +207,6 @@ describe('WebullAuth helpers', () => {
     const expected = await hmacSha256Base64('app-secret', urlEncodeCanonical(canonical))
     expect(headers['x-signature']).toBe(expected)
 
-    // SHA1 で同じ canonical を署名すると **異なる値** になる事を確認 = 切替が effective。
     const sha1Sig = await hmacSha1Base64('app-secret', urlEncodeCanonical(canonical))
     expect(headers['x-signature']).not.toBe(sha1Sig)
   })

--- a/test/infrastructure/webull/webullHttpClient.test.ts
+++ b/test/infrastructure/webull/webullHttpClient.test.ts
@@ -105,10 +105,10 @@ describe('WebullHttpClient', () => {
       'Content-Type': 'application/json',
       host: 'broker.example.test',
       'x-app-key': 'app-key',
-      // host が SDK の upgrade_hosts に含まれない場合は HMAC-SHA256 (#21 Phase B
-      // follow-up)。`broker.example.test` は fake host なので default の SHA256
-      // 経路に乗る。本物の prod (api.webull.co.jp) も同じく SHA256。
-      'x-signature-algorithm': 'HMAC-SHA256',
+      // signing algo は **x-version base** で決まる (#21 Phase B follow-up):
+      // x-version=v1 → SHA1 / v2 → SHA256。default tradeVersion は v1 なので
+      // SHA1 が選ばれる。
+      'x-signature-algorithm': 'HMAC-SHA1',
       'x-signature-version': '1.0',
       'x-signature-nonce': expect.any(String),
       'x-timestamp': expect.any(String),


### PR DESCRIPTION
## Summary
- \`pickSignerAlgorithm\` を **host base → x-version base** に切り替え
- \`v1\` (or undefined / 未知) → HMAC-SHA1 + MD5 body
- \`v2\` → HMAC-SHA256 + SHA256 body
- \`HMAC_SHA1_HOSTS\` 定数を削除 (host base ロジックは廃止)

## なぜ
PR #331 で SDK の host base 実装を移植したが、JP 本番 staging probe の結果で **実態は version base** と判明:

| endpoint | x-version | algo | result |
|---|---|---|---|
| positions (旧 v1) | v1 | SHA256 | **401 \`SIGNATURE_ALGORITHM_NOT_SUPPORTED\`** ← v1 endpoint は SHA256 を拒否 |
| positionsNew (新 v2) | v2 | SHA256 | 401 INVALID_TOKEN ← signing 通過、別の token 問題 |
| orderHistoryOld (旧 v1) | v1 | SHA256 | **401 \`SIGNATURE_ALGORITHM_NOT_SUPPORTED\`** |
| orderHistoryNew (新 v2) | v2 | SHA256 | 401 INVALID_TOKEN |

= **v1 endpoint は SHA1 必須 / v2 endpoint は SHA256 必須**。host (api.webull.co.jp) は同じでも version で挙動が変わる。SDK の host-based 実装は SDK 自身が「host ごとに使う version を固定」してたから動いてただけ。

## 実装

\`\`\`ts
export function pickSignerAlgorithm(version: string | undefined): 'HMAC-SHA1' | 'HMAC-SHA256' {
  return version === 'v2' ? 'HMAC-SHA256' : 'HMAC-SHA1'
}
\`\`\`

\`buildSignedHeaders\` は \`version\` を受け取ってるのでそれを利用。host への依存は除去。

## 期待される staging probe 結果

- \`positions\` / \`orderHistoryOld\` (v1) → **200** (SHA1 + token で auth 通過)
- \`positionsNew\` / \`orderHistoryNew\` (v2) → 引き続き 401 INVALID_TOKEN (これは別 PR で対処)
- \`accessToken.source: do_normal\` は変わらず

## Test plan
- [x] \`pnpm typecheck\` ✅
- [x] \`pnpm test\` 1140 tests pass (新規 7 件: version base 選択 / v1 + JP host で SHA1 / v2 + JP host で SHA256 / SHA1 fallback) ✅
- [ ] staging deploy 後 probe で v1 endpoint が 200、v2 endpoint で SIGNATURE 系エラーが消える事を確認

## scope 外 (次の follow-up)
- v2 endpoint の INVALID_TOKEN — signing は通ってるので token 側の問題 (token format / account_id pairing / 未知の追加要件)。本 PR の後で切り分け継続。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated signature algorithm selection logic to be based on API version instead of host configuration, improving consistency in authentication handling for Webull API integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/332?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->