### PR TITLE
🚀リリース2026-06-02 16:56:44

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -14,6 +14,7 @@ reviews:
     ignore_title_keywords:
       - "[skip-coderabbit]"
       - "release: promote main to production"
+      - "🚀リリース"
 
   path_filters:
     - "!.local/**"

--- a/.github/workflows/production-release-pr.yml
+++ b/.github/workflows/production-release-pr.yml
@@ -106,27 +106,40 @@ jobs:
         if: steps.production_delta.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ secrets.PRODUCTION_RELEASE_TOKEN }}
-          TITLE: "release: promote main to production [skip-coderabbit]"
-          BODY: |
-            ## Purpose
-
-            Promote the current `main` branch to the `production` branch.
-
-            This PR is a release gate, not a second code-review stage. CodeRabbit is intentionally skipped for release PRs; normal feature PRs into `main` remain reviewed.
-
-            ## Required before merge
-
-            - [ ] `production preflight` check passes
-            - [ ] Cloudflare Workers Builds production branch is `production`
-            - [ ] Production D1 binding is no longer a placeholder
-            - [ ] Rollback path has been rehearsed recently
-            - [ ] `/admin/production-readiness` has no `fail` checks
-            - [ ] Release PR was created by `PRODUCTION_RELEASE_TOKEN`, not the default `GITHUB_TOKEN`
-
-            ## Deployment
-
-            Merging this PR into `production` lets Cloudflare Workers Builds run the production build command.
         run: |
+          release_prs="$(
+            git log --reverse --pretty=format:%s origin/production..release/production \
+              | grep -Eo '#[0-9]+' \
+              | awk '!seen[$0]++ { print "- " $0 }'
+          )"
+
+          if [ -z "$release_prs" ]; then
+            release_prs="- PR 番号を commit message から特定できませんでした"
+          fi
+
+          {
+            echo "## 概要"
+            echo
+            echo "\`main\` の現在の内容を \`production\` に昇格するリリースPRです。"
+            echo
+            echo "このPRは本番昇格の承認ゲートであり、コードの再レビュー用ではありません。通常のコードレビューとCIは \`main\` に入る通常PRで完了済みです。"
+            echo
+            echo "## リリース対象PR"
+            echo
+            echo "$release_prs"
+            echo
+            echo "## Merge前チェック"
+            echo
+            echo "- [ ] \`production deploy preflight\` が通っている"
+            echo "- [ ] Cloudflare Workers Builds の production branch が \`production\` になっている"
+            echo "- [ ] rollback 手順を直近で確認している"
+            echo "- [ ] \`/admin/production-readiness\` に \`fail\` がない"
+            echo
+            echo "## Deploy"
+            echo
+            echo "このPRを \`production\` に merge すると、Cloudflare Workers Builds が production deploy を開始します。"
+          } > release-pr-body.md
+
           existing="$(gh pr list \
             --base production \
             --head release/production \
@@ -135,8 +148,9 @@ jobs:
             --jq '.[0].number // empty')"
 
           if [ -n "$existing" ]; then
-            gh pr edit "$existing" --title "$TITLE" --body "$BODY"
+            gh pr edit "$existing" --body-file release-pr-body.md
             echo "Updated PR #$existing"
           else
-            gh pr create --base production --head release/production --title "$TITLE" --body "$BODY"
+            title="$(TZ=Asia/Tokyo date '+🚀リリース%Y-%m-%d %H:%M:%S')"
+            gh pr create --base production --head release/production --title "$title" --body-file release-pr-body.md
           fi

--- a/.github/workflows/production-release-pr.yml
+++ b/.github/workflows/production-release-pr.yml
@@ -55,10 +55,18 @@ jobs:
         env:
           PRODUCTION_RELEASE_TOKEN: ${{ secrets.PRODUCTION_RELEASE_TOKEN }}
         run: |
+          remote="https://x-access-token:${PRODUCTION_RELEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          remote_release_sha="$(git ls-remote --heads "$remote" release/production | cut -f1)"
+
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -B release/production origin/main
-          git push --force-with-lease "https://x-access-token:${PRODUCTION_RELEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" release/production
+
+          if [ -n "$remote_release_sha" ]; then
+            git push --force-with-lease=refs/heads/release/production:"$remote_release_sha" "$remote" release/production:refs/heads/release/production
+          else
+            git push "$remote" release/production:refs/heads/release/production
+          fi
 
       - name: Check production delta
         id: production_delta

--- a/.github/workflows/production-release-pr.yml
+++ b/.github/workflows/production-release-pr.yml
@@ -60,7 +60,25 @@ jobs:
           git checkout -B release/production origin/main
           git push --force-with-lease "https://x-access-token:${PRODUCTION_RELEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" release/production
 
+      - name: Check production delta
+        id: production_delta
+        env:
+          PRODUCTION_RELEASE_TOKEN: ${{ secrets.PRODUCTION_RELEASE_TOKEN }}
+        run: |
+          remote="https://x-access-token:${PRODUCTION_RELEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git fetch --no-tags "$remote" production:refs/remotes/origin/production
+
+          ahead_count="$(git rev-list --count origin/production..release/production)"
+          if [ "$ahead_count" = "0" ]; then
+            echo "::notice::production is already up to date with main; skipping production release PR creation."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "release/production is $ahead_count commit(s) ahead of production."
+          fi
+
       - name: Create or update production PR
