### PR TITLE
fix: localize production release PR template

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -14,6 +14,7 @@ reviews:
     ignore_title_keywords:
       - "[skip-coderabbit]"
       - "release: promote main to production"
+      - "🚀リリース"
 
   path_filters:
     - "!.local/**"

--- a/.github/workflows/production-release-pr.yml
+++ b/.github/workflows/production-release-pr.yml
@@ -106,27 +106,40 @@ jobs:
         if: steps.production_delta.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ secrets.PRODUCTION_RELEASE_TOKEN }}
-          TITLE: "release: promote main to production [skip-coderabbit]"
-          BODY: |
-            ## Purpose
-
-            Promote the current `main` branch to the `production` branch.
-
-            This PR is a release gate, not a second code-review stage. CodeRabbit is intentionally skipped for release PRs; normal feature PRs into `main` remain reviewed.
-
-            ## Required before merge
-
-            - [ ] `production preflight` check passes
-            - [ ] Cloudflare Workers Builds production branch is `production`
-            - [ ] Production D1 binding is no longer a placeholder
-            - [ ] Rollback path has been rehearsed recently
-            - [ ] `/admin/production-readiness` has no `fail` checks
-            - [ ] Release PR was created by `PRODUCTION_RELEASE_TOKEN`, not the default `GITHUB_TOKEN`
-
-            ## Deployment
-
-            Merging this PR into `production` lets Cloudflare Workers Builds run the production build command.
         run: |
+          release_prs="$(
+            git log --reverse --pretty=format:%s origin/production..release/production \
+              | grep -Eo '#[0-9]+' \
+              | awk '!seen[$0]++ { print "- " $0 }'
+          )"
+
+          if [ -z "$release_prs" ]; then
+            release_prs="- PR 番号を commit message から特定できませんでした"
+          fi
+
+          {
+            echo "## 概要"
+            echo
+            echo "\`main\` の現在の内容を \`production\` に昇格するリリースPRです。"
+            echo
+            echo "このPRは本番昇格の承認ゲートであり、コードの再レビュー用ではありません。通常のコードレビューとCIは \`main\` に入る通常PRで完了済みです。"
+            echo
+            echo "## リリース対象PR"
+            echo
+            echo "$release_prs"
+            echo
+            echo "## Merge前チェック"
+            echo
+            echo "- [ ] \`production deploy preflight\` が通っている"
+            echo "- [ ] Cloudflare Workers Builds の production branch が \`production\` になっている"
+            echo "- [ ] rollback 手順を直近で確認している"
+            echo "- [ ] \`/admin/production-readiness\` に \`fail\` がない"
+            echo
+            echo "## Deploy"
+            echo
+            echo "このPRを \`production\` に merge すると、Cloudflare Workers Builds が production deploy を開始します。"
+          } > release-pr-body.md
+
           existing="$(gh pr list \
             --base production \
             --head release/production \
@@ -135,8 +148,9 @@ jobs:
             --jq '.[0].number // empty')"
 
           if [ -n "$existing" ]; then
-            gh pr edit "$existing" --title "$TITLE" --body "$BODY"
+            gh pr edit "$existing" --body-file release-pr-body.md
             echo "Updated PR #$existing"
           else
-            gh pr create --base production --head release/production --title "$TITLE" --body "$BODY"
+            title="$(TZ=Asia/Tokyo date '+🚀リリース%Y-%m-%d %H:%M:%S')"
+            gh pr create --base production --head release/production --title "$title" --body-file release-pr-body.md
           fi

--- a/docs/production-cd.md
+++ b/docs/production-cd.md
@@ -36,7 +36,9 @@ pnpm install --frozen-lockfile && pnpm deploy:production
 
 `main` push で `release/production` branch を `main` に更新し、`production` 向け PR を作成または更新する。
 
-この PR は「コードの再レビュー」ではなく「本番昇格の承認ゲート」。title に `[skip-coderabbit]` を含め、`.coderabbit.yaml` 側でも CodeRabbit auto review を skip する。
+この PR は「コードの再レビュー」ではなく「本番昇格の承認ゲート」。初回作成時の title は `🚀リリースyyyy-MM-dd HH:mm:ss` (Asia/Tokyo) にし、その後 `main` に追加 PR が merge されても title は維持する。Description には `production..release/production` に含まれる PR 番号 (`#xxx`) を一覧する。
+
+`.coderabbit.yaml` 側では release PR title keyword で CodeRabbit auto review を skip する。
 
 `production` がすでに `main` と同じ commit を指している場合、release PR に差分がないため workflow は PR 作成を skip して success にする。初回 bootstrap 直後や、production が main に追いついている状態ではこれが期待値。
 


### PR DESCRIPTION
## Summary

- change production release PR body to Japanese
- list release target PR numbers from production..release/production
- create new release PRs with an initial Asia/Tokyo timestamp title
- keep existing release PR titles stable on later updates
- keep CodeRabbit skipped for the new release title prefix

## Verification

- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/production-release-pr.yml .coderabbit.yaml
- git diff --check
- local release PR number extraction against origin/production..origin/release/production