### PR TITLE
docs: prune stale #22 and bridge/ refs from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@
 
 | 実体 | 場所 | いつ使う |
 |---|---|---|
-| `trading-developer` skill | `.claude/skills/trading-developer/` | 取引系コード (`src/trading/`, `bridge/`, `src/infrastructure/webull/`) を触る時。ドメイン姿勢と safety invariants を自動で適用 |
+| `trading-developer` skill | `.claude/skills/trading-developer/` | 取引系コード (`src/trading/`, `src/infrastructure/webull/`) を触る時。ドメイン姿勢と safety invariants を自動で適用 |
 | `trading-strategist` agent | `.claude/agents/trading-strategist.md` | 戦略設計・backtest 議論。コード実装は main に戻す。`Task(subagent_type="trading-strategist", ...)` で呼ぶ |
 | `phase-scope` skill | `.claude/skills/phase-scope/` | PR 作成前 / CodeRabbit 指摘受領時。scope 判定して他 Phase に回す判断 |
 | `coderabbit-policy` skill | `.claude/skills/coderabbit-policy/` | findings の apply / skip 判断、スキップ理由テンプレ |
@@ -41,8 +41,7 @@
 
 ### POC 後の follow-up
 - [#21](https://github.com/ochanuco/webull-trading/issues/21) Webull OpenAPI 実運用化 (canonical signing / live 疎通 / エラー細分化)
-- [#22](https://github.com/ochanuco/webull-trading/issues/22) gRPC bridge 本実装 (Webull proto / runtime deploy)
-- [#23](https://github.com/ochanuco/webull-trading/issues/23) Risk policy 詳細化 (DST / halt / PDT / short locate / settlement)
+- [#23](https://github.com/ochanuco/webull-trading/issues/23) Risk policy 詳細化 (halt / PDT / short locate / settlement — DST は #338 で解決済)
 - [#24](https://github.com/ochanuco/webull-trading/issues/24) Production operational readiness (secrets / CI / deploy / observability)
 
 ## 迷ったら


### PR DESCRIPTION
## Why

CLAUDE.md was still listing #22 in the active follow-up section and referencing `bridge/` as a path the trading-developer skill should activate on. Both are dead:

- **#22** was closed on 2026-04-18 by PR #110 (`refactor: remove gRPC bridge, port SELL post-processing to reconcileFills`). The bridge dir no longer exists in the tree.
- **DST slice of #23** was resolved in PR #338; updated the parenthetical so the remaining sub-scopes (halt / PDT / short locate / settlement) are what agents pick up next.

## Verification

- `git log --all -- bridge` shows the dir was removed in PR #110.
- `gh issue view 22` → CLOSED.
- Repo root has no `bridge/` directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * プロジェクト指示文を更新し、開発ガイダンスの参照パスを整理しました。
  * 関連する issue の記載と注記を更新しました。

**注記**: これらの変更は内部ドキュメントの更新であり、ユーザー向けの機能変更はありません。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/341?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->