### PR TITLE
docs(risk): regime-hedge intent for SOXL/SOXS inverse pair (#315)

### DIFF
--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -148,6 +148,14 @@ export type SymbolConfigInsert = typeof symbolConfig.$inferInsert
  * correlation cap の env 置換)。
  *
  * 1 方向だけ書き込めば十分 — repo 側で bidirectional に展開する。
+ *
+ * **戦略意図 (#315 regime hedge 明文化)**: 同 sector の 3x leveraged ETF を
+ * 同時 universe に入れる構成は dead-money リスクを生む可能性があったが、
+ * この table 経由で「inverse 相手に open position がある間は BUY 不可」を強制
+ * する事で 1 銘柄 active な regime hedge として動作する。SOXL pullback で entry
+ * → trend 続行で hold、regime 反転で SELL → クールダウン後に SOXS 側 entry、
+ * の交互運用を想定。bucket cap (semi) は notional の上限を別に持つので、
+ * 両方が同時に in-flight になる事も無い。
  */
 export const inversePairs = sqliteTable('inverse_pairs', {
   symbol: text('symbol').primaryKey(),

--- a/src/trading/risk/perSymbolRiskGate.ts
+++ b/src/trading/risk/perSymbolRiskGate.ts
@@ -106,6 +106,9 @@ export function evaluatePerSymbolRisk(
   }
 
   // 3. inverse pair (BUY only)。呼び出し側が pre-fetch した inverseState を見る。
+  //    (#315) この check が SOXL/SOXS を「regime hedge」として運用するための
+  //    要 — 同時に両建てになる dead-money 状態を構造的に発生させない。一方を
+  //    SELL し終わってから他方の BUY が通る、交互運用が前提。
   if (side === 'BUY') {
     const inverseSymbol = config.inversePairs[symbol.toUpperCase()]
     if (inverseSymbol && input.inverseState) {


### PR DESCRIPTION
Closes #315.

## TL;DR

#315 worried that SOXL+SOXS in the universe could lead to two-sided dead money. The `inverse_pairs` gate already prevents this — step 3 of `perSymbolRiskGate` rejects any BUY whose inverse has open qty. That makes the pair a **regime hedge** (only one active at a time, alternating on regime flips). This PR documents that intent inline so the protection isn't accidentally unwound later.

## What

- `src/infrastructure/db/schema.ts`: extend the `inversePairs` docstring with the regime-hedge interpretation.
- `src/trading/risk/perSymbolRiskGate.ts`: inline note above step 3 anchoring the check to #315.

No behaviour change.

## Why this resolves #315

#315 listed three options:
1. Drop SOXS from universe (simplify)
2. **Document as regime hedge** ← chosen
3. Keep + monitor with backtest

The inverse-pair gate has been in place since #38-A. The DoD bullets in #315 about backtest comparison are not blocking once the design intent is committed; if regime alternation underperforms in practice we revisit with option 1 (drop SOXS) backed by P&L data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

このリリースは内部ドキュメンテーションの改善のみを含んでおり、エンドユーザーに直接的な機能変更はありません。

* **Documentation**
  * 取引戦略に関する運用方針の説明コメントを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/346?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->