### PR TITLE
feat(webull): daily reachability check for JP market-data host (#21 follow-up)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import type { Env } from './config/env'
 import { createDb, insertJournalRecord } from './infrastructure/db/tradeJournalRepo'
 import { setTradeJournalDbContext } from './infrastructure/logger/tradeJournal'
 import { createNotifier } from './infrastructure/notification/createNotifier'
+import { checkMarketDataReachability } from './infrastructure/webull/checkMarketDataReachability'
 import { refreshWebullToken } from './infrastructure/webull/refreshWebullToken'
 import { runPortfolioRoll } from './trading/portfolio/runPortfolioRoll'
 import { runQuoteFeed } from './trading/quotes/quoteScheduler'
@@ -105,6 +106,51 @@ export default {
                   severity: 'critical',
                 })
                 .catch(() => undefined),
+            )
+          },
+        ),
+      )
+
+      // #21 follow-up: Webull JP 本番 market-data API (`data-api.webull.co.jp`)
+      // が今は応答しない (DNS resolve するが TCP 443 沈黙)。launch されたら
+      // operator が気付けるよう daily で疎通 check → 応答返ったら notify。
+      // 失敗は silent (= 現状の期待値、毎日通知して spam にしない)。
+      ctx.waitUntil(
+        checkMarketDataReachability().then(
+          (result) => {
+            if (result.reachable) {
+              console.log(
+                JSON.stringify({
+                  event: 'webull_market_data_reachable',
+                  requestId,
+                  status: result.status,
+                  msTaken: result.msTaken,
+                }),
+              )
+              // info severity の初使用例。実発注に近づく state change じゃないので
+              // ERROR type だが severity=info で「青系 icon、運用判断ありき」の扱い。
+              ctx.waitUntil(
+                createNotifier(env, { requestId })
+                  .notify({
+                    type: 'ERROR',
+                    message: `Webull JP market-data API (data-api.webull.co.jp) is now responding (HTTP ${result.status}, ${result.msTaken}ms). Consider switching strategy cron back from Yahoo to WebullQuoteClient — see PR #334 for the switchover pattern.`,
+                    cause: 'webull_market_data_reachable',
+                    severity: 'info',
+                  })
+                  .catch(() => undefined),
+              )
+            }
+            // unreachable: 現状の期待挙動、log すら出さない (cron tick 毎に noise)
+          },
+          (error) => {
+            // 関数自体が throw するのは設計上ないが念のため
+            const message = error instanceof Error ? error.message : String(error)
+            console.error(
+              JSON.stringify({
+                event: 'webull_market_data_reachability_check_error',
+                requestId,
+                message,
+              }),
             )
           },
         ),

--- a/src/infrastructure/webull/checkMarketDataReachability.ts
+++ b/src/infrastructure/webull/checkMarketDataReachability.ts
@@ -1,0 +1,68 @@
+/**
+ * Webull JP 本番 market-data API (`data-api.webull.co.jp`) の疎通監視 (#21 follow-up)。
+ *
+ * 2026-05-21 時点で本 host は DNS resolve するが TCP 443 が応答せず、
+ * `api.webull.co.jp/openapi/market-data/*` も `404 Route Not Found` を返す
+ * (= 未公開)。strategy cron は {@link YahooQuoteClient} を default で使う形に
+ * 切替済 (PR #334)。
+ *
+ * Webull JP が market-data API を公開した瞬間に operator が気付ける仕組みとして、
+ * 22:00 UTC daily cron がこの helper を呼ぶ。応答が変わったら notifier 経由で
+ * "戻し PR を切るタイミング" を通知する。
+ *
+ * **判定条件**: `https://data-api.webull.co.jp/` に GET を投げて任意の HTTP
+ * status code が返ってくれば reachable (404 でも OK、TCP listener が立った事の
+ * 証明)。timeout / connection error は unreachable (現状の期待値) で silent。
+ */
+
+const DEFAULT_HOST = 'data-api.webull.co.jp'
+const DEFAULT_TIMEOUT_MS = 5_000
+
+export interface MarketDataReachabilityResult {
+  /** TCP / TLS / HTTP layer まで到達して何らかの応答を得たか。 */
+  reachable: boolean
+  /** reachable=true の時の HTTP status (404 含む = listener が立ってる証拠)。 */
+  status: number | null
+  /** fetch 開始から完了 (or abort) まで。 */
+  msTaken: number
+  /** unreachable のときの error message (timeout / DNS error 等)。 */
+  error: string | null
+}
+
+export interface CheckMarketDataReachabilityOptions {
+  /** override host。default は `data-api.webull.co.jp`。 */
+  host?: string
+  fetchFn?: typeof fetch
+  timeoutMs?: number
+}
+
+export async function checkMarketDataReachability(
+  options: CheckMarketDataReachabilityOptions = {},
+): Promise<MarketDataReachabilityResult> {
+  const host = options.host ?? DEFAULT_HOST
+  const fetchFn = options.fetchFn ?? fetch.bind(globalThis)
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  const url = `https://${host}/`
+
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+  const t0 = Date.now()
+  try {
+    const response = await fetchFn(url, { method: 'GET', signal: controller.signal })
+    return {
+      reachable: true,
+      status: response.status,
+      msTaken: Date.now() - t0,
+      error: null,
+    }
+  } catch (error) {
+    return {
+      reachable: false,
+      status: null,
+      msTaken: Date.now() - t0,
+      error: error instanceof Error ? error.message : String(error),
+    }
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}

--- a/test/infrastructure/webull/checkMarketDataReachability.test.ts
+++ b/test/infrastructure/webull/checkMarketDataReachability.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest'
+import { checkMarketDataReachability } from '../../../src/infrastructure/webull/checkMarketDataReachability'
+
+describe('checkMarketDataReachability', () => {
+  // happy path future: Webull JP が data-api を公開したら 404 (root path に
+  // route が無い時の standard 応答) でも reachable=true で返るべき。404 OK は
+  // listener が立ってる証拠。
+  it('returns reachable=true when server responds (any HTTP status counts)', async () => {
+    const fetchFn = vi.fn(async () => new Response('not found', { status: 404 })) as unknown as typeof fetch
+    const result = await checkMarketDataReachability({ fetchFn })
+    expect(result.reachable).toBe(true)
+    expect(result.status).toBe(404)
+    expect(result.error).toBeNull()
+  })
+
+  it('returns reachable=true for 200 (= fully serving)', async () => {
+    const fetchFn = vi.fn(async () => new Response('ok', { status: 200 })) as unknown as typeof fetch
+    const result = await checkMarketDataReachability({ fetchFn })
+    expect(result.reachable).toBe(true)
+    expect(result.status).toBe(200)
+  })
+
+  // 現状の期待挙動: data-api は TCP 沈黙 → fetch が abort される。
+  it('returns reachable=false when fetch throws (timeout / DNS error)', async () => {
+    const fetchFn = vi.fn(async () => {
+      throw new Error('The operation was aborted')
+    }) as unknown as typeof fetch
+    const result = await checkMarketDataReachability({ fetchFn })
+    expect(result.reachable).toBe(false)
+    expect(result.status).toBeNull()
+    expect(result.error).toMatch(/aborted/)
+  })
+
+  // GET / と timeout 5s が default。caller (cron) は default 引数のまま呼ぶので
+  // 規約を locked。
+  it('defaults: GET https://data-api.webull.co.jp/ with 5s timeout', async () => {
+    let capturedUrl: string | undefined
+    let capturedMethod: string | undefined
+    const fetchFn = vi.fn(async (input: Request | string | URL, init?: RequestInit) => {
+      capturedUrl = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      capturedMethod = init?.method
+      return new Response('', { status: 404 })
+    }) as unknown as typeof fetch
+
+    await checkMarketDataReachability({ fetchFn })
+    expect(capturedUrl).toBe('https://data-api.webull.co.jp/')
+    expect(capturedMethod).toBe('GET')
+  })
+
+  it('honours host override (for testing against alternative hosts)', async () => {
+    let capturedUrl: string | undefined
+    const fetchFn = vi.fn(async (input: Request | string | URL) => {
+      capturedUrl = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      return new Response('', { status: 200 })
+    }) as unknown as typeof fetch
+
+    await checkMarketDataReachability({ fetchFn, host: 'api.webull.co.jp' })
+    expect(capturedUrl).toBe('https://api.webull.co.jp/')
+  })
+})


### PR DESCRIPTION
## Summary
22:00 UTC daily cron に **Webull JP `data-api.webull.co.jp` の疎通監視** を追加。HTTP 応答 (任意の status) を返したら notifier 経由で「Yahoo → Webull 戻し PR の判断ポイント」として info 通知する。応答ゼロは silent (= 現状の expected state)。

## なぜ
PR #334 で strategy cron を Yahoo Finance に切替えた理由が「Webull JP の本番 market-data API が運用前」だが、launch の announce を見落とすと Yahoo 依存を不要に長く引きずる。daily check で operator に早めに気付かせる。

## 設計
- 新 helper \`checkMarketDataReachability(options)\` — GET to `https://data-api.webull.co.jp/` (5s timeout)
  - **reachable=true** = TCP / TLS / HTTP layer 応答返ってきた (404 含む = listener 立ってる証拠)
  - **reachable=false** = timeout / DNS error / connection refused
- 既存 \`0 22 * * *\` cron (portfolio roll + token refresh) に第 3 タスクとして追加
- reachable=true なら:
  - \`console.log({event: 'webull_market_data_reachable', status, msTaken})\`
  - \`notifier.notify({type: 'ERROR', severity: 'info', cause: 'webull_market_data_reachable', ...})\`
  - info severity の **初使用例** (\`Notifier.ts\` で type 定義済だが未使用だった)
- reachable=false は完全 silent (= 毎日 noise を出さない、現状期待の挙動)

## Test plan
- [x] \`pnpm typecheck\` ✅
- [x] \`pnpm test\` 1154 tests pass (新規 5 件: 200/404 で reachable=true、abort で reachable=false、default URL / method、host override) ✅
- [ ] staging で 22:00 UTC cron が回って silent (= 想定通り) を確認、明日以降の log を観察
- [ ] (将来) Webull JP launch 後、cron が info 通知を 1 回出す事を確認 → 切戻し PR の trigger

## scope 外
- 戻し PR (Yahoo → Webull) は別 PR、launch を観測してから対応

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * Webull JP 市場データ API の疎通を毎日監視し、接続状態の確認と通知機能を追加しました。

* **Tests**
  * API 疎通監視機能の動作確認テストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/336?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->