### PR TITLE
fix: retry production release branch push

### DIFF
--- a/.github/workflows/production-release-pr.yml
+++ b/.github/workflows/production-release-pr.yml
@@ -62,10 +62,27 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -B release/production origin/main
 
+          push_with_retry() {
+            attempt=1
+            while [ "$attempt" -le 3 ]; do
+              if "$@"; then
+                return 0
+              fi
+
+              if [ "$attempt" = "3" ]; then
+                return 1
+              fi
+
+              echo "::notice::git push failed; retrying in $((attempt * 5)) seconds."
+              sleep $((attempt * 5))
+              attempt=$((attempt + 1))
+            done
+          }
+
           if [ -n "$remote_release_sha" ]; then
-            git push --force-with-lease=refs/heads/release/production:"$remote_release_sha" "$remote" release/production:refs/heads/release/production
+            push_with_retry git push --force-with-lease=refs/heads/release/production:"$remote_release_sha" "$remote" release/production:refs/heads/release/production
           else
-            git push "$remote" release/production:refs/heads/release/production
+            push_with_retry git push "$remote" release/production:refs/heads/release/production
           fi
 
       - name: Check production delta


### PR DESCRIPTION
## Summary

- wrap the release/production push in a small retry helper
- keep the explicit --force-with-lease SHA behavior while tolerating transient GitHub remote failures

## Verification

- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/production-release-pr.yml
- git diff --check