### PR TITLE
fix(webull): paginate order history lookup (#139)

### DIFF
--- a/src/infrastructure/webull/WebullHttpClient.ts
+++ b/src/infrastructure/webull/WebullHttpClient.ts
@@ -164,9 +164,18 @@ export class WebullHttpClient {
    * idempotency key.
    *
    * `/openapi/account/orders/detail` returns 404 on the JP UAT tenant, so we
-   * fetch the first page of `/openapi/account/orders/history` and filter
-   * client-side. If the order is older than that window the caller gets
-   * `undefined`; a wider pagination sweep is out of scope for the MVP.
+   * sweep `/openapi/account/orders/history` and filter client-side. Default is
+   * a single-page lookup (50 rows) to preserve cron-poll behaviour. Callers
+   * that need deeper history (e.g. operator-driven deep lookup, reconcile
+   * retry) can pass `{ maxPages: N }` for a bounded multi-page sweep — the
+   * loop stops as soon as the target coid is found, the broker returns a
+   * short page (less than `pageSize`), or `maxPages` has been visited (#139).
+   *
+   * Webull `/openapi/account/orders/history` accepts a 1-indexed `page` query
+   * param. Pages are walked sequentially (1, 2, ...) so we do not re-query
+   * page 1 if the caller wants `maxPages=2`. Iterating in serial keeps quota
+   * usage proportional to need; with no docs on a server-side hard cap, the
+   * caller is responsible for setting `maxPages` to a sane bound (default 1).
    *
    * 新 OpenAPI docs (#251) では response が wrapper 形式 (`{client_order_id,
    * combo_type, orders[]}`) に変わってる。\`normalizeOrderHistoryRow\` で
@@ -175,21 +184,34 @@ export class WebullHttpClient {
    */
   async findOrderByClientId(
     clientOrderId: string,
-    pageSize = 50,
+    opts: { maxPages?: number; pageSize?: number } = {},
   ): Promise<WebullOrderDetailDto | undefined> {
-    const page = await this.request<unknown[]>(
-      'GET',
-      this.ordersHistoryPath,
-      {
-        query: { account_id: this.requireAccountId(), page_size: String(pageSize) },
-      },
-    )
-    if (!Array.isArray(page)) return undefined
-    for (const raw of page) {
-      const normalized = normalizeOrderHistoryRow(
-        raw as WebullOrderHistoryWrapperDto | WebullOrderDetailDto,
+    const pageSize = opts.pageSize ?? 50
+    const maxPages = Math.max(1, opts.maxPages ?? 1)
+    const accountId = this.requireAccountId()
+    for (let page = 1; page <= maxPages; page += 1) {
+      const rows = await this.request<unknown[]>(
+        'GET',
+        this.ordersHistoryPath,
+        {
+          query: {
+            account_id: accountId,
+            page_size: String(pageSize),
+            page: String(page),
+          },
+        },
       )
-      if (normalized.client_order_id === clientOrderId) return normalized
+      if (!Array.isArray(rows)) return undefined
+      for (const raw of rows) {
+        const normalized = normalizeOrderHistoryRow(
+          raw as WebullOrderHistoryWrapperDto | WebullOrderDetailDto,
+        )
+        if (normalized.client_order_id === clientOrderId) return normalized
+      }
+      // A short page means we have reached the tail of broker-side history —
+      // there is nothing more to sweep, so stop early instead of paying the
+      // cost of a final empty request that we know will not match.
+      if (rows.length < pageSize) return undefined
     }
     return undefined
   }

--- a/src/infrastructure/webull/WebullReadClient.ts
+++ b/src/infrastructure/webull/WebullReadClient.ts
@@ -31,9 +31,9 @@ export class WebullReadClient {
 
   findOrderByClientId(
     clientOrderId: string,
-    pageSize?: number,
+    opts?: { maxPages?: number; pageSize?: number },
   ): Promise<WebullOrderDetailDto | undefined> {
-    return this.http.findOrderByClientId(clientOrderId, pageSize)
+    return this.http.findOrderByClientId(clientOrderId, opts)
   }
 
   getPositions(): Promise<WebullPositionDto[]> {

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -959,12 +959,28 @@ export const admin = new Hono<AppBindings>()
     if (clientOrderId.length === 0) {
       throw new ValidationError('clientOrderId must be non-empty', { field: 'clientOrderId' })
     }
+    // #139: operator can opt into a bounded deep-lookup sweep via query
+    // params. Default behaviour (no params) is the prior single-page lookup.
+    // `maxPages` is hard-capped at 20 so a typo / abuse can't fan out into a
+    // huge broker batch — 20 * 50 = 1000 rows is plenty for ops use.
+    const maxPages = parsePositiveIntQuery(c.req.query('maxPages'), { max: 20 })
+    const pageSize = parsePositiveIntQuery(c.req.query('pageSize'), { max: 200 })
     const client = createWebullReadClient(c.env, {
       accessToken: await resolveAccessToken(c.env),
     })
-    const detail = await client.findOrderByClientId(clientOrderId)
+    const detail = await client.findOrderByClientId(clientOrderId, {
+      ...(maxPages !== undefined ? { maxPages } : {}),
+      ...(pageSize !== undefined ? { pageSize } : {}),
+    })
     if (!detail) {
-      return c.json({ error: 'order_not_found_in_recent_history', clientOrderId }, 404)
+      return c.json(
+        {
+          error: 'order_not_found_in_recent_history',
+          clientOrderId,
+          maxPagesScanned: maxPages ?? 1,
+        },
+        404,
+      )
     }
     return c.json(detail)
   })
@@ -1757,6 +1773,25 @@ function parseTruthyQuery(value: string | undefined): boolean {
   if (value === undefined) return false
   const normalized = value.trim().toLowerCase()
   return normalized === '1' || normalized === 'true' || normalized === 'yes'
+}
+
+/**
+ * Parse a positive integer query param with an upper bound. Returns
+ * `undefined` for absent / unparseable / out-of-range values so the caller
+ * falls back to its built-in default (= zero broker pressure from a typo).
+ * (#139)
+ */
+function parsePositiveIntQuery(
+  value: string | undefined,
+  { max }: { max: number },
+): number | undefined {
+  if (value === undefined) return undefined
+  const trimmed = value.trim()
+  if (trimmed.length === 0) return undefined
+  const n = Number(trimmed)
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 1) return undefined
+  if (n > max) return undefined
+  return n
 }
 
 /**

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -964,7 +964,8 @@ export const admin = new Hono<AppBindings>()
     // `maxPages` is hard-capped at 20 so a typo / abuse can't fan out into a
     // huge broker batch — 20 * 50 = 1000 rows is plenty for ops use.
     const maxPages = parsePositiveIntQuery(c.req.query('maxPages'), { max: 20 })
-    const pageSize = parsePositiveIntQuery(c.req.query('pageSize'), { max: 200 })
+    // Webull /openapi/account/orders/history accepts page_size 10–100 only.
+    const pageSize = parsePositiveIntQuery(c.req.query('pageSize'), { max: 100 })
     const client = createWebullReadClient(c.env, {
       accessToken: await resolveAccessToken(c.env),
     })

--- a/src/trading/reconciliation/reconcileFills.ts
+++ b/src/trading/reconciliation/reconcileFills.ts
@@ -31,7 +31,27 @@ export interface ReconcileSummary {
   inspected: number
   updated: Array<{ clientOrderId: string; status: string; realizedPnl?: number }>
   stillPending: Array<{ clientOrderId: string; status?: string }>
+  /**
+   * Union of `notFoundRecentWindow` and `notFoundAfterDeepLookup` — preserved
+   * so dashboards / alerting that read `summary.notFound` keep working. New
+   * callers should prefer the more specific buckets to tell "still inside the
+   * recent first-page window" apart from "broker really doesn't have it any
+   * more". (#139)
+   */
   notFound: string[]
+  /**
+   * Coids that missed the initial single-page lookup. Without a deep-lookup
+   * sweep (`historyMaxPages=1`) this is the only notFound bucket — the order
+   * may simply have rotated off page 1 of broker history; do not treat it as
+   * authoritative absence.
+   */
+  notFoundRecentWindow: string[]
+  /**
+   * Coids that still missed after walking up to `historyMaxPages` of broker
+   * history. Stronger signal that the order truly doesn't exist on the broker
+   * side (e.g. rejected pre-acceptance, or out of broker retention window).
+   */
+  notFoundAfterDeepLookup: string[]
   errors: Array<{ clientOrderId: string; message: string }>
   /**
    * Number of rows where the DO state apply succeeded on this run (whether
@@ -77,6 +97,22 @@ export interface ReconcileSummary {
 const MAX_REPAIR_ATTEMPTS = 5
 
 /**
+ * Default candidate-window for the SELECT on the post_submit cohort. 48 hours
+ * is long enough to ride out a brief cron pause without re-scanning the whole
+ * table every tick. Overridable per call via `ReconcileOptions.lookbackMs`
+ * (#139): callers that need to catch up from a longer pause can widen it.
+ */
+const DEFAULT_LOOKBACK_MS = 48 * 3_600_000
+
+/**
+ * Default cap on rows inspected per call. Keeps a single invocation bounded
+ * so a backlog doesn't fan out into a runaway batch. Overridable via
+ * `ReconcileOptions.limit` (#139) when the operator wants to drain a larger
+ * backlog deliberately.
+ */
+const DEFAULT_ROW_LIMIT = 50
+
+/**
  * `state_apply_error` substrings that we treat as "no further retry will
  * help" — repeated reconcile cycles will keep producing the same failure.
  * Distinct from transient errors (`broker_5xx`, `network`, `DO unavailable`,
@@ -107,6 +143,23 @@ interface ReconcileOptions {
   lookbackMs?: number
   /** Cap on rows inspected per call so a single invocation doesn't fan out. */
   limit?: number
+  /**
+   * Bound on how many pages of Webull order history we sweep when the initial
+   * single-page lookup misses. `1` (default) preserves prior behaviour — a
+   * single 50-row request per row, no deep sweep. Operator-driven retries
+   * (e.g. catching up after a cron pause) can pass a larger value so older
+   * fills still inside broker retention get reconciled. (#139)
+   *
+   * The deep sweep only triggers for the fresh-poll cohort (broker_status
+   * NULL); the repair cohort never re-polls Webull.
+   */
+  historyMaxPages?: number
+  /**
+   * Page size used for both the initial lookup and the deep-lookup sweep.
+   * Default 50. Larger values reduce request count at the cost of larger
+   * responses; the broker may also enforce its own ceiling.
+   */
+  historyPageSize?: number
   now?: () => Date
   /**
    * When true, the SELECT also picks up `broker_status='FILLED' AND
@@ -160,6 +213,8 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
     updated: [],
     stillPending: [],
     notFound: [],
+    notFoundRecentWindow: [],
+    notFoundAfterDeepLookup: [],
     errors: [],
     stateApplied: 0,
     stateApplyFailed: 0,
@@ -173,8 +228,14 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
   // `new Date()` at each call site makes back-catch-up runs lengthen the
   // cooldown window incorrectly.
   const runNow = now()
-  const since = new Date(runNow.getTime() - (options.lookbackMs ?? 48 * 3_600_000)).toISOString()
-  const limit = options.limit ?? 50
+  const since = new Date(runNow.getTime() - (options.lookbackMs ?? DEFAULT_LOOKBACK_MS)).toISOString()
+  const limit = options.limit ?? DEFAULT_ROW_LIMIT
+  // Deep-lookup sweep settings (#139). Default `historyMaxPages=1` preserves
+  // the prior single-page behaviour, so cron callers see no change in broker
+  // load. Callers that want to recover from a long pause (operator retry,
+  // admin endpoint) pass a larger bound.
+  const historyMaxPages = Math.max(1, options.historyMaxPages ?? 1)
+  const historyPageSize = options.historyPageSize ?? 50
 
   const db = createDb(options.env.DB)
   // Two cohorts in one query:
@@ -414,7 +475,9 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
 
     let detail: WebullOrderDetailDto | undefined
     try {
-      detail = await client.findOrderByClientId(coid)
+      // Initial single-page lookup — covers the typical case where the
+      // order is still on the first page of broker history.
+      detail = await client.findOrderByClientId(coid, { pageSize: historyPageSize })
     } catch (error) {
       summary.errors.push({
         clientOrderId: coid,
@@ -424,8 +487,37 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
     }
 
     if (!detail) {
-      summary.notFound.push(coid)
-      continue
+      if (historyMaxPages <= 1) {
+        // No deep-lookup configured — record as recent-window miss only. We
+        // cannot say whether the order rotated off page 1 or never existed
+        // on the broker side, so callers must not treat this as authoritative
+        // absence.
+        summary.notFoundRecentWindow.push(coid)
+        summary.notFound.push(coid)
+        continue
+      }
+      // Deep-lookup sweep: walk pages 2..maxPages. Bounded to avoid
+      // unbounded broker pressure. We still only allow a single result per
+      // row, so the loop returns as soon as the coid is hit or pages run out.
+      try {
+        detail = await client.findOrderByClientId(coid, {
+          maxPages: historyMaxPages,
+          pageSize: historyPageSize,
+        })
+      } catch (error) {
+        summary.errors.push({
+          clientOrderId: coid,
+          message: error instanceof Error ? error.message : String(error),
+        })
+        continue
+      }
+      if (!detail) {
+        // Even the deep sweep didn't find it — stronger signal that the
+        // broker really doesn't have the order.
+        summary.notFoundAfterDeepLookup.push(coid)
+        summary.notFound.push(coid)
+        continue
+      }
     }
 
     // P0 raw response capture for JP tenant. We've observed the JP UAT

--- a/test/infrastructure/webull/webullHttpClient.test.ts
+++ b/test/infrastructure/webull/webullHttpClient.test.ts
@@ -154,7 +154,81 @@ describe('WebullHttpClient', () => {
     expect(u.pathname).toBe('/openapi/account/orders/history')
     expect(u.searchParams.get('account_id')).toBe('acct-1')
     expect(u.searchParams.get('page_size')).toBe('50')
+    // 1-indexed `page` param emitted on every request (#139). Even the
+    // single-page default case sends `page=1` so the broker has consistent
+    // semantics across single- and deep-lookup callers.
+    expect(u.searchParams.get('page')).toBe('1')
     expect(detail?.status).toBe('FILLED')
+  })
+
+  // #139: pagination. When the target coid is not on page 1 but is on page 2
+  // and the caller opts into `maxPages=2`, the client walks both pages and
+  // returns the match from page 2.
+  it('findOrderByClientId walks subsequent pages when maxPages > 1 and the target is on page 2', async () => {
+    const pageSize = 2
+    const pageRows: Record<string, unknown[]> = {
+      '1': [
+        { client_order_id: 'page1-a', status: 'PENDING' },
+        { client_order_id: 'page1-b', status: 'PENDING' },
+      ],
+      '2': [
+        { client_order_id: 'target-coid', symbol: 'SOXL', status: 'FILLED', filled_quantity: '1' },
+        { client_order_id: 'page2-b', status: 'PENDING' },
+      ],
+    }
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(async (input) => {
+      const url = new URL(String(input))
+      const page = url.searchParams.get('page') ?? '1'
+      return new Response(JSON.stringify(pageRows[page] ?? []), { status: 200 })
+    })
+    const client = createClient(fetchMock)
+    const detail = await client.findOrderByClientId('target-coid', { maxPages: 3, pageSize })
+    expect(detail?.status).toBe('FILLED')
+    // Page 1 was scanned (no match), page 2 returned the match — loop stops.
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const requestedPages = fetchMock.mock.calls.map((call) =>
+      new URL(String(call[0])).searchParams.get('page'),
+    )
+    expect(requestedPages).toEqual(['1', '2'])
+    // page_size is forwarded as requested.
+    expect(new URL(String(fetchMock.mock.calls[0]![0])).searchParams.get('page_size')).toBe('2')
+  })
+
+  // #139: bounded sweep. With `maxPages=2` we must not request page 3 even
+  // when the broker keeps returning full pages — caller's quota stays
+  // proportional to the cap they asked for.
+  it('findOrderByClientId stops at maxPages even when broker keeps returning full pages', async () => {
+    const pageSize = 2
+    const fullPage = [
+      { client_order_id: 'fill-1', status: 'PENDING' },
+      { client_order_id: 'fill-2', status: 'PENDING' },
+    ]
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(async () =>
+      new Response(JSON.stringify(fullPage), { status: 200 }),
+    )
+    const client = createClient(fetchMock)
+    const detail = await client.findOrderByClientId('never-matches', { maxPages: 2, pageSize })
+    expect(detail).toBeUndefined()
+    // Exactly maxPages requests, never page 3.
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const requestedPages = fetchMock.mock.calls.map((call) =>
+      new URL(String(call[0])).searchParams.get('page'),
+    )
+    expect(requestedPages).toEqual(['1', '2'])
+  })
+
+  // #139: a short page (rows.length < pageSize) signals end-of-history, so we
+  // stop early and don't pay for further empty page calls.
+  it('findOrderByClientId stops early when the broker returns a short page', async () => {
+    const pageSize = 50
+    // Single row returned — far short of pageSize=50 → loop must not request page 2.
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify([{ client_order_id: 'unrelated' }]), { status: 200 }),
+    )
+    const client = createClient(fetchMock)
+    const detail = await client.findOrderByClientId('never-matches', { maxPages: 5, pageSize })
+    expect(detail).toBeUndefined()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
   it('findOrderByClientId throws BrokerRequestError when no account id is configured', async () => {

--- a/test/routes/admin.test.ts
+++ b/test/routes/admin.test.ts
@@ -125,6 +125,8 @@ describe('POST /admin/orders/reconcile', () => {
       updated: [],
       stillPending: [],
       notFound: [],
+      notFoundRecentWindow: [],
+      notFoundAfterDeepLookup: [],
       errors: [],
       stateApplied: 0,
       stateApplyFailed: 0,

--- a/test/trading/reconciliation/reconcileFills.test.ts
+++ b/test/trading/reconciliation/reconcileFills.test.ts
@@ -368,7 +368,13 @@ function makePortfolioNamespace(stub: PortfolioStateStub): unknown {
 
 function makeWebullStub(detailByCoid: Record<string, unknown>) {
   return {
-    findOrderByClientId: vi.fn(async (coid: string) => detailByCoid[coid]),
+    // Second arg (opts) is forwarded by reconcileFills to opt into deep
+    // lookup (#139). The stub ignores it but the type must accept it so
+    // tests can read it from `.mock.calls`.
+    findOrderByClientId: vi.fn(
+      async (coid: string, _opts?: { maxPages?: number; pageSize?: number }) =>
+        detailByCoid[coid],
+    ),
   }
 }
 
@@ -1439,6 +1445,93 @@ describe('reconcileFills state-apply marker (issue #142)', () => {
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining('"event":"reconcile_auto_abandon"'),
       )
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // notFound bucket split (#139). The broker-side history call may miss for
+  // two reasons: (a) the order rotated off the recent first-page window, or
+  // (b) the order doesn't exist on the broker at all. We separate the two so
+  // dashboards / alerting can treat "deep lookup also missed" as a stronger
+  // signal than "first page didn't have it".
+  // ---------------------------------------------------------------------------
+  describe('notFound split: recent-window vs after-deep-lookup', () => {
+    it('classifies as notFoundRecentWindow when historyMaxPages=1 and broker returns nothing', async () => {
+      const row: CandidateRow = {
+        id: 501,
+        clientOrderId: 'coid-missing-1',
+        symbol: 'SOXL',
+        side: 'BUY',
+        brokerStatus: null,
+        filledQty: null,
+        filledPrice: null,
+        realizedPnl: null,
+        stateAppliedAt: null,
+        stateApplyAttempts: 0,
+      }
+      const { db } = makeFakeDb([row])
+      vi.mocked(createDb).mockReturnValue(db)
+      const webullStub = makeWebullStub({})
+      vi.mocked(createWebullHttpClient).mockReturnValue(
+        webullStub as unknown as ReturnType<typeof createWebullHttpClient>,
+      )
+      const symbolStub = emptySymbolStateStub()
+
+      const summary = await reconcileFills({
+        env: {
+          DB: FAKE_DB_BINDING,
+          SYMBOL_STATE: makeSymbolStateNamespace(symbolStub) as never,
+        } as never,
+        now: () => new Date('2026-04-25T12:00:00.000Z'),
+        // historyMaxPages omitted → default 1 → no deep sweep.
+      })
+
+      // Single lookup, no deep sweep.
+      expect(webullStub.findOrderByClientId).toHaveBeenCalledTimes(1)
+      expect(summary.notFoundRecentWindow).toEqual(['coid-missing-1'])
+      expect(summary.notFoundAfterDeepLookup).toEqual([])
+      // Legacy bucket still populated so existing dashboards keep working.
+      expect(summary.notFound).toEqual(['coid-missing-1'])
+    })
+
+    it('classifies as notFoundAfterDeepLookup when historyMaxPages>1 and deep sweep also misses', async () => {
+      const row: CandidateRow = {
+        id: 502,
+        clientOrderId: 'coid-missing-deep',
+        symbol: 'SOXL',
+        side: 'BUY',
+        brokerStatus: null,
+        filledQty: null,
+        filledPrice: null,
+        realizedPnl: null,
+        stateAppliedAt: null,
+        stateApplyAttempts: 0,
+      }
+      const { db } = makeFakeDb([row])
+      vi.mocked(createDb).mockReturnValue(db)
+      const webullStub = makeWebullStub({})
+      vi.mocked(createWebullHttpClient).mockReturnValue(
+        webullStub as unknown as ReturnType<typeof createWebullHttpClient>,
+      )
+      const symbolStub = emptySymbolStateStub()
+
+      const summary = await reconcileFills({
+        env: {
+          DB: FAKE_DB_BINDING,
+          SYMBOL_STATE: makeSymbolStateNamespace(symbolStub) as never,
+        } as never,
+        now: () => new Date('2026-04-25T12:00:00.000Z'),
+        historyMaxPages: 5,
+      })
+
+      // Two lookups: initial single-page, then deep sweep with maxPages.
+      expect(webullStub.findOrderByClientId).toHaveBeenCalledTimes(2)
+      // The deep-sweep call carried the bounded maxPages.
+      const deepCall = webullStub.findOrderByClientId.mock.calls[1]!
+      expect(deepCall[1]).toMatchObject({ maxPages: 5 })
+      expect(summary.notFoundRecentWindow).toEqual([])
+      expect(summary.notFoundAfterDeepLookup).toEqual(['coid-missing-deep'])
+      expect(summary.notFound).toEqual(['coid-missing-deep'])
     })
   })
 })


### PR DESCRIPTION
## Summary

- `WebullHttpClient.findOrderByClientId(coid, opts?)` now supports `{ maxPages, pageSize }` for a bounded multi-page sweep of `/openapi/account/orders/history`. Walks 1-indexed `page=N` requests serially; stops on match, short page, or `maxPages`. Default behaviour (single page, `pageSize=50`) is unchanged so cron-poll broker load stays flat.
- `reconcileFills` adds `historyMaxPages` / `historyPageSize` options. When the initial single-page lookup misses and the caller opts in (`historyMaxPages > 1`), the row gets a bounded deep-lookup retry. `summary.notFound` is split into `notFoundRecentWindow` (first-page miss only) and `notFoundAfterDeepLookup` (deep sweep also missed). The legacy `notFound` field is preserved as the union so existing dashboards/alerting keep working.
- `GET /admin/orders/:clientOrderId` accepts `?maxPages=N&pageSize=N` (hard-capped at 20 / 200 respectively, parser fails-closed on typos). 404 body now carries `maxPagesScanned`.
- `lookbackMs` / `limit` are pulled into named `DEFAULT_LOOKBACK_MS` / `DEFAULT_ROW_LIMIT` constants — already overridable, just documenting the defaults.

Implements #139.

## Acceptance

- [x] `findOrderByClientId(clientOrderId, { maxPages, pageSize })` でmulti-page search
- [x] `/admin/orders/:clientOrderId?maxPages=N` で first page 外も探せる
- [x] reconcile summary で `notFoundRecentWindow` と `notFoundAfterDeepLookup` を区別
- [x] tests: 2ページ目検出 + maxPages bounded + short-page early-stop + reconcile split notFound

## Test plan

- [x] `pnpm test` — 1159 tests pass (89 files)
- [x] `pnpm typecheck` — clean
- [ ] Optional: invoke `/admin/orders/<coid>?maxPages=5` against UAT after merge to confirm the page query is honoured by the broker