### PR TITLE
feat(risk): portfolio exposure gate per currency (#77)

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1472,6 +1472,73 @@ export const admin = new Hono<AppBindings>()
       })
     }
   })
+  /**
+   * #77 portfolio exposure gate: operator-supplied baseline for
+   * `openExposure{Usd,Jpy}`. Use after a holdings rebuild (e.g.
+   * `/admin/orders/sync-holdings`) when the on-DO counter has drifted from
+   * broker truth, or to zero things out on a fresh tenant.
+   *
+   * Body: `{ usd?: number, jpy?: number }`. Either side may be omitted to
+   * leave that currency's counter untouched. Numbers must be finite >= 0.
+   * At least one of the two must be present.
+   */
+  .post('/portfolio/seed-exposure', rateLimit('ADMIN_WRITE'), async (c) => {
+    if (!c.env.PORTFOLIO_STATE) {
+      throw new ValidationError('PORTFOLIO_STATE binding is not configured', { field: 'env' })
+    }
+    const body = (await c.req.json().catch(() => null)) as unknown
+    const args = readSeedExposureBody(body)
+    const client = new PortfolioStateClient(c.env.PORTFOLIO_STATE)
+    const before = await safeGetPortfolioState(client)
+    const state = await client.seedOpenExposure(args)
+    await writeAuditLog(
+      c,
+      '/admin/portfolio/seed-exposure',
+      'portfolio=daily',
+      {
+        openExposureUsd: before?.openExposureUsd ?? null,
+        openExposureJpy: before?.openExposureJpy ?? null,
+      },
+      {
+        openExposureUsd: state.openExposureUsd,
+        openExposureJpy: state.openExposureJpy,
+      },
+    )
+    return c.json({
+      openExposureUsd: state.openExposureUsd,
+      openExposureJpy: state.openExposureJpy,
+      updatedAt: state.updatedAt,
+    })
+  })
+
+/**
+ * Parse `/admin/portfolio/seed-exposure` body. At least one of `usd` / `jpy`
+ * must be a finite number >= 0; the other can be omitted (= leave that
+ * currency untouched). Reject negatives and NaN.
+ */
+function readSeedExposureBody(body: unknown): { usd?: number; jpy?: number } {
+  if (body === null || typeof body !== 'object' || Array.isArray(body)) {
+    throw new ValidationError('body must be a JSON object with { usd?, jpy? }', { field: 'body' })
+  }
+  const raw = body as { usd?: unknown; jpy?: unknown }
+  const out: { usd?: number; jpy?: number } = {}
+  if (raw.usd !== undefined && raw.usd !== null) {
+    if (typeof raw.usd !== 'number' || !Number.isFinite(raw.usd) || raw.usd < 0) {
+      throw new ValidationError('usd must be a finite number >= 0', { field: 'usd' })
+    }
+    out.usd = raw.usd
+  }
+  if (raw.jpy !== undefined && raw.jpy !== null) {
+    if (typeof raw.jpy !== 'number' || !Number.isFinite(raw.jpy) || raw.jpy < 0) {
+      throw new ValidationError('jpy must be a finite number >= 0', { field: 'jpy' })
+    }
+    out.jpy = raw.jpy
+  }
+  if (out.usd === undefined && out.jpy === undefined) {
+    throw new ValidationError('at least one of usd / jpy must be provided', { field: 'body' })
+  }
+  return out
+}
 
 /**
  * Validate a single `/admin/macro-events/seed` body entry。

--- a/src/routes/trade.ts
+++ b/src/routes/trade.ts
@@ -113,6 +113,13 @@ export async function createTradingService(
       staleQuoteMs: global.staleQuoteMs,
       gapRejectPct: global.gapRejectPct,
       drawdownKillThreshold: global.drawdownKillThreshold,
+      // #77 portfolio exposure gate. `total_capital_*` null disables the
+      // check for that currency. `symbolCurrency` is required to route the
+      // ceiling to the correct budget (USD vs JPY).
+      maxPortfolioExposurePct: global.maxPortfolioExposurePct,
+      totalCapitalUsd: global.totalCapitalUsd,
+      totalCapitalJpy: global.totalCapitalJpy,
+      symbolCurrency: universe.symbolCurrency,
     },
   )
 }

--- a/src/trading/application/TradingService.ts
+++ b/src/trading/application/TradingService.ts
@@ -75,6 +75,26 @@ export interface TradingServiceOptions {
    * avgPrice と lastQuote.price の gap が |pct| を超えれば reject。
    */
   gapRejectPct?: number
+  /**
+   * Portfolio-wide BUY exposure ceiling expressed as a fraction of
+   * per-currency total capital. The gate rejects a BUY when
+   * `openExposure[currency] + orderNotional > totalCapital[currency] *
+   * maxPortfolioExposurePct`. Default 0.6 (= 60%). #77.
+   */
+  maxPortfolioExposurePct?: number
+  /**
+   * Account-wide capital baseline per currency. `null` for either side
+   * disables the exposure gate for that currency (= POC fail-open default
+   * when the operator has not seeded a number yet). #77.
+   */
+  totalCapitalUsd?: number | null
+  totalCapitalJpy?: number | null
+  /**
+   * Symbol → currency lookup populated from `symbol_config`. Required by
+   * the portfolio exposure gate; the gate falls back to a JP 4-digit
+   * heuristic when the map is missing or the symbol is unknown. #77.
+   */
+  symbolCurrency?: Record<string, 'USD' | 'JPY'>
   now?: () => Date
 }
 
@@ -83,6 +103,7 @@ const DEFAULT_SPREAD_LIMITS = { US: 0.0025, JP: 0.006 } as const
 const DEFAULT_STALE_QUOTE_MS = 15 * 60 * 1_000
 const DEFAULT_GAP_REJECT_PCT = 0.03
 const DEFAULT_DRAWDOWN_KILL_THRESHOLD = -0.02
