### PR TITLE
Production readiness preflight

### DIFF
--- a/docs/env-separation.md
+++ b/docs/env-separation.md
@@ -27,6 +27,8 @@ pnpm deploy:production
 ```
 
 scripts は `wrangler d1 migrations apply --env=<env> --remote` → `wrangler deploy --env=<env>` の 2 段。migration 失敗時は deploy 走らない。
+`pnpm deploy` は unqualified top-level deploy 事故を避けるため default では失敗する。
+意図して top-level worker を deploy する場合だけ `ALLOW_UNQUALIFIED_DEPLOY=1 pnpm deploy` を使う。
 
 ## ユーザー側の初期作業 (実マネー前)
 
@@ -119,6 +121,7 @@ staging で cron を試したい場合は `env.staging` に `triggers` を一時
 pnpm exec wrangler deploy --env=dev        --dry-run
 pnpm exec wrangler deploy --env=staging    --dry-run
 pnpm exec wrangler deploy --env=production --dry-run
+pnpm verify:production-d1
 ```
 
 dry-run 出力に出る binding 一覧 (D1 name / DO class) と cron 一覧を見て、env ごとに分離されている事を確認する。`REPLACE_WITH_*` のまま deploy しようとすると `wrangler d1 migrations apply` が先に失敗する設計。

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -28,6 +28,9 @@ pnpm wrangler d1 create webull-trading-production
 
 # Migration を流す
 pnpm wrangler d1 migrations apply webull-trading-production --env=production --remote
+
+# wrangler.jsonc の production D1 binding が placeholder でないことを確認
+pnpm verify:production-d1
 ```
 
 ### A2. Secret を production env に投入
@@ -114,7 +117,13 @@ op run -- pnpm run issue-token
   "positions":      { "phase": "response", "status": 200, "bodyTruncated": "[...]" },
   "positionsNew":   { "phase": "response", "status": 200, ... },
   "orderHistoryOld":{ "phase": "response", "status": 200, "bodyTruncated": "[]" },
-  "orderHistoryNew":{ "phase": "response", "status": 200, "bodyTruncated": "[]" }
+  "orderHistoryNew":{ "phase": "response", "status": 200, "bodyTruncated": "[]" },
+  "readiness": {
+    "tokenOk": true,
+    "tradeEndpointsOk": true,
+    "newTradeEndpointsOk": true,
+    "yahooQuoteOk": true
+  }
 }
 ```
 
@@ -159,6 +168,15 @@ op run -- pnpm run issue-token
 - `/dashboard/portfolio` で累積 PnL を観察
 - 通知 (Slack/Discord) が想定通り飛ぶか確認
 
+### C5. rollback rehearsal
+
+live 有効化前に最低 1 回、停止手段を実演して audit log に残す:
+
+- `/dashboard/config` で `dryRun=true` に戻せること
+- `/dashboard/cron` の「取引停止」ボタンで `trading_enabled=false` に落とせること
+- `pnpm wrangler secret put TRADING_ENABLED --env=production` で `false` を再投入できること
+- `/dashboard/webull-token` から token 状態を確認できること
+
 ## [D] Live 有効化
 
 paper trading で問題なければ、以下 3 step で live trade を有効化:
@@ -172,6 +190,13 @@ paper trading で問題なければ、以下 3 step で live trade を有効化:
 同 page から toggle。env override で依然強制 OFF なので発注しない (= 2 重 safety net 維持)。
 
 ### D3. env `TRADING_ENABLED` を削除
