### PR TITLE
chore(pnpm): onlyBuiltDependencies allowlist for v11 prep (#362)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,12 @@
     "typescript": "^6.0.0",
     "vitest": "^2.1.9",
     "wrangler": "^4.0.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "sharp",
+      "workerd"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- Adds `pnpm.onlyBuiltDependencies` to `package.json` listing `esbuild`, `sharp`, `workerd`.
- Prepares the repo for the next Renovate retry of the pnpm v11 bump, which previously failed in PR #359 CI install with `[ERR_PNPM_IGNORED_BUILDS]` for those three packages (pnpm v11 stops running install scripts by default; wrangler / vitest need their native binaries).
- Config-only change. pnpm itself is **not** bumped here — that stays the Renovate retry's job, keeping config and version bump in separate PRs.

Refs #362.

## Test plan

- [x] `pnpm install --frozen-lockfile` clean exit on pnpm 10.33.4 (unknown-field tolerance verified)
- [x] `pnpm typecheck` clean
- [x] `pnpm test` green — 1196 / 1196 passed (90 files), baseline matches
- [ ] CI green on the PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * パッケージマネージャーの設定を最適化し、特定のビルド済み依存パッケージの取扱いを改善しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/367?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->