### PR TITLE
fix: skip production release PR when unchanged

### DIFF
--- a/.github/workflows/production-release-pr.yml
+++ b/.github/workflows/production-release-pr.yml
@@ -60,7 +60,25 @@ jobs:
           git checkout -B release/production origin/main
           git push --force-with-lease "https://x-access-token:${PRODUCTION_RELEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" release/production
 
+      - name: Check production delta
+        id: production_delta
+        env:
+          PRODUCTION_RELEASE_TOKEN: ${{ secrets.PRODUCTION_RELEASE_TOKEN }}
+        run: |
+          remote="https://x-access-token:${PRODUCTION_RELEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git fetch --no-tags "$remote" production:refs/remotes/origin/production
+
+          ahead_count="$(git rev-list --count origin/production..release/production)"
+          if [ "$ahead_count" = "0" ]; then
+            echo "::notice::production is already up to date with main; skipping production release PR creation."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "release/production is $ahead_count commit(s) ahead of production."
+          fi
+
       - name: Create or update production PR
+        if: steps.production_delta.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ secrets.PRODUCTION_RELEASE_TOKEN }}
           TITLE: "release: promote main to production [skip-coderabbit]"

--- a/docs/production-cd.md
+++ b/docs/production-cd.md
@@ -38,6 +38,8 @@ pnpm install --frozen-lockfile && pnpm deploy:production
 
 この PR は「コードの再レビュー」ではなく「本番昇格の承認ゲート」。title に `[skip-coderabbit]` を含め、`.coderabbit.yaml` 側でも CodeRabbit auto review を skip する。
 
+`production` がすでに `main` と同じ commit を指している場合、release PR に差分がないため workflow は PR 作成を skip して success にする。初回 bootstrap 直後や、production が main に追いついている状態ではこれが期待値。
+
 この workflow は default `GITHUB_TOKEN` を使わず、repository secret `PRODUCTION_RELEASE_TOKEN` を必須にする。`GITHUB_TOKEN` で workflow から PR を作成/更新すると、その PR の `pull_request` workflow が自動実行されず approval 待ちになり得るため。
 
 `PRODUCTION_RELEASE_TOKEN` は fine-grained PAT か GitHub App installation token を使う。必要権限:


### PR DESCRIPTION
## Summary

- skip production release PR creation when production is already up to date with main
- document the expected no-op behavior after bootstrap

## Verification

- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/production-release-pr.yml
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 本番リリースワークフローを最適化し、変更がない場合はPR作成をスキップするように改善しました。
  * 本番環境デプロイメントプロセスのドキュメントを更新し、動作の明確化を実施しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->