### PR TITLE
refactor(dashboard): remove env DRY_RUN badge

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1294,39 +1294,7 @@ const STYLE = `
   tr.symbol-disabled-row{background:#fafafa}
   tr.symbol-disabled-row td{color:#86868b}
   .grid-panel.symbol-inactive{background:#fafafa;opacity:0.65}
-  .env-badge{display:inline-block;margin-left:10px;padding:2px 10px;font-size:11px;font-weight:700;letter-spacing:0.5px;border-radius:10px;vertical-align:middle}
-  .env-badge.live{background:#c22;color:#fff}
-  .env-badge.dry{background:#057a55;color:#fff}
-  .env-badge.unknown{background:#f5c518;color:#3a2a00}
 `
-
-/**
- * Env badge (#275): operator が画面で live / dry-run を即判別できるよう、
- * 全 dashboard page の header に常時表示するための env state derivation。
- * `c.env` 未配線 / `DRY_RUN` 未設定でも 500 を起こさないよう defensive に default。
- */
-export type EnvBadgeMode = 'LIVE' | 'DRY-RUN' | 'UNKNOWN'
-
-export function resolveEnvBadgeMode(env: unknown): EnvBadgeMode {
-  const raw =
-    env && typeof env === 'object' && 'DRY_RUN' in env
-      ? (env as { DRY_RUN?: unknown }).DRY_RUN
-      : undefined
-  if (raw === 'true') return 'DRY-RUN'
-  if (raw === 'false') return 'LIVE'
-  return 'UNKNOWN'
-}
-
-function envBadgeTitlePrefix(mode: EnvBadgeMode): string {
-  if (mode === 'LIVE') return '[LIVE]'
-  if (mode === 'DRY-RUN') return '[DRY]'
-  return '[?]'
-}
-
-function renderEnvBadge(mode: EnvBadgeMode): string {
-  const cls = mode === 'LIVE' ? 'live' : mode === 'DRY-RUN' ? 'dry' : 'unknown'
-  return `<span class="env-badge ${cls}" title="DRY_RUN=${esc(mode)}">${esc(mode)}</span>`
-}
 
 function renderLayout(
   c: {
@@ -1337,7 +1305,7 @@ function renderLayout(
   body: string,
 ): string {
   const banner = killSwitchBanner(c.var.killSwitchState)
-  return layout(title, banner + body, c.env)
+  return layout(title, banner + body)
 }
 
 function killSwitchBanner(state: KillSwitchBannerState | null): string {
@@ -1367,20 +1335,17 @@ function killSwitchBanner(state: KillSwitchBannerState | null): string {
   </div>`
 }
 
-function layout(title: string, body: string, env?: unknown): string {
-  const mode = resolveEnvBadgeMode(env)
-  const titlePrefix = envBadgeTitlePrefix(mode)
-  const badge = renderEnvBadge(mode)
+function layout(title: string, body: string): string {
   return `<!doctype html>
 <html lang="ja">
 <head>
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width,initial-scale=1"/>
-<title>${titlePrefix} ${esc(title)} — Webull Trading</title>
+<title>${esc(title)} — Webull Trading</title>
 <style>${STYLE}</style>
 </head>
 <body>
-<h1>Webull Trading — ${esc(title)}${badge}</h1>
+<h1>Webull Trading — ${esc(title)}</h1>
 <nav>
   <a href="/dashboard">ホーム</a>
   <span class="nav-group">取引状況</span>

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -100,53 +100,8 @@ describe('dashboard', () => {
     const res = await app.request('/dashboard', { headers: authHeader }, baseEnv)
     expect(res.status).toBe(200)
     const body = await res.text()
-    // #275: env badge prefix ([?] = UNKNOWN since DRY_RUN unset in baseEnv) goes
-    // before the page title.
-    expect(body).toContain('<title>[?] ダッシュボード')
+    expect(body).toContain('<title>ダッシュボード')
     expect(body).toContain('/dashboard/positions')
-  })
-
-  // #275: header env badge — operator が live / dry-run を画面で即判別できるよう
-  // 全 dashboard page に常時表示する。DRY_RUN env から派生、未設定 / 不正値は
-  // UNKNOWN に倒れて 500 にしない。
-  describe('env badge (#275)', () => {
-    it('renders green DRY-RUN badge when DRY_RUN=true', async () => {
-      const app = createApp()
-      const res = await app.request(
-        '/dashboard',
-        { headers: authHeader },
-        { ...baseEnv, DRY_RUN: 'true' },
-      )
-      expect(res.status).toBe(200)
-      const body = await res.text()
-      expect(body).toContain('<title>[DRY] ダッシュボード')
-      expect(body).toContain('class="env-badge dry"')
-      expect(body).toContain('>DRY-RUN<')
-    })
-
-    it('renders red LIVE badge when DRY_RUN=false', async () => {
-      const app = createApp()
-      const res = await app.request(
-        '/dashboard',
-        { headers: authHeader },
-        { ...baseEnv, DRY_RUN: 'false' },
-      )
-      expect(res.status).toBe(200)
-      const body = await res.text()
-      expect(body).toContain('<title>[LIVE] ダッシュボード')
-      expect(body).toContain('class="env-badge live"')
-      expect(body).toContain('>LIVE<')
-    })
-
-    it('renders yellow UNKNOWN badge when DRY_RUN is unset (defensive default)', async () => {
-      const app = createApp()
-      const res = await app.request('/dashboard', { headers: authHeader }, baseEnv)
-      expect(res.status).toBe(200)
-      const body = await res.text()
-      expect(body).toContain('<title>[?] ダッシュボード')
-      expect(body).toContain('class="env-badge unknown"')
-      expect(body).toContain('>UNKNOWN<')
-    })
   })
 
   // #276: kill-switch banner は全 page 共通の header として layout 内に


### PR DESCRIPTION
## 概要
dashboard header の env バッジ (LIVE / DRY-RUN / **UNKNOWN**) と title prefix (`[?]` 等) を撤去。

## 背景
- バッジは env 変数 `DRY_RUN` を読む (#275) が、production では `DRY_RUN` を未設定運用にしたため**常時 UNKNOWN**表示になっていた。
- さらにこのバッジは **実際の取引モードと連動しない**。実行 gate は env ではなく **D1 `global_config.dry_run`** (`runStrategyCron.ts`: `global.dryRun ? null : createWebullTradeClient(...)`)。env バッジは誤情報源になり得た。
- real state は `/dashboard/config` (D1 を読む) と kill-switch banner で確認できる。

## 変更
- `layout()` から title prefix / badge を削除、`env` 引数も除去
- `resolveEnvBadgeMode` / `envBadgeTitlePrefix` / `renderEnvBadge` / `EnvBadgeMode` / `.env-badge` CSS を削除
- 関連 test (env badge #275) を削除、index の title assertion を更新

## 確認
- typecheck OK / test 1198 passed
- env `DRY_RUN` はこれで code から未参照 (Env 型の field / .dev.vars.example の記載は別途整理可)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ダッシュボード改善

* **バグ修正**
  * ダッシュボード表示から環境バッジを削除しました。ページタイトルおよび共通レイアウトから環境情報表示が統一的に削除されます。キルスイッチバナーのみがページ上部に表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->