+const DEFAULT_MAX_PORTFOLIO_EXPOSURE_PCT = 0.6
 
 export class TradingService {
   private readonly positionStore?: PositionStore
@@ -93,6 +114,10 @@ export class TradingService {
   private readonly spreadLimits: { US: number; JP: number }
   private readonly staleQuoteMs: number
   private readonly gapRejectPct: number
+  private readonly maxPortfolioExposurePct: number
+  private readonly totalCapitalUsd: number | null
+  private readonly totalCapitalJpy: number | null
+  private readonly symbolCurrency: Record<string, 'USD' | 'JPY'>
   private readonly now: () => Date
 
   constructor(
@@ -142,6 +167,16 @@ export class TradingService {
       options.gapRejectPct > 0
         ? options.gapRejectPct
         : DEFAULT_GAP_REJECT_PCT
+    this.maxPortfolioExposurePct =
+      options.maxPortfolioExposurePct !== undefined &&
+      Number.isFinite(options.maxPortfolioExposurePct) &&
+      options.maxPortfolioExposurePct > 0 &&
+      options.maxPortfolioExposurePct <= 1
+        ? options.maxPortfolioExposurePct
+        : DEFAULT_MAX_PORTFOLIO_EXPOSURE_PCT
+    this.totalCapitalUsd = sanitizeTotalCapital(options.totalCapitalUsd)
+    this.totalCapitalJpy = sanitizeTotalCapital(options.totalCapitalJpy)
+    this.symbolCurrency = options.symbolCurrency ?? {}
     this.now = options.now ?? (() => new Date())
   }
 
@@ -267,6 +302,31 @@ export class TradingService {
           }
         }
       }
+
+      // #77 portfolio exposure ceiling. Only applies to BUY (SELL reduces
+      // exposure). Skipped when `total_capital_<currency>` is unset (null) —
+      // POC default = "operator has not seeded a capital baseline yet, leave
+      // the gate disabled rather than fail-close all entries with a 0
+      // ceiling". USD and JPY budgets are independent.
+      if (decision.orderIntent.side === 'BUY') {
+        const currency = this.resolveSymbolCurrency(decision.orderIntent.symbol)
+        const totalCapital = currency === 'USD' ? this.totalCapitalUsd : this.totalCapitalJpy
+        if (totalCapital !== null) {
+          const ceiling = totalCapital * this.maxPortfolioExposurePct
+          const current =
+            currency === 'USD' ? portfolio.openExposureUsd : portfolio.openExposureJpy
+          const projected = current + decision.orderIntent.notional
+          if (projected > ceiling) {
+            return {
+              allowed: false,
+              riskDecision: appendReason(
+                decision.riskDecision,
+                `portfolio exposure exceeded: ${currency} projected ${projected.toFixed(2)} > ceiling ${ceiling.toFixed(2)} (open ${current.toFixed(2)} + order ${decision.orderIntent.notional.toFixed(2)}; cap ${totalCapital} * ${this.maxPortfolioExposurePct})`,
+              ),
+            }
+          }
+        }
+      }
     }
 
     // Per-symbol gate を pure function に集約 (issue #138 — cron 側と unify)。
@@ -320,6 +380,17 @@ export class TradingService {
     return { allowed: true }
   }
 
