### PR TITLE
refactor(calendar): dedup NYSE/TSE holidays into tradingCalendar (#354)

### DIFF
--- a/src/infrastructure/calendar/jpMarketCalendar.ts
+++ b/src/infrastructure/calendar/jpMarketCalendar.ts
@@ -4,64 +4,15 @@
  * 22:00 UTC daily roll cron は「翌日 JP が open する」前提で動くため、土日 /
  * TSE 祝日が「明日」に当たる場合は roll を skip して連続性を保つ。
  *
- * Approach (POC): 外部 API に依存せず hard-coded list。usMarketCalendar と
- * 設計対称。詳細な動機は同じファイルの header コメント参照。
+ * Approach (POC): 外部 API に依存せず、`src/trading/domain/tradingCalendar.ts`
+ * の `TSE_CLOSURES` (single source of truth, #354) + weekday 判定。
+ * usMarketCalendar と設計対称。詳細な動機は同じファイルの header コメント参照。
  *
- * TODO(annual): 翌年の TSE holiday を追記し `TSE_SUPPORTED_YEARS` を伸ばす。
- * JPX は前年の年央〜年末に翌年カレンダーを公表する
- * (https://www.jpx.co.jp/corporate/about-jpx/calendar/)。
+ * Holiday data 自体の更新は `tradingCalendar.ts` 側で行う。当 module は
+ * tz-aware (Asia/Tokyo) な session-day 判定のみを責務にする。
  */
 
-/**
- * TSE 2026 full closures。
- *
- * 出典: JPX trading calendar 2026 (https://www.jpx.co.jp/corporate/about-jpx/calendar/)。
- * 振替休日 (substitute holiday) は当該振替日を含む。年末 / 年始 (12/31, 1/2,
- * 1/3) は祝日扱いではないが TSE が立会を行わない (大納会 12/30 / 大発会 1/5)
- * ため closure に含める。
- *
- * 2026 list:
- *   - 2026-01-01 元日 (New Year's Day, Thu)
- *   - 2026-01-02 (Fri) 年始 TSE 休場
- *   - 2026-01-12 成人の日 (Coming of Age, Mon)
- *   - 2026-02-11 建国記念の日 (Foundation Day, Wed)
- *   - 2026-02-23 天皇誕生日 (Emperor's Birthday, Mon)
- *   - 2026-03-20 春分の日 (Vernal Equinox, Fri)
- *   - 2026-04-29 昭和の日 (Showa Day, Wed)
- *   - 2026-05-04 みどりの日 (Greenery Day, Mon)
- *   - 2026-05-05 こどもの日 (Children's Day, Tue)
- *   - 2026-05-06 振替休日 (substitute, Wed) — Sun May 3 was 憲法記念日
- *   - 2026-07-20 海の日 (Marine Day, Mon)
- *   - 2026-08-11 山の日 (Mountain Day, Tue)
- *   - 2026-09-21 敬老の日 (Respect for the Aged Day, Mon)
- *   - 2026-09-22 国民の休日 (Citizens' Holiday, Tue) — between 敬老の日 and 秋分の日
- *   - 2026-09-23 秋分の日 (Autumnal Equinox, Wed)
- *   - 2026-10-12 スポーツの日 (Sports Day, Mon)
- *   - 2026-11-03 文化の日 (Culture Day, Tue)
- *   - 2026-11-23 勤労感謝の日 (Labor Thanksgiving, Mon)
- *   - 2026-12-31 (Thu) 年末 TSE 休場 — 12/30 大納会で 12/31 立会なし
- */
-const TSE_2026_CLOSURES: ReadonlySet<string> = new Set([
-  '2026-01-01',
-  '2026-01-02',
-  '2026-01-12',
-  '2026-02-11',
-  '2026-02-23',
-  '2026-03-20',
-  '2026-04-29',
-  '2026-05-04',
-  '2026-05-05',
-  '2026-05-06',
-  '2026-07-20',
-  '2026-08-11',
-  '2026-09-21',
-  '2026-09-22',
-  '2026-09-23',
-  '2026-10-12',
-  '2026-11-03',
-  '2026-11-23',
-  '2026-12-31',
-])
+import { TSE_CLOSURES } from '../../trading/domain/tradingCalendar'
 
 /** Hard-coded holiday data の有効年セット。範囲外は呼び出し側で fail-closed。 */
 const TSE_SUPPORTED_YEARS: ReadonlySet<number> = new Set([2026])
@@ -124,7 +75,7 @@ export function isWithinSupportedRange(date: Date): boolean {
 export function isTseSessionDay(date: Date): boolean {
   if (!isWithinSupportedRange(date)) return false
   const ymd = formatJpYmd(date)
-  if (TSE_2026_CLOSURES.has(ymd)) return false
+  if (TSE_CLOSURES.has(ymd)) return false
   const weekday = JP_WEEKDAY_FORMATTER.format(date)
   if (weekday === 'Sat' || weekday === 'Sun') return false
   return true

--- a/src/infrastructure/calendar/usMarketCalendar.ts
+++ b/src/infrastructure/calendar/usMarketCalendar.ts
@@ -8,47 +8,18 @@
  * `lastRolledAt` の連続性を保つ。
  *
  * Approach (POC):
- *   - 外部 API に依存せず、`NYSE_2026_CLOSURES` の hard-coded set + weekday 判定。
- *   - 範囲外 (e.g. 2027 以降) を引いた場合は呼び出し側で fail-closed 判断できる
+ *   - 外部 API に依存せず、`src/trading/domain/tradingCalendar.ts` の
+ *     `NYSE_CLOSURES` (single source of truth, #354) + weekday 判定。
+ *   - 範囲外 (e.g. 2028 以降) を引いた場合は呼び出し側で fail-closed 判断できる
  *     よう `isWithinSupportedRange` を分けて公開する。
  *
- * TODO(annual): 年末ごとに翌年の NYSE closure list を追記し
- * `NYSE_SUPPORTED_YEARS` を伸ばす事。NYSE は通常前年の早い段階で翌年
- * holiday schedule を公表する (https://www.nyse.com/markets/hours-calendars)。
+ * Holiday data 自体の更新は `tradingCalendar.ts` 側で行う。当 module は
+ * tz-aware (America/New_York) な session-day 判定のみを責務にする。
+ * `NYSE_SUPPORTED_YEARS` だけは hard-coded data の有効範囲という
+ * このファイル固有の不変条件なので local に持つ。
  */
 
-/**
- * NYSE 2026 full closures。
- *
- * 出典: NYSE Holidays & Trading Hours
- * (https://www.nyse.com/markets/hours-calendars — 2025-12 時点で公表済み)。
- * Early-close (1300 ET) days はここに含めない (full close ではないので
- * 22:00 UTC = 17:00 ET 時点では session は終わっており roll 自体は妥当)。
- *
- * 2026 list:
- *   - 2026-01-01 New Year's Day (Thu)
- *   - 2026-01-19 MLK Jr. Day (Mon)
- *   - 2026-02-16 Presidents' Day (Mon)
- *   - 2026-04-03 Good Friday (Fri)
- *   - 2026-05-25 Memorial Day (Mon)
- *   - 2026-06-19 Juneteenth (Fri)
- *   - 2026-07-03 Independence Day (Fri) — observed (Jul 4 is Sat)
- *   - 2026-09-07 Labor Day (Mon)
- *   - 2026-11-26 Thanksgiving (Thu)
- *   - 2026-12-25 Christmas (Fri)
- */
-const NYSE_2026_CLOSURES: ReadonlySet<string> = new Set([
-  '2026-01-01',
-  '2026-01-19',
-  '2026-02-16',
-  '2026-04-03',
-  '2026-05-25',
-  '2026-06-19',
-  '2026-07-03',
-  '2026-09-07',
-  '2026-11-26',
-  '2026-12-25',
-])
+import { NYSE_CLOSURES } from '../../trading/domain/tradingCalendar'
 
 /** Hard-coded holiday data の有効年セット。範囲外は呼び出し側で fail-closed。 */
 const NYSE_SUPPORTED_YEARS: ReadonlySet<number> = new Set([2026])
@@ -121,7 +92,7 @@ export function isWithinSupportedRange(date: Date): boolean {
 export function isNyseSessionDay(date: Date): boolean {
   if (!isWithinSupportedRange(date)) return false
   const ymd = formatNyYmd(date)
-  if (NYSE_2026_CLOSURES.has(ymd)) return false
+  if (NYSE_CLOSURES.has(ymd)) return false
   const weekday = NY_WEEKDAY_FORMATTER.format(date)
   if (weekday === 'Sat' || weekday === 'Sun') return false
   return true

--- a/src/trading/domain/tradingCalendar.ts
+++ b/src/trading/domain/tradingCalendar.ts
@@ -14,10 +14,15 @@ export type TradingMarket = 'JP' | 'US'
 
 const MS_PER_DAY = 86_400_000
 
-// TODO: 2028 以降の祝日を運用入り前に追記する。
+// TODO(annual): 2028 以降の祝日を運用入り前に追記する。
 // JP: 東証休業日 (国民の祝日 + 振替休日 + 年始 1/1–1/3 + 大晦日 12/31)
 // US NYSE: 9 祝日 + Good Friday。土日と重なる祝日は observed day (振替) を入れる。
-const HOLIDAYS: Record<TradingMarket, ReadonlySet<string>> = {
+//
+// このテーブルは market holiday set の単一情報源 (#354)。
+// `src/infrastructure/calendar/{us,jp}MarketCalendar.ts` の tz-aware
+// session-day check も `NYSE_CLOSURES` / `TSE_CLOSURES` re-export を経由して
+// 同じデータを参照する。
+export const HOLIDAYS: Record<TradingMarket, ReadonlySet<string>> = {
   JP: new Set<string>([
     // 2026
     '2026-01-01', // 元日 (exchange closed)
@@ -84,6 +89,14 @@ const HOLIDAYS: Record<TradingMarket, ReadonlySet<string>> = {
     '2027-12-31', // New Year's Day observed (Jan 1 2028 is Sat)
   ]),
 }
+
+/**
+ * `HOLIDAYS` の market 別 alias。infrastructure 層の tz-aware session-day check
+ * が import するためだけに公開する (#354)。新しい消費者は `HOLIDAYS[market]`
+ * を使うか、`isTradingDay` 等の関数 API を使うこと。
+ */
+export const NYSE_CLOSURES: ReadonlySet<string> = HOLIDAYS.US
+export const TSE_CLOSURES: ReadonlySet<string> = HOLIDAYS.JP
 
 function toYmdUtc(date: Date): string {
   return date.toISOString().slice(0, 10)


### PR DESCRIPTION
## Summary

Closes #354.

PR #347 (#319 daily-roll calendar awareness) added `src/infrastructure/calendar/{us,jp}MarketCalendar.ts` with hard-coded 2026 NYSE / TSE closure sets, but `src/trading/domain/tradingCalendar.ts` already had the same holiday data for UTC business-day arithmetic. Two lists per market = drift risk at each annual update.

- Hold the holiday set once in `tradingCalendar.ts`. Export `HOLIDAYS` plus market aliases `NYSE_CLOSURES` / `TSE_CLOSURES`.
- `usMarketCalendar.ts` / `jpMarketCalendar.ts` drop their local `NYSE_2026_CLOSURES` / `TSE_2026_CLOSURES` constants and import the aliases. tz-aware `Intl.DateTimeFormat` logic and the `*_SUPPORTED_YEARS` invariant stay local — only the underlying set is consolidated.
- The annual TODO reminder now lives once, in `tradingCalendar.ts`.

API surface unchanged: `isNyseSessionDay`, `isTseSessionDay`, `formatNyYmd`, `formatJpYmd`, `isWithinSupportedRange`, plus all `tradingCalendar` exports are bit-identical.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` green — 90 files, 1196 tests pass (scheduledHandler calendar-aware roll cases, tradingCalendar.test.ts, no test changes)
- [x] Diff: -96 / +31 lines across 3 files; no API or behaviour change for 2026; 2027+ continues to fail-closed via `*_SUPPORTED_YEARS`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * マーケットカレンダーの祝日・休場日定義を統一管理へ移行しました。複数の場所に散在していた祝日データを一元管理することで、保守性と一貫性を向上させました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/363?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->