### PR TITLE
feat(ops): calendar-aware daily roll (#319)

### DIFF
--- a/src/infrastructure/calendar/jpMarketCalendar.ts
+++ b/src/infrastructure/calendar/jpMarketCalendar.ts
@@ -1,0 +1,105 @@
+/**
+ * TSE (JP equity) session-day calendar (issue #319)。
+ *
+ * 22:00 UTC daily roll cron は「翌日 JP が open する」前提で動くため、土日 /
+ * TSE 祝日が「明日」に当たる場合は roll を skip して連続性を保つ。
+ *
+ * Approach (POC): 外部 API に依存せず hard-coded list。usMarketCalendar と
+ * 設計対称。詳細な動機は同じファイルの header コメント参照。
+ *
+ * TODO(annual): 翌年の TSE holiday を追記し `TSE_SUPPORTED_YEARS` を伸ばす。
+ * JPX は前年の年央〜年末に翌年カレンダーを公表する
+ * (https://www.jpx.co.jp/corporate/about-jpx/calendar/)。
+ */
+
+/**
+ * TSE 2026 full closures。
+ *
+ * 出典: JPX trading calendar 2026 (https://www.jpx.co.jp/corporate/about-jpx/calendar/)。
+ * 振替休日 (substitute holiday) は当該振替日を含む。年末 / 年始 (12/31, 1/2,
+ * 1/3) は祝日扱いではないが TSE が立会を行わない (大納会 12/30 / 大発会 1/5)
+ * ため closure に含める。
+ *
+ * 2026 list:
+ *   - 2026-01-01 元日 (New Year's Day, Thu)
+ *   - 2026-01-02 (Fri) 年始 TSE 休場
+ *   - 2026-01-12 成人の日 (Coming of Age, Mon)
+ *   - 2026-02-11 建国記念の日 (Foundation Day, Wed)
+ *   - 2026-02-23 天皇誕生日 (Emperor's Birthday, Mon)
+ *   - 2026-03-20 春分の日 (Vernal Equinox, Fri)
+ *   - 2026-04-29 昭和の日 (Showa Day, Wed)
+ *   - 2026-05-04 みどりの日 (Greenery Day, Mon)
+ *   - 2026-05-05 こどもの日 (Children's Day, Tue)
+ *   - 2026-05-06 振替休日 (substitute, Wed) — Sun May 3 was 憲法記念日
+ *   - 2026-07-20 海の日 (Marine Day, Mon)
+ *   - 2026-08-11 山の日 (Mountain Day, Tue)
+ *   - 2026-09-21 敬老の日 (Respect for the Aged Day, Mon)
+ *   - 2026-09-22 国民の休日 (Citizens' Holiday, Tue) — between 敬老の日 and 秋分の日
+ *   - 2026-09-23 秋分の日 (Autumnal Equinox, Wed)
+ *   - 2026-10-12 スポーツの日 (Sports Day, Mon)
+ *   - 2026-11-03 文化の日 (Culture Day, Tue)
+ *   - 2026-11-23 勤労感謝の日 (Labor Thanksgiving, Mon)
+ *   - 2026-12-31 (Thu) 年末 TSE 休場 — 12/30 大納会で 12/31 立会なし
+ */
+const TSE_2026_CLOSURES: ReadonlySet<string> = new Set([
+  '2026-01-01',
+  '2026-01-02',
+  '2026-01-12',
+  '2026-02-11',
+  '2026-02-23',
+  '2026-03-20',
+  '2026-04-29',
+  '2026-05-04',
+  '2026-05-05',
+  '2026-05-06',
+  '2026-07-20',
+  '2026-08-11',
+  '2026-09-21',
+  '2026-09-22',
+  '2026-09-23',
+  '2026-10-12',
+  '2026-11-03',
+  '2026-11-23',
+  '2026-12-31',
+])
+
+/** Hard-coded holiday data の有効年セット。範囲外は呼び出し側で fail-closed。 */
+const TSE_SUPPORTED_YEARS: ReadonlySet<number> = new Set([2026])
+
+const JP_YMD_FORMATTER = new Intl.DateTimeFormat('en-CA', {
+  timeZone: 'Asia/Tokyo',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+})
+
+const JP_WEEKDAY_FORMATTER = new Intl.DateTimeFormat('en-US', {
+  timeZone: 'Asia/Tokyo',
+  weekday: 'short',
+})
+
+/** `date` (UTC instant) を Asia/Tokyo の "YYYY-MM-DD" に format。 */
+export function formatJpYmd(date: Date): string {
+  return JP_YMD_FORMATTER.format(date)
+}
+
+/** `date` 時点の JP 暦日が hard-coded supported range に含まれているか。 */
+export function isWithinSupportedRange(date: Date): boolean {
+  const ymd = formatJpYmd(date)
+  const year = Number.parseInt(ymd.slice(0, 4), 10)
+  if (!Number.isFinite(year)) return false
+  return TSE_SUPPORTED_YEARS.has(year)
+}
+
+/**
+ * `date` 時点の JP 暦日が TSE の session day (= 月-金 かつ holiday でない) か。
+ * Supported range 外は `false` を返す (fail-closed)。
+ */
+export function isTseSessionDay(date: Date): boolean {
+  if (!isWithinSupportedRange(date)) return false
+  const ymd = formatJpYmd(date)
+  if (TSE_2026_CLOSURES.has(ymd)) return false
+  const weekday = JP_WEEKDAY_FORMATTER.format(date)
+  if (weekday === 'Sat' || weekday === 'Sun') return false
+  return true
+}

--- a/src/infrastructure/calendar/usMarketCalendar.ts
+++ b/src/infrastructure/calendar/usMarketCalendar.ts
@@ -1,0 +1,100 @@
+/**
+ * NYSE (US equity) session-day calendar (issue #319)。
+ *
+ * 22:00 UTC の daily roll cron は「今日 NY が close した」事を前提に
+ * `dailyRealizedPnl` を畳むが、土日 / NYSE 祝日にも cron 自体は発火するため
+ * 「実際には立会が無かった日」に roll を 1 回足してしまう。`isNyseSessionDay`
+ * を pre-check に挟む事で、real session boundary でない日は roll を skip し、
+ * `lastRolledAt` の連続性を保つ。
+ *
+ * Approach (POC):
+ *   - 外部 API に依存せず、`NYSE_2026_CLOSURES` の hard-coded set + weekday 判定。
+ *   - 範囲外 (e.g. 2027 以降) を引いた場合は呼び出し側で fail-closed 判断できる
+ *     よう `isWithinSupportedRange` を分けて公開する。
+ *
+ * TODO(annual): 年末ごとに翌年の NYSE closure list を追記し
+ * `NYSE_SUPPORTED_YEARS` を伸ばす事。NYSE は通常前年の早い段階で翌年
+ * holiday schedule を公表する (https://www.nyse.com/markets/hours-calendars)。
+ */
+
+/**
+ * NYSE 2026 full closures。
+ *
+ * 出典: NYSE Holidays & Trading Hours
+ * (https://www.nyse.com/markets/hours-calendars — 2025-12 時点で公表済み)。
+ * Early-close (1300 ET) days はここに含めない (full close ではないので
+ * 22:00 UTC = 17:00 ET 時点では session は終わっており roll 自体は妥当)。
+ *
+ * 2026 list:
+ *   - 2026-01-01 New Year's Day (Thu)
+ *   - 2026-01-19 MLK Jr. Day (Mon)
+ *   - 2026-02-16 Presidents' Day (Mon)
+ *   - 2026-04-03 Good Friday (Fri)
+ *   - 2026-05-25 Memorial Day (Mon)
+ *   - 2026-06-19 Juneteenth (Fri)
+ *   - 2026-07-03 Independence Day (Fri) — observed (Jul 4 is Sat)
+ *   - 2026-09-07 Labor Day (Mon)
+ *   - 2026-11-26 Thanksgiving (Thu)
+ *   - 2026-12-25 Christmas (Fri)
+ */
+const NYSE_2026_CLOSURES: ReadonlySet<string> = new Set([
+  '2026-01-01',
+  '2026-01-19',
+  '2026-02-16',
+  '2026-04-03',
+  '2026-05-25',
+  '2026-06-19',
+  '2026-07-03',
+  '2026-09-07',
+  '2026-11-26',
+  '2026-12-25',
+])
+
+/** Hard-coded holiday data の有効年セット。範囲外は呼び出し側で fail-closed。 */
+const NYSE_SUPPORTED_YEARS: ReadonlySet<number> = new Set([2026])
+
+const NY_YMD_FORMATTER = new Intl.DateTimeFormat('en-CA', {
+  timeZone: 'America/New_York',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+})
+
+const NY_WEEKDAY_FORMATTER = new Intl.DateTimeFormat('en-US', {
+  timeZone: 'America/New_York',
+  weekday: 'short',
+})
+
+/**
+ * `date` (UTC instant) を America/New_York の "YYYY-MM-DD" に format。
+ * DST は `Intl.DateTimeFormat` が解決するので worker side で扱う必要なし。
+ */
+export function formatNyYmd(date: Date): string {
+  return NY_YMD_FORMATTER.format(date)
+}
+
+/**
+ * `date` 時点の NY 暦日が NYSE supported range (hard-coded list) に
+ * 含まれているか。false の年は呼び出し側で safe-default (skip) する。
+ */
+export function isWithinSupportedRange(date: Date): boolean {
+  const ymd = formatNyYmd(date)
+  const year = Number.parseInt(ymd.slice(0, 4), 10)
+  if (!Number.isFinite(year)) return false
+  return NYSE_SUPPORTED_YEARS.has(year)
+}
+
+/**
+ * `date` 時点の NY 暦日が NYSE の session day (= 月-金 かつ holiday でない) か。
+ *
+ * Supported range 外 (e.g. 2027) は `false` を返す。日付計算は完全に
+ * `Intl.DateTimeFormat` に委任しているので caller 側の tz 補正は不要。
+ */
+export function isNyseSessionDay(date: Date): boolean {
+  if (!isWithinSupportedRange(date)) return false
+  const ymd = formatNyYmd(date)
+  if (NYSE_2026_CLOSURES.has(ymd)) return false
+  const weekday = NY_WEEKDAY_FORMATTER.format(date)
+  if (weekday === 'Sat' || weekday === 'Sun') return false
+  return true
+}

--- a/src/trading/portfolio/runPortfolioRoll.ts
+++ b/src/trading/portfolio/runPortfolioRoll.ts
@@ -1,11 +1,27 @@
 import type { Env } from '../../config/env'
+import {
+  isNyseSessionDay,
+  isWithinSupportedRange as isNyseWithinSupportedRange,
+  formatNyYmd,
+} from '../../infrastructure/calendar/usMarketCalendar'
+import {
+  isTseSessionDay,
+  isWithinSupportedRange as isTseWithinSupportedRange,
+  formatJpYmd,
+} from '../../infrastructure/calendar/jpMarketCalendar'
 import { PortfolioStateClient } from '../state/PortfolioStateClient'
 import type { PortfolioStore } from '../state/PortfolioStore'
 
 /**
- * EOD daily rollover (issue #140)。`PortfolioStateDO.rollDaily()` を一発叩いて
- * `dailyStartEquity += dailyRealizedPnl` / `dailyRealizedPnl = 0` を確定し、
- * `lastRolledAt` を ISO timestamp で更新する。
+ * EOD daily rollover (issue #140 / #319)。`PortfolioStateDO.rollDaily()` を一発
+ * 叩いて `dailyStartEquity += dailyRealizedPnl` / `dailyRealizedPnl = 0` を確定
+ * し、`lastRolledAt` を ISO timestamp で更新する。
+ *
+ * Calendar-aware skip (issue #319):
+ *   - cron は 22:00 UTC 固定で発火するが、その日が NYSE 立会日でない (土日 /
+ *     祝日) もしくは翌日が TSE 立会日でない (土日 / 祝日) 場合は roll を skip。
+ *   - hard-coded list が当該年をカバーしない場合も fail-closed で skip。
+ *   - skip 理由は `event: 'daily_roll_skipped'` の structured log で出す。
  *
  * Silent fallback 設計:
  *   - PORTFOLIO_STATE binding 不在 → log だけ出して return (cron は失敗扱いに
@@ -21,6 +37,8 @@ export interface RunPortfolioRollDeps {
   /** Override for unit tests — defaults to wrapping `env.PORTFOLIO_STATE` in a
    * `PortfolioStateClient`. Pass a hand-rolled stub to avoid the DO namespace. */
   portfolioStoreFactory?: (env: Env) => PortfolioStore
+  /** Override for unit tests — `Date.now()` 等価。指定が無ければ `new Date()`。 */
+  now?: () => Date
 }
 
 export async function runPortfolioRoll(
@@ -28,6 +46,25 @@ export async function runPortfolioRoll(
   requestId: string,
   deps: RunPortfolioRollDeps = {},
 ): Promise<void> {
+  const now = deps.now ? deps.now() : new Date()
+
+  // Issue #319: calendar-aware pre-check。NY 今日 (= cron 発火時の NY 暦日) が
+  // NYSE session day で、かつ JP 明日 (= NY close 後 ~JP open までの間) が TSE
+  // session day である事を要件とする。どちらかが満たされなければ skip。
+  const skipReason = decideSkipReason(now)
+  if (skipReason) {
+    console.warn(
+      JSON.stringify({
+        event: 'daily_roll_skipped',
+        requestId,
+        reason: skipReason.reason,
+        nyYmd: skipReason.nyYmd,
+        jpTomorrowYmd: skipReason.jpTomorrowYmd,
+      }),
+    )
+    return
+  }
+
   let store: PortfolioStore
   if (deps.portfolioStoreFactory) {
     store = deps.portfolioStoreFactory(env)
@@ -71,4 +108,62 @@ export async function runPortfolioRoll(
       }),
     )
   }
