### PR TITLE
chore(deps): bump pnpm to v11.3.0 (#362)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "webull-trading",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.33.4",
+  "packageManager": "pnpm@11.3.0",
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
@@ -28,12 +28,5 @@
     "vite": "^8.0.14",
     "vitest": "^4.0.0",
     "wrangler": "^4.0.0"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "sharp",
-      "workerd"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,13 @@
+# pnpm 11+ moved settings out of package.json's "pnpm" block.
+# esbuild / sharp / workerd ship native postinstall scripts that
+# wrangler / vitest / workers require — allow them explicitly.
+allowBuilds:
+  esbuild: true
+  sharp: true
+  workerd: true
+
+# pnpm 11 defaults minimumReleaseAge to 24h as a supply-chain check. That
+# blocks every fresh Renovate lockfile-bump PR for the first day, which this
+# repo can't tolerate during POC. 0 = disabled; revisit once we have a
+# non-bot release gating layer.
+minimumReleaseAge: 0


### PR DESCRIPTION
Closes #362.

## Why

#362 (pnpm v11) prep PR #367 で \`pnpm.onlyBuiltDependencies\` を package.json に追加していたが、pnpm 11 で settings の格納場所が変わって警告:
\`The \"pnpm\" field in package.json is no longer read by pnpm.\`

加えて pnpm 11 が新たに導入した supply-chain check (\`minimumReleaseAge\` default = 24h) が、Renovate が作る lockfile-bump PR を「依存が新しすぎる」として 24 時間 block する。POC では受け入れ難い。

## What

- \`package.json\`: \`packageManager: pnpm@10.33.4\` → \`pnpm@11.3.0\`、旧 \`pnpm\` block を削除
- \`pnpm-workspace.yaml\` (new): pnpm 11 の新 settings 場所
  - \`allowBuilds\`: \`esbuild\` / \`sharp\` / \`workerd\` を \`true\` (postinstall 必須)
  - \`minimumReleaseAge: 0\`: supply-chain check を disable (POC 期間限定、再評価予定)
- CI workflow は \`pnpm/action-setup@v4\` が \`packageManager\` を読むので変更なし

## Verification

- \`CI=true pnpm install --no-frozen-lockfile\` → clean (esbuild / sharp / workerd の postinstall も走った)
- \`pnpm typecheck\` clean
- \`pnpm test\` → **1196 / 1196 passing** under pnpm 11.3.0

## Follow-up

- \`minimumReleaseAge: 0\` は意図的に supply-chain hardening を disable している。production 切替 (#24) 時に non-bot release gating を入れて再評価。別 issue を切るかも。
- pnpm 11 で\`onlyBuiltDependencies\` 配列 → \`allowBuilds\` map に key 変更されたため、prep の format も同時刷新。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * パッケージマネージャーを最新バージョン（11.3.0）に更新しました。
  * ビルド関連の設定を最適化し、ネイティブスクリプト実行の処理を改善しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ochanuco/webull-trading/pull/370?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->