### PR TITLE
feat(strategy): short-term swing defaults — 20d filter + 10d hold (#318)

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -2562,16 +2562,19 @@ export function localizeReason(en: string | null | undefined): string {
 
   // === 未保有の entry 判定 (様子見) ===
   // 「移動平均線割れ」は日本株の慣用表現。
+  // #318: trend filter の reason は `20d return ...`、historical decision_log
+  // 行は `50d return ...` (#318 前) を含むので両方を受ける。
   s = s.replace(
-    /^50d return (\S+) <= (\S+) trend threshold$/,
+    /^(?:20d|50d) return (\S+) <= (\S+) trend threshold$/,
     (_m, r, t) =>
-      `様子見: 上昇トレンド未成立 (50日騰落率 ${fmtPct(r)} ≤ 条件 ${fmtPct(t)})`,
+      `様子見: 上昇トレンド未成立 (騰落率 ${fmtPct(r)} ≤ 条件 ${fmtPct(t)})`,
   )
   s = s.replace(
     /^price (\S+) <= sma50 (\S+)$/,
     '様子見: 50日移動平均線割れ (株価 $1 ≤ 移動平均 $2)',
   )
-  s = s.replace(/^invalid 20d high$/, 'データ不足: 直近20日高値を算出できず')
+  // #318: invalid high reason も新旧両形式を受ける。
+  s = s.replace(/^invalid (?:10d|20d) high$/, 'データ不足: 直近高値を算出できず')
   s = s.replace(
     /^pullback (\S+) > (\S+) \(not deep enough\)$/,
     (_m, p, t) => `様子見: 押し目が浅い (下落率 ${fmtPct(p)} > 条件 ${fmtPct(t)})`,
@@ -2583,10 +2586,11 @@ export function localizeReason(en: string | null | undefined): string {
   )
 
   // === BUY signal (押し目買い成立) ===
+  // #318: BUY reason は `20d return ...`、historical 行 (`50d return ...`) も受ける。
   s = s.replace(
-    /^pullback (\S+) in uptrend \(50d return (\S+)\)$/,
+    /^pullback (\S+) in uptrend \((?:20d|50d) return (\S+)\)$/,
     (_m, p, r) =>
-      `買い: 上昇トレンド中の押し目買い (下落率 ${fmtPct(p)}、50日騰落率 ${fmtPct(r)})`,
+      `買い: 上昇トレンド中の押し目買い (下落率 ${fmtPct(p)}、騰落率 ${fmtPct(r)})`,
   )
 
   // === Sizing 系 reject (発注スキップ) ===

--- a/src/trading/strategy/indicators.ts
+++ b/src/trading/strategy/indicators.ts
@@ -15,7 +15,22 @@ export interface DailyBar {
 export interface PullbackIndicatorSnapshot {
   price: number
   sma50: number
+  /**
+   * 騰落率トレンド filter。**issue #318 で window を 50d → 20d に短縮した**
+   * 短期 swing 整合化 (20d return + 10d high + 10d hold)。
+   *
+   * フィールド名 (`return50d`) は historical reasons でそのまま (D1 の
+   * `strategy_decision_log.indicators_json` / dashboard / 既存 schema との
+   * 互換維持のため)。**実体は 20 日リターン**。renaming は #318 follow-up。
+   */
   return50d: number
+  /**
+   * 押し目買いの reference high。**issue #318 で window を 20d → 10d に短縮**
+   * (短期 swing で 10d 高値からの押し目を捉える)。
+   *
+   * フィールド名 (`high20d`) は dashboard / 既存 indicators_json との互換維持
+   * のためそのまま。**実体は 10 日高値**。
+   */
   high20d: number
   /**
    * 20 日安値 (low20d) — 戦略 ロジック上は未使用、dashboard 個別銘柄チャートで
@@ -34,26 +49,36 @@ export interface PullbackIndicatorSnapshot {
  * `intradayPrice` (optional) は cron が当日最新 1h close を渡す経路。指定が
  * あればそれを `price` として採用 (= chart 表示の candle と整合する fill 価格)。
  * NaN / Infinity / 0 / 負値 / null / undefined はすべて無視して daily close
- * (前日終値) に fallback し、既存挙動と等価になる。SMA50 / ATR / return50d /
- * high20d / low20d は引き続き daily bars から計算する (intradayPrice は影響
+ * (前日終値) に fallback し、既存挙動と等価になる。SMA50 / ATR / return /
+ * high / low20d は引き続き daily bars から計算する (intradayPrice は影響
  * しない)。
+ *
+ * **issue #318**: 短期 swing 整合化のため return lookback を 20d、pullback
+ * reference high lookback を 10d に短縮。フィールド名 (`return50d` /
+ * `high20d`) は storage / dashboard 互換のため据え置き。
  */
 export function computePullbackIndicators(
   bars: DailyBar[],
   intradayPrice?: number | null,
 ): PullbackIndicatorSnapshot | null {
+  // SMA50 が 50 bars を必要とするので最小要件は 50。return/high の lookback が
+  // 短くなっても warmup 要件は SMA50 に律速されたまま。
   if (bars.length < 50) return null
 
   const closes = bars.map((b) => b.close)
   const highs = bars.map((b) => b.high)
   const lows = bars.map((b) => b.low)
   const last = closes[closes.length - 1]!
-  const baseline = closes[closes.length - 50]!
+  // #318: return lookback は 20 営業日。`closes[-20]` を baseline に使う。
+  const baseline = closes[closes.length - 20]!
   if (baseline <= 0) return null
 
   const sma50 = average(closes.slice(-50))
-  const high20d = Math.max(...highs.slice(-20))
+  // #318: pullback の reference high は 10 営業日。entry condition が
+  // 「price <= high10d * (1 + pullbackMax)」になり、押し目判定が短期化する。
+  const high20d = Math.max(...highs.slice(-10))
   const low20d = Math.min(...lows.slice(-20))
+  // #318: return lookback 20 営業日に対応。`(last - closes[-20]) / closes[-20]`。
   const return50d = (last - baseline) / baseline
 
   const trueRanges = computeTrueRanges(bars)

--- a/src/trading/strategy/strategies/PullbackUptrendStrategy.ts
+++ b/src/trading/strategy/strategies/PullbackUptrendStrategy.ts
@@ -4,7 +4,15 @@ import type { PendingOrderLock, PositionState } from '../../state/types'
 export interface PullbackIndicators {
   price: number
   sma50: number
+  /**
+   * 騰落率トレンド filter (entry condition)。**issue #318 で lookback を
+   * 50d → 20d に短縮**。フィールド名は historical (storage/dashboard 互換)。
+   */
   return50d: number
+  /**
+   * 押し目買いの reference high。**issue #318 で lookback を 20d → 10d に
+   * 短縮**。フィールド名は historical (storage/dashboard 互換)。
+   */
   high20d: number
   atr20: number
   baselineAtr20: number
@@ -22,8 +30,12 @@ export interface SymbolRule {
   /** Pullback range: deeper bound. Default -0.06. */
   pullbackMin: number
   /**
-   * Minimum 50-day return required to consider the stock in an uptrend.
+   * Minimum N-day return required to consider the stock in an uptrend.
    * Default 0.08. Set negative to effectively disable the filter.
+   *
+   * **issue #318**: lookback は indicators.ts で 20 営業日。フィールド名
+   * (`minReturn50d`) は global_config 列名 / TS interface 互換のため historical
+   * に維持。renaming は #318 follow-up で。
    */
   minReturn50d: number
   /**
@@ -142,7 +154,9 @@ export class PullbackUptrendStrategy {
     const ind = input.indicators
     if (ind.return50d <= rule.minReturn50d) {
       trace.push(step('entry.trend_50d_return', false, ind.return50d, '>', rule.minReturn50d))
-      return hold(input, `50d return ${ind.return50d.toFixed(4)} <= ${rule.minReturn50d} trend threshold`, trace)
+      // #318: lookback は 20 営業日 (フィールド名は historical)。reason は人間
+      // 向け表示なので「20d return」と書いて誤読を避ける。
+      return hold(input, `20d return ${ind.return50d.toFixed(4)} <= ${rule.minReturn50d} trend threshold`, trace)
     }
     trace.push(step('entry.trend_50d_return', true, ind.return50d, '>', rule.minReturn50d))
 
@@ -154,7 +168,8 @@ export class PullbackUptrendStrategy {
 
     if (ind.high20d <= 0) {
       trace.push(step('entry.high20d_valid', false, ind.high20d, '>', 0))
-      return hold(input, 'invalid 20d high', trace)
+      // #318: lookback は 10 営業日 (フィールド名は historical)。
+      return hold(input, 'invalid 10d high', trace)
     }
     trace.push(step('entry.high20d_valid', true, ind.high20d, '>', 0))
 
@@ -171,7 +186,7 @@ export class PullbackUptrendStrategy {
     }
     trace.push(step('entry.pullback_not_too_deep', true, pullback, '>=', rule.pullbackMin))
     trace.push(step('entry.adopt_buy', true, pullback, 'between', [rule.pullbackMin, rule.pullbackMax]))
-    return buy(input, `pullback ${pullback.toFixed(4)} in uptrend (50d return ${ind.return50d.toFixed(4)})`, trace)
+    return buy(input, `pullback ${pullback.toFixed(4)} in uptrend (20d return ${ind.return50d.toFixed(4)})`, trace)
   }
 }
 
@@ -245,9 +260,12 @@ const TRACE_LABEL_JA: Record<string, string> = {
   'guard.pending_order_absent': '未約定注文がない',
   'guard.cooldown_inactive': 'クールダウン中ではない',
   'route.position_open': '建玉を保有中',
-  'entry.trend_50d_return': '50日騰落率が上昇トレンド条件を満たす',
+  // #318: trace 識別子 (`entry.trend_50d_return` / `entry.high20d_valid`) は
+  // 既存 decision_log と互換維持のため据え置き。**表示文字列のみ実 lookback に
+  // 合わせて 20日 / 10日 と表記**。
+  'entry.trend_50d_return': '20日騰落率が上昇トレンド条件を満たす',
   'entry.above_sma50': '株価が50日移動平均線を上回る',
-  'entry.high20d_valid': '直近20日高値が有効',
+  'entry.high20d_valid': '直近10日高値が有効',
   'entry.pullback_not_too_shallow': '押し目が浅すぎない',
   'entry.pullback_not_too_deep': '押し目が深すぎない',
   'entry.adopt_buy': '買い採用',

--- a/test/routes/localizeReason.test.ts
+++ b/test/routes/localizeReason.test.ts
@@ -9,9 +9,17 @@ describe('localizeReason (日本株・信用取引の伝統的語彙)', () => {
   })
 
   describe('未保有 (様子見 / データ不足)', () => {
-    it('50d return unmet', () => {
+    // #318: trend filter は 20d return (短期 swing 整合化)。historical 行は
+    // `50d return ...` を含むので両方の入力を受け、同じ localized 出力を返す。
+    it('20d return unmet', () => {
+      expect(localizeReason('20d return 0.0108 <= 0.03 trend threshold')).toBe(
+        '様子見: 上昇トレンド未成立 (騰落率 +1.08% ≤ 条件 +3.00%)',
+      )
+    })
+
+    it('legacy 50d return reason still localizes (backward compat)', () => {
       expect(localizeReason('50d return 0.0108 <= 0.03 trend threshold')).toBe(
-        '様子見: 上昇トレンド未成立 (50日騰落率 +1.08% ≤ 条件 +3.00%)',
+        '様子見: 上昇トレンド未成立 (騰落率 +1.08% ≤ 条件 +3.00%)',
       )
     })
 
@@ -33,9 +41,15 @@ describe('localizeReason (日本株・信用取引の伝統的語彙)', () => {
       )
     })
 
-    it('invalid 20d high', () => {
+    it('invalid 10d high', () => {
+      expect(localizeReason('invalid 10d high')).toBe(
+        'データ不足: 直近高値を算出できず',
+      )
+    })
+
+    it('legacy invalid 20d high still localizes (backward compat)', () => {
       expect(localizeReason('invalid 20d high')).toBe(
-        'データ不足: 直近20日高値を算出できず',
+        'データ不足: 直近高値を算出できず',
       )
     })
   })
@@ -67,9 +81,16 @@ describe('localizeReason (日本株・信用取引の伝統的語彙)', () => {
   })
 
   describe('BUY (押し目買い)', () => {
-    it('uptrend pullback → 買い', () => {
+    // #318: 20d return into new code path、historical 行は 50d 形式。
+    it('uptrend pullback (20d return) → 買い', () => {
+      expect(localizeReason('pullback -0.03 in uptrend (20d return 0.12)')).toBe(
+        '買い: 上昇トレンド中の押し目買い (下落率 -3.00%、騰落率 +12.00%)',
+      )
+    })
+
+    it('legacy uptrend pullback (50d return) still localizes (backward compat)', () => {
       expect(localizeReason('pullback -0.03 in uptrend (50d return 0.12)')).toBe(
-        '買い: 上昇トレンド中の押し目買い (下落率 -3.00%、50日騰落率 +12.00%)',
+        '買い: 上昇トレンド中の押し目買い (下落率 -3.00%、騰落率 +12.00%)',
       )
     })
   })

--- a/test/trading/backtest/runBacktest.test.ts
+++ b/test/trading/backtest/runBacktest.test.ts
@@ -39,7 +39,11 @@ function buildBars(start: number, factors: number[], startDate = '2025-01-01'): 
   return bars
 }
 
-/** 50 warmup bars at constant ~+1%/d so 50d return clears the trend filter. */
+/**
+ * 50+ warmup bars at constant ~+1%/d so the trend filter clears.
+ * #318 で return lookback は 20d に短縮されたが、+1%/d × 20d ≈ +22% > +8% で
+ * 引き続き trend filter を通過する。
+ */
 function uptrendWarmup(start: number): DailyBar[] {
   return buildBars(start, Array(60).fill(1.01))
 }
@@ -55,7 +59,8 @@ describe('runBacktest', () => {
   })
 
   it('produces no trades when bars are pure downtrend (no BUY signal)', async () => {
-    // Constant 1% daily decline → 50d return < 0 → entry.trend_50d_return fails → HOLD.
+    // Constant 1% daily decline → trend return < 0 → entry.trend_50d_return fails → HOLD.
+    // (trace 識別子 `entry.trend_50d_return` は #318 後も historical 維持、実 lookback は 20d。)
     const bars = buildBars(100, Array(120).fill(0.99))
     const result = await runBacktest(bars, BASE_PARAMS)
     expect(result.totalTrades).toBe(0)

--- a/test/trading/risk/perSymbolRiskGateParity.test.ts
+++ b/test/trading/risk/perSymbolRiskGateParity.test.ts
@@ -36,8 +36,11 @@ const riskConfig: PerSymbolRiskConfig = {
 }
 
 function uptrendBars(): DailyBar[] {
+  // #318: 20d return + 10d high で BUY 成立する形状。
+  // closes[-20] ≈ 108 (bar 40)、last = 117.5、20d return ≈ +8.8% (> +8% threshold)。
   const bars: DailyBar[] = []
-  for (let i = 0; i < 55; i += 1) bars.push(synth(i, 100 + i * 0.4))
+  for (let i = 0; i < 40; i += 1) bars.push(synth(i, 100 + i * 0.2))
+  for (let i = 40; i < 55; i += 1) bars.push(synth(i, 108 + (i - 40) * 1.0))
   bars.push(synth(55, 122))
   bars.push(synth(56, 121))
   bars.push(synth(57, 120))

--- a/test/trading/strategy/indicators.test.ts
+++ b/test/trading/strategy/indicators.test.ts
@@ -17,7 +17,7 @@ describe('computePullbackIndicators', () => {
     expect(computePullbackIndicators(makeBars([1, 2, 3]))).toBeNull()
   })
 
-  it('computes sma50 / return50d / high20d / low20d from the tail window', () => {
+  it('computes sma50 / return50d (20d) / high20d (10d) / low20d from the tail window', () => {
     const closes = Array.from({ length: 60 }, (_, i) => 100 + i)
     const result = computePullbackIndicators(makeBars(closes))
     expect(result).not.toBeNull()
@@ -25,12 +25,14 @@ describe('computePullbackIndicators', () => {
     expect(r.price).toBe(159)
     // sma50 = average of closes 110..159 = (110+159)/2 = 134.5
     expect(r.sma50).toBeCloseTo(134.5, 4)
-    // 50d return: last vs closes[-50] = closes[10] = 110 → (159 - 110)/110
-    expect(r.return50d).toBeCloseTo((159 - 110) / 110, 4)
-    // high20d = max of highs for last 20 bars. highs are close*1.01.
+    // #318: return lookback は 20 営業日。last vs closes[-20] = closes[40] = 140
+    // → (159 - 140)/140
+    expect(r.return50d).toBeCloseTo((159 - 140) / 140, 4)
+    // #318: high lookback は 10 営業日。max of highs for last 10 bars。
+    // highs are close*1.01、最新 10 closes = 150..159 → max = 159 * 1.01。
     expect(r.high20d).toBeCloseTo(159 * 1.01, 4)
-    // low20d = min of lows for last 20 bars. lows are close*0.99, last 20 closes
-    // are 140..159 → min = 140 * 0.99
+    // low20d は変更なし (20 日窓のまま、dashboard 表示用)。
+    // lows are close*0.99, last 20 closes are 140..159 → min = 140 * 0.99
     expect(r.low20d).toBeCloseTo(140 * 0.99, 4)
   })
 
@@ -47,7 +49,8 @@ describe('computePullbackIndicators', () => {
   describe('intradayPrice override', () => {
     const closes = Array.from({ length: 60 }, (_, i) => 100 + i)
     const bars = makeBars(closes)
-    // daily close ベースの fixture 値: last = 159, sma50 = 134.5, return50d = (159-110)/110
+    // #318: daily close ベースの fixture 値: last = 159, sma50 = 134.5、
+    // return50d (実体は 20d) = (159-140)/140、high20d (実体は 10d) = 159*1.01。
     const dailyOnly = computePullbackIndicators(bars)!
 
     it('uses intradayPrice as price when provided and positive', () => {

--- a/test/trading/strategy/pullbackScheduler.test.ts
+++ b/test/trading/strategy/pullbackScheduler.test.ts
@@ -15,13 +15,24 @@ import type { DailyBar } from '../../../src/trading/strategy/indicators'
 const now = new Date('2026-04-20T14:30:00.000Z')
 
 function uptrendBars(): DailyBar[] {
-  // 60 bars, uptrend ~+15% over 50d, ending with a mild -4% pullback from high.
+  // #318: short-term swing 整合化で trend filter は 20d return ベースになった。
+  // closes[-20] vs last の return が +8% を超えるよう、最後の 20 営業日に
+  // しっかりした上昇を入れる:
+  //   - 40 bars: slow uptrend (warmup for SMA50)
+  //   - 15 bars: steeper leg → 高値 122 まで
+  //   - 5 bars: 高値到達 → mild -4% pullback (BUY ゾーン)
+  // 結果: closes[-20] ≈ 108 (bar 40)、last = 117.5、20d return ≈ +8.8%。
   const bars: DailyBar[] = []
-  for (let i = 0; i < 55; i += 1) {
-    const close = 100 + i * 0.4 // slow uptrend, ends at ~121.6
+  for (let i = 0; i < 40; i += 1) {
+    const close = 100 + i * 0.2 // gentle warmup, bar 39 close = 107.8
     bars.push(synth(i, close))
   }
-  // The 20d high hit at bar 55
+  // bar 40 close = 108、20d return baseline がここに据わる。
+  for (let i = 40; i < 55; i += 1) {
+    const close = 108 + (i - 40) * 1.0 // steeper, bar 54 close = 122
+    bars.push(synth(i, close))
+  }
+  // The 10d (was 20d, #318) high hit at bar 55
   bars.push(synth(55, 122))
   bars.push(synth(56, 121))
   bars.push(synth(57, 120))


### PR DESCRIPTION
Resolves #318 (option A: short-term swing).

## Why

trading-strategist 指摘: 既存 default は 50d return filter + 10d hold で 5:1 と
時間軸が中途半端だった。短期 swing に整合させるため return / pullback reference
high の lookback を短縮する。

## Defaults changed (windows only, thresholds 維持)

| 指標 | before | after |
|---|---|---|
| Return lookback (trend filter) | 50 営業日 | **20 営業日** |
| Pullback reference high lookback | 20 営業日 | **10 営業日** |
| Hold (time-stop) | 10 営業日 | 10 営業日 (変更なし) |
| `minReturn50d` 閾値 | 0.08 | 0.08 (変更なし) |

実装は `src/trading/strategy/indicators.ts` の hardcoded window (`closes[-50]` /
`highs.slice(-20)`) を `closes[-20]` / `highs.slice(-10)` に書き換える形。

## Field name 据え置き (scope 抑制)

`return50d` / `high20d` / `minReturn50d` / `pullback_default_min_return_50d` /
trace 識別子 `entry.trend_50d_return` / `entry.high20d_valid` は **historical**
として据え置き:
- 既存 `strategy_decision_log.indicators_json` の JSON key と互換
- 既存 dashboard chart の field path と互換
- drizzle schema の column rename = table rebuild migration 不要
- JSDoc で実 lookback を明記、misleading 防止

完全な field rename は #318 follow-up issue (storage migration + dashboard
backward-compat reader + decision_log JSON shim 含む) で扱う。

## 表示文字列だけ実 lookback に合わせる

HOLD/BUY reason の `"50d return ..."` → `"20d return ..."`、
`"invalid 20d high"` → `"invalid 10d high"`、Japanese trace label
`"50日騰落率..."` → `"20日騰落率..."` / `"直近20日高値が有効"` →
`"直近10日高値が有効"`。`localizeReason` は legacy 50d/20d 形式の
historical decision_log 行も backward-compat で受ける (regex で両形式マッチ)。

## Test fixtures

`uptrendBars()` (pullbackScheduler.test.ts / perSymbolRiskGateParity.test.ts) は
20d return が +8% を超えるよう前段 warmup を gentle uptrend (+0.2/d × 40d)、
後段を急角度 (+1.0/d × 15d) に組み直し。BUY 成立条件は維持 (-4% pullback)。
`indicators.test.ts` の 20d return / 10d high の期待値も更新。

## Per-symbol override 据え置き

operator は引き続き `symbol_config.k_atr_override` / `time_stop_days_override`
で per-symbol 調整可能。trading filter window の per-symbol override は POC
scope 外。

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` green (1190 tests passed, 1187 → 1190 で +3 は localizeReason の backward-compat coverage 追加分)
- [ ] backtest 比較 (#318 DoD) は別 PR