+  private resolveSymbolCurrency(symbol: string): 'USD' | 'JPY' {
+    const upper = symbol.toUpperCase()
+    const mapped = this.symbolCurrency[upper]
+    if (mapped === 'USD' || mapped === 'JPY') return mapped
+    // Fallback heuristic kept consistent with `routes/trade.ts`:
+    // 4-digit numeric ticker → JPY, anything else → USD. The gate only
+    // triggers when `total_capital_<currency>` is set, so a misclassified
+    // symbol on an unseeded currency still routes through (= no false reject).
+    return /^\d{4}$/.test(upper) ? 'JPY' : 'USD'
+  }
+
   private createOrderIntent(signal: Signal): OrderIntent | undefined {
     if (signal.action === 'HOLD') {
       return undefined
@@ -334,6 +405,12 @@ export class TradingService {
       clientOrderId: crypto.randomUUID().replaceAll('-', ''),
     }
   }
+}
+
+function sanitizeTotalCapital(value: number | null | undefined): number | null {
+  if (value === null || value === undefined) return null
+  if (!Number.isFinite(value) || value <= 0) return null
+  return value
 }
 
 function endOfUtcDay(now: Date): Date {

--- a/src/trading/reconciliation/reconcileFills.ts
+++ b/src/trading/reconciliation/reconcileFills.ts
@@ -8,6 +8,8 @@ import { createWebullReadClient } from '../../infrastructure/webull/WebullReadCl
 import type { WebullOrderDetailDto } from '../../infrastructure/webull/dto'
 import { inferWebullMarket } from '../../infrastructure/webull/mapper'
 import { inferTradingMarket, nextTradingDay } from '../domain/tradingCalendar'
+import { loadSymbolUniverse } from '../../infrastructure/db/symbolUniverse'
+import type { SymbolCurrency } from '../../infrastructure/db/symbolConfigRepo'
 import { PortfolioStateClient } from '../state/PortfolioStateClient'
 import { SymbolStateClient } from '../state/SymbolStateClient'
 
@@ -175,6 +177,30 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
   const runNow = now()
   const since = new Date(runNow.getTime() - (options.lookbackMs ?? 48 * 3_600_000)).toISOString()
   const limit = options.limit ?? 50
+
+  // #77 portfolio exposure tracking: resolve symbol → currency once so each
+  // fill apply can update `openExposure{Usd,Jpy}` without per-row DB hits.
+  // Best-effort: a failure here (DB transient, fake DB in tests) falls back
+  // to the JP-numeric heuristic inside `applyFillToState` (see
+  // `resolveFillCurrency`). The exposure counter is informational for the
+  // gate — a missed update is recoverable via `/admin/portfolio/seed-exposure`.
+  // Loaded BEFORE the main `db` handle so `createDb` mock ordering in tests
+  // remains stable (main SELECT uses the second mock return).
+  let symbolCurrency: Record<string, SymbolCurrency> | undefined
+  if (options.env.PORTFOLIO_STATE) {
+    try {
+      const universe = await loadSymbolUniverse(options.env)
+      symbolCurrency = universe.symbolCurrency
+    } catch (error) {
+      console.warn(
+        JSON.stringify({
+          event: 'reconcile_symbol_currency_load_failed',
+          requestId: options.requestId,
+          message: error instanceof Error ? error.message : String(error),
+        }),
+      )
+    }
+  }
 
   const db = createDb(options.env.DB)
   // Two cohorts in one query:
@@ -398,6 +424,7 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
         realizedPnl,
         runNow,
         nowIso: runNow.toISOString(),
+        symbolCurrency,
       })
       if (ok) {
         summary.stateApplied += 1
@@ -551,6 +578,7 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
           realizedPnl,
           runNow,
           nowIso: runNow.toISOString(),
+          symbolCurrency,
         })
         if (ok) {
           summary.stateApplied += 1
@@ -667,6 +695,10 @@ async function tryApplyAndStamp(args: {
   realizedPnl: number | null
   runNow: Date
   nowIso: string
+  /** Symbol → currency map preloaded by `reconcileFills` (#77). Undefined
+   * when the universe load failed — `applyFillToState` falls back to the
+   * JP-numeric heuristic. */
+  symbolCurrency?: Record<string, SymbolCurrency>
 }): Promise<boolean> {
   const {
     env,
@@ -681,6 +713,7 @@ async function tryApplyAndStamp(args: {
     realizedPnl,
     runNow,
     nowIso,
+    symbolCurrency,
   } = args
 
   try {
@@ -694,6 +727,7 @@ async function tryApplyAndStamp(args: {
       filledPrice,
       realizedPnl,
       runNow,
+      symbolCurrency,
     })
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
@@ -884,8 +918,21 @@ async function applyFillToState(args: {
   /** Reconcile run basis time — used for cooldown expiry so back-catch-up runs
    * don't lengthen the window past the original fill's next trading day. */
   runNow: Date
+  /** Pre-loaded symbol → currency map (#77 portfolio exposure tracking). */
+  symbolCurrency?: Record<string, SymbolCurrency>
 }): Promise<void> {
-  const { env, requestId, clientOrderId, symbol, side, filledQty, filledPrice, realizedPnl, runNow } = args
+  const {
+    env,
+    requestId,
+    clientOrderId,
+    symbol,
+    side,
+    filledQty,
+    filledPrice,
+    realizedPnl,
+    runNow,
+    symbolCurrency,
+  } = args
   let symbolApplied = false
   let portfolioApplied = false
 
@@ -903,6 +950,40 @@ async function applyFillToState(args: {
   if (side === 'SELL' && realizedPnl !== null && env.PORTFOLIO_STATE) {
     const result = await new PortfolioStateClient(env.PORTFOLIO_STATE).applyRealizedPnlOnce(clientOrderId, realizedPnl)
     portfolioApplied = result.applied
+  }
+
+  // #77 portfolio exposure tracking. BUY adds, SELL subtracts (clamped >=0
+  // inside the DO). Non-fatal: a failure here must not poison the journal
+  // marker because the position-side apply (SymbolStateDO.recordFillOnce)
+  // is already idempotent via clientOrderId. The exposure counter drift can
+  // be repaired via `/admin/portfolio/seed-exposure`. We only fire the call
+  // when SymbolStateDO.recordFillOnce reported a fresh apply (`symbolApplied`)
+  // so repair retries don't double-count exposure.
+  if (env.PORTFOLIO_STATE && symbolApplied) {
+    const currency = resolveFillCurrency(symbol, symbolCurrency)
+    const notional = filledPrice * filledQty
+    if (Number.isFinite(notional) && notional > 0) {
+      try {
+        await new PortfolioStateClient(env.PORTFOLIO_STATE).applyFillExposure({
+          currency,
+          side,
+          notional,
+        })
+      } catch (error) {
+        console.error(
+          JSON.stringify({
+            event: 'reconcile_exposure_apply_error',
+            requestId,
+            clientOrderId,
+            symbol,
+            side,
+            currency,
+            notional,
+            message: error instanceof Error ? error.message : String(error),
+          }),
+        )
+      }
+    }
   }
 
   // Stop-out cooldown: a losing exit parks the symbol until the next trading
@@ -1124,10 +1205,29 @@ function resolveFilledPrice(
   return candidate
 }
 
+/**
+ * Symbol → currency lookup for the #77 portfolio exposure tracker. Prefer
+ * the preloaded `symbol_config` map; if missing (universe load failed, or
+ * symbol not in `symbol_config`) fall back to the same JP-numeric heuristic
+ * the `/trade/*` route uses (4-digit numeric = JPY, else USD). The fallback
+ * keeps exposure tracking alive on misconfigured environments without
+ * silently misclassifying a US ETF as JPY.
+ */
+function resolveFillCurrency(
+  symbol: string,
+  symbolCurrency: Record<string, SymbolCurrency> | undefined,
+): SymbolCurrency {
+  const upper = symbol.toUpperCase()
+  const mapped = symbolCurrency?.[upper]
+  if (mapped === 'USD' || mapped === 'JPY') return mapped
+  return /^\d{4}$/.test(upper) ? 'JPY' : 'USD'
+}
+
 // Exposed for tests.
 export const _internal = {
   TERMINAL_STATUSES,
   pickFilledPrice,
   resolveFilledPrice,
+  resolveFillCurrency,
   shouldRetryStateApply,
 }

--- a/src/trading/state/PortfolioStateClient.ts
+++ b/src/trading/state/PortfolioStateClient.ts
@@ -36,6 +36,18 @@ export class PortfolioStateClient implements PortfolioStore {
     return this.stub().setTradingDisabledUntil(iso)
   }
 
+  applyFillExposure(args: {
+    currency: 'USD' | 'JPY'
+    side: 'BUY' | 'SELL'
+    notional: number
+  }): Promise<PortfolioState> {
+    return this.stub().applyFillExposure(args)
+  }
+
+  seedOpenExposure(args: { usd?: number; jpy?: number }): Promise<PortfolioState> {
+    return this.stub().seedOpenExposure(args)
+  }
+
   rollDaily(): Promise<{ before: PortfolioState; after: PortfolioState }> {
     return this.stub().rollDaily()
   }

--- a/src/trading/state/PortfolioStateDO.ts
+++ b/src/trading/state/PortfolioStateDO.ts
@@ -1,9 +1,11 @@
 import { DurableObject } from 'cloudflare:workers'
 import {
+  applyFillExposure,
   applyRealizedPnlOnce,
   applyRealizedPnl,
   rollDaily,
   seedDailyStartEquity,
+  seedOpenExposure,
   setTradingDisabledUntil,
   type PortfolioTransitionContext,
 } from './portfolioStateTransitions'
@@ -47,6 +49,24 @@ export class PortfolioStateDO extends DurableObject<object> {
     return result
   }
 
+  async applyFillExposure(args: {
+    currency: 'USD' | 'JPY'
+    side: 'BUY' | 'SELL'
+    notional: number
+  }): Promise<PortfolioState> {
+    const state = await this.load()
+    const next = applyFillExposure(state, args, this.transitionCtx)
+    await this.save(next)
+    return next
+  }
+
+  async seedOpenExposure(args: { usd?: number; jpy?: number }): Promise<PortfolioState> {
+    const state = await this.load()
+    const next = seedOpenExposure(state, args, this.transitionCtx)
+    await this.save(next)
+    return next
+  }
+
   async setTradingDisabledUntil(iso: string | null): Promise<PortfolioState> {
     const state = await this.load()
     const next = setTradingDisabledUntil(state, iso, this.transitionCtx)
@@ -79,14 +99,31 @@ export class PortfolioStateDO extends DurableObject<object> {
   }
 
   private normalize(state: PortfolioState): PortfolioState {
+    const raw = state as {
+      appliedClientOrderIds?: unknown
+      lastRolledAt?: unknown
+      openExposureUsd?: unknown
+      openExposureJpy?: unknown
+    }
     return {
       ...state,
-      appliedClientOrderIds: Array.isArray((state as { appliedClientOrderIds?: unknown }).appliedClientOrderIds)
+      appliedClientOrderIds: Array.isArray(raw.appliedClientOrderIds)
         ? state.appliedClientOrderIds
         : [],
-      lastRolledAt: !('lastRolledAt' in state) || (state as { lastRolledAt?: unknown }).lastRolledAt === undefined
+      lastRolledAt: !('lastRolledAt' in state) || raw.lastRolledAt === undefined
         ? null
         : state.lastRolledAt,
+      // #77: backfill open-exposure counters for DO instances persisted before
+      // the field was added. `undefined`/non-finite reads as 0 so the gate
+      // starts from a clean baseline without an explicit migration step.
+      openExposureUsd:
+        typeof raw.openExposureUsd === 'number' && Number.isFinite(raw.openExposureUsd)
+          ? raw.openExposureUsd
+          : 0,
+      openExposureJpy:
+        typeof raw.openExposureJpy === 'number' && Number.isFinite(raw.openExposureJpy)
+          ? raw.openExposureJpy
+          : 0,
     }
   }
 }

--- a/src/trading/state/PortfolioStore.ts
+++ b/src/trading/state/PortfolioStore.ts
@@ -11,4 +11,20 @@ export interface PortfolioStore {
   applyRealizedPnl(delta: number): Promise<PortfolioState>
   setTradingDisabledUntil(iso: string | null): Promise<PortfolioState>
   rollDaily(): Promise<{ before: PortfolioState; after: PortfolioState }>
+  /**
+   * Mutate `openExposure{Usd,Jpy}` from a terminal fill. BUY adds notional,
+   * SELL subtracts (clamped >= 0). Called by reconcileFills after the
+   * realized-pnl path; read by the portfolio exposure gate (#77).
+   */
+  applyFillExposure(args: {
+    currency: 'USD' | 'JPY'
+    side: 'BUY' | 'SELL'
+    notional: number
+  }): Promise<PortfolioState>
+  /**
+   * Operator override for `openExposure{Usd,Jpy}` — used by
+   * `/admin/portfolio/seed-exposure` to snap to a known baseline after a
+   * holdings rebuild. Either side can be omitted.
+   */
+  seedOpenExposure(args: { usd?: number; jpy?: number }): Promise<PortfolioState>
 }

--- a/src/trading/state/portfolioStateTransitions.ts
+++ b/src/trading/state/portfolioStateTransitions.ts
@@ -97,6 +97,69 @@ export function setTradingDisabledUntil(
 }
 
 /**
+ * BUY fill: add notional to the currency-specific openExposure. SELL fill:
+ * subtract, but clamp to >= 0 so we never go negative even if a SELL runs
+ * ahead of its BUY (e.g. position seeded out-of-band, or a stale fill
+ * arrives after `seedOpenExposure` reset the counter).
+ *
+ * Pure: returns a new state. The portfolio exposure gate (#77) reads
+ * `openExposure{Usd,Jpy}` and compares against `total_capital_* *
+ * max_portfolio_exposure_pct`.
+ */
+export function applyFillExposure(
+  state: PortfolioState,
+  args: { currency: 'USD' | 'JPY'; side: 'BUY' | 'SELL'; notional: number },
+  ctx: PortfolioTransitionContext = defaultCtx,
+): PortfolioState {
+  if (!Number.isFinite(args.notional) || args.notional < 0) {
+    throw new Error(
+      `Invalid applyFillExposure notional: ${args.notional} (must be a finite number >= 0)`,
+    )
+  }
+  const delta = args.side === 'BUY' ? args.notional : -args.notional
+  if (args.currency === 'USD') {
+    return {
+      ...state,
+      openExposureUsd: Math.max(0, state.openExposureUsd + delta),
+      updatedAt: ctx.now().toISOString(),
+    }
+  }
+  return {
+    ...state,
+    openExposureJpy: Math.max(0, state.openExposureJpy + delta),
+    updatedAt: ctx.now().toISOString(),
+  }
+}
+
+/**
+ * Operator override: snap one or both `openExposure*` counters to a known
+ * baseline. Used by `/admin/portfolio/seed-exposure` to reset after an
+ * out-of-band position rebuild. Either side can be omitted to leave that
+ * currency's counter untouched.
+ */
+export function seedOpenExposure(
+  state: PortfolioState,
+  args: { usd?: number; jpy?: number },
+  ctx: PortfolioTransitionContext = defaultCtx,
+): PortfolioState {
+  const next: PortfolioState = { ...state }
+  if (args.usd !== undefined) {
+    if (!Number.isFinite(args.usd) || args.usd < 0) {
+      throw new Error(`Invalid seedOpenExposure usd: ${args.usd} (must be a finite number >= 0)`)
+    }
+    next.openExposureUsd = args.usd
+  }
+  if (args.jpy !== undefined) {
+    if (!Number.isFinite(args.jpy) || args.jpy < 0) {
+      throw new Error(`Invalid seedOpenExposure jpy: ${args.jpy} (must be a finite number >= 0)`)
+    }
+    next.openExposureJpy = args.jpy
+  }
+  next.updatedAt = ctx.now().toISOString()
+  return next
+}
+
+/**
  * EOD rollover: computes `nextStart = dailyStartEquity + dailyRealizedPnl`,
  * resets `dailyRealizedPnl` to 0, and returns both the before and after states.
  * This is the atomic version that prevents races with `applyRealizedPnl`.

--- a/src/trading/state/portfolioTypes.ts
+++ b/src/trading/state/portfolioTypes.ts
@@ -13,6 +13,16 @@ export interface PortfolioState {
    * the runStrategyCron pre-flight to detect stale rollovers (issue #140).
    */
   lastRolledAt: string | null
+  /**
+   * Currently-open BUY notional in USD across all symbols. BUY fills add to
+   * this, SELL fills subtract. Clamped to >= 0 to avoid drift when SELLs
+   * run ahead of their BUYs (e.g. seeded position). Read by the portfolio
+   * exposure gate against `global_config.total_capital_usd *
+   * max_portfolio_exposure_pct` (#77).
+   */
+  openExposureUsd: number
+  /** JPY counterpart of {@link openExposureUsd}. Independent budget. */
+  openExposureJpy: number
   updatedAt: string
 }
 
@@ -23,6 +33,8 @@ export function emptyPortfolioState(now: () => Date = () => new Date()): Portfol
     appliedClientOrderIds: [],
     tradingDisabledUntil: null,
     lastRolledAt: null,
+    openExposureUsd: 0,
+    openExposureJpy: 0,
     updatedAt: now().toISOString(),
   }
 }

--- a/test/routes/adminPortfolio.test.ts
+++ b/test/routes/adminPortfolio.test.ts
@@ -91,3 +91,136 @@ describe('POST /admin/portfolio/seed-equity', () => {
     expect(captured.calls).toEqual([{ amount: 100_000 }])
   })
 })
+
+// #77: POST /admin/portfolio/seed-exposure roundtrip — operator override of
+// the openExposure{Usd,Jpy} counters. Validates strict body parsing (at
+// least one of usd/jpy; >= 0; finite) and forwards to PORTFOLIO_STATE.
+function fakePortfolioExposureState(
+  captured: { calls: Array<{ usd?: number; jpy?: number }> },
+  current = { openExposureUsd: 0, openExposureJpy: 0 },
+) {
+  const stub = {
+    async getPortfolio() {
+      return {
+        dailyStartEquity: 0,
+        dailyRealizedPnl: 0,
+        tradingDisabledUntil: null,
+        lastRolledAt: null,
+        appliedClientOrderIds: [],
+        openExposureUsd: current.openExposureUsd,
+        openExposureJpy: current.openExposureJpy,
+        updatedAt: '2026-04-21T10:00:00.000Z',
+      }
+    },
+    async seedOpenExposure(args: { usd?: number; jpy?: number }) {
+      captured.calls.push(args)
+      const next = {
+        ...current,
+        ...(args.usd !== undefined ? { openExposureUsd: args.usd } : {}),
+        ...(args.jpy !== undefined ? { openExposureJpy: args.jpy } : {}),
+      }
+      current.openExposureUsd = next.openExposureUsd
+      current.openExposureJpy = next.openExposureJpy
+      return {
+        dailyStartEquity: 0,
+        dailyRealizedPnl: 0,
+        tradingDisabledUntil: null,
+        lastRolledAt: null,
+        appliedClientOrderIds: [],
+        openExposureUsd: next.openExposureUsd,
+        openExposureJpy: next.openExposureJpy,
+        updatedAt: '2026-04-21T10:00:00.000Z',
+      }
+    },
+  }
+  return {
+    idFromName: (_name: string) => 'id',
+    get: (_id: string) => stub,
+  } as unknown
+}
+
+describe('POST /admin/portfolio/seed-exposure (#77)', () => {
+  it('401s without Access JWT', async () => {
+    const app = createApp()
+    const res = await app.request(
+      '/admin/portfolio/seed-exposure',
+      { method: 'POST', body: JSON.stringify({ usd: 0 }) },
+      unauthEnv,
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it('400s when neither usd nor jpy is provided', async () => {
+    const app = createApp()
+    const captured = { calls: [] as Array<{ usd?: number; jpy?: number }> }
+    const res = await app.request(
+      '/admin/portfolio/seed-exposure',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      },
+      { ...baseEnv, PORTFOLIO_STATE: fakePortfolioExposureState(captured) },
+    )
+    expect(res.status).toBe(400)
+    expect(captured.calls).toEqual([])
+  })
+
+  it('400s on negative usd', async () => {
+    const app = createApp()
+    const captured = { calls: [] as Array<{ usd?: number; jpy?: number }> }
+    const res = await app.request(
+      '/admin/portfolio/seed-exposure',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ usd: -1 }),
+      },
+      { ...baseEnv, PORTFOLIO_STATE: fakePortfolioExposureState(captured) },
+    )
+    expect(res.status).toBe(400)
+    expect(captured.calls).toEqual([])
+  })
+
+  it('200s and forwards both usd and jpy to PORTFOLIO_STATE.seedOpenExposure', async () => {
+    const app = createApp()
+    const captured = { calls: [] as Array<{ usd?: number; jpy?: number }> }
+    const res = await app.request(
+      '/admin/portfolio/seed-exposure',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ usd: 250, jpy: 30_000 }),
+      },
+      { ...baseEnv, PORTFOLIO_STATE: fakePortfolioExposureState(captured) },
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      openExposureUsd: number
+      openExposureJpy: number
+      updatedAt: string
+    }
+    expect(body).toEqual({
+      openExposureUsd: 250,
+      openExposureJpy: 30_000,
+      updatedAt: '2026-04-21T10:00:00.000Z',
+    })
+    expect(captured.calls).toEqual([{ usd: 250, jpy: 30_000 }])
+  })
+
+  it('accepts only one side (jpy alone) leaving usd untouched', async () => {
+    const app = createApp()
+    const captured = { calls: [] as Array<{ usd?: number; jpy?: number }> }
+    const res = await app.request(
+      '/admin/portfolio/seed-exposure',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ jpy: 12_345 }),
+      },
+      { ...baseEnv, PORTFOLIO_STATE: fakePortfolioExposureState(captured) },
+    )
+    expect(res.status).toBe(200)
+    expect(captured.calls).toEqual([{ jpy: 12_345 }])
+  })
+})

