### PR TITLE
feat(risk): tz-aware US equity market hours (#23)

### DIFF
--- a/src/trading/risk/DefaultRiskPolicy.ts
+++ b/src/trading/risk/DefaultRiskPolicy.ts
@@ -56,13 +56,48 @@ function defaultNow(): Date {
   return new Date()
 }
 
+const NY_TIME_FORMATTER = new Intl.DateTimeFormat('en-US', {
+  timeZone: 'America/New_York',
+  hour12: false,
+  weekday: 'short',
+  hour: '2-digit',
+  minute: '2-digit',
+})
+
+const WEEKDAY_TO_INDEX: Record<string, number> = {
+  Sun: 0,
+  Mon: 1,
+  Tue: 2,
+  Wed: 3,
+  Thu: 4,
+  Fri: 5,
+  Sat: 6,
+}
+
+function getNyTimeParts(now: Date): { weekday: number; minutes: number } {
+  const parts = NY_TIME_FORMATTER.formatToParts(now)
+  let weekday = -1
+  let hour = -1
+  let minute = -1
+  for (const part of parts) {
+    if (part.type === 'weekday') {
+      weekday = WEEKDAY_TO_INDEX[part.value] ?? -1
+    } else if (part.type === 'hour') {
+      // Intl returns "24" for midnight when hour12 is false on some runtimes; normalize to 0.
+      const parsed = Number.parseInt(part.value, 10)
+      hour = parsed === 24 ? 0 : parsed
+    } else if (part.type === 'minute') {
+      minute = Number.parseInt(part.value, 10)
+    }
+  }
+  return { weekday, minutes: hour * 60 + minute }
+}
+
 function isWithinUsEquityRegularTradingHours(now: Date): boolean {
-  const day = now.getUTCDay()
-  if (day === 0 || day === 6) {
+  const { weekday, minutes } = getNyTimeParts(now)
+  if (weekday === 0 || weekday === 6) {
     return false
   }
-
-  const minutes = now.getUTCHours() * 60 + now.getUTCMinutes()
-  // TODO(Phase 5): handle DST accurately
-  return minutes >= 13 * 60 + 30 && minutes < 20 * 60
+  // US equity regular session: 09:30–16:00 America/New_York (DST handled by Intl).
+  return minutes >= 9 * 60 + 30 && minutes < 16 * 60
 }

--- a/test/risk/defaultRiskPolicy.test.ts
+++ b/test/risk/defaultRiskPolicy.test.ts
@@ -208,4 +208,130 @@ describe('DefaultRiskPolicy', () => {
 
     expect(decision.allowed).toBe(true)
   })
+
+  describe('market hours DST handling', () => {
+    const buyIntent = {
+      symbol: 'SOXL',
+      side: 'BUY' as const,
+      quantity: 2,
+      price: 10,
+      notional: 20,
+      clientOrderId: 'test-coid',
+    }
+    const marketHoursInput = {
+      ...baseInput,
+      orderIntent: buyIntent,
+      marketHoursCheck: true,
+    }
+
+    it('opens at 09:30 EST in winter (UTC-5)', () => {
+      // 2026-01-15 14:30 UTC = 09:30 EST (Thursday)
+      const decision = policy.evaluate({
+        ...marketHoursInput,
+        now: () => new Date('2026-01-15T14:30:00.000Z'),
+      })
+      expect(decision.allowed).toBe(true)
+    })
+
+    it('is closed one minute before open in winter (EST)', () => {
+      // 2026-01-15 14:29 UTC = 09:29 EST
+      const decision = policy.evaluate({
+        ...marketHoursInput,
+        now: () => new Date('2026-01-15T14:29:00.000Z'),
+      })
+      expect(decision.allowed).toBe(false)
+      expect(decision.reasons.some((r) => r.toLowerCase().includes('market hours'))).toBe(true)
+    })
+
+    it('opens at 09:30 EDT in summer (UTC-4)', () => {
+      // 2026-07-15 13:30 UTC = 09:30 EDT (Wednesday)
+      const decision = policy.evaluate({
+        ...marketHoursInput,
+        now: () => new Date('2026-07-15T13:30:00.000Z'),
+      })
+      expect(decision.allowed).toBe(true)
+    })
+
+    it('is closed one minute before open in summer (EDT)', () => {
+      // 2026-07-15 13:29 UTC = 09:29 EDT
+      const decision = policy.evaluate({
+        ...marketHoursInput,
+        now: () => new Date('2026-07-15T13:29:00.000Z'),
+      })
+      expect(decision.allowed).toBe(false)
+    })
+
+    it('is closed at the 16:00 EDT boundary (close exclusive)', () => {
+      // 2026-07-15 20:00 UTC = 16:00 EDT
+      const decision = policy.evaluate({
+        ...marketHoursInput,
+        now: () => new Date('2026-07-15T20:00:00.000Z'),
+      })
+      expect(decision.allowed).toBe(false)
+    })
+
+    it('is open one minute before close in winter (EST)', () => {
+      // 2026-01-15 20:59 UTC = 15:59 EST
+      const decision = policy.evaluate({
+        ...marketHoursInput,
+        now: () => new Date('2026-01-15T20:59:00.000Z'),
+      })
+      expect(decision.allowed).toBe(true)
+    })
+
+    it('rejects Saturday in NY even when the UTC clock looks active', () => {
+      // 2026-04-25 15:00 UTC = 11:00 EDT on Saturday
+      const decision = policy.evaluate({
+        ...marketHoursInput,
+        now: () => new Date('2026-04-25T15:00:00.000Z'),
+      })
+      expect(decision.allowed).toBe(false)
+    })
+
+    it('uses NY weekday: late Sunday UTC that maps to NY Sunday is rejected', () => {
+      // 2026-04-26 20:00 UTC = 16:00 EDT on Sunday
+      const decision = policy.evaluate({
+        ...marketHoursInput,
+        now: () => new Date('2026-04-26T20:00:00.000Z'),
+      })
+      expect(decision.allowed).toBe(false)
+    })
+
+    it('uses NY weekday: Friday UTC night that maps to NY Friday is still NY Friday (outside hours)', () => {
+      // 2026-04-24 23:30 UTC = 19:30 EDT Friday (after close, but Friday in NY)
+      const decision = policy.evaluate({
+        ...marketHoursInput,
+        now: () => new Date('2026-04-24T23:30:00.000Z'),
+      })
+      expect(decision.allowed).toBe(false)
+    })
+
+    it('handles the DST spring-forward day (2026-03-08)', () => {
+      // After 02:00 local on 2026-03-08, NY shifts EST→EDT.
+      // 13:30 UTC on 2026-03-08 = 09:30 EDT (already on DST).
+      const decision = policy.evaluate({
+        ...marketHoursInput,
+        now: () => new Date('2026-03-08T13:30:00.000Z'),
+      })
+      // Sunday in NY → still rejected by weekend rule, which is the correct conservative answer.
+      expect(decision.allowed).toBe(false)
+
+      // 13:30 UTC on Monday 2026-03-09 = 09:30 EDT → open.
+      const nextDay = policy.evaluate({
+        ...marketHoursInput,
+        now: () => new Date('2026-03-09T13:30:00.000Z'),
+      })
+      expect(nextDay.allowed).toBe(true)
+    })
+
+    it('handles the DST fall-back day (2026-11-01)', () => {
+      // 2026-11-01 is Sunday — closed.
+      // Monday 2026-11-02 after fall-back: 14:30 UTC = 09:30 EST → open.
+      const decision = policy.evaluate({
+        ...marketHoursInput,
+        now: () => new Date('2026-11-02T14:30:00.000Z'),
+      })
+      expect(decision.allowed).toBe(true)
+    })
+  })
 })