+}
+
+interface SkipReason {
+  reason: string
+  nyYmd: string
+  jpTomorrowYmd: string
+}
+
+/**
+ * Returns a skip reason if today's NY date is not an NYSE session day, or if
+ * the next JP business day (= JP local date at cron fire-time, since cron runs
+ * 22:00 UTC ≈ NY 17/18:00 same date = JP next-calendar-date 07:00) is not a
+ * TSE session day. Otherwise `null` (proceed).
+ *
+ * Out-of-range (e.g. 2027 before annual refresh) → skip with reason so the
+ * operator is forced to refresh the hard-coded tables.
+ *
+ * Time-of-day assumption: this helper is correct *only* when called close to
+ * the cron's 22:00 UTC fire time. At 22:00 UTC, JP local time is already on
+ * "tomorrow" relative to NY's calendar date (UTC+9 → 07:00 next day in JP),
+ * so `formatJpYmd(now)` already returns the "JP next day" without explicit
+ * `+24h` arithmetic. The handler does not enforce the call-time invariant —
+ * `src/index.ts` only invokes this from the `CRON_PORTFOLIO_ROLL` branch.
+ */
+function decideSkipReason(now: Date): SkipReason | null {
+  const nyYmd = formatNyYmd(now)
+  // JP local date at cron fire-time ≈ NY date + 1 calendar day.
+  const jpTomorrowYmd = formatJpYmd(now)
+
+  if (!isNyseWithinSupportedRange(now)) {
+    return {
+      reason: `NYSE calendar out of supported range for NY date ${nyYmd}; refresh hard-coded closure list`,
+      nyYmd,
+      jpTomorrowYmd,
+    }
+  }
+  if (!isTseWithinSupportedRange(now)) {
+    return {
+      reason: `TSE calendar out of supported range for JP date ${jpTomorrowYmd}; refresh hard-coded closure list`,
+      nyYmd,
+      jpTomorrowYmd,
+    }
+  }
+  if (!isNyseSessionDay(now)) {
+    return {
+      reason: `NY ${nyYmd} is not an NYSE session day (weekend or holiday)`,
+      nyYmd,
+      jpTomorrowYmd,
+    }
+  }
+  if (!isTseSessionDay(now)) {
+    return {
+      reason: `JP ${jpTomorrowYmd} is not a TSE session day (weekend or holiday)`,
+      nyYmd,
+      jpTomorrowYmd,
+    }
+  }
+  return null
 }

