### PR TITLE
fix: use explicit lease for production release branch

### DIFF
--- a/.github/workflows/production-release-pr.yml
+++ b/.github/workflows/production-release-pr.yml
@@ -55,10 +55,18 @@ jobs:
         env:
           PRODUCTION_RELEASE_TOKEN: ${{ secrets.PRODUCTION_RELEASE_TOKEN }}
         run: |
+          remote="https://x-access-token:${PRODUCTION_RELEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          remote_release_sha="$(git ls-remote --heads "$remote" release/production | cut -f1)"
+
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -B release/production origin/main
-          git push --force-with-lease "https://x-access-token:${PRODUCTION_RELEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" release/production
+
+          if [ -n "$remote_release_sha" ]; then
+            git push --force-with-lease=refs/heads/release/production:"$remote_release_sha" "$remote" release/production:refs/heads/release/production
+          else
+            git push "$remote" release/production:refs/heads/release/production
+          fi
 
       - name: Check production delta
         id: production_delta


### PR DESCRIPTION
## Summary

- read the current remote release/production SHA before updating the release branch
- pass that SHA to --force-with-lease so the workflow does not fail with stale info while still protecting concurrent updates

## Verification

- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/production-release-pr.yml
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * リリースプロセスの安全性を向上。本番リリースブランチの更新時に、既存ブランチと新規作成で異なる処理フローを採用することで、より堅牢で安全な更新メカニズムを実現。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->