### PR TITLE
fix(calendar): formatToParts-based YYYY-MM-DD (#349)

### DIFF
--- a/src/infrastructure/calendar/jpMarketCalendar.ts
+++ b/src/infrastructure/calendar/jpMarketCalendar.ts
@@ -66,6 +66,8 @@ const TSE_2026_CLOSURES: ReadonlySet<string> = new Set([
 /** Hard-coded holiday data の有効年セット。範囲外は呼び出し側で fail-closed。 */
 const TSE_SUPPORTED_YEARS: ReadonlySet<number> = new Set([2026])
 
+// formatToParts ベースで year / month / day を抜く理由は usMarketCalendar.ts
+// 参照 (#349 — runtime-portable な YYYY-MM-DD 組立)。
 const JP_YMD_FORMATTER = new Intl.DateTimeFormat('en-CA', {
   timeZone: 'Asia/Tokyo',
   year: 'numeric',
@@ -78,17 +80,41 @@ const JP_WEEKDAY_FORMATTER = new Intl.DateTimeFormat('en-US', {
   weekday: 'short',
 })
 
-/** `date` (UTC instant) を Asia/Tokyo の "YYYY-MM-DD" に format。 */
+interface YmdParts {
+  ymd: string
+  year: number
+}
+
+function extractJpYmdParts(date: Date): YmdParts | null {
+  let year = ''
+  let month = ''
+  let day = ''
+  for (const part of JP_YMD_FORMATTER.formatToParts(date)) {
+    if (part.type === 'year') year = part.value
+    else if (part.type === 'month') month = part.value
+    else if (part.type === 'day') day = part.value
+  }
+  if (!year || !month || !day) return null
+  const yearInt = Number.parseInt(year, 10)
+  if (!Number.isFinite(yearInt)) return null
+  return { ymd: `${year}-${month}-${day}`, year: yearInt }
+}
+
+/**
+ * `date` (UTC instant) を Asia/Tokyo の "YYYY-MM-DD" に format。
+ *
+ * formatToParts ベースで runtime drift に強い (#349)。抽出失敗時は空文字 →
+ * caller (`isTseSessionDay`) で fail-closed (false) になる。
+ */
 export function formatJpYmd(date: Date): string {
-  return JP_YMD_FORMATTER.format(date)
+  return extractJpYmdParts(date)?.ymd ?? ''
 }
 
 /** `date` 時点の JP 暦日が hard-coded supported range に含まれているか。 */
 export function isWithinSupportedRange(date: Date): boolean {
-  const ymd = formatJpYmd(date)
-  const year = Number.parseInt(ymd.slice(0, 4), 10)
-  if (!Number.isFinite(year)) return false
-  return TSE_SUPPORTED_YEARS.has(year)
+  const parts = extractJpYmdParts(date)
+  if (!parts) return false
+  return TSE_SUPPORTED_YEARS.has(parts.year)
 }
 
 /**

--- a/src/infrastructure/calendar/usMarketCalendar.ts
+++ b/src/infrastructure/calendar/usMarketCalendar.ts
@@ -53,6 +53,11 @@ const NYSE_2026_CLOSURES: ReadonlySet<string> = new Set([
 /** Hard-coded holiday data の有効年セット。範囲外は呼び出し側で fail-closed。 */
 const NYSE_SUPPORTED_YEARS: ReadonlySet<number> = new Set([2026])
 
+// formatToParts ベースで year / month / day を抜く理由 (#349):
+// `Intl.DateTimeFormat#format` の出力区切り・順序は ECMA-402 上 implementation-
+// dependent。Cloudflare Workers (V8/ICU) では `en-CA` で実測 YYYY-MM-DD だが、
+// runtime 更新 / 別 ICU build で drift する可能性があるため
+// `formatToParts` で part を取って自前で組み立てる。
 const NY_YMD_FORMATTER = new Intl.DateTimeFormat('en-CA', {
   timeZone: 'America/New_York',
   year: 'numeric',
@@ -65,12 +70,36 @@ const NY_WEEKDAY_FORMATTER = new Intl.DateTimeFormat('en-US', {
   weekday: 'short',
 })
 
+interface YmdParts {
+  ymd: string
+  year: number
+}
+
+function extractNyYmdParts(date: Date): YmdParts | null {
+  let year = ''
+  let month = ''
+  let day = ''
+  for (const part of NY_YMD_FORMATTER.formatToParts(date)) {
+    if (part.type === 'year') year = part.value
+    else if (part.type === 'month') month = part.value
+    else if (part.type === 'day') day = part.value
+  }
+  if (!year || !month || !day) return null
+  const yearInt = Number.parseInt(year, 10)
+  if (!Number.isFinite(yearInt)) return null
+  return { ymd: `${year}-${month}-${day}`, year: yearInt }
+}
+
 /**
  * `date` (UTC instant) を America/New_York の "YYYY-MM-DD" に format。
  * DST は `Intl.DateTimeFormat` が解決するので worker side で扱う必要なし。
+ *
+ * formatToParts ベースなので runtime / locale 差で出力が drift しない (#349)。
+ * 抽出失敗 (Invalid Date 等) は空文字を返す — caller は `isNyseSessionDay`
+ * で fail-closed (false) になる。
  */
 export function formatNyYmd(date: Date): string {
-  return NY_YMD_FORMATTER.format(date)
+  return extractNyYmdParts(date)?.ymd ?? ''
 }
 
 /**
@@ -78,10 +107,9 @@ export function formatNyYmd(date: Date): string {
  * 含まれているか。false の年は呼び出し側で safe-default (skip) する。
  */
 export function isWithinSupportedRange(date: Date): boolean {
-  const ymd = formatNyYmd(date)
-  const year = Number.parseInt(ymd.slice(0, 4), 10)
-  if (!Number.isFinite(year)) return false
-  return NYSE_SUPPORTED_YEARS.has(year)
+  const parts = extractNyYmdParts(date)
+  if (!parts) return false
+  return NYSE_SUPPORTED_YEARS.has(parts.year)
 }
 
 /**


### PR DESCRIPTION
Closes #349.

## Why

PR #347 used \`Intl.DateTimeFormat({...}).format(date)\` to get \`YYYY-MM-DD\` strings. CodeRabbit (🟠 Major) pointed out the format separator and ordering are implementation-defined per ECMA-402 — Cloudflare Workers (V8/ICU) happens to emit \`YYYY-MM-DD\` for \`en-CA\` today, but a V8/ICU update or different runtime could drift the layout (e.g. \`YYYY/MM/DD\`) and silently break our hard-coded YYYY-MM-DD comparisons + \`slice(0,4)\` year extraction.

## What

For both \`usMarketCalendar.ts\` and \`jpMarketCalendar.ts\`:

- Introduce a private \`extract{Ny,Jp}YmdParts(date)\` helper that walks \`formatToParts()\` and assembles \`{ ymd, year }\` ourselves.
- \`format{Ny,Jp}Ymd(date)\` returns the assembled \`YYYY-MM-DD\` (or empty string on extraction failure).
- \`isWithinSupportedRange(date)\` uses the parsed \`year\` directly — no more \`ymd.slice(0,4)\`.
- Behaviour on \`Invalid Date\` / unparseable parts: helper returns null → caller falls through to fail-closed (skip session day, skip roll). Matches existing safety stance.

No public API changes. No new deps.

## Verification

- \`pnpm typecheck\` clean
- \`pnpm test\` → 1196 / 1196 passing (no change to the calendar-related test suite — coverage already exercises ymd / weekday paths through the public functions)