--- a/test/routes/adminPortfolio.test.ts
+++ b/test/routes/adminPortfolio.test.ts
@@ -211,6 +211,8 @@ describe('POST /admin/portfolio/seed-exposure (#77)', () => {
   it('accepts only one side (jpy alone) leaving usd untouched', async () => {
     const app = createApp()
     const captured = { calls: [] as Array<{ usd?: number; jpy?: number }> }
+    // Seed a non-zero USD so a regression that silently zeroes USD would fail.
+    const initial = { openExposureUsd: 123, openExposureJpy: 0 }
     const res = await app.request(
       '/admin/portfolio/seed-exposure',
       {
@@ -218,9 +220,16 @@ describe('POST /admin/portfolio/seed-exposure (#77)', () => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ jpy: 12_345 }),
       },
-      { ...baseEnv, PORTFOLIO_STATE: fakePortfolioExposureState(captured) },
+      { ...baseEnv, PORTFOLIO_STATE: fakePortfolioExposureState(captured, initial) },
     )
     expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      openExposureUsd: number
+      openExposureJpy: number
+      updatedAt: string
+    }
+    expect(body.openExposureUsd).toBe(123)
+    expect(body.openExposureJpy).toBe(12_345)
     expect(captured.calls).toEqual([{ jpy: 12_345 }])
   })
 })