### PR DESCRIPTION
Closes part of #23 (DST market-hours scope).

## Why

`DefaultRiskPolicy.isWithinUsEquityRegularTradingHours` used a fixed UTC window (13:30–20:00). That window drifts by one hour across the EST↔EDT transition, so for half the year the gate fires at the wrong wall-clock time.

## What

- Replace the UTC math with `Intl.DateTimeFormat(..., { timeZone: 'America/New_York' })`. The runtime handles DST automatically.
- Check against the NY local weekday + 09:30–16:00 session window.
- Add unit tests covering both EST and EDT, the spring-forward and fall-back days, the open/close minute boundaries, and weekend handling (incl. UTC times that map across the day boundary in NY).

No external date library added — `Intl.DateTimeFormat` with `timeZone` works in the Cloudflare Workers runtime.

## Scope

This PR covers only the **DST / market-hours** slice of #23. Halt, PDT, short locate, settlement remain open in that issue.

## Acceptance (subset of #23)

- [x] DST 横断 (冬↔夏) の市場時間 unit test

## Verification

- `pnpm test` → 1165/1165 pass
- `pnpm typecheck` → clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 米国株式の定時取引時間の判定ロジックを改善。夏時間（DST）切り替え時の処理が正確になり、週末の判定も改善されました。

* **Tests**
  * 市場営業時間とDST対応をカバーするテストケースを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/338?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->