### PR TITLE
feat(admin): surface app_key head + length in broker probe response (#21 Phase B follow-up)

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -722,6 +722,15 @@ export const admin = new Hono<AppBindings>()
         length: accessToken?.length ?? 0,
         doStatus: tokenResolved.doStatus ?? null,
       },
+      // #21 app_key diagnostic: staging / production の WEBULL_APP_KEY が
+      // 手元 1Password 値と一致してるかを確認するための head 6 文字 (32 文字 hex
+      // の先頭 6 文字は十分公開しても安全)。token と app_key が違う app に紐付く
+      // と broker が INVALID_TOKEN を返すため、operator が手元値と並べて確認できる
+      // ようにする。
+      appKey: {
+        length: appKey.length,
+        head: appKey.slice(0, 6),
+      },
       quote: quoteResult,
       // 後方互換: dashboard UI が `positions` を保有銘柄リスト描画に使うので
       // 旧 path 結果を従来通り返す。


### PR DESCRIPTION
## Summary
\`/admin/broker/probe\` response の meta に \`appKey: { length, head }\` を追加。staging worker 内の \`WEBULL_APP_KEY\` の先頭 6 文字を可視化して、手元 1Password 値との一致を operator が目視で確認できるようにする。

## なぜ
全 broker endpoint が依然 \`401 INVALID_TOKEN\` で reject される状況で、code 層の最後の sanity check が「staging の WEBULL_APP_KEY と token を発行した app_key が **同じ値か**」。\`wrangler secret list\` は名前しか出さない (値は API 経由でも取れない仕様)。worker code 内から head を返すしか比較方法がない。

## 安全性
hex 32 文字の app_key の先頭 6 文字 = 24 bit。仮に全数攻撃しても残り 26 文字 (104 bit) の探索空間が残るため、head 6 文字単独では crack に使えない。Browser cache / log に残っても、secret 文字列としては実用上意味がない。

## 期待される使い方

\`\`\`bash
# 手元 1Password
op read 'op://Personal/Webull-API Key/WEBULL_APP_KEY' | head -c 6
# → "1f2484"

# staging worker (probe response の meta から)
curl -s '.../admin/broker/probe?symbol=AAPL&category=US_STOCK' | jq '.appKey'
# → {"length": 32, "head": "1f2484"}
\`\`\`

- 一致 → app_key 整合性 OK、次は Webull JP サポート問合せ
- 不一致 → staging の \`wrangler secret put WEBULL_APP_KEY --env=staging\` を上書き

## Test plan
- [x] \`pnpm typecheck\` ✅
- [x] \`pnpm test\` 1140 tests pass (新規 test なし — probe response shape の変更のみ) ✅
- [ ] staging deploy 後 probe で \`appKey.head\` が "1f2484" になることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* **管理エンドポイント診断機能の拡張**
  * `GET /admin/broker/probe` レスポンスに `appKey` 診断フィールドを追加。アプリケーションキーの長さと先頭6文字を表示することで、トークンに紐付くアプリケーションの特定が容易になりました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/333?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->