--- a/test/scheduledHandler.test.ts
+++ b/test/scheduledHandler.test.ts
@@ -60,6 +60,10 @@ describe('runPortfolioRoll (issue #140)', () => {
   let logSpy: ReturnType<typeof vi.spyOn>
   let warnSpy: ReturnType<typeof vi.spyOn>
   let errorSpy: ReturnType<typeof vi.spyOn>
+  // Issue #319: roll は calendar-aware で skip するため、helper test 群は
+  // NY/JP 両方 session day である瞬間を固定で渡す (Wed 2026-04-22 22:00 UTC =
+  // NY 18:00 Wed / JP 翌日 Thu)。
+  const nowOnSessionDay = (): Date => new Date('2026-04-22T22:00:00.000Z')
   beforeEach(() => {
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
     warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
@@ -93,7 +97,10 @@ describe('runPortfolioRoll (issue #140)', () => {
       updatedAt: '2026-04-25T22:00:00.000Z',
     }
     const fixture = makeStore({ before, after })
-    await runPortfolioRoll(baseEnv, 'req-1', { portfolioStoreFactory: () => fixture.store })
+    await runPortfolioRoll(baseEnv, 'req-1', {
+      portfolioStoreFactory: () => fixture.store,
+      now: nowOnSessionDay,
+    })
     expect(fixture.calls).toBe(1)
     const logs = logSpy.mock.calls
       .map((args) => args[0])
@@ -111,7 +118,7 @@ describe('runPortfolioRoll (issue #140)', () => {
   })
 
   it('emits portfolio_roll_skipped (warn) when PORTFOLIO_STATE binding is missing', async () => {
-    await runPortfolioRoll(baseEnv, 'req-2')
+    await runPortfolioRoll(baseEnv, 'req-2', { now: nowOnSessionDay })
     const skipped = warnSpy.mock.calls
       .map((args) => args[0])
       .filter((s): s is string => typeof s === 'string' && s.includes('portfolio_roll_skipped'))
@@ -139,7 +146,10 @@ describe('runPortfolioRoll (issue #140)', () => {
     // resolve = silent fallback。reject にならないこと自体が cron を fail に
     // させない仕様の根拠。
     await expect(
-      runPortfolioRoll(baseEnv, 'req-3', { portfolioStoreFactory: () => fixture.store }),
+      runPortfolioRoll(baseEnv, 'req-3', {
+        portfolioStoreFactory: () => fixture.store,
+        now: nowOnSessionDay,
+      }),
     ).resolves.toBeUndefined()
     const errors = errorSpy.mock.calls
       .map((args) => args[0])
@@ -149,5 +159,99 @@ describe('runPortfolioRoll (issue #140)', () => {
     if (!first) throw new Error('portfolio_roll_error log was not emitted')
     const payload = JSON.parse(first) as Record<string, unknown>
     expect(payload).toMatchObject({ event: 'portfolio_roll_error', message: 'DO unreachable' })
+  })
+
+  // Issue #319: calendar-aware skip。22:00 UTC cron は実 session boundary
+  // でない日 (土日 / NYSE holiday / TSE holiday) には roll を skip する。
+  describe('calendar-aware skip (issue #319)', () => {
+    const baseState: PortfolioState = {
+      dailyStartEquity: 10_000,
+      dailyRealizedPnl: 0,
+      appliedClientOrderIds: [],
+      tradingDisabledUntil: null,
+      lastRolledAt: null,
+      openExposureUsd: 0,
+      openExposureJpy: 0,
+      updatedAt: '2026-04-25T22:00:00.000Z',
+    }
+
+    function expectSkippedWithReason(reasonMatch: RegExp): void {
+      const skipped = warnSpy.mock.calls
+        .map((args) => args[0])
+        .filter((s): s is string => typeof s === 'string' && s.includes('daily_roll_skipped'))
+      expect(skipped).toHaveLength(1)
+      const first = skipped[0]
+      if (!first) throw new Error('daily_roll_skipped log was not emitted')
+      const payload = JSON.parse(first) as { event: string; reason: string }
+      expect(payload.event).toBe('daily_roll_skipped')
+      expect(payload.reason).toMatch(reasonMatch)
+    }
+
+    it('rolls normally on a regular weekday when both NYSE and TSE are open', async () => {
+      // Wed 2026-04-22 22:00 UTC: NY=Wed Apr 22 (session), JP next=Thu Apr 23 (session).
+      const fixture = makeStore({ before: baseState, after: baseState })
+      await runPortfolioRoll(baseEnv, 'req-weekday', {
+        portfolioStoreFactory: () => fixture.store,
+        now: () => new Date('2026-04-22T22:00:00.000Z'),
+      })
+      expect(fixture.calls).toBe(1)
+    })
+
+    it('skips on NYSE holiday (Memorial Day 2026-05-25 Mon)', async () => {
+      // 2026-05-25 22:00 UTC: NY=Mon May 25 (Memorial Day, NYSE closed).
+      const fixture = makeStore({ before: baseState, after: baseState })
+      await runPortfolioRoll(baseEnv, 'req-nyse-holiday', {
+        portfolioStoreFactory: () => fixture.store,
+        now: () => new Date('2026-05-25T22:00:00.000Z'),
+      })
+      expect(fixture.calls).toBe(0)
+      expectSkippedWithReason(/NYSE session day/)
+    })
+
+    it('skips when JP next day is a TSE substitute holiday (Wed 2026-05-06)', async () => {
+      // 2026-05-05 22:00 UTC = NY Tue May 5 (NYSE session day).
+      // JP next-day at UTC+24h is JP 2026-05-06 07:00 = Wed (TSE substitute holiday).
+      const fixture = makeStore({ before: baseState, after: baseState })
+      await runPortfolioRoll(baseEnv, 'req-tse-holiday', {
+        portfolioStoreFactory: () => fixture.store,
+        now: () => new Date('2026-05-05T22:00:00.000Z'),
+      })
+      expect(fixture.calls).toBe(0)
+      expectSkippedWithReason(/TSE session day/)
+    })
+
+    it('skips on weekend (Sat 2026-05-23 22:00 UTC)', async () => {
+      // 2026-05-23 22:00 UTC: NY=Sat May 23 (weekend, NYSE closed).
+      const fixture = makeStore({ before: baseState, after: baseState })
+      await runPortfolioRoll(baseEnv, 'req-weekend', {
+        portfolioStoreFactory: () => fixture.store,
+        now: () => new Date('2026-05-23T22:00:00.000Z'),
+      })
+      expect(fixture.calls).toBe(0)
+      expectSkippedWithReason(/NYSE session day/)
+    })
+
+    it('rolls on a DST-transition day when both markets are open (Mon 2026-03-09)', async () => {
+      // 2026-03-08 (Sun) is the US DST spring-forward; 22:00 UTC on Mon 2026-03-09
+      // is NY Mon 18:00 EDT — fully in the post-DST regime, NYSE session day.
+      // JP next = Tue 2026-03-10 (session day).
+      const fixture = makeStore({ before: baseState, after: baseState })
+      await runPortfolioRoll(baseEnv, 'req-dst', {
+        portfolioStoreFactory: () => fixture.store,
+        now: () => new Date('2026-03-09T22:00:00.000Z'),
+      })
+      expect(fixture.calls).toBe(1)
+    })
+
+    it('skips (fail-closed) when the date is outside the hard-coded supported range', async () => {
+      // 2027 is not in NYSE_SUPPORTED_YEARS until the annual refresh — must skip.
+      const fixture = makeStore({ before: baseState, after: baseState })
+      await runPortfolioRoll(baseEnv, 'req-out-of-range', {
+        portfolioStoreFactory: () => fixture.store,
+        now: () => new Date('2027-04-21T22:00:00.000Z'),
+      })
+      expect(fixture.calls).toBe(0)
+      expectSkippedWithReason(/out of supported range/)
+    })
   })
 })


### PR DESCRIPTION
## Summary

Closes #319.

22:00 UTC daily-roll cron fires unconditionally, which means on weekends, US holidays, and JP holidays the handler advances `dailyStartEquity` even though no real session boundary occurred. This PR introduces hard-coded NYSE/TSE 2026 calendars and a fail-closed pre-check.

- **`src/infrastructure/calendar/usMarketCalendar.ts`** - `isNyseSessionDay(date)` + supported-range gate. 2026 NYSE closures (New Year, MLK, Presidents Day, Good Friday, Memorial Day, Juneteenth, Independence Day observed, Labor Day, Thanksgiving, Christmas) + weekend filtering via tz-aware `Intl.DateTimeFormat('en-CA', { timeZone: 'America/New_York' })`. No external API, no npm dep.
- **`src/infrastructure/calendar/jpMarketCalendar.ts`** - `isTseSessionDay(date)` mirroring the NYSE module; 2026 TSE closures (national holidays incl. Golden Week + 振替休日, plus 1/2 & 12/31 non-session days) + Asia/Tokyo tz formatter.
- **`src/trading/portfolio/runPortfolioRoll.ts`** - new `decideSkipReason()` checks (a) NY today is an NYSE session day and (b) the JP local date at cron-fire is a TSE session day. Either fails -> emit `event: 'daily_roll_skipped'` warn log with the reason and return; never crashes, never double-rolls. Out-of-range years (e.g. 2027 pre-refresh) also skip (fail-closed).
- A `TODO(annual)` comment near each closure list reminds operators to refresh the table each December.

## Test plan

- [x] `pnpm typecheck` clean.
- [x] `pnpm test` green (1193/1193).
- [x] New tests cover the DoD matrix: regular weekday rolls, NYSE-holiday skip (Memorial Day), TSE-holiday skip (May 6 substitute holiday), weekend skip, DST-transition Mon 2026-03-09 still rolls when both markets are open, out-of-supported-range skip (2027).
- [x] Existing `runPortfolioRoll` tests adapted to inject a deterministic `now` so they remain stable regardless of when the suite is run.

## DoD cross-reference (#319)

- [x] Hard-coded NYSE closures for 2026 (no external API).
- [x] Hard-coded TSE closures for 2026.
- [x] Handler checks "NY today is real NYSE close" AND "JP next session is real TSE day"; skips otherwise with a structured log.
- [x] Cron schedule unchanged (`0 22 * * *`); skip logic lives in the handler.
- [x] Fail-closed on lookup outside the hard-coded range.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ポートフォリオ自動更新が日本市場（TSE）と米国市場（NYSE）の営業日カレンダーに対応しました。営業日（月〜金、市場休場日除く）のみに自動更新が実行されるようになり、市場閉場日の不要な処理をスキップします。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/347?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->