### PR TITLE
fix: configure production D1 binding

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -178,7 +178,7 @@
         {
           "binding": "DB",
           "database_name": "webull-trading-production",
-          "database_id": "REPLACE_WITH_PRODUCTION_ID",
+          "database_id": "2257d669-0a3c-497d-9be1-15626b2522bb",
           "migrations_dir": "drizzle"
         }
       ],


### PR DESCRIPTION
## Summary

- create Cloudflare D1 database `webull-trading-production`
- set `env.production.d1_databases[0].database_id` in `wrangler.jsonc`
- apply all D1 migrations to the new production database

## Verification

- pnpm verify:production-d1
- pnpm exec wrangler d1 migrations apply webull-trading-production --env=production --remote
- pnpm run deploy:production:dry-run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 本番環境のデータベース設定を更新しました。プレースホルダーから実際の本番データベースIDに変更され、正常な環境構成が確保されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->