### PR TITLE
chore(test): annotate mocks for vitest v4 readiness (#361)

### DIFF
--- a/test/infrastructure/webull/webullTradeClient.test.ts
+++ b/test/infrastructure/webull/webullTradeClient.test.ts
@@ -17,8 +17,13 @@ const intent: OrderIntent = {
 
 const okResponse: WebullPlaceOrderResponseDto = { order_id: 'ord-1' }
 
-function fakeHttp(): { placeOrder: ReturnType<typeof vi.fn> } {
-  return { placeOrder: vi.fn(async () => okResponse) }
+// vitest v4 infers `vi.fn()` as `Mock<Procedure | Constructable>` which does
+// not satisfy `Pick<WebullHttpClient, 'placeOrder'>['placeOrder']`. Pin the
+// generic to the exact method signature so v4 typecheck accepts the stub and
+// v2 keeps working (the generic form is supported by both versions).
+type PlaceOrderFn = (intent: OrderIntent) => Promise<WebullPlaceOrderResponseDto>
+function fakeHttp(): { placeOrder: ReturnType<typeof vi.fn<PlaceOrderFn>> } {
+  return { placeOrder: vi.fn<PlaceOrderFn>(async () => okResponse) }
 }
 
 describe('WebullTradeClient', () => {

--- a/test/scheduledHandler.test.ts
+++ b/test/scheduledHandler.test.ts
@@ -103,7 +103,7 @@ describe('runPortfolioRoll (issue #140)', () => {
     })
     expect(fixture.calls).toBe(1)
     const logs = logSpy.mock.calls
-      .map((args) => args[0])
+      .map((args: unknown[]) => args[0])
       .filter((s): s is string => typeof s === 'string' && s.includes('portfolio_roll_run'))
     expect(logs).toHaveLength(1)
     const first = logs[0]
@@ -120,7 +120,7 @@ describe('runPortfolioRoll (issue #140)', () => {
   it('emits portfolio_roll_skipped (warn) when PORTFOLIO_STATE binding is missing', async () => {
     await runPortfolioRoll(baseEnv, 'req-2', { now: nowOnSessionDay })
     const skipped = warnSpy.mock.calls
-      .map((args) => args[0])
+      .map((args: unknown[]) => args[0])
       .filter((s): s is string => typeof s === 'string' && s.includes('portfolio_roll_skipped'))
     expect(skipped).toHaveLength(1)
     const first = skipped[0]
@@ -152,7 +152,7 @@ describe('runPortfolioRoll (issue #140)', () => {
       }),
     ).resolves.toBeUndefined()
     const errors = errorSpy.mock.calls
-      .map((args) => args[0])
+      .map((args: unknown[]) => args[0])
       .filter((s): s is string => typeof s === 'string' && s.includes('portfolio_roll_error'))
     expect(errors).toHaveLength(1)
     const first = errors[0]
@@ -177,7 +177,7 @@ describe('runPortfolioRoll (issue #140)', () => {
 
     function expectSkippedWithReason(reasonMatch: RegExp): void {
       const skipped = warnSpy.mock.calls
-        .map((args) => args[0])
+        .map((args: unknown[]) => args[0])
         .filter((s): s is string => typeof s === 'string' && s.includes('daily_roll_skipped'))
       expect(skipped).toHaveLength(1)
       const first = skipped[0]

--- a/test/trading/reconciliation/syncHoldings.test.ts
+++ b/test/trading/reconciliation/syncHoldings.test.ts
@@ -203,7 +203,7 @@ describe('syncHoldings', () => {
 
     // Audit log emitted once for the actual sync (NVDA error path doesn't log).
     const syncLogs = logSpy.mock.calls
-      .map((c) => (typeof c[0] === 'string' ? safeParse(c[0]) : null))
+      .map((c: unknown[]) => (typeof c[0] === 'string' ? safeParse(c[0]) : null))
       .filter((p): p is { event: string } => p !== null && p.event === 'holdings_sync_applied')
     expect(syncLogs).toHaveLength(1)
   })


### PR DESCRIPTION
## Summary

Preparatory work for the deferred vitest v4 bump (Renovate PR #358 closed). This PR does NOT bump vitest itself — it only annotates the test files that vitest v4's stricter generic inference would otherwise reject under `pnpm typecheck`.

Refs: #361

### Changes

- `test/infrastructure/webull/webullTradeClient.test.ts` — pin `vi.fn()` for the `placeOrder` stub with an explicit `(intent: OrderIntent) => Promise<WebullPlaceOrderResponseDto>` generic so it satisfies `Pick<WebullHttpClient, 'placeOrder'>` under v4 (v4 widens bare `vi.fn()` to `Mock<Procedure | Constructable>`).
- `test/scheduledHandler.test.ts` — annotate `.mock.calls.map((args) => …)` callbacks as `unknown[]` (lines 106, 123, 155, 180). The previous implicit `any` was tolerated by v2 but trips `noImplicitAny` under v4-era types.
- `test/trading/reconciliation/syncHoldings.test.ts` — same `unknown[]` annotation for the `(c)` callback (line 206).

### Why now / why this isolated PR

The Renovate vitest v4 bump (#358) was closed because the bump produced ~10 typecheck failures concentrated in these three files. Landing the type annotations independently lets the next Renovate retry succeed with a pure dependency bump, keeping that PR mechanically reviewable.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 90 files / 1196 tests pass under current vitest v2 (no behaviour change)
- [ ] Follow-up: Renovate re-opens the vitest v4 bump, which should now typecheck without further edits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * テストの TypeScript 型注釈を改善し、型安全性を向上させました。モック関数とコンソール出力の型定義がより正確になり、テスト品質が向上しました。

---

**注記：** このリリースはテストインフラストラクチャの内部改善であり、エンドユーザーへの機能的な変更はありません。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/366?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->