+
+削除前に preflight を実行:
+
+```bash
+curl https://trading.chanu.co/admin/production-readiness
+# → "ready": true かつ fail check が無いこと
+```
 
 ```bash
 pnpm wrangler secret delete TRADING_ENABLED --env=production

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "packageManager": "pnpm@11.3.0",
   "scripts": {
     "dev": "wrangler dev",
-    "deploy": "wrangler deploy",
+    "deploy": "tsx scripts/guard-deploy.ts && wrangler deploy",
     "deploy:dev": "wrangler d1 migrations apply webull-trading-dev --env=dev --remote && wrangler deploy --env=dev",
     "deploy:staging": "wrangler d1 migrations apply webull-trading-staging --env=staging --remote && wrangler deploy --env=staging",
     "deploy:production": "wrangler d1 migrations apply webull-trading-production --env=production --remote && wrangler deploy --env=production",
@@ -13,7 +13,8 @@
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "accounts": "tsx scripts/list-webull-accounts.ts",
-    "issue-token": "tsx scripts/issue-webull-token.ts"
+    "issue-token": "tsx scripts/issue-webull-token.ts",
+    "verify:production-d1": "tsx scripts/verify-production-d1.ts"
   },
   "dependencies": {
     "drizzle-orm": "^0.45.2",

--- a/scripts/guard-deploy.ts
+++ b/scripts/guard-deploy.ts
@@ -1,0 +1,15 @@
+const allow = process.env.ALLOW_UNQUALIFIED_DEPLOY
+
+if (allow === '1' || allow === 'true') {
+  console.warn('ALLOW_UNQUALIFIED_DEPLOY is set; continuing with top-level wrangler deploy.')
+  process.exit(0)
+}
+
+console.error(
+  [
+    'Refusing unqualified deploy.',
+    'Use pnpm deploy:dev, pnpm deploy:staging, or pnpm deploy:production.',
+    'For a deliberate top-level deploy, rerun with ALLOW_UNQUALIFIED_DEPLOY=1.',
+  ].join('\n'),
+)
+process.exit(1)

--- a/scripts/verify-production-d1.ts
+++ b/scripts/verify-production-d1.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs'
+
+const configPath = process.argv[2] ?? 'wrangler.jsonc'
+const wrangler = readFileSync(configPath, 'utf8')
+const prodBlock = wrangler.match(/"production"\s*:\s*\{[\s\S]*?"d1_databases"\s*:\s*\[[\s\S]*?\{([\s\S]*?)\}[\s\S]*?\]/)
+const databaseName = prodBlock?.[1]?.match(/"database_name"\s*:\s*"([^"]+)"/)?.[1] ?? null
+const databaseId = prodBlock?.[1]?.match(/"database_id"\s*:\s*"([^"]+)"/)?.[1] ?? null
+
+const failures: string[] = []
+if (databaseName !== 'webull-trading-production') {
+  failures.push(`expected production database_name=webull-trading-production, got ${databaseName ?? '<missing>'}`)
+}
+if (!databaseId || databaseId === 'REPLACE_WITH_PRODUCTION_ID') {
+  failures.push('production database_id is missing or still set to REPLACE_WITH_PRODUCTION_ID')
+}
+
+if (failures.length > 0) {
+  console.error(`Production D1 verification failed:\n- ${failures.join('\n- ')}`)
+  process.exit(1)
+}
+
+console.log(`Production D1 binding looks configured: ${databaseName} (${databaseId})`)

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -464,3 +464,15 @@ import type { WebullTokenStateDO } from '../trading/state/WebullTokenStateDO'
 export interface Env {
   WEBULL_TOKEN_STATE?: DurableObjectNamespace<WebullTokenStateDO>
 }
+
+
+// #379 / #376: first-live production readiness policy. These are not trading
+// gates by themselves; they bound `/admin/production-readiness` so the operator
+// gets a fail-closed preflight before deleting the production TRADING_ENABLED
+// deploy gate.
+export interface Env {
+  FIRST_LIVE_MAX_ACTIVE_SYMBOLS?: string
+  FIRST_LIVE_MAX_ORDER_NOTIONAL_USD?: string
+  FIRST_LIVE_MAX_ORDER_NOTIONAL_JPY?: string
+  ROLLBACK_REHEARSAL_MAX_AGE_HOURS?: string
+}

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -40,6 +40,7 @@ import {
   createTradingToggleDb,
 } from '../infrastructure/db/tradingToggleRepo'
 import { resolveTradingEnabled } from '../trading/runtime/killSwitch'
+import { collectProductionReadiness } from '../trading/runtime/productionReadiness'
 import {
   createEarningsCalendarDb,
   createEarningsCalendarRepo,
@@ -59,6 +60,15 @@ import type { SymbolRule } from '../trading/strategy/strategies/PullbackUptrendS
  * and should only be called for initial seeding or reconciliation.
  */
 export const admin = new Hono<AppBindings>()
+  /**
+   * Production readiness preflight (#375-#380)。Read-only: D1 / DO / env の
+   * 現在状態を集約し、live enablement 前に fail-closed で確認できるようにする。
+   * Broker 実通信は `/admin/broker/probe` に分離し、ここでは発注経路に触れない。
+   */
+  .get('/production-readiness', async (c) => {
+    c.header('Cache-Control', 'no-store')
+    return c.json(await collectProductionReadiness(c.env, c.get('requestId')))
+  })
   /**
    * Operator override for a corrupted `position`. Used when a past reconcile
    * race left DO state with a qty above broker truth (#215) — the regular
@@ -802,6 +812,20 @@ export const admin = new Hono<AppBindings>()
       // Yahoo Finance 経由の同 symbol snapshot (#21 follow-up)。Webull の data-api
       // が応答しない状況での代替経路の生死を可視化する。
       quoteYahoo: quoteYahooResult,
+      readiness: {
+        tokenOk: tokenResolved.source === 'do_normal',
+        tradeEndpointsOk:
+          positionsOld.phase === 'response' &&
+          positionsOld.status === 200 &&
+          orderHistoryOld.phase === 'response' &&
+          orderHistoryOld.status === 200,
+        newTradeEndpointsOk:
+          positionsNew.phase === 'response' &&
+          positionsNew.status === 200 &&
+          orderHistoryNew.phase === 'response' &&
+          orderHistoryNew.status === 200,
+        yahooQuoteOk: quoteYahooResult.phase === 'response' && quoteYahooResult.status === 200,
+      },
     })
   })
   /**

--- a/src/trading/runtime/productionReadiness.ts
+++ b/src/trading/runtime/productionReadiness.ts
@@ -1,0 +1,363 @@
+import { desc } from 'drizzle-orm'
+import type { Env } from '../../config/env'
+import { loadGlobalConfigFrom } from '../../infrastructure/db/globalConfigLoader'
+import { loadSymbolUniverse } from '../../infrastructure/db/symbolUniverse'
+import { tradingToggleHistory } from '../../infrastructure/db/schema'
+import { createDb } from '../../infrastructure/db/tradeJournalRepo'
+import { resolveAccessTokenWithSource } from '../../infrastructure/webull/resolveAccessToken'
+import { WebullTokenStateClient } from '../state/WebullTokenStateClient'
+import { resolveTradingEnabled } from './killSwitch'
+
+export type ReadinessSeverity = 'pass' | 'warn' | 'fail'
+
+export interface ProductionReadinessCheck {
+  id: string
+  severity: ReadinessSeverity
+  message: string
+  details?: Record<string, unknown>
+}
+
+export interface ProductionReadinessPolicy {
+  maxActiveSymbols: number
+  maxOrderNotionalUsd: number
+  maxOrderNotionalJpy: number
+  rollbackRehearsalMaxAgeHours: number
+}
+
+export interface ProductionReadinessReport {
+  timestamp: string
+  ready: boolean
+  policy: ProductionReadinessPolicy
+  state: {
+    environment: string | null
+    dryRun: boolean | null
+    dbTradingEnabled: boolean | null
+    effectiveTradingEnabled: boolean | null
+    envTradingEnabledRaw: string | null
+    envOverrideActive: boolean | null
+    activeSymbols: string[]
+    maxOrderNotionalUsd: number | null
+    maxOrderNotionalJpy: number | null
+    marketHoursCheck: boolean | null
+    tokenSource: string | null
+    tokenStatus: string | null
+    tokenExpires: number | null
+    lastRollbackRehearsalAt: string | null
+  }
+  checks: ProductionReadinessCheck[]
+}
+
+const DEFAULT_POLICY: ProductionReadinessPolicy = Object.freeze({
+  maxActiveSymbols: 2,
+  maxOrderNotionalUsd: 500,
+  maxOrderNotionalJpy: 100_000,
+  rollbackRehearsalMaxAgeHours: 72,
+})
+
+export function parseProductionReadinessPolicy(env: Env): ProductionReadinessPolicy {
+  return {
+    maxActiveSymbols: parsePositiveInt(env.FIRST_LIVE_MAX_ACTIVE_SYMBOLS, DEFAULT_POLICY.maxActiveSymbols),
+    maxOrderNotionalUsd: parsePositiveNumber(
+      env.FIRST_LIVE_MAX_ORDER_NOTIONAL_USD,
+      DEFAULT_POLICY.maxOrderNotionalUsd,
+    ),
+    maxOrderNotionalJpy: parsePositiveNumber(
+      env.FIRST_LIVE_MAX_ORDER_NOTIONAL_JPY,
+      DEFAULT_POLICY.maxOrderNotionalJpy,
+    ),
+    rollbackRehearsalMaxAgeHours: parsePositiveNumber(
+      env.ROLLBACK_REHEARSAL_MAX_AGE_HOURS,
+      DEFAULT_POLICY.rollbackRehearsalMaxAgeHours,
+    ),
+  }
+}
+
+export async function collectProductionReadiness(
+  env: Env,
+  requestId?: string,
+  now: Date = new Date(),
+): Promise<ProductionReadinessReport> {
+  const policy = parseProductionReadinessPolicy(env)
+  const checks: ProductionReadinessCheck[] = []
+  const label = normalizeOptional(env.ENVIRONMENT)
+  const envTradingRaw = env.TRADING_ENABLED ?? null
+  const globalResult = await loadOptional('global_config', () => loadGlobalConfigFrom(env, requestId))
+  const universeResult = await loadOptional('symbol_universe', () => loadSymbolUniverse(env))
+  const tokenResult = await resolveAccessTokenWithSource(env)
+  const tokenState = await loadTokenState(env)
+  const rollbackRehearsal = await loadLatestRollbackRehearsal(env)
+
+  if (!globalResult.ok) {
+    checks.push({
+      id: 'global_config_load',
+      severity: 'fail',
+      message: 'global_config could not be loaded from production D1',
+      details: { error: globalResult.error },
+    })
+  }
+  if (!universeResult.ok) {
+    checks.push({
+      id: 'symbol_universe_load',
+      severity: 'fail',
+      message: 'symbol universe could not be loaded from production D1',
+      details: { error: universeResult.error },
+    })
+  }
+
+  const global = globalResult.ok ? globalResult.value : null
+  const universe = universeResult.ok ? universeResult.value : null
+  const effectiveTrading = global
+    ? resolveTradingEnabled(global.tradingEnabled, env.TRADING_ENABLED)
+    : null
+  const envOverrideActive = global ? effectiveTrading !== global.tradingEnabled : null
+
+  pushCheck(checks, {
+    id: 'environment_label',
+    ok: label === 'production',
+    failMessage: 'ENVIRONMENT must be production before live trading can be enabled',
+    passMessage: 'ENVIRONMENT is production',
+    details: { environment: label },
+  })
+
+  pushCheck(checks, {
+    id: 'deploy_gate_staged',
+    ok: env.TRADING_ENABLED === 'false',
+    failMessage: 'TRADING_ENABLED=false should remain set until the final live enablement step',
+    passMessage: 'TRADING_ENABLED=false deploy gate is still blocking live orders',
+    details: { raw: envTradingRaw, effectiveTradingEnabled: effectiveTrading },
+  })
+
+  if (global) {
+    pushCheck(checks, {
+      id: 'dry_run_staged_off',
+      ok: global.dryRun === false,
+      failMessage: 'D1 dryRun should be false only after the operator intentionally stages live enablement',
+      passMessage: 'D1 dryRun=false is staged',
+      details: { dryRun: global.dryRun },
+    })
+    pushCheck(checks, {
+      id: 'db_trading_enabled_staged_on',
+      ok: global.tradingEnabled === true,
+      failMessage: 'D1 trading_enabled should be true before deleting the deploy gate',
+      passMessage: 'D1 trading_enabled=true is staged',
+      details: { dbTradingEnabled: global.tradingEnabled, effectiveTradingEnabled: effectiveTrading },
+    })
+    pushCheck(checks, {
+      id: 'market_hours_check',
+      ok: global.marketHoursCheck === true,
+      failMessage: 'marketHoursCheck must be enabled before live trading',
+      passMessage: 'marketHoursCheck is enabled',
+    })
+    pushCheck(checks, {
+      id: 'max_order_notional_usd',
+      ok: global.maxOrderNotionalUsd <= policy.maxOrderNotionalUsd,
+      failMessage: 'USD max order notional exceeds first-live policy',
+      passMessage: 'USD max order notional is within first-live policy',
+      details: { configured: global.maxOrderNotionalUsd, limit: policy.maxOrderNotionalUsd },
+    })
+    pushCheck(checks, {
+      id: 'max_order_notional_jpy',
+      ok: global.maxOrderNotionalJpy <= policy.maxOrderNotionalJpy,
+      failMessage: 'JPY max order notional exceeds first-live policy',
+      passMessage: 'JPY max order notional is within first-live policy',
+      details: { configured: global.maxOrderNotionalJpy, limit: policy.maxOrderNotionalJpy },
+    })
+  }
+
+  if (universe) {
+    pushCheck(checks, {
+      id: 'active_symbol_count',
+      ok: universe.allowedSymbols.length > 0 && universe.allowedSymbols.length <= policy.maxActiveSymbols,
+      failMessage: 'active symbol universe must be narrow for first live enablement',
+      passMessage: 'active symbol universe is narrow for first live enablement',
+      details: { activeSymbols: universe.allowedSymbols, limit: policy.maxActiveSymbols },
+    })
+    const oversizedSymbolCaps = Object.entries(universe.symbolMaxNotional).filter(([symbol, limit]) => {
+      const currency = universe.symbolCurrency[symbol] ?? 'USD'
+      return limit > (currency === 'JPY' ? policy.maxOrderNotionalJpy : policy.maxOrderNotionalUsd)
+    })
+    pushCheck(checks, {
+      id: 'per_symbol_notional_caps',
+      ok: oversizedSymbolCaps.length === 0,
+      failMessage: 'one or more per-symbol notional caps exceed first-live policy',
+      passMessage: 'per-symbol notional caps are within first-live policy',
+      details: { oversized: oversizedSymbolCaps },
+    })
+  }
+
+  pushCheck(checks, {
+    id: 'webull_credentials',
+    ok: hasTrimmed(env.WEBULL_APP_KEY) &&
+      hasTrimmed(env.WEBULL_APP_SECRET) &&
+      hasTrimmed(env.WEBULL_ACCOUNT_ID_JP_CASH),
+    failMessage: 'Webull app key, app secret, and JP cash account ID must all be configured',
+    passMessage: 'Webull credential bindings are present',
+    details: {
+      appKeyPresent: hasTrimmed(env.WEBULL_APP_KEY),
+      appSecretPresent: hasTrimmed(env.WEBULL_APP_SECRET),
+      accountIdPresent: hasTrimmed(env.WEBULL_ACCOUNT_ID_JP_CASH),
+    },
+  })
+
+  pushCheck(checks, {
+    id: 'webull_token_source',
+    ok: tokenResult.source === 'do_normal',
+    failMessage: 'Webull token must resolve from WEBULL_TOKEN_STATE with NORMAL status',
+    passMessage: 'Webull token resolves from DO with NORMAL status',
+    details: { source: tokenResult.source, doStatus: tokenResult.doStatus ?? null },
+  })
+
+  pushCheck(checks, {
+    id: 'cloudflare_access',
+    ok: hasTrimmed(env.CF_ACCESS_TEAM_DOMAIN) && hasTrimmed(env.CF_ACCESS_AUD),
+    failMessage: 'Cloudflare Access team domain and AUD must be configured',
+    passMessage: 'Cloudflare Access config is present',
+    details: {
+      teamDomainPresent: hasTrimmed(env.CF_ACCESS_TEAM_DOMAIN),
+      audPresent: hasTrimmed(env.CF_ACCESS_AUD),
+    },
+  })
+  pushCheck(checks, {
+    id: 'dev_bypass_absent',
+    ok: label !== 'production' || !hasTrimmed(env.ACCESS_DEV_BYPASS_USER),
+    failMessage: 'ACCESS_DEV_BYPASS_USER must not be set in production',
+    passMessage: 'production dev bypass secret is absent',
+  })
+
+  const rehearsalFresh = isRecentIso(
+    rollbackRehearsal.timestamp,
+    now,
+    policy.rollbackRehearsalMaxAgeHours,
+  )
+  checks.push({
+    id: 'rollback_rehearsal',
+    severity: rehearsalFresh ? 'pass' : 'warn',
+    message: rehearsalFresh
+      ? 'recent rollback/kill-switch rehearsal is recorded'
+      : 'no recent rollback rehearsal was found; rehearse rollback before first live trade',
+    details: {
+      lastRollbackRehearsalAt: rollbackRehearsal.timestamp,
+      reason: rollbackRehearsal.reason,
+      maxAgeHours: policy.rollbackRehearsalMaxAgeHours,
+    },
+  })
+
+  checks.push({
+    id: 'broker_probe',
+    severity: 'warn',
+    message: 'run /admin/broker/probe immediately before deleting TRADING_ENABLED',
+    details: {
+      expected: 'positions/order history endpoints return 200 and token source is do_normal',
+    },
+  })
+
+  return {
+    timestamp: now.toISOString(),
+    ready: checks.every((check) => check.severity !== 'fail'),
+    policy,
+    state: {
+      environment: label,
+      dryRun: global?.dryRun ?? null,
+      dbTradingEnabled: global?.tradingEnabled ?? null,
+      effectiveTradingEnabled: effectiveTrading,
+      envTradingEnabledRaw: envTradingRaw,
+      envOverrideActive,
+      activeSymbols: universe?.allowedSymbols ?? [],
+      maxOrderNotionalUsd: global?.maxOrderNotionalUsd ?? null,
+      maxOrderNotionalJpy: global?.maxOrderNotionalJpy ?? null,
+      marketHoursCheck: global?.marketHoursCheck ?? null,
+      tokenSource: tokenResult.source,
+      tokenStatus: tokenState?.status ?? tokenResult.doStatus ?? null,
+      tokenExpires: tokenState?.expires ?? null,
+      lastRollbackRehearsalAt: rollbackRehearsal.timestamp,
+    },
+    checks,
+  }
+}
+
+async function loadOptional<T>(
+  id: string,
+  fn: () => Promise<T>,
+): Promise<{ ok: true; value: T } | { ok: false; error: string; id: string }> {
+  try {
+    return { ok: true, value: await fn() }
+  } catch (error) {
+    return { ok: false, id, error: error instanceof Error ? error.message : String(error) }
+  }
+}
+
+async function loadTokenState(env: Env) {
+  if (!env.WEBULL_TOKEN_STATE) return null
+  try {
+    return await new WebullTokenStateClient(env.WEBULL_TOKEN_STATE).getState()
+  } catch {
+    return null
+  }
+}
+
+async function loadLatestRollbackRehearsal(env: Env): Promise<{
+  timestamp: string | null
+  reason: string | null
+}> {
+  if (!env.DB) return { timestamp: null, reason: null }
+  try {
+    const db = createDb(env.DB)
+    const rows = await db
+      .select({
+        timestamp: tradingToggleHistory.timestamp,
+        reason: tradingToggleHistory.reason,
+      })
+      .from(tradingToggleHistory)
+      .orderBy(desc(tradingToggleHistory.timestamp))
+      .limit(1)
+    const row = rows[0]
+    return { timestamp: row?.timestamp ?? null, reason: row?.reason ?? null }
+  } catch {
+    return { timestamp: null, reason: null }
+  }
+}
+
+function pushCheck(
+  checks: ProductionReadinessCheck[],
+  input: {
+    id: string
+    ok: boolean
+    passMessage: string
+    failMessage: string
+    details?: Record<string, unknown>
+  },
+): void {
+  checks.push({
+    id: input.id,
+    severity: input.ok ? 'pass' : 'fail',
+    message: input.ok ? input.passMessage : input.failMessage,
+    ...(input.details ? { details: input.details } : {}),
+  })
+}
+
+function normalizeOptional(value: string | undefined): string | null {
+  const trimmed = value?.trim()
+  return trimmed && trimmed.length > 0 ? trimmed : null
+}
+
+function hasTrimmed(value: string | undefined): boolean {
+  return (value ?? '').trim().length > 0
+}
+
+function parsePositiveNumber(value: string | undefined, fallback: number): number {
+  if (value === undefined || value.trim() === '') return fallback
+  const parsed = Number(value)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  const parsed = parsePositiveNumber(value, fallback)
+  return Math.max(1, Math.floor(parsed))
+}
+
+function isRecentIso(value: string | null, now: Date, maxAgeHours: number): boolean {
+  if (!value) return false
+  const timestamp = Date.parse(value)
+  if (!Number.isFinite(timestamp)) return false
+  return now.getTime() - timestamp <= maxAgeHours * 60 * 60 * 1000
+}

--- a/test/routes/adminProductionReadiness.test.ts
+++ b/test/routes/adminProductionReadiness.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp } from '../../src/app'
+import type { Env } from '../../src/config/env'
+import { loadGlobalConfigFrom } from '../../src/infrastructure/db/globalConfigLoader'
+import { loadSymbolUniverse } from '../../src/infrastructure/db/symbolUniverse'
+import { createDb } from '../../src/infrastructure/db/tradeJournalRepo'
+import { makeGlobalConfigSnapshot, makeSymbolUniverse } from '../helpers/configFixtures'
+
+vi.mock('../../src/infrastructure/db/globalConfigLoader', () => ({
+  loadGlobalConfigFrom: vi.fn(),
+}))
+vi.mock('../../src/infrastructure/db/symbolUniverse', () => ({
+  loadSymbolUniverse: vi.fn(),
+}))
+vi.mock('../../src/infrastructure/db/tradeJournalRepo', () => ({
+  createDb: vi.fn(),
+}))
+
+const authEnv = {
+  ACCESS_DEV_BYPASS_USER: 'admin',
+  SYMBOL_STATE: {} as Env['SYMBOL_STATE'],
+  ENVIRONMENT: 'production',
+  TRADING_ENABLED: 'false',
+  WEBULL_APP_KEY: 'app-key',
+  WEBULL_APP_SECRET: 'app-secret',
+  WEBULL_ACCOUNT_ID_JP_CASH: 'account',
+  CF_ACCESS_TEAM_DOMAIN: 'https://team.cloudflareaccess.com',
+  CF_ACCESS_AUD: 'aud',
+  DB: {} as D1Database,
+}
+
+function fakeTokenNamespace() {
+  const stub = {
+    async getState() {
+      return {
+        token: 'tok_live_1234567890',
+        expires: 1_800_000_000,
+        status: 'NORMAL',
+        fetchedAt: '2026-06-01T00:00:00.000Z',
+        lastAttemptAt: '2026-06-01T00:00:00.000Z',
+        lastSuccessAt: '2026-06-01T00:00:00.000Z',
+      }
+    },
+  }
+  return {
+    idFromName: () => 'id',
+    get: () => stub,
+  } as unknown as Env['WEBULL_TOKEN_STATE']
+}
+
+function fakeToggleHistory() {
+  const query = {
+    from: vi.fn(() => query),
+    orderBy: vi.fn(() => query),
+    limit: vi.fn(async () => [{ timestamp: '2026-06-01T00:00:00.000Z', reason: 'rehearsal' }]),
+  }
+  return { select: vi.fn(() => query) }
+}
+
+describe('GET /admin/production-readiness', () => {
+  beforeEach(() => {
+    vi.mocked(loadGlobalConfigFrom).mockResolvedValue(
+      makeGlobalConfigSnapshot({
+        dryRun: false,
+        tradingEnabled: true,
+        marketHoursCheck: true,
+        maxOrderNotionalUsd: 250,
+        maxOrderNotionalJpy: 50_000,
+      }),
+    )
+    vi.mocked(loadSymbolUniverse).mockResolvedValue(
+      makeSymbolUniverse({ allowedSymbols: ['SOXL'], symbolMaxNotional: { SOXL: 250 } }),
+    )
+    vi.mocked(createDb).mockReturnValue(fakeToggleHistory() as never)
+  })
+
+  afterEach(() => vi.resetAllMocks())
+
+  it('401s without Access JWT or dev bypass', async () => {
+    const app = createApp()
+    const res = await app.request('/admin/production-readiness', {}, {
+      SYMBOL_STATE: {} as Env['SYMBOL_STATE'],
+    })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns no-store JSON readiness report', async () => {
+    const app = createApp()
+    const res = await app.request('/admin/production-readiness', {}, {
+      ...authEnv,
+      CF_ACCESS_TEAM_DOMAIN: undefined,
+      CF_ACCESS_AUD: undefined,
+      WEBULL_TOKEN_STATE: fakeTokenNamespace(),
+    })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Cache-Control')).toBe('no-store')
+    const body = (await res.json()) as {
+      ready: boolean
+      checks: Array<{ id: string; severity: string }>
+      state: { tokenSource: string; envOverrideActive: boolean }
+    }
+    expect(body.ready).toBe(false)
+    expect(body.state.tokenSource).toBe('do_normal')
+    expect(body.state.envOverrideActive).toBe(true)
+    expect(body.checks.find((check) => check.id === 'deploy_gate_staged')?.severity).toBe('pass')
+    expect(body.checks.find((check) => check.id === 'cloudflare_access')?.severity).toBe('fail')
+  })
+})

--- a/test/trading/runtime/productionReadiness.test.ts
+++ b/test/trading/runtime/productionReadiness.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { collectProductionReadiness } from '../../../src/trading/runtime/productionReadiness'
+import type { Env } from '../../../src/config/env'
+import { loadGlobalConfigFrom } from '../../../src/infrastructure/db/globalConfigLoader'
+import { loadSymbolUniverse } from '../../../src/infrastructure/db/symbolUniverse'
+import { createDb } from '../../../src/infrastructure/db/tradeJournalRepo'
+import { makeGlobalConfigSnapshot, makeSymbolUniverse } from '../../helpers/configFixtures'
+
+vi.mock('../../../src/infrastructure/db/globalConfigLoader', () => ({
+  loadGlobalConfigFrom: vi.fn(),
+}))
+vi.mock('../../../src/infrastructure/db/symbolUniverse', () => ({
+  loadSymbolUniverse: vi.fn(),
+}))
+vi.mock('../../../src/infrastructure/db/tradeJournalRepo', () => ({
+  createDb: vi.fn(),
+}))
+
+function fakeTokenNamespace(status: 'NORMAL' | 'INVALID' = 'NORMAL') {
+  const stub = {
+    async getState() {
+      return {
+        token: status === 'NORMAL' ? 'tok_live_1234567890' : '',
+        expires: 1_800_000_000,
+        status,
+        fetchedAt: '2026-06-01T00:00:00.000Z',
+        lastAttemptAt: '2026-06-01T00:00:00.000Z',
+        lastSuccessAt: status === 'NORMAL' ? '2026-06-01T00:00:00.000Z' : null,
+      }
+    },
+  }
+  return {
+    idFromName: () => 'id',
+    get: () => stub,
+  } as unknown as Env['WEBULL_TOKEN_STATE']
+}
+
+function fakeToggleHistory(timestamp: string | null) {
+  const query = {
+    from: vi.fn(() => query),
+    orderBy: vi.fn(() => query),
+    limit: vi.fn(async () => timestamp ? [{ timestamp, reason: 'rollback rehearsal' }] : []),
+  }
+  return { select: vi.fn(() => query) }
+}
+
+describe('collectProductionReadiness', () => {
+  beforeEach(() => {
+    vi.mocked(loadGlobalConfigFrom).mockResolvedValue(
+      makeGlobalConfigSnapshot({
+        dryRun: false,
+        tradingEnabled: true,
+        marketHoursCheck: true,
+        maxOrderNotionalUsd: 250,
+        maxOrderNotionalJpy: 50_000,
+      }),
+    )
+    vi.mocked(loadSymbolUniverse).mockResolvedValue(
+      makeSymbolUniverse({
+        allowedSymbols: ['SOXL'],
+        symbolMaxNotional: { SOXL: 250 },
+        symbolCurrency: { SOXL: 'USD' },
+      }),
+    )
+    vi.mocked(createDb).mockReturnValue(fakeToggleHistory('2026-05-31T00:00:00.000Z') as never)
+  })
+
+  afterEach(() => vi.resetAllMocks())
+
+  it('passes the first-live preflight when all hard gates are staged safely', async () => {
+    const report = await collectProductionReadiness(
+      {
+        SYMBOL_STATE: {} as Env['SYMBOL_STATE'],
+        ENVIRONMENT: 'production',
+        TRADING_ENABLED: 'false',
+        WEBULL_APP_KEY: 'app-key',
+        WEBULL_APP_SECRET: 'app-secret',
+        WEBULL_ACCOUNT_ID_JP_CASH: 'account',
+        CF_ACCESS_TEAM_DOMAIN: 'https://team.cloudflareaccess.com',
+        CF_ACCESS_AUD: 'aud',
+        WEBULL_TOKEN_STATE: fakeTokenNamespace(),
+        DB: {} as D1Database,
+      } as Env,
+      'req-1',
+      new Date('2026-06-01T00:00:00.000Z'),
+    )
+
+    expect(report.ready).toBe(true)
+    expect(report.checks.filter((check) => check.severity === 'fail')).toEqual([])
+    expect(report.state.effectiveTradingEnabled).toBe(false)
+    expect(report.state.envOverrideActive).toBe(true)
+    expect(report.state.tokenSource).toBe('do_normal')
+  })
+
+  it('fails when the live deploy gate is already removed before preflight', async () => {
+    const report = await collectProductionReadiness(
+      {
+        SYMBOL_STATE: {} as Env['SYMBOL_STATE'],
+        ENVIRONMENT: 'production',
+        WEBULL_APP_KEY: 'app-key',
+        WEBULL_APP_SECRET: 'app-secret',
+        WEBULL_ACCOUNT_ID_JP_CASH: 'account',
+        CF_ACCESS_TEAM_DOMAIN: 'https://team.cloudflareaccess.com',
+        CF_ACCESS_AUD: 'aud',
+        WEBULL_TOKEN_STATE: fakeTokenNamespace(),
+        DB: {} as D1Database,
+      } as Env,
+      'req-2',
+      new Date('2026-06-01T00:00:00.000Z'),
+    )
+
+    expect(report.ready).toBe(false)
+    expect(report.checks.find((check) => check.id === 'deploy_gate_staged')?.severity).toBe('fail')
+    expect(report.state.effectiveTradingEnabled).toBe(true)
+  })
+
+  it('fails on wide universe, oversized limits, missing Access, and non-DO token', async () => {
+    vi.mocked(loadGlobalConfigFrom).mockResolvedValue(
+      makeGlobalConfigSnapshot({
+        dryRun: false,
+        tradingEnabled: true,
+        marketHoursCheck: true,
+        maxOrderNotionalUsd: 2_000,
+      }),
+    )
+    vi.mocked(loadSymbolUniverse).mockResolvedValue(
+      makeSymbolUniverse({ allowedSymbols: ['SOXL', 'SOXS', 'QQQ'] }),
+    )
+
+    const report = await collectProductionReadiness(
+      {
+        SYMBOL_STATE: {} as Env['SYMBOL_STATE'],
+        ENVIRONMENT: 'production',
+        TRADING_ENABLED: 'false',
+        WEBULL_APP_KEY: 'app-key',
+        WEBULL_APP_SECRET: 'app-secret',
+        WEBULL_ACCOUNT_ID_JP_CASH: 'account',
+        WEBULL_ACCESS_TOKEN: 'env-fallback-token',
+        ACCESS_DEV_BYPASS_USER: 'admin',
+        DB: {} as D1Database,
+      } as Env,
+      'req-3',
+      new Date('2026-06-01T00:00:00.000Z'),
+    )
+
+    const failed = report.checks.filter((check) => check.severity === 'fail').map((check) => check.id)
+    expect(failed).toEqual(expect.arrayContaining([
+      'max_order_notional_usd',
+      'active_symbol_count',
+      'webull_token_source',
+      'cloudflare_access',
+      'dev_bypass_absent',
+    ]))
+  })
+})


### PR DESCRIPTION
## Summary
- add read-only /admin/production-readiness preflight for first-live operations
- add broker probe readiness summary, unqualified deploy guard, and production D1 placeholder verification
- update production runbook with D1 verification, rollback rehearsal, and preflight steps

## Verification
- pnpm exec tsc --noEmit
- pnpm exec vitest run
- pnpm run deploy (expected guard failure)
- pnpm exec tsx scripts/verify-production-d1.ts (expected placeholder failure)

Closes #375
Closes #376
Closes #377
Closes #378
Closes #379
Closes #380

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 本番環境のデプロイ前に安全性を確認するプリフライト検査エンドポイントを追加しました
  * デプロイ前のガード機構を導入し、意図しないデプロイを防止します

* **Documentation**
  * 本番デプロイ手順を詳細化し、検証手順とロールバック予行プロセスを追加しました
  * デプロイ時の環境変数設定ガイダンスを追加しました

* **Chores**
  * デプロイおよび本番環境検証用スクリプトを追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->