### PR TITLE
fix: remove CI check from release checklist

### DIFF
--- a/.github/workflows/production-release-pr.yml
+++ b/.github/workflows/production-release-pr.yml
@@ -130,7 +130,6 @@ jobs:
             echo
             echo "## Merge前チェック"
             echo
-            echo "- [ ] \`production deploy preflight\` が通っている"
             echo "- [ ] Cloudflare Workers Builds の production branch が \`production\` になっている"
             echo "- [ ] rollback 手順を直近で確認している"
             echo "- [ ] \`/admin/production-readiness\` に \`fail\` がない"


### PR DESCRIPTION
## Summary

- remove the manual `production deploy preflight` checklist item from the generated production release PR body
- keep that validation enforced by the required GitHub check instead

## Verification

- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/production-release-pr.yml"); puts "ok"'
- git diff --check