### PR TITLE
feat(quotes): switch snapshot source to Yahoo Finance with source label (#21 follow-up)

### DIFF
--- a/src/infrastructure/quotes/YahooQuoteClient.ts
+++ b/src/infrastructure/quotes/YahooQuoteClient.ts
@@ -1,0 +1,151 @@
+import { BrokerRequestError, brokerErrorForStatus } from '../../shared/errors'
+import { toYahooSymbol } from './YahooBarClient'
+import type { QuoteResult, WebullQuoteCategory } from './WebullQuoteClient'
+
+/**
+ * Yahoo Finance backed quote (snapshot) client (#21 follow-up)。
+ *
+ * Webull JP 本番の market-data API (`data-api.webull.co.jp`) がまだ未公開
+ * (DNS は存在するが TCP port 443 が応答せず、`api.webull.co.jp` 上の
+ * `/openapi/market-data/*` も `404 Route Not Found`) のため、Webull market-data
+ * が運用開始するまでの恒久 fallback として導入。`YahooBarClient` と同じ
+ * `/v8/finance/chart` endpoint を使うので auth 不要・JP/US 両対応。
+ *
+ * Webull の市場制限 (UAT が SOXL を弾く等) も無いので staging E2E が回せる
+ * メリットも大きい。
+ */
+
+const DEFAULT_BASE_URL = 'https://query1.finance.yahoo.com'
+const DEFAULT_TIMEOUT_MS = 5_000
+// Yahoo は anonymous request を 429 で弾くので browser-like UA を付ける
+// (YahooBarClient と同じ pattern)。
+const DEFAULT_USER_AGENT = 'Mozilla/5.0'
+
+/** `QuoteSnapshot.source` に書き込まれる値。dashboard / log で source 識別に使う。 */
+export const YAHOO_QUOTE_SOURCE = 'yahoo-snapshot'
+
+export interface YahooQuoteClientOptions {
+  baseUrl?: string
+  timeoutMs?: number
+  fetchFn?: typeof fetch
+  userAgent?: string
+  now?: () => Date
+}
+
+interface YahooChartMeta {
+  symbol?: string
+  regularMarketPrice?: number
+  regularMarketTime?: number
+  currency?: string
+}
+
+interface YahooChartResponse {
+  chart?: {
+    result?: Array<{ meta?: YahooChartMeta }>
+    error?: { code?: string; description?: string } | null
+  }
+}
+
+export class YahooQuoteClient {
+  /** dashboard / log での source 識別ラベル。`runQuoteFeed` で QuoteSnapshot.source に転写される。 */
+  readonly source = YAHOO_QUOTE_SOURCE
+
+  private readonly baseUrl: string
+  private readonly timeoutMs: number
+  private readonly fetchFn: typeof fetch
+  private readonly userAgent: string
+  private readonly now: () => Date
+
+  constructor(options: YahooQuoteClientOptions = {}) {
+    this.baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '')
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+    this.fetchFn = options.fetchFn ?? fetch.bind(globalThis)
+    this.userAgent = options.userAgent ?? DEFAULT_USER_AGENT
+    this.now = options.now ?? (() => new Date())
+  }
+
+  /**
+   * シンボルごとに `/v8/finance/chart/{symbol}?interval=1m&range=1d` を叩いて
+   * `meta.regularMarketPrice` を current price として返す。Yahoo は category を
+   * 知らないので _category は無視 (Webull 系の interface と互換性を保つため受ける
+   * だけ)。
+   *
+   * 失敗した symbol は結果配列から除外 (Webull 側の `normalizeSnapshots` と同じ
+   * 挙動)。caller は要求した symbol 数より少ない結果が返ってきたら個別 fallback
+   * を考える。
+   */
+  async getSnapshots(symbols: string[], _category: WebullQuoteCategory): Promise<QuoteResult[]> {
+    if (symbols.length === 0) return []
+    // Yahoo の chart endpoint は per-symbol fan-out が必要 (batch snapshot は無い)。
+    // Promise.all で並列化、個別失敗は許容 (skip)。
+    const results = await Promise.all(
+      symbols.map(async (symbol) => {
+        try {
+          return await this.fetchOne(symbol)
+        } catch {
+          return null
+        }
+      }),
+    )
+    return results.filter((r): r is QuoteResult => r !== null)
+  }
+
+  private async fetchOne(symbol: string): Promise<QuoteResult | null> {
+    const yahooSymbol = toYahooSymbol(symbol)
+    const url = new URL(`/v8/finance/chart/${encodeURIComponent(yahooSymbol)}`, this.baseUrl)
+    url.searchParams.set('interval', '1m')
+    url.searchParams.set('range', '1d')
+
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs)
+    let response: Response
+    try {
+      response = await this.fetchFn(url.href, {
+        method: 'GET',
+        headers: { Accept: 'application/json', 'User-Agent': this.userAgent },
+        signal: controller.signal,
+      })
+    } catch (error) {
+      throw new BrokerRequestError(
+        `Yahoo quote fetch failed: ${error instanceof Error ? error.message : String(error)}`,
+        `GET /v8/finance/chart/${yahooSymbol}`,
+        { cause: error instanceof Error ? error : undefined },
+      )
+    } finally {
+      clearTimeout(timeoutId)
+    }
+
+    if (!response.ok) {
+      throw brokerErrorForStatus(
+        response.status,
+        `Yahoo quote request failed with status ${response.status}`,
+        `GET /v8/finance/chart/${yahooSymbol}`,
+      )
+    }
+
+    let json: YahooChartResponse
+    try {
+      json = (await response.json()) as YahooChartResponse
+    } catch (error) {
+      throw new BrokerRequestError(
+        `Yahoo quote response parse failed: ${error instanceof Error ? error.message : String(error)}`,
+        `GET /v8/finance/chart/${yahooSymbol}`,
+        { cause: error instanceof Error ? error : undefined },
+      )
+    }
+
+    const meta = json.chart?.result?.[0]?.meta
+    const price = meta?.regularMarketPrice
+    if (typeof price !== 'number' || !Number.isFinite(price) || price <= 0) {
+      return null
+    }
+    // regularMarketTime は秒精度の epoch (Yahoo 慣例)。chart endpoint は最終取引
+    // 時刻を返すので、市場外でも前日 close が乗る。`asOf` フィールドの ms 精度
+    // ISO に揃える。
+    const asOf =
+      typeof meta?.regularMarketTime === 'number' && Number.isFinite(meta.regularMarketTime)
+        ? new Date(meta.regularMarketTime * 1000).toISOString()
+        : this.now().toISOString()
+    return { symbol, price, asOf }
+  }
+}

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -642,6 +642,59 @@ export const admin = new Hono<AppBindings>()
       }
     }
 
