### PR TITLE
chore(webull): drop unnecessary Pick + mark Webull quote/bar clients deprecated

### DIFF
--- a/src/infrastructure/quotes/BarClient.ts
+++ b/src/infrastructure/quotes/BarClient.ts
@@ -74,6 +74,11 @@ interface WebullBarClientOptions {
  * the response mapper is forgiving — any bar missing a usable close is
  * filtered out instead of throwing. Once the production path is known, this
  * client can be locked down.
+ *
+ * @deprecated since 2026-05-22 — JP 本番の market-data API がまだ稼働してない
+ * ため、strategy cron は {@link YahooBarClient} を default で使う構造に切替済。
+ * 本 class は将来 Webull JP が bars API を運用開始したときの切戻し用に残してある
+ * のみで、現時点で実 callers は無い。
  */
 export class WebullBarClient implements BarClient {
   private readonly baseUrl: string
@@ -173,6 +178,10 @@ export class WebullBarClient implements BarClient {
  */
 const DEFAULT_QUOTES_API_BASE = 'https://data-api.webull.co.jp'
 
+/**
+ * @deprecated since 2026-05-22 — see {@link WebullBarClient}。default では
+ * {@link YahooBarClient} を使う設計に移行済。
+ */
 export function createWebullBarClient(
   env: WebullBarClientEnv,
   options?: {

--- a/src/infrastructure/quotes/WebullQuoteClient.ts
+++ b/src/infrastructure/quotes/WebullQuoteClient.ts
@@ -85,6 +85,13 @@ const DEFAULT_QUOTES_API_BASE = 'https://data-api.webull.co.jp'
  * HMAC-SHA1 canonical signing used by {@link WebullHttpClient}. Scope for #37-B
  * is read-only last-price + asOf so the cron handler can land a
  * {@link QuoteSnapshot} into each symbol's Durable Object.
+ *
+ * @deprecated since 2026-05-22 — JP 本番の market-data API がまだ稼働してない
+ * (`data-api.webull.co.jp` の TCP 443 が応答せず、`api.webull.co.jp` 上の
+ * `/openapi/market-data/*` は `404 Route Not Found`)。strategy cron は
+ * {@link YahooQuoteClient} を default で使う構造に切替済 (PR #334)。本 class
+ * は `/admin/broker/probe` で疎通監視用に残してあるのみ。Webull JP が
+ * market-data API を運用開始したら deprecation 解除して default に戻す予定。
  */
 export class WebullQuoteClient {
   private readonly baseUrl: string
@@ -180,6 +187,10 @@ export class WebullQuoteClient {
   }
 }
 
+/**
+ * @deprecated since 2026-05-22 — see {@link WebullQuoteClient}。default では
+ * {@link YahooQuoteClient} を使う設計に移行済。
+ */
 export function createWebullQuoteClient(
   env: WebullQuoteClientEnv,
   options?: {

--- a/src/trading/execution/WebullExecution.ts
+++ b/src/trading/execution/WebullExecution.ts
@@ -12,7 +12,10 @@ export class WebullExecution implements Execution {
   // #21: `WebullTradeClient` 経由でしか trade API に触れない。staging からの
   // 誤発注は client constructor で disable されているため、ここに来た時点で
   // production deploy + ENVIRONMENT=production の不変条件が満たされている。
-  constructor(private readonly client: Pick<WebullTradeClient, 'placeOrder'>) {}
+  // 旧 `Pick<WebullHttpClient, 'placeOrder'>` 時代の narrowing は削除済 — 今は
+  // WebullTradeClient 自体が placeOrder + isLiveTradingEnabled のみ持つ薄い
+  // facade なので Pick で絞る意味がない (#21 Phase B 後 cleanup)。
+  constructor(private readonly client: WebullTradeClient) {}
 
   async execute(intent: OrderIntent): Promise<ExecutionResult> {
     try {

--- a/test/trading/execution/webullExecution.test.ts
+++ b/test/trading/execution/webullExecution.test.ts
@@ -20,7 +20,11 @@ describe('WebullExecution', () => {
         order_id: 'ord-123',
       }),
     }
-    const execution = new WebullExecution(client)
+    // test 用に WebullTradeClient の `placeOrder` のみ実装した minimal mock を
+    // 型 cast で渡す。`isLiveTradingEnabled` getter は WebullExecution が読まないので不要。
+    const execution = new WebullExecution(
+      client as unknown as ConstructorParameters<typeof WebullExecution>[0],
+    )
 
     await expect(execution.execute(intent)).resolves.toEqual({
       mode: 'LIVE',
@@ -35,7 +39,11 @@ describe('WebullExecution', () => {
     const client = {
       placeOrder: vi.fn().mockRejectedValue(new Error('network down')),
     }
-    const execution = new WebullExecution(client)
+    // test 用に WebullTradeClient の `placeOrder` のみ実装した minimal mock を
+    // 型 cast で渡す。`isLiveTradingEnabled` getter は WebullExecution が読まないので不要。
+    const execution = new WebullExecution(
+      client as unknown as ConstructorParameters<typeof WebullExecution>[0],
+    )
 
     await expect(execution.execute(intent)).rejects.toBeInstanceOf(BrokerRequestError)
     await expect(execution.execute(intent)).rejects.toMatchObject({


### PR DESCRIPTION
## Summary
Small cleanup after PR #334 (Yahoo Finance への quote 切替) が落ち着いたタイミングで:

1. **WebullExecution の `Pick<WebullTradeClient, 'placeOrder'>` 削除** — WebullTradeClient 自体が placeOrder + isLiveTradingEnabled getter のみの薄い facade なので Pick で絞る意味がない (旧 \`Pick<WebullHttpClient, 'placeOrder'>\` 時代の narrowing が惰性で残ってた)
2. **\`WebullQuoteClient\` / \`WebullBarClient\` に @deprecated JSDoc 付与** — strategy cron は Yahoo を使う構造に移行済、これらは /admin/broker/probe で疎通監視用に残ってるのみ。Webull JP が market-data API を運用開始したら deprecation 解除予定

## なぜ今
PR #334 merge 後、quote/bar 系で Webull / Yahoo が共存する形になった。意図せず Webull 版を再利用するのを防ぐため (IDE strikethrough で気付く)、また「現状未使用、Webull JP 公開待ち」を canonical docs として残すため。

## 影響範囲
- \`WebullExecution\` constructor の型シグネチャ広がるだけ (機能変更なし)
- test mock は \`ConstructorParameters\` cast に変更 (`isLiveTradingEnabled` getter は WebullExecution が読まないので不要のまま)
- \`@deprecated\` JSDoc は実コード挙動に影響なし、IDE 上の警告のみ

## scope 外 (別途検討中)
- \`resolveAccessToken\` wrapper の inline 化 → 5 caller 全部 \`.token\` 取り出し形に書き換える方が verbose と判断、現状維持
- v1 → v2 path migration → place_order schema が実質的に違うため staging で v2 schema probe テストが必要、別 PR
- \`WEBULL_PATH_*\` env override 廃止 → 上記 v2 移行と同時

## Test plan
- [x] \`pnpm typecheck\` ✅
- [x] \`pnpm test\` 1149 tests pass (regression なし) ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Webull API統合に廃止予定（2026-05-22以降）マークを追加しました。JP本番環境でのmarket-data API未稼働に伴い、デフォルトではYahoo API統合を使用するよう移行しました。既存のWebull統合は監視目的で継続利用可能です。

* **Refactor**
  * 内部実装の単純化を行いました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/335?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->