+        if: steps.production_delta.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ secrets.PRODUCTION_RELEASE_TOKEN }}
           TITLE: "release: promote main to production [skip-coderabbit]"

--- a/.github/workflows/production-release-pr.yml
+++ b/.github/workflows/production-release-pr.yml
@@ -130,7 +130,6 @@ jobs:
             echo
             echo "## Merge前チェック"
             echo
-            echo "- [ ] \`production deploy preflight\` が通っている"
             echo "- [ ] Cloudflare Workers Builds の production branch が \`production\` になっている"
             echo "- [ ] rollback 手順を直近で確認している"
             echo "- [ ] \`/admin/production-readiness\` に \`fail\` がない"

--- a/.github/workflows/production-release-pr.yml
+++ b/.github/workflows/production-release-pr.yml
@@ -62,10 +62,27 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -B release/production origin/main
 
+          push_with_retry() {
+            attempt=1
+            while [ "$attempt" -le 3 ]; do
+              if "$@"; then
+                return 0
+              fi
+
+              if [ "$attempt" = "3" ]; then
+                return 1
+              fi
+
+              echo "::notice::git push failed; retrying in $((attempt * 5)) seconds."
+              sleep $((attempt * 5))
+              attempt=$((attempt + 1))
+            done
+          }
+
           if [ -n "$remote_release_sha" ]; then
-            git push --force-with-lease=refs/heads/release/production:"$remote_release_sha" "$remote" release/production:refs/heads/release/production
+            push_with_retry git push --force-with-lease=refs/heads/release/production:"$remote_release_sha" "$remote" release/production:refs/heads/release/production
           else
-            git push "$remote" release/production:refs/heads/release/production
+            push_with_retry git push "$remote" release/production:refs/heads/release/production
           fi
 
       - name: Check production delta

--- a/docs/production-cd.md
+++ b/docs/production-cd.md
@@ -38,6 +38,8 @@ pnpm install --frozen-lockfile && pnpm deploy:production
 
 この PR は「コードの再レビュー」ではなく「本番昇格の承認ゲート」。title に `[skip-coderabbit]` を含め、`.coderabbit.yaml` 側でも CodeRabbit auto review を skip する。
 
+`production` がすでに `main` と同じ commit を指している場合、release PR に差分がないため workflow は PR 作成を skip して success にする。初回 bootstrap 直後や、production が main に追いついている状態ではこれが期待値。
+
 この workflow は default `GITHUB_TOKEN` を使わず、repository secret `PRODUCTION_RELEASE_TOKEN` を必須にする。`GITHUB_TOKEN` で workflow から PR を作成/更新すると、その PR の `pull_request` workflow が自動実行されず approval 待ちになり得るため。
 
 `PRODUCTION_RELEASE_TOKEN` は fine-grained PAT か GitHub App installation token を使う。必要権限:

--- a/docs/production-cd.md
+++ b/docs/production-cd.md
@@ -36,7 +36,9 @@ pnpm install --frozen-lockfile && pnpm deploy:production
 
 `main` push で `release/production` branch を `main` に更新し、`production` 向け PR を作成または更新する。
 
-この PR は「コードの再レビュー」ではなく「本番昇格の承認ゲート」。title に `[skip-coderabbit]` を含め、`.coderabbit.yaml` 側でも CodeRabbit auto review を skip する。
+この PR は「コードの再レビュー」ではなく「本番昇格の承認ゲート」。初回作成時の title は `🚀リリースyyyy-MM-dd HH:mm:ss` (Asia/Tokyo) にし、その後 `main` に追加 PR が merge されても title は維持する。Description には `production..release/production` に含まれる PR 番号 (`#xxx`) を一覧する。
+
+`.coderabbit.yaml` 側では release PR title keyword で CodeRabbit auto review を skip する。
 
 `production` がすでに `main` と同じ commit を指している場合、release PR に差分がないため workflow は PR 作成を skip して success にする。初回 bootstrap 直後や、production が main に追いついている状態ではこれが期待値。
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -178,7 +178,7 @@
         {
           "binding": "DB",
           "database_name": "webull-trading-production",
-          "database_id": "REPLACE_WITH_PRODUCTION_ID",
+          "database_id": "2257d669-0a3c-497d-9be1-15626b2522bb",
           "migrations_dir": "drizzle"
         }
       ],


### PR DESCRIPTION
## 概要

`main` の現在の内容を `production` に昇格するリリースPRです。

このPRは本番昇格の承認ゲートであり、コードの再レビュー用ではありません。通常のコードレビューとCIは `main` に入る通常PRで完了済みです。

## リリース対象PR

- #386
- #387
- #388
- #390
- #391
- #392

## Merge前チェック

- [ ] Cloudflare Workers Builds の production branch が `production` になっている
- [ ] rollback 手順を直近で確認している
- [ ] `/admin/production-readiness` に `fail` がない

## Deploy

このPRを `production` に merge すると、Cloudflare Workers Builds が production deploy を開始します。