+    /**
+     * Yahoo Finance 経由の同 symbol snapshot probe (#21 follow-up)。`probeOnce`
+     * と同じ uniform shape を返すが auth/signing 不要なので fetch を直接叩く。
+     * Yahoo は JP 銘柄に `.T` suffix を付ける convention (YahooBarClient/QuoteClient と同じ)。
+     */
+    async function probeYahooSnapshot(symbolForProbe: string): Promise<ProbeResult> {
+      const isJp = /^\d{4}$/.test(symbolForProbe) || /^[0-9]+[A-Z]$/.test(symbolForProbe)
+      const yahooSymbol = isJp ? `${symbolForProbe}.T` : symbolForProbe
+      const url = new URL(
+        `/v8/finance/chart/${encodeURIComponent(yahooSymbol)}`,
+        'https://query1.finance.yahoo.com',
+      )
+      url.searchParams.set('interval', '1m')
+      url.searchParams.set('range', '1d')
+
+      const controller = new AbortController()
+      const timeoutId = setTimeout(() => controller.abort(), 10_000)
+      const t0 = Date.now()
+      try {
+        const response = await fetch(url.href, {
+          method: 'GET',
+          headers: {
+            Accept: 'application/json',
+            // Yahoo は anonymous request を 429 で返すので browser-like UA を付ける。
+            'User-Agent': 'Mozilla/5.0',
+          },
+          signal: controller.signal,
+        })
+        const body = await response.text()
+        clearTimeout(timeoutId)
+        return {
+          phase: 'response',
+          status: response.status,
+          ok: response.ok,
+          bodyTruncated: body.slice(0, 4000),
+          bodyLength: body.length,
+          msTaken: Date.now() - t0,
+          error: null,
+        }
+      } catch (e) {
+        clearTimeout(timeoutId)
+        return {
+          phase: 'fetch',
+          status: null,
+          ok: null,
+          bodyTruncated: null,
+          bodyLength: null,
+          msTaken: Date.now() - t0,
+          error: e instanceof Error ? e.message : String(e),
+        }
+      }
+    }
+
     // #251 / #254: drift 検証のため旧 path (v1) と 新 path (v2) を **並列** で
     // 叩いて比較する。各セクションを result 配列の object として返却:
     //   - quote (path 共通、v2 ヘッダ): 既存