--- a/test/scheduledHandler.test.ts
+++ b/test/scheduledHandler.test.ts
@@ -36,6 +36,12 @@ function makeStore(opts: {
     async setTradingDisabledUntil() {
       return opts.before
     },
+    async applyFillExposure() {
+      return opts.before
+    },
+    async seedOpenExposure() {
+      return opts.before
+    },
     async rollDaily() {
       calls++
       if (opts.throwOnRoll) throw opts.throwOnRoll
@@ -72,6 +78,8 @@ describe('runPortfolioRoll (issue #140)', () => {
       appliedClientOrderIds: [],
       tradingDisabledUntil: null,
       lastRolledAt: null,
+      openExposureUsd: 0,
+      openExposureJpy: 0,
       updatedAt: '2026-04-25T22:00:00.000Z',
     }
     const after: PortfolioState = {
@@ -80,6 +88,8 @@ describe('runPortfolioRoll (issue #140)', () => {
       appliedClientOrderIds: [],
       tradingDisabledUntil: null,
       lastRolledAt: '2026-04-25T22:00:00.000Z',
+      openExposureUsd: 0,
+      openExposureJpy: 0,
       updatedAt: '2026-04-25T22:00:00.000Z',
     }
     const fixture = makeStore({ before, after })
@@ -121,6 +131,8 @@ describe('runPortfolioRoll (issue #140)', () => {
       appliedClientOrderIds: [],
       tradingDisabledUntil: null,
       lastRolledAt: null,
+      openExposureUsd: 0,
+      openExposureJpy: 0,
       updatedAt: '2026-04-25T22:00:00.000Z',
     }
     const fixture = makeStore({ before, after: before, throwOnRoll: new Error('DO unreachable') })

--- a/test/trading/application/tradingServiceDrawdown.test.ts
+++ b/test/trading/application/tradingServiceDrawdown.test.ts
@@ -83,6 +83,23 @@ function makePortfolioStore(initial: PortfolioState): {
       current = { ...current, tradingDisabledUntil: iso }
       return current
     },
+    async applyFillExposure(args: { currency: 'USD' | 'JPY'; side: 'BUY' | 'SELL'; notional: number }) {
+      const delta = args.side === 'BUY' ? args.notional : -args.notional
+      if (args.currency === 'USD') {
+        current = { ...current, openExposureUsd: Math.max(0, current.openExposureUsd + delta) }
+      } else {
+        current = { ...current, openExposureJpy: Math.max(0, current.openExposureJpy + delta) }
+      }
+      return current
+    },
+    async seedOpenExposure(args: { usd?: number; jpy?: number }) {
+      current = {
+        ...current,
+        ...(args.usd !== undefined ? { openExposureUsd: args.usd } : {}),
+        ...(args.jpy !== undefined ? { openExposureJpy: args.jpy } : {}),
+      }
+      return current
+    },
     async rollDaily() {
       const before = current
       const nextStart = current.dailyStartEquity + current.dailyRealizedPnl

--- a/test/trading/application/tradingServicePortfolioExposure.test.ts
+++ b/test/trading/application/tradingServicePortfolioExposure.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, it } from 'vitest'
+import { TradingService, type TradingConfig } from '../../../src/trading/application/TradingService'
+import { MockExecution } from '../../../src/trading/execution/MockExecution'
+import { DefaultRiskPolicy } from '../../../src/trading/risk/DefaultRiskPolicy'
+import type { PortfolioStore } from '../../../src/trading/state/PortfolioStore'
+import type { PositionStore } from '../../../src/trading/state/PositionStore'
+import {
+  emptyPortfolioState,
+  type PortfolioState,
+} from '../../../src/trading/state/portfolioTypes'
+import { emptySymbolState, type SymbolState } from '../../../src/trading/state/types'
+import { FixedRuleStrategy } from '../../../src/trading/strategy/strategies/FixedRuleStrategy'
+
+const fixedNow = new Date('2026-04-21T14:00:00.000Z')
+
+// Stretched maxOrderNotional so the per-symbol risk gate never trips before
+// the portfolio exposure gate. The point of these tests is the exposure
+// ceiling specifically (#77).
+const baseConfig: TradingConfig = {
+  dryRun: true,
+  tradingEnabled: true,
+  allowedSymbols: ['SOXL', '7203'],
+  maxOrderNotional: 10_000_000,
+  symbolMaxNotional: {},
+  marketHoursCheck: false,
+}
+
+const buyUsd = {
+  symbol: 'SOXL',
+  price: 10,
+  quantity: 50, // notional = 500
+  buyBelow: 11,
+  sellAbove: 999,
+}
+
+const buyJpy = {
+  symbol: '7203',
+  price: 1_000,
+  quantity: 100, // notional = 100_000
+  buyBelow: 1_100,
+  sellAbove: 999_999,
+}
+
+function makePositionStore(state: SymbolState): PositionStore {
+  return {
+    async getState() {
+      return state
+    },
+    async lockPendingOrder() {
+      return { ok: true, state }
+    },
+    async clearPendingOrder() {
+      return state
+    },
+    async recordFill() {
+      return state
+    },
+    async addPendingSettlement() {
+      return state
+    },
+    async setCooldown() {
+      return state
+    },
+    async seedSettledCash() {
+      return state
+    },
+    async overridePosition() {
+      return state
+    },
+  }
+}
+
+function makePortfolioStore(initial: PortfolioState): PortfolioStore {
+  let current = initial
+  return {
+    async getPortfolio() {
+      return current
+    },
+    async seedDailyStartEquity(amount: number) {
+      current = { ...current, dailyStartEquity: amount, dailyRealizedPnl: 0 }
+      return current
+    },
+    async applyRealizedPnl(delta: number) {
+      current = { ...current, dailyRealizedPnl: current.dailyRealizedPnl + delta }
+      return current
+    },
+    async setTradingDisabledUntil(iso: string | null) {
+      current = { ...current, tradingDisabledUntil: iso }
+      return current
+    },
+    async applyFillExposure(args: {
+      currency: 'USD' | 'JPY'
+      side: 'BUY' | 'SELL'
+      notional: number
+    }) {
+      const delta = args.side === 'BUY' ? args.notional : -args.notional
+      if (args.currency === 'USD') {
+        current = { ...current, openExposureUsd: Math.max(0, current.openExposureUsd + delta) }
+      } else {
+        current = { ...current, openExposureJpy: Math.max(0, current.openExposureJpy + delta) }
+      }
+      return current
+    },
+    async seedOpenExposure(args: { usd?: number; jpy?: number }) {
+      current = {
+        ...current,
+        ...(args.usd !== undefined ? { openExposureUsd: args.usd } : {}),
+        ...(args.jpy !== undefined ? { openExposureJpy: args.jpy } : {}),
+      }
+      return current
+    },
+    async rollDaily() {
+      const before = current
+      const nextStart = current.dailyStartEquity + current.dailyRealizedPnl
+      current = { ...current, dailyStartEquity: nextStart, dailyRealizedPnl: 0 }
+      return { before, after: current }
+    },
+  }
+}
+
+function makeService(
+  positionStore: PositionStore,
+  portfolioStore: PortfolioStore,
+  opts: {
+    totalCapitalUsd?: number | null
+    totalCapitalJpy?: number | null
+    maxPortfolioExposurePct?: number
+    symbolCurrency?: Record<string, 'USD' | 'JPY'>
+    buyBelow?: number
+    sellAbove?: number
+  } = {},
+): TradingService {
+  return new TradingService(
+    new FixedRuleStrategy(opts.buyBelow ?? buyUsd.buyBelow, opts.sellAbove ?? buyUsd.sellAbove),
+    new DefaultRiskPolicy(),
+    new MockExecution(),
+    {
+      positionStore,
+      portfolioStore,
+      now: () => fixedNow,
+      ...(opts.totalCapitalUsd !== undefined ? { totalCapitalUsd: opts.totalCapitalUsd } : {}),
+      ...(opts.totalCapitalJpy !== undefined ? { totalCapitalJpy: opts.totalCapitalJpy } : {}),
+      ...(opts.maxPortfolioExposurePct !== undefined
+        ? { maxPortfolioExposurePct: opts.maxPortfolioExposurePct }
+        : {}),
+      symbolCurrency: opts.symbolCurrency ?? { SOXL: 'USD', '7203': 'JPY' },
+    },
+  )
+}
+
+describe('TradingService portfolio exposure gate (#77)', () => {
+  it('rejects BUY when projected USD exposure exceeds the ceiling', async () => {
+    // total_capital_usd = 1333, max_pct = 0.6 → ceiling = 799.8.
+    // openExposure = 500, order = 500 → projected 1000 > 799.8 → reject.
+    const portfolio: PortfolioState = {
+      ...emptyPortfolioState(() => fixedNow),
+      openExposureUsd: 500,
+    }
+    const service = makeService(
+      makePositionStore(emptySymbolState('SOXL', () => fixedNow)),
+      makePortfolioStore(portfolio),
+      { totalCapitalUsd: 1333, totalCapitalJpy: null, maxPortfolioExposurePct: 0.6 },
+    )
+
+    const result = await service.executeTrade(buyUsd, baseConfig)
+
+    expect(result.riskDecision.allowed).toBe(false)
+    expect(
+      result.riskDecision.reasons.some((r) => r.includes('portfolio exposure exceeded')),
+    ).toBe(true)
+    expect(result.executionResult).toBeUndefined()
+  })
+
+  it('allows BUY when projected exposure stays at or below the ceiling', async () => {
+    // ceiling = 800 (= 1333 * 0.6). open 0 + order 500 = 500 ≤ 800.
+    const portfolio: PortfolioState = emptyPortfolioState(() => fixedNow)
+    const service = makeService(
+      makePositionStore(emptySymbolState('SOXL', () => fixedNow)),
+      makePortfolioStore(portfolio),
+      { totalCapitalUsd: 1333, totalCapitalJpy: null, maxPortfolioExposurePct: 0.6 },
+    )
+
+    const result = await service.executeTrade(buyUsd, baseConfig)
+
+    expect(result.riskDecision.allowed).toBe(true)
+  })
+
+  it('skips the gate when total_capital_usd is null (POC default)', async () => {
+    // With null capital baseline, openExposure can be arbitrarily large but
+    // the gate must not trigger — POC requirement is "fail-open until the
+    // operator seeds a number".
+    const portfolio: PortfolioState = {
+      ...emptyPortfolioState(() => fixedNow),
+      openExposureUsd: 9_999_999,
+    }
+    const service = makeService(
+      makePositionStore(emptySymbolState('SOXL', () => fixedNow)),
+      makePortfolioStore(portfolio),
+      { totalCapitalUsd: null, totalCapitalJpy: null },
+    )
+
+    const result = await service.executeTrade(buyUsd, baseConfig)
+
+    expect(result.riskDecision.allowed).toBe(true)
+  })
+
+  it('treats USD and JPY budgets independently (USD exposure does not consume JPY ceiling)', async () => {
+    // USD heavily exposed but a JPY BUY still passes because the JPY budget
+    // is untouched.
+    const portfolio: PortfolioState = {
+      ...emptyPortfolioState(() => fixedNow),
+      openExposureUsd: 1_000_000,
+    }
+    const service = makeService(
+      makePositionStore(emptySymbolState('7203', () => fixedNow)),
+      makePortfolioStore(portfolio),
+      {
+        totalCapitalUsd: 1_000,
+        totalCapitalJpy: 1_000_000,
+        maxPortfolioExposurePct: 0.6,
+        buyBelow: buyJpy.buyBelow,
+        sellAbove: buyJpy.sellAbove,
+      },
+    )
+
+    const result = await service.executeTrade(buyJpy, baseConfig)
+
+    expect(result.riskDecision.allowed).toBe(true)
+  })
+
+  it('SELL is never rejected by the exposure gate even when exposure is over-ceiling', async () => {
+    // SELLs reduce exposure; the gate only applies to BUYs.
+    const sellInput = {
+      symbol: 'SOXL',
+      price: 20, // strategy → SELL when > 15
+      quantity: 5,
+      buyBelow: 5,
+      sellAbove: 15,
+    }
+    const portfolio: PortfolioState = {
+      ...emptyPortfolioState(() => fixedNow),
+      openExposureUsd: 10_000,
+    }
+    const symbolState: SymbolState = {
+      ...emptySymbolState('SOXL', () => fixedNow),
+      position: { qty: 5, avgPrice: 18, openedAt: '2026-04-20T00:00:00.000Z' },
+    }
+    const service = new TradingService(
+      new FixedRuleStrategy(sellInput.buyBelow, sellInput.sellAbove),
+      new DefaultRiskPolicy(),
+      new MockExecution(),
+      {
+        positionStore: makePositionStore(symbolState),
+        portfolioStore: makePortfolioStore(portfolio),
+        now: () => fixedNow,
+        totalCapitalUsd: 100,
+        maxPortfolioExposurePct: 0.6,
+        symbolCurrency: { SOXL: 'USD' },
+      },
+    )
+
+    const result = await service.executeTrade(sellInput, baseConfig)
+
+    expect(result.riskDecision.allowed).toBe(true)
+    expect(
+      result.riskDecision.reasons.some((r) => r.includes('portfolio exposure exceeded')),
+    ).toBe(false)
+  })
+})

--- a/test/trading/reconciliation/reconcileFills.test.ts
+++ b/test/trading/reconciliation/reconcileFills.test.ts
@@ -357,6 +357,8 @@ function makeSymbolStateNamespace(stub: SymbolStateStub): unknown {
 interface PortfolioStateStub {
   applyRealizedPnl: ReturnType<typeof vi.fn>
   applyRealizedPnlOnce: ReturnType<typeof vi.fn>
+  applyFillExposure?: ReturnType<typeof vi.fn>
+  seedOpenExposure?: ReturnType<typeof vi.fn>
 }
 
 function makePortfolioNamespace(stub: PortfolioStateStub): unknown {
@@ -745,6 +747,7 @@ describe('reconcileFills state-apply marker (issue #142)', () => {
     const portfolioStub: PortfolioStateStub = {
       applyRealizedPnl: vi.fn(async () => ({})),
       applyRealizedPnlOnce: vi.fn(async () => ({ state: {}, applied: true })),
+      applyFillExposure: vi.fn(async () => ({})),
     }
 
     const summary = await reconcileFills({
@@ -780,7 +783,18 @@ describe('reconcileFills state-apply marker (issue #142)', () => {
     }
     const first = makeFakeDb([row], { failStateAppliedAtOnce: true })
     const second = makeFakeDb([row])
-    vi.mocked(createDb).mockReturnValueOnce(first.db).mockReturnValueOnce(second.db)
+    // #77: reconcileFills now also calls `createDb` once at startup for the
+    // symbol_universe lookup (= 2 createDb invocations per reconcileFills
+    // call). Queue an extra "universe" fake before each pass — the universe
+    // load is wrapped in try/catch so its result doesn't have to be a real
+    // symbol_config row set; an empty fake DB whose SELECT throws is fine
+    // (handler falls back to the JP-numeric currency heuristic).
+    const universeFake = makeFakeDb([])
+    vi.mocked(createDb)
+      .mockReturnValueOnce(universeFake.db)
+      .mockReturnValueOnce(first.db)
+      .mockReturnValueOnce(universeFake.db)
+      .mockReturnValueOnce(second.db)
     vi.mocked(createWebullHttpClient).mockReturnValue(
       makeWebullStub({}) as unknown as ReturnType<typeof createWebullHttpClient>,
     )
@@ -793,6 +807,7 @@ describe('reconcileFills state-apply marker (issue #142)', () => {
       applyRealizedPnlOnce: vi.fn()
         .mockResolvedValueOnce({ state: {}, applied: true })
         .mockResolvedValueOnce({ state: {}, applied: false }),
+      applyFillExposure: vi.fn(async () => ({})),
     }
 
     const env = {

--- a/test/trading/state/portfolioStateTransitions.test.ts
+++ b/test/trading/state/portfolioStateTransitions.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import {
+  applyFillExposure,
   applyRealizedPnl,
   applyRealizedPnlOnce,
   rollDaily,
   seedDailyStartEquity,
+  seedOpenExposure,
   setTradingDisabledUntil,
 } from '../../../src/trading/state/portfolioStateTransitions'
 import { emptyPortfolioState } from '../../../src/trading/state/portfolioTypes'
@@ -130,6 +132,98 @@ describe('portfolioStateTransitions', () => {
       }
       const { after } = rollDaily(armed, { now: fixedNow })
       expect(after.tradingDisabledUntil).toBe('2026-04-22T00:00:00.000Z')
+    })
+  })
+
+  // #77: per-currency open BUY exposure tracker. BUY adds notional, SELL
+  // subtracts (clamp >=0). USD and JPY are independent budgets.
+  describe('applyFillExposure', () => {
+    it('BUY adds notional to the matching currency openExposure', () => {
+      const s0 = emptyPortfolioState(fixedNow)
+      const s1 = applyFillExposure(
+        s0,
+        { currency: 'USD', side: 'BUY', notional: 500 },
+        { now: fixedNow },
+      )
+      expect(s1.openExposureUsd).toBe(500)
+      expect(s1.openExposureJpy).toBe(0)
+      expect(s1.updatedAt).toBe('2026-04-21T10:00:00.000Z')
+    })
+
+    it('SELL subtracts notional', () => {
+      const s0 = { ...emptyPortfolioState(fixedNow), openExposureUsd: 800 }
+      const s1 = applyFillExposure(
+        s0,
+        { currency: 'USD', side: 'SELL', notional: 300 },
+        { now: fixedNow },
+      )
+      expect(s1.openExposureUsd).toBe(500)
+    })
+
+    it('SELL clamps to >= 0 when exposure is already at zero', () => {
+      const s0 = emptyPortfolioState(fixedNow)
+      const s1 = applyFillExposure(
+        s0,
+        { currency: 'USD', side: 'SELL', notional: 500 },
+        { now: fixedNow },
+      )
+      expect(s1.openExposureUsd).toBe(0)
+    })
+
+    it('USD and JPY budgets do not interfere', () => {
+      const s0 = emptyPortfolioState(fixedNow)
+      const s1 = applyFillExposure(
+        s0,
+        { currency: 'USD', side: 'BUY', notional: 1_000 },
+        { now: fixedNow },
+      )
+      const s2 = applyFillExposure(
+        s1,
+        { currency: 'JPY', side: 'BUY', notional: 250_000 },
+        { now: fixedNow },
+      )
+      expect(s2.openExposureUsd).toBe(1_000)
+      expect(s2.openExposureJpy).toBe(250_000)
+
+      const s3 = applyFillExposure(
+        s2,
+        { currency: 'JPY', side: 'SELL', notional: 100_000 },
+        { now: fixedNow },
+      )
+      expect(s3.openExposureUsd).toBe(1_000)
+      expect(s3.openExposureJpy).toBe(150_000)
+    })
+
+    it('rejects non-finite / negative notional', () => {
+      const s0 = emptyPortfolioState(fixedNow)
+      expect(() =>
+        applyFillExposure(s0, { currency: 'USD', side: 'BUY', notional: NaN }, { now: fixedNow }),
+      ).toThrow('Invalid applyFillExposure notional')
+      expect(() =>
+        applyFillExposure(s0, { currency: 'USD', side: 'BUY', notional: -1 }, { now: fixedNow }),
+      ).toThrow('Invalid applyFillExposure notional')
+    })
+  })
+
+  describe('seedOpenExposure', () => {
+    it('overwrites only the provided side', () => {
+      const s0 = {
+        ...emptyPortfolioState(fixedNow),
+        openExposureUsd: 100,
+        openExposureJpy: 200_000,
+      }
+      const next = seedOpenExposure(s0, { usd: 0 }, { now: fixedNow })
+      expect(next.openExposureUsd).toBe(0)
+      expect(next.openExposureJpy).toBe(200_000)
+    })
+
+    it('rejects negative / non-finite values', () => {
+      expect(() =>
+        seedOpenExposure(emptyPortfolioState(fixedNow), { usd: -1 }, { now: fixedNow }),
+      ).toThrow('Invalid seedOpenExposure usd')
+      expect(() =>
+        seedOpenExposure(emptyPortfolioState(fixedNow), { jpy: NaN }, { now: fixedNow }),
+      ).toThrow('Invalid seedOpenExposure jpy')
     })
   })
 })


### PR DESCRIPTION
## Summary

- PortfolioStateDO now tracks `openExposureUsd` / `openExposureJpy` via `applyFillExposure` (BUY adds, SELL subtracts, clamped >= 0). reconcileFills feeds it after a successful symbol-state apply, idempotent via the existing `recordFillOnce.applied` gate.
- TradingService.applyStateGate enforces `openExposure[ccy] + orderNotional <= total_capital_<ccy> * max_portfolio_exposure_pct` on BUY; rejects with `portfolio exposure exceeded`. Skipped when `total_capital_<ccy>` is null (POC fail-open until operator seeds a baseline). USD / JPY budgets are independent.
- New `POST /admin/portfolio/seed-exposure` endpoint lets the operator snap `openExposure{Usd,Jpy}` to a known baseline (post holdings rebuild / fresh tenant).

## Acceptance (#77)

- [x] `total_capital_usd = 1333` / `max_portfolio_exposure_pct = 0.6` -> BUY rejected when projected exposure > $800 (60%) — see `tradingServicePortfolioExposure.test.ts` "rejects BUY when projected USD exposure exceeds the ceiling".
- [x] BUY fill increases, SELL fill decreases openExposure — `portfolioStateTransitions.test.ts` "applyFillExposure".
- [x] USD and JPY independent — `tradingServicePortfolioExposure.test.ts` "treats USD and JPY budgets independently".
- [x] `total_capital_*` null -> skip check — `tradingServicePortfolioExposure.test.ts` "skips the gate when total_capital_usd is null".

Ref #77.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (1171 passing, no regressions)
- [ ] Staging: seed `total_capital_usd` via D1, verify gate rejects BUY at 60% via `/trade/decide` reasons
- [ ] Staging: `/admin/portfolio/seed-exposure` roundtrip + drift correction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 通貨別（USD/JPY）オープン・エクスポージャーの追跡を追加
  * 管理者向けエンドポイントでエクスポージャー初期値を設定可能に
  * シンボルごとの通貨判定に基づくポートフォリオ上限ルールを導入し、上限超過するBUYを自動制限

* **テスト**
  * 管理API・露出適用・ゲート挙動をカバーするテスト群を追加

* **修正**
  * 永続状態の互換性と正規化（露出初期値の安全な読み取り）を改善

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/340?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->