@@ -651,6 +704,7 @@ export const admin = new Hono<AppBindings>()
     // 後方互換維持 (`positions` field 名据え置き)、新 path 結果は追加 field。
     const [
       quoteResult,
+      quoteYahooResult,
       positionsOld,
       positionsNew,
       orderHistoryOld,
@@ -673,6 +727,11 @@ export const admin = new Hono<AppBindings>()
         // JP UAT (ALB) では同じ URL が入るので no-op。
         host: quotesBaseUrl,
       }),
+      // Yahoo Finance を quote 用 backup source として probe (#21 follow-up)。
+      // 現状 strategy cron の default 経路でもあり、Webull JP の market-data API
+      // が稼働開始する前まで主軸を担う。auth/signing は不要なので probeOnce ではなく
+      // 直接 fetch する小 helper を呼ぶ。
+      probeYahooSnapshot(symbol),
       // OLD: WebullHttpClient.getPositions (現行 cron が叩く path + v1)
       probeOnce({
         method: 'GET',
@@ -739,6 +798,9 @@ export const admin = new Hono<AppBindings>()
       positionsNew,
       orderHistoryOld,
       orderHistoryNew,
+      // Yahoo Finance 経由の同 symbol snapshot (#21 follow-up)。Webull の data-api
+      // が応答しない状況での代替経路の生死を可視化する。
+      quoteYahoo: quoteYahooResult,
     })
   })
   /**

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -20,7 +20,7 @@ import { reconcileFills } from '../trading/reconciliation/reconcileFills'
 import { syncHoldings } from '../trading/reconciliation/syncHoldings'
 import { runStrategyCron } from '../trading/strategy/runStrategyCron'
 import { loadSymbolUniverse } from '../infrastructure/db/symbolUniverse'
-import { YahooBarClient } from '../infrastructure/quotes/YahooBarClient'
+import { YahooBarClient, toYahooSymbol } from '../infrastructure/quotes/YahooBarClient'
 import { loadGlobalConfigFrom } from '../infrastructure/db/globalConfigLoader'
 import { createDb } from '../infrastructure/db/tradeJournalRepo'
 import { earningsCalendar, macroEventCalendar, tradeJournal } from '../infrastructure/db/schema'
@@ -648,8 +648,9 @@ export const admin = new Hono<AppBindings>()
      * Yahoo は JP 銘柄に `.T` suffix を付ける convention (YahooBarClient/QuoteClient と同じ)。
      */
     async function probeYahooSnapshot(symbolForProbe: string): Promise<ProbeResult> {
-      const isJp = /^\d{4}$/.test(symbolForProbe) || /^[0-9]+[A-Z]$/.test(symbolForProbe)
-      const yahooSymbol = isJp ? `${symbolForProbe}.T` : symbolForProbe
+      // JP 判定は `toYahooSymbol` に一本化 (CodeRabbit #334)。re-implement すると
+      // YahooBarClient / YahooQuoteClient の convention 変更時にズレる。
+      const yahooSymbol = toYahooSymbol(symbolForProbe)
       const url = new URL(
         `/v8/finance/chart/${encodeURIComponent(yahooSymbol)}`,
         'https://query1.finance.yahoo.com',

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1542,8 +1542,11 @@ function brokerProbeBody(args: {
   <button type="button" class="probe-pickbtn" data-symbol="AAPL" data-category="US_STOCK" style="padding:4px 12px;font-size:12px;border:1px solid #ccc;border-radius:4px;background:#fff;cursor:pointer">AAPL (US_STOCK)</button>
 </div>
 
-<h2 style="font-size:14px;margin:16px 0 4px 0">quote 結果 <span class="muted" id="probe-current" style="font-size:12px;font-weight:normal"></span></h2>
+<h2 style="font-size:14px;margin:16px 0 4px 0">quote 結果 (Webull) <span class="muted" id="probe-current" style="font-size:12px;font-weight:normal"></span></h2>
 <pre id="probe-quote" style="background:#f6f6f6;border:1px solid #ddd;border-radius:4px;padding:8px;font-size:12px;overflow:auto;max-height:400px;white-space:pre-wrap;word-break:break-all">(まだ probe 未実行)</pre>
+
+<h2 style="font-size:14px;margin:16px 0 4px 0">quote 結果 (Yahoo Finance) <span class="muted" style="font-size:12px;font-weight:normal">— strategy cron が default で使う source</span></h2>
+<pre id="probe-quote-yahoo" style="background:#f6f6f6;border:1px solid #ddd;border-radius:4px;padding:8px;font-size:12px;overflow:auto;max-height:400px;white-space:pre-wrap;word-break:break-all">(まだ probe 未実行)</pre>
 
 <h2 style="font-size:14px;margin:16px 0 4px 0">meta</h2>
 <pre id="probe-meta" style="background:#f6f6f6;border:1px solid #ddd;border-radius:4px;padding:8px;font-size:12px">(まだ probe 未実行)</pre>
@@ -1677,6 +1680,8 @@ function brokerProbeBody(args: {
         // CodeRabbit #262: body fields が欠けてても UI を必ず更新して stale を
         // 残さない。quote / positions / 各 raw を **常に** 上書き。
         quoteEl.textContent = body.quote ? prettify(body.quote) : '(no data)';
+        var quoteYahooEl = document.getElementById('probe-quote-yahoo');
+        if (quoteYahooEl) quoteYahooEl.textContent = body.quoteYahoo ? prettify(body.quoteYahoo) : '(no data)';
         renderPositionsList(body.positions || null);
         // drift 比較: 新 path 結果も raw + table へ。値が無くても "(no data)"
         // を入れて stale 表示にしない。

--- a/src/trading/quotes/quoteScheduler.ts
+++ b/src/trading/quotes/quoteScheduler.ts
@@ -64,9 +64,22 @@ export async function runQuoteFeed(options: RunQuoteFeedOptions): Promise<QuoteR
   const { grouped, unsupported } = groupSymbolsByCategory(symbols)
   const fetchedAt = now().toISOString()
 
-  // JP symbols have no working snapshot endpoint yet — mark as skipped so the
-  // summary reflects "known unfetchable" rather than a silent drop.
-  for (const symbol of unsupported) summary.skipped.push(symbol)
+  // `groupSymbolsByCategory` は Webull の制約 (JP snapshot endpoint なし) で
+  // JP 銘柄を `unsupported` に分類する。Yahoo は `.T` suffix で JP も普通に
+  // 取得できるので、Yahoo 経路では unsupported を fetch 対象に戻す。
+  // Webull 経路では従来通り skip (CodeRabbit #334)。
+  const clientSupportsJp = client.source !== 'webull-snapshot'
+  if (clientSupportsJp) {
+    // Yahoo (or 将来の同等 client): unsupported (= JP) を US_STOCK に混ぜて投げる。
+    // category は Yahoo 側で ignore されるので分類は便宜上のもの。
+    if (unsupported.length > 0) {
+      grouped.US_STOCK.push(...unsupported)
+    }
+  } else {
+    // Webull: JP snapshot は依然 unsupported。summary に "known unfetchable"
+    // として残す (silent drop を避ける)。
+    for (const symbol of unsupported) summary.skipped.push(symbol)
+  }
 
   for (const [category, group] of Object.entries(grouped) as Array<[WebullQuoteCategory, string[]]>) {
     if (group.length === 0) continue

--- a/src/trading/quotes/quoteScheduler.ts
+++ b/src/trading/quotes/quoteScheduler.ts
@@ -2,25 +2,34 @@ import type { Env } from '../../config/env'
 import { loadSymbolUniverse } from '../../infrastructure/db/symbolUniverse'
 import {
   groupSymbolsByCategory,
-  WebullQuoteClient,
-  createWebullQuoteClient,
   type QuoteResult,
   type WebullQuoteCategory,
 } from '../../infrastructure/quotes/WebullQuoteClient'
+import { YahooQuoteClient } from '../../infrastructure/quotes/YahooQuoteClient'
 import type { QuoteSnapshot } from '../state/types'
 
-const QUOTE_SOURCE = 'webull-snapshot'
+/**
+ * snapshot client が満たすべき shape (#21 follow-up)。Webull / Yahoo を
+ * 並列で扱えるよう interface を抽出。`source` は QuoteSnapshot に転写され
+ * dashboard / log で「今どの data source か」を区別可能にする。
+ */
+export interface SnapshotClient {
+  readonly source: string
+  getSnapshots(symbols: string[], category: WebullQuoteCategory): Promise<QuoteResult[]>
+}
 
 export interface QuoteRunSummary {
   fetched: number
   persisted: number
   skipped: string[]
   errors: Array<{ category: WebullQuoteCategory; message: string }>
+  /** 実際に使われた snapshot source (`'yahoo-snapshot'` / `'webull-snapshot'`)。 */
+  source: string
 }
 
 interface RunQuoteFeedOptions {
   env: Env
-  client?: WebullQuoteClient
+  client?: SnapshotClient
   now?: () => Date
 }
 
@@ -36,10 +45,22 @@ export async function runQuoteFeed(options: RunQuoteFeedOptions): Promise<QuoteR
   const universe = await loadSymbolUniverse(env)
   const symbols = universe.allowedSymbols
 
-  const summary: QuoteRunSummary = { fetched: 0, persisted: 0, skipped: [], errors: [] }
+  // default は Yahoo Finance (#21 follow-up)。Webull JP の market-data API
+  // (`data-api.webull.co.jp`) がまだ運用開始してない (DNS は存在するが TCP 無応答
+  // + `api.webull.co.jp/openapi/market-data/*` が 404) ので、運用開始するまでは
+  // Yahoo 経由で snapshot を取る。Webull market-data が live になったら caller
+  // 側で `WebullQuoteClient` を `options.client` に渡せば切替可能。
+  const client: SnapshotClient = options.client ?? new YahooQuoteClient({ now })
+
+  const summary: QuoteRunSummary = {
+    fetched: 0,
+    persisted: 0,
+    skipped: [],
+    errors: [],
+    source: client.source,
+  }
   if (symbols.length === 0) return summary
 
-  const client = options.client ?? createWebullQuoteClient(env, { now })
   const { grouped, unsupported } = groupSymbolsByCategory(symbols)
   const fetchedAt = now().toISOString()
 
@@ -73,7 +94,10 @@ export async function runQuoteFeed(options: RunQuoteFeedOptions): Promise<QuoteR
         price: result.price,
         asOf: result.asOf,
         fetchedAt,
-        source: QUOTE_SOURCE,
+        // `client.source` から取る ('yahoo-snapshot' / 'webull-snapshot')。
+        // hardcoded constant をやめ、実際に使った client から動的に取る事で
+        // 切替時の source 漏れを防ぐ。
+        source: client.source,
       }
       if (result.bid !== undefined) quote.bid = result.bid
       if (result.ask !== undefined) quote.ask = result.ask

--- a/test/infrastructure/quotes/yahooQuoteClient.test.ts
+++ b/test/infrastructure/quotes/yahooQuoteClient.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  YahooQuoteClient,
+  YAHOO_QUOTE_SOURCE,
+} from '../../../src/infrastructure/quotes/YahooQuoteClient'
+
+function mockJson(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('YahooQuoteClient', () => {
+  // #21 follow-up: dashboard / log で source 識別に使う label を locked。
+  // 'yahoo-snapshot' / 'webull-snapshot' の 2 値しか想定してないので drift 防止。
+  it('exposes source = "yahoo-snapshot"', () => {
+    const client = new YahooQuoteClient()
+    expect(client.source).toBe(YAHOO_QUOTE_SOURCE)
+    expect(client.source).toBe('yahoo-snapshot')
+  })
+
+  it('GETs /v8/finance/chart/{symbol}?interval=1m&range=1d with Mozilla UA', async () => {
+    let capturedUrl: URL | undefined
+    let capturedHeaders: Headers | undefined
+    const fetchFn = vi.fn(async (input: Request | string | URL, init?: RequestInit) => {
+      const urlStr = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      capturedUrl = new URL(urlStr)
+      capturedHeaders = new Headers(init?.headers)
+      return mockJson({
+        chart: {
+          result: [
+            { meta: { symbol: 'AAPL', regularMarketPrice: 200.5, regularMarketTime: 1700000000 } },
+          ],
+        },
+      })
+    }) as unknown as typeof fetch
+
+    const client = new YahooQuoteClient({ fetchFn })
+    const results = await client.getSnapshots(['AAPL'], 'US_STOCK')
+
+    expect(capturedUrl?.pathname).toBe('/v8/finance/chart/AAPL')
+    expect(capturedUrl?.searchParams.get('interval')).toBe('1m')
+    expect(capturedUrl?.searchParams.get('range')).toBe('1d')
+    expect(capturedHeaders?.get('User-Agent')).toBe('Mozilla/5.0')
+
+    expect(results).toEqual([
+      { symbol: 'AAPL', price: 200.5, asOf: '2023-11-14T22:13:20.000Z' },
+    ])
+  })
+
+  // JP symbol は Yahoo convention で `.T` suffix を付ける必要あり。
+  // YahooBarClient と同じ `toYahooSymbol` を再利用してる事の locked。
+  it('appends `.T` suffix to JP symbols on the wire', async () => {
+    let capturedPath: string | undefined
+    const fetchFn = vi.fn(async (input: Request | string | URL) => {
+      const urlStr = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      capturedPath = new URL(urlStr).pathname
+      return mockJson({
+        chart: { result: [{ meta: { regularMarketPrice: 1500, regularMarketTime: 1700000000 } }] },
+      })
+    }) as unknown as typeof fetch
+
+    const client = new YahooQuoteClient({ fetchFn })
+    await client.getSnapshots(['7203'], 'US_STOCK')
+
+    expect(capturedPath).toBe('/v8/finance/chart/7203.T')
+  })
+
+  it('returns empty array when symbols input is empty (no fetch)', async () => {
+    const fetchFn = vi.fn() as unknown as typeof fetch
+    const client = new YahooQuoteClient({ fetchFn })
+    const results = await client.getSnapshots([], 'US_STOCK')
+    expect(results).toEqual([])
+    expect(fetchFn).not.toHaveBeenCalled()
+  })
+
+  // Yahoo は batch snapshot を持たないので per-symbol fan-out。N requests = N
+  // fetches を保証 (= 並列で Promise.all される)。
+  it('fans out one fetch per symbol', async () => {
+    const fetchFn = vi.fn(async () =>
+      mockJson({
+        chart: { result: [{ meta: { regularMarketPrice: 100, regularMarketTime: 1700000000 } }] },
+      }),
+    ) as unknown as typeof fetch
+    const client = new YahooQuoteClient({ fetchFn })
+    await client.getSnapshots(['AAPL', 'MSFT', 'GOOG'], 'US_STOCK')
+    expect(fetchFn).toHaveBeenCalledTimes(3)
+  })
+
+  // 個別失敗は skip (= 配列から除外) する事を locked。strategy cron 側は per-symbol
+  // で「結果あり/なし」を見て fallback / skip 判定するため。
+  it('drops symbols whose individual fetch errors (does not abort the whole batch)', async () => {
+    const fetchFn = vi.fn(async (input: Request | string | URL) => {
+      const urlStr = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      if (urlStr.includes('FAIL')) {
+        return mockJson({ chart: { error: 'service unavailable' } }, 503)
+      }
+      return mockJson({
+        chart: { result: [{ meta: { regularMarketPrice: 100, regularMarketTime: 1700000000 } }] },
+      })
+    }) as unknown as typeof fetch
+    const client = new YahooQuoteClient({ fetchFn })
+    const results = await client.getSnapshots(['OK1', 'FAIL', 'OK2'], 'US_STOCK')
+    expect(results.map((r) => r.symbol)).toEqual(['OK1', 'OK2'])
+  })
+
+  // meta.regularMarketPrice が無い (delisted / typo / API drift) ケースを除外。
+  it('drops symbols whose response is missing regularMarketPrice', async () => {
+    const fetchFn = vi.fn(async () =>
+      mockJson({
+        chart: { result: [{ meta: { symbol: 'X', regularMarketTime: 1700000000 } }] },
+      }),
+    ) as unknown as typeof fetch
+    const client = new YahooQuoteClient({ fetchFn })
+    const results = await client.getSnapshots(['X'], 'US_STOCK')
+    expect(results).toEqual([])
+  })
+
+  // 非正の price (Yahoo が一時的に 0 を返すケース) も除外。
+  it('drops symbols whose regularMarketPrice is zero or negative', async () => {
+    const fetchFn = vi.fn(async () =>
+      mockJson({
+        chart: { result: [{ meta: { regularMarketPrice: 0, regularMarketTime: 1700000000 } }] },
+      }),
+    ) as unknown as typeof fetch
+    const client = new YahooQuoteClient({ fetchFn })
+    const results = await client.getSnapshots(['ZERO'], 'US_STOCK')
+    expect(results).toEqual([])
+  })
+
+  // regularMarketTime が無い場合は now() を fallback として asOf に使う
+  // (Webull 側と同じ挙動)。staling 判定が後段で動くので date があれば足りる。
+  it('falls back to now() when regularMarketTime is missing', async () => {
+    const fixedNow = new Date('2026-05-20T15:00:00.000Z')
+    const fetchFn = vi.fn(async () =>
+      mockJson({
+        chart: { result: [{ meta: { regularMarketPrice: 100 } }] },
+      }),
+    ) as unknown as typeof fetch
+    const client = new YahooQuoteClient({ fetchFn, now: () => fixedNow })
+    const results = await client.getSnapshots(['AAPL'], 'US_STOCK')
+    expect(results).toEqual([{ symbol: 'AAPL', price: 100, asOf: '2026-05-20T15:00:00.000Z' }])
+  })
+})


### PR DESCRIPTION
## Summary
- Strategy cron の snapshot source を **Yahoo Finance** に切替 (Webull JP の market-data API が未公開のため)
- 新規 \`YahooQuoteClient\` (既存 \`YahooBarClient\` と同じ \`/v8/finance/chart\` endpoint を再利用)
- \`QuoteSnapshot.source\` を client から動的取得 (\`'yahoo-snapshot'\` / \`'webull-snapshot'\` を区別可能)
- \`/admin/broker/probe\` に **Yahoo snapshot probe** を並列追加 (\`quoteYahoo\` field)
- \`/dashboard/broker-probe\` に「quote 結果 (Yahoo Finance)」セクション追加

## なぜ
JP 本番の market-data endpoint が稼働してない事を実機検証:

\`\`\`
data-api.webull.co.jp:443  → DNS resolve するが TCP timeout (誰からも届かない)
api.webull.co.jp/openapi/market-data/stock/snapshot → 404 Route Not Found (APISIX 上に route 未登録)
\`\`\`

Webull JP の market-data API が利用可能になるまで待つわけにはいかないので、既に **daily bars で実績ある Yahoo Finance** を snapshot にも転用。auth 不要・JP/US 両対応・staging E2E が回せる。

## 設計
- \`YahooQuoteClient\` は \`WebullQuoteClient\` と同じ interface (\`getSnapshots(symbols, category)\`)。category は ignore (Yahoo 側でカテゴリ概念がないため)
- \`SnapshotClient\` interface を抽出して \`runQuoteFeed\` を Yahoo/Webull 両対応に
- \`QuoteSnapshot.source\` は \`client.source\` から動的取得。hardcode 撤廃で source 漏れ防止
- Yahoo 復旧後に Webull に戻すときは \`runQuoteFeed({ env, client: createWebullQuoteClient(env) })\` を渡すだけ

## データソース可視化
| location | 表示内容 |
|---|---|
| \`/dashboard/positions\` 表 (既存) | 銘柄ごとに \`(yahoo-snapshot, 14:23:45)\` のように price 横に source 表示 (line 1913) |
| \`/dashboard/broker-probe\` | 「quote 結果 (Webull)」と「quote 結果 (Yahoo Finance)」を上下に並べて両者の生死を一目で確認 |
| \`/admin/broker/probe\` JSON | \`quoteYahoo: { status, body, msTaken }\` field を追加 |
| Worker logs | \`runQuoteFeed\` summary に \`source\` field を追加、運用者が直近の cron でどっち使ったか分かる |

## Test plan
- [x] \`pnpm typecheck\` ✅
- [x] \`pnpm test\` 1149 tests pass (新規 9 件: YahooQuoteClient の path / UA / JP `.T` suffix / 失敗 skip / regularMarketPrice 欠落 / 0 price / now fallback) ✅
- [ ] staging deploy 後、\`/dashboard/broker-probe\` で Yahoo セクションに AAPL の current price が表示される事を確認
- [ ] strategy cron が 1 周回って \`/dashboard/positions\` の quote source が \`yahoo-snapshot\` 表示されることを確認

## 将来の戻し方
Webull JP が market-data API を運用開始したら:
1. \`api.webull.co.jp/openapi/market-data/\` or \`data-api.webull.co.jp\` で probe を叩く
2. 動いたら \`runQuoteFeed\` の default を \`createWebullQuoteClient\` に戻す PR
3. Yahoo は backup として残す or 撤去

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Yahoo Finance からの株価スナップショット取得を追加し、ブローカープローブ結果にYahoo側のデータを併記
  * ダッシュボードで既存ブローカーデータとYahoo結果を並列表示

* **リファクタ**
  * 複数のスナップショット取得先を切替可能にし、実行結果に利用された取得元情報を含めるよう変更

* **テスト**
  * Yahoo クライアントの包括的な自動テストを追加

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/334?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->