### PR TITLE
feat(dashboard): mf-dashboard 風 overview + sidebar shell

### DIFF
--- a/drizzle/0021_add_overview_panels.sql
+++ b/drizzle/0021_add_overview_panels.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `global_config` ADD `overview_panels` text DEFAULT 'kpi,equity,composition,recent' NOT NULL;

--- a/drizzle/meta/0021_snapshot.json
+++ b/drizzle/meta/0021_snapshot.json
@@ -1,0 +1,1317 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e7d12d65-3ae1-434b-8314-0bdb01341eaa",
+  "prevId": "70cdd2bb-6ac5-40a3-854c-a8e700eeee6a",
+  "tables": {
+    "config_audit_log": {
+      "name": "config_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before_json": {
+          "name": "before_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "after_json": {
+          "name": "after_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "config_audit_log_timestamp_id_idx": {
+          "name": "config_audit_log_timestamp_id_idx",
+          "columns": [
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "config_audit_log_actor_timestamp_id_idx": {
+          "name": "config_audit_log_actor_timestamp_id_idx",
+          "columns": [
+            "actor",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "config_audit_log_endpoint_timestamp_id_idx": {
+          "name": "config_audit_log_endpoint_timestamp_id_idx",
+          "columns": [
+            "endpoint",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "config_state_snapshot": {
+      "name": "config_state_snapshot",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "earnings_calendar": {
+      "name": "earnings_calendar",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "earnings_date": {
+          "name": "earnings_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "earnings_calendar_symbol_date_unique": {
+          "name": "earnings_calendar_symbol_date_unique",
+          "columns": [
+            "symbol",
+            "earnings_date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "global_config": {
+      "name": "global_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "trading_enabled": {
+          "name": "trading_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "market_hours_check": {
+          "name": "market_hours_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "max_order_notional": {
+          "name": "max_order_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "max_order_notional_usd": {
+          "name": "max_order_notional_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2000
+        },
+        "max_order_notional_jpy": {
+          "name": "max_order_notional_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100000
+        },
+        "total_capital_usd": {
+          "name": "total_capital_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_capital_jpy": {
+          "name": "total_capital_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_portfolio_exposure_pct": {
+          "name": "max_portfolio_exposure_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.6
+        },
+        "drawdown_kill_threshold": {
+          "name": "drawdown_kill_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.02
+        },
+        "stale_quote_ms": {
+          "name": "stale_quote_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 900000
+        },
+        "gap_reject_pct": {
+          "name": "gap_reject_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.03
+        },
+        "spread_limit_pct_us": {
+          "name": "spread_limit_pct_us",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.0025
+        },
+        "spread_limit_pct_jp": {
+          "name": "spread_limit_pct_jp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.006
+        },
+        "pullback_default_stop_pct": {
+          "name": "pullback_default_stop_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.04
+        },
+        "pullback_default_take_profit_pct": {
+          "name": "pullback_default_take_profit_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.07
+        },
+        "pullback_default_time_stop_days": {
+          "name": "pullback_default_time_stop_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "pullback_default_pullback_max": {
+          "name": "pullback_default_pullback_max",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.03
+        },
+        "pullback_default_pullback_min": {
+          "name": "pullback_default_pullback_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.06
+        },
+        "pullback_default_min_return_50d": {
+          "name": "pullback_default_min_return_50d",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.08
+        },
+        "pullback_default_require_above_sma50": {
+          "name": "pullback_default_require_above_sma50",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "pullback_default_k_atr": {
+          "name": "pullback_default_k_atr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "risk_base_per_trade_pct": {
+          "name": "risk_base_per_trade_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.004
+        },
+        "risk_dd_half_threshold": {
+          "name": "risk_dd_half_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.05
+        },
+        "risk_dd_halt_threshold": {
+          "name": "risk_dd_halt_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.1
+        },
+        "bucket_exposure_pct": {
+          "name": "bucket_exposure_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.3
+        },
+        "vix_warning_threshold": {
+          "name": "vix_warning_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 25
+        },
+        "vix_critical_threshold": {
+          "name": "vix_critical_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "vix_warning_size_scale": {
+          "name": "vix_warning_size_scale",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.5
+        },
+        "overview_panels": {
+          "name": "overview_panels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'kpi,equity,composition,recent'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "global_config_max_order_notional_range": {
+          "name": "global_config_max_order_notional_range",
+          "value": "\"global_config\".\"max_order_notional\" > 0 AND \"global_config\".\"max_order_notional\" <= 10000000"
+        },
+        "global_config_max_order_notional_usd_range": {
+          "name": "global_config_max_order_notional_usd_range",
+          "value": "\"global_config\".\"max_order_notional_usd\" > 0 AND \"global_config\".\"max_order_notional_usd\" <= 1000000"
+        },
+        "global_config_max_order_notional_jpy_range": {
+          "name": "global_config_max_order_notional_jpy_range",
+          "value": "\"global_config\".\"max_order_notional_jpy\" > 0 AND \"global_config\".\"max_order_notional_jpy\" <= 100000000"
+        },
+        "global_config_total_capital_usd_range": {
+          "name": "global_config_total_capital_usd_range",
+          "value": "\"global_config\".\"total_capital_usd\" IS NULL OR \"global_config\".\"total_capital_usd\" > 0"
+        },
+        "global_config_total_capital_jpy_range": {
+          "name": "global_config_total_capital_jpy_range",
+          "value": "\"global_config\".\"total_capital_jpy\" IS NULL OR \"global_config\".\"total_capital_jpy\" > 0"
+        },
+        "global_config_max_portfolio_exposure_pct_range": {
+          "name": "global_config_max_portfolio_exposure_pct_range",
+          "value": "\"global_config\".\"max_portfolio_exposure_pct\" > 0 AND \"global_config\".\"max_portfolio_exposure_pct\" <= 1"
+        },
+        "global_config_drawdown_kill_threshold_range": {
+          "name": "global_config_drawdown_kill_threshold_range",
+          "value": "\"global_config\".\"drawdown_kill_threshold\" >= -1 AND \"global_config\".\"drawdown_kill_threshold\" <= 0"
+        },
+        "global_config_stale_quote_ms_range": {
+          "name": "global_config_stale_quote_ms_range",
+          "value": "\"global_config\".\"stale_quote_ms\" >= 0"
+        },
+        "global_config_gap_reject_pct_range": {
+          "name": "global_config_gap_reject_pct_range",
+          "value": "\"global_config\".\"gap_reject_pct\" >= 0 AND \"global_config\".\"gap_reject_pct\" <= 1"
+        },
+        "global_config_spread_limit_pct_us_range": {
+          "name": "global_config_spread_limit_pct_us_range",
+          "value": "\"global_config\".\"spread_limit_pct_us\" >= 0 AND \"global_config\".\"spread_limit_pct_us\" <= 1"
+        },
+        "global_config_spread_limit_pct_jp_range": {
+          "name": "global_config_spread_limit_pct_jp_range",
+          "value": "\"global_config\".\"spread_limit_pct_jp\" >= 0 AND \"global_config\".\"spread_limit_pct_jp\" <= 1"
+        },
+        "global_config_pullback_default_stop_pct_range": {
+          "name": "global_config_pullback_default_stop_pct_range",
+          "value": "\"global_config\".\"pullback_default_stop_pct\" < 0 AND \"global_config\".\"pullback_default_stop_pct\" >= -1"
+        },
+        "global_config_pullback_default_take_profit_pct_range": {
+          "name": "global_config_pullback_default_take_profit_pct_range",
+          "value": "\"global_config\".\"pullback_default_take_profit_pct\" > 0 AND \"global_config\".\"pullback_default_take_profit_pct\" <= 1"
+        },
+        "global_config_pullback_default_time_stop_days_range": {
+          "name": "global_config_pullback_default_time_stop_days_range",
+          "value": "\"global_config\".\"pullback_default_time_stop_days\" > 0 AND \"global_config\".\"pullback_default_time_stop_days\" <= ?"
+        },
+        "global_config_pullback_default_pullback_max_range": {
+          "name": "global_config_pullback_default_pullback_max_range",
+          "value": "\"global_config\".\"pullback_default_pullback_max\" <= 0 AND \"global_config\".\"pullback_default_pullback_max\" >= -1"
+        },
+        "global_config_pullback_default_pullback_min_range": {
+          "name": "global_config_pullback_default_pullback_min_range",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= 0 AND \"global_config\".\"pullback_default_pullback_min\" >= -1"
+        },
+        "global_config_pullback_default_min_return_50d_range": {
+          "name": "global_config_pullback_default_min_return_50d_range",
+          "value": "\"global_config\".\"pullback_default_min_return_50d\" >= -1 AND \"global_config\".\"pullback_default_min_return_50d\" <= 10"
+        },
+        "global_config_pullback_default_k_atr_range": {
+          "name": "global_config_pullback_default_k_atr_range",
+          "value": "\"global_config\".\"pullback_default_k_atr\" > 0 AND \"global_config\".\"pullback_default_k_atr\" <= 10"
+        },
+        "global_config_pullback_default_pullback_window_order": {
+          "name": "global_config_pullback_default_pullback_window_order",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= \"global_config\".\"pullback_default_pullback_max\""
+        },
+        "global_config_risk_base_per_trade_pct_range": {
+          "name": "global_config_risk_base_per_trade_pct_range",
+          "value": "\"global_config\".\"risk_base_per_trade_pct\" > 0 AND \"global_config\".\"risk_base_per_trade_pct\" <= 1"
+        },
+        "global_config_risk_dd_half_threshold_range": {
+          "name": "global_config_risk_dd_half_threshold_range",
+          "value": "\"global_config\".\"risk_dd_half_threshold\" < 0 AND \"global_config\".\"risk_dd_half_threshold\" >= -1"
+        },
+        "global_config_risk_dd_halt_threshold_range": {
+          "name": "global_config_risk_dd_halt_threshold_range",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" < 0 AND \"global_config\".\"risk_dd_halt_threshold\" >= -1"
+        },
+        "global_config_risk_dd_threshold_order": {
+          "name": "global_config_risk_dd_threshold_order",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" <= \"global_config\".\"risk_dd_half_threshold\""
+        },
+        "global_config_bucket_exposure_pct_range": {
+          "name": "global_config_bucket_exposure_pct_range",
+          "value": "\"global_config\".\"bucket_exposure_pct\" > 0 AND \"global_config\".\"bucket_exposure_pct\" <= 1"
+        },
+        "global_config_vix_warning_threshold_range": {
+          "name": "global_config_vix_warning_threshold_range",
+          "value": "\"global_config\".\"vix_warning_threshold\" > 0 AND \"global_config\".\"vix_warning_threshold\" <= 200"
+        },
+        "global_config_vix_critical_threshold_range": {
+          "name": "global_config_vix_critical_threshold_range",
+          "value": "\"global_config\".\"vix_critical_threshold\" > 0 AND \"global_config\".\"vix_critical_threshold\" <= 200"
+        },
+        "global_config_vix_threshold_order": {
+          "name": "global_config_vix_threshold_order",
+          "value": "\"global_config\".\"vix_warning_threshold\" <= \"global_config\".\"vix_critical_threshold\""
+        },
+        "global_config_vix_warning_size_scale_range": {
+          "name": "global_config_vix_warning_size_scale_range",
+          "value": "\"global_config\".\"vix_warning_size_scale\" >= 0 AND \"global_config\".\"vix_warning_size_scale\" <= 1"
+        }
+      }
+    },
+    "inverse_pairs": {
+      "name": "inverse_pairs",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inverse": {
+          "name": "inverse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "macro_event_calendar": {
+      "name": "macro_event_calendar",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_time": {
+          "name": "event_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "macro_event_calendar_type_date_unique": {
+          "name": "macro_event_calendar_type_date_unique",
+          "columns": [
+            "event_type",
+            "event_date"
+          ],
+          "isUnique": true
+        },
+        "macro_event_calendar_date_idx": {
+          "name": "macro_event_calendar_date_idx",
+          "columns": [
+            "event_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_emit_log": {
+      "name": "notification_emit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cause": {
+          "name": "cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notification_emit_log_timestamp_id_idx": {
+          "name": "notification_emit_log_timestamp_id_idx",
+          "columns": [
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "notification_emit_log_severity_timestamp_id_idx": {
+          "name": "notification_emit_log_severity_timestamp_id_idx",
+          "columns": [
+            "severity",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "notification_emit_log_event_type_timestamp_id_idx": {
+          "name": "notification_emit_log_event_type_timestamp_id_idx",
+          "columns": [
+            "event_type",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "portfolio_equity_snapshot": {
+      "name": "portfolio_equity_snapshot",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "daily_start_equity_usd": {
+          "name": "daily_start_equity_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_start_equity_jpy": {
+          "name": "daily_start_equity_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_realized_pnl_usd": {
+          "name": "daily_realized_pnl_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_realized_pnl_jpy": {
+          "name": "daily_realized_pnl_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "drawdown_pct": {
+          "name": "drawdown_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "portfolio_equity_snapshot_at_idx": {
+          "name": "portfolio_equity_snapshot_at_idx",
+          "columns": [
+            "snapshot_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "strategy_decision_log": {
+      "name": "strategy_decision_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indicators_json": {
+          "name": "indicators_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "strategy_decision_log_symbol_id_idx": {
+          "name": "strategy_decision_log_symbol_id_idx",
+          "columns": [
+            "symbol",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "strategy_decision_log_coid_idx": {
+          "name": "strategy_decision_log_coid_idx",
+          "columns": [
+            "client_order_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "symbol_config": {
+      "name": "symbol_config",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "market": {
+          "name": "market",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_notional": {
+          "name": "max_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_stop_days_override": {
+          "name": "time_stop_days_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "k_atr_override": {
+          "name": "k_atr_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "symbol_config_currency_enum": {
+          "name": "symbol_config_currency_enum",
+          "value": "\"symbol_config\".\"currency\" IN ('USD', 'JPY')"
+        },
+        "symbol_config_time_stop_days_override_range": {
+          "name": "symbol_config_time_stop_days_override_range",
+          "value": "\"symbol_config\".\"time_stop_days_override\" IS NULL OR (\"symbol_config\".\"time_stop_days_override\" >= 1 AND \"symbol_config\".\"time_stop_days_override\" <= ?)"
+        },
+        "symbol_config_k_atr_override_range": {
+          "name": "symbol_config_k_atr_override_range",
+          "value": "\"symbol_config\".\"k_atr_override\" IS NULL OR (\"symbol_config\".\"k_atr_override\" >= 0.5 AND \"symbol_config\".\"k_atr_override\" <= 5.0)"
+        }
+      }
+    },
+    "trade_journal": {
+      "name": "trade_journal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trade_event_type": {
+          "name": "trade_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "strategy_name": {
+          "name": "strategy_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_action": {
+          "name": "signal_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_reason": {
+          "name": "signal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_allowed": {
+          "name": "risk_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_reasons": {
+          "name": "risk_reasons",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "limit_price": {
+          "name": "limit_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notional": {
+          "name": "notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "broker_status": {
+          "name": "broker_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "submitted": {
+          "name": "submitted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_qty": {
+          "name": "filled_qty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_price": {
+          "name": "filled_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "realized_pnl": {
+          "name": "realized_pnl",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hold_days": {
+          "name": "hold_days",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_reason": {
+          "name": "exit_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_applied_at": {
+          "name": "state_applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_error": {
+          "name": "state_apply_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_attempts": {
+          "name": "state_apply_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trading_toggle_history": {
+      "name": "trading_toggle_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before": {
+          "name": "before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "after": {
+          "name": "after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1780400611000,
       "tag": "0020_add_bucket_exposure_pct",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "6",
+      "when": 1780485549735,
+      "tag": "0021_add_overview_panels",
+      "breakpoints": true
     }
   ]
 }

--- a/src/infrastructure/db/globalConfigRepo.ts
+++ b/src/infrastructure/db/globalConfigRepo.ts
@@ -110,25 +110,22 @@ export async function loadOverviewPanelsCsv(db: DrizzleD1Database): Promise<stri
   }
 }
 
-/** `applyTradingToggle` と同様、row 未 seed なら INSERT で作る。 */
+/**
+ * row 未 seed でも作れるよう upsert で原子的に書く (CodeRabbit #397: read-then-write
+ * は同時 POST で INSERT 主キー衝突し得る)。他列は schema default 任せ。
+ */
 export async function setOverviewPanels(
   db: DrizzleD1Database,
   csv: string,
   nowIso: string,
 ): Promise<void> {
-  const existing = await db
-    .select({ id: globalConfig.id })
-    .from(globalConfig)
-    .where(eq(globalConfig.id, 'default'))
-    .limit(1)
-  if (existing[0]) {
-    await db
-      .update(globalConfig)
-      .set({ overviewPanels: csv, updatedAt: nowIso })
-      .where(eq(globalConfig.id, 'default'))
-  } else {
-    await db.insert(globalConfig).values({ id: 'default', overviewPanels: csv, updatedAt: nowIso })
-  }
+  await db
+    .insert(globalConfig)
+    .values({ id: 'default', overviewPanels: csv, updatedAt: nowIso })
+    .onConflictDoUpdate({
+      target: globalConfig.id,
+      set: { overviewPanels: csv, updatedAt: nowIso },
+    })
 }
 
 /**

--- a/src/infrastructure/db/globalConfigRepo.ts
+++ b/src/infrastructure/db/globalConfigRepo.ts
@@ -111,21 +111,36 @@ export async function loadOverviewPanelsCsv(db: DrizzleD1Database): Promise<stri
 }
 
 /**
- * row 未 seed でも作れるよう upsert で原子的に書く (CodeRabbit #397: read-then-write
- * は同時 POST で INSERT 主キー衝突し得る)。他列は schema default 任せ。
+ * overview_panels を upsert で書く。row 未 seed でも作れ、同時 POST でも INSERT
+ * 主キー衝突しない (CodeRabbit #397)。
+ *
+ * 旧値 read と write を **同一 D1 batch (= 1 transaction)** に束ね、監査ログ用の
+ * `before` が write と原子境界を共有するようにする (CodeRabbit #397 2nd round:
+ * 別操作だと同時更新で before/after がズレ誤監査になる)。`before` を返す。
+ * 他列は schema default 任せ。
  */
 export async function setOverviewPanels(
   db: DrizzleD1Database,
   csv: string,
   nowIso: string,
-): Promise<void> {
-  await db
-    .insert(globalConfig)
-    .values({ id: 'default', overviewPanels: csv, updatedAt: nowIso })
-    .onConflictDoUpdate({
-      target: globalConfig.id,
-      set: { overviewPanels: csv, updatedAt: nowIso },
-    })
+): Promise<{ before: string }> {
+  const results = await db.batch([
+    db
+      .select({ value: globalConfig.overviewPanels })
+      .from(globalConfig)
+      .where(eq(globalConfig.id, 'default'))
+      .limit(1),
+    db
+      .insert(globalConfig)
+      .values({ id: 'default', overviewPanels: csv, updatedAt: nowIso })
+      .onConflictDoUpdate({
+        target: globalConfig.id,
+        set: { overviewPanels: csv, updatedAt: nowIso },
+      }),
+  ])
+  const beforeRows = results[0] as Array<{ value: string | null }>
+  const prev = beforeRows[0]?.value
+  return { before: typeof prev === 'string' && prev.trim().length > 0 ? prev : OVERVIEW_PANELS_DEFAULT }
 }
 
 /**

--- a/src/infrastructure/db/globalConfigRepo.ts
+++ b/src/infrastructure/db/globalConfigRepo.ts
@@ -89,6 +89,49 @@ export const GLOBAL_CONFIG_DEFAULTS: GlobalConfigSnapshot = Object.freeze({
 })
 
 /**
+ * Dashboard overview パネル表示設定 (#dashboard-mf-layout)。`global_config.overview_panels`
+ * の CSV を読み書きする。表示専用なので `GlobalConfigSnapshot` / cron 経路には通さず、
+ * dashboard だけが参照する独立 read/write。
+ */
+export const OVERVIEW_PANELS_DEFAULT = 'kpi,equity,composition,recent'
+
+export async function loadOverviewPanelsCsv(db: DrizzleD1Database): Promise<string> {
+  try {
+    const rows = await db
+      .select({ value: globalConfig.overviewPanels })
+      .from(globalConfig)
+      .where(eq(globalConfig.id, 'default'))
+      .limit(1)
+    const v = rows[0]?.value
+    return typeof v === 'string' && v.trim().length > 0 ? v : OVERVIEW_PANELS_DEFAULT
+  } catch {
+    // 列未 migration / D1 エラーは全表示 default に倒す (overview は描画継続)。
+    return OVERVIEW_PANELS_DEFAULT
+  }
+}
+
+/** `applyTradingToggle` と同様、row 未 seed なら INSERT で作る。 */
+export async function setOverviewPanels(
+  db: DrizzleD1Database,
+  csv: string,
+  nowIso: string,
+): Promise<void> {
+  const existing = await db
+    .select({ id: globalConfig.id })
+    .from(globalConfig)
+    .where(eq(globalConfig.id, 'default'))
+    .limit(1)
+  if (existing[0]) {
+    await db
+      .update(globalConfig)
+      .set({ overviewPanels: csv, updatedAt: nowIso })
+      .where(eq(globalConfig.id, 'default'))
+  } else {
+    await db.insert(globalConfig).values({ id: 'default', overviewPanels: csv, updatedAt: nowIso })
+  }
+}
+
+/**
  * VIX 値の application-level validation。
  *
  * 0015 migration は ALTER TABLE ADD COLUMN しか実行しておらず CHECK 制約は

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -249,6 +249,13 @@ export const globalConfig = sqliteTable(
      * default 0.5 (= 半分に縮小)。0..1 で運用想定。
      */
     vixWarningSizeScale: real('vix_warning_size_scale').notNull().default(0.5),
+    /**
+     * Dashboard overview パネルの表示 ON/OFF (#dashboard-mf-layout)。有効パネル
+     * key の CSV。表示専用設定なので trading config (`GlobalConfigSnapshot`) には
+     * 通さず、dashboard が専用 read (`loadOverviewPanels`) で参照する。
+     * key: kpi / equity / composition / recent。default は全表示。
+     */
+    overviewPanels: text('overview_panels').notNull().default('kpi,equity,composition,recent'),
     updatedAt: text('updated_at').notNull(),
   },
   (t) => ({

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -261,8 +261,9 @@ export const dashboard = new Hono<DashboardBindings>()
     const csv = Array.from(new Set(selected)).join(',')
     // CodeRabbit #397: global_config への永続変更なので before/after + requestId を
     // 構造化ログに残す (audit 追跡)。display 設定なので config_audit_log table までは使わない。
-    const before = await loadOverviewPanelsCsv(db)
-    await setOverviewPanels(db, csv, new Date().toISOString())
+    // before は setOverviewPanels の batch (= write と同一 transaction) から取得し
+    // 同時更新でも監査がズレないようにする。
+    const { before } = await setOverviewPanels(db, csv, new Date().toISOString())
     console.log(
       JSON.stringify({
         event: 'overview_panels_updated',

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -142,21 +142,7 @@ export const dashboard = new Hono<DashboardBindings>()
               )
             : Promise.resolve([] as Array<{ sym: string; state: SymbolState | null; error: string | null }>),
           loadLatestStrategyPrices(c.env.DB, allDisplaySymbols),
-          db
-            .select({
-              id: tradeJournal.id,
-              timestamp: tradeJournal.timestamp,
-              symbol: tradeJournal.symbol,
-              side: tradeJournal.side,
-              filledQty: tradeJournal.filledQty,
-              filledPrice: tradeJournal.filledPrice,
-              realizedPnl: tradeJournal.realizedPnl,
-              brokerStatus: tradeJournal.brokerStatus,
-            })
-            .from(tradeJournal)
-            .where(eq(tradeJournal.tradeEventType, 'post_submit'))
-            .orderBy(desc(tradeJournal.id))
-            .limit(8),
+          loadRecentFills(c.env.DB, 8),
           c.env.DB
             ? loadVixRegimeSnapshot(c.env.DB, c.get('requestId')).catch(() => null)
             : Promise.resolve(null),
@@ -172,7 +158,9 @@ export const dashboard = new Hono<DashboardBindings>()
         recentTrades,
         vixRegime,
         dryRun: global.dryRun,
-        tradingEnabled: global.tradingEnabled,
+        // env TRADING_ENABLED の deploy-gate を反映した effective 値 (CodeRabbit #397:
+        // 上部バナーと同じ resolveTradingEnabled を通し、生 DB 値との食い違いを防ぐ)。
+        tradingEnabled: resolveTradingEnabled(global.tradingEnabled, c.env.TRADING_ENABLED),
         universe,
       }
       return c.html(renderLayout(c, 'ダッシュボード', overviewBody(data)))
@@ -264,13 +252,26 @@ export const dashboard = new Hono<DashboardBindings>()
     if (!c.env.DB) {
       return c.html(renderLayout(c, '設定', unavailable('DB not bound')))
     }
+    const db = createDb(c.env.DB)
     const form = await c.req.formData()
     const selected = form
       .getAll('panels')
       .map(String)
       .filter((s) => (ALL_OVERVIEW_PANELS as readonly string[]).includes(s))
     const csv = Array.from(new Set(selected)).join(',')
-    await setOverviewPanels(createDb(c.env.DB), csv, new Date().toISOString())
+    // CodeRabbit #397: global_config への永続変更なので before/after + requestId を
+    // 構造化ログに残す (audit 追跡)。display 設定なので config_audit_log table までは使わない。
+    const before = await loadOverviewPanelsCsv(db)
+    await setOverviewPanels(db, csv, new Date().toISOString())
+    console.log(
+      JSON.stringify({
+        event: 'overview_panels_updated',
+        requestId: c.get('requestId') ?? null,
+        actor: extractActor(c.get('actor')),
+        before,
+        after: csv,
+      }),
+    )
     return c.redirect('/dashboard/config', 303)
   })
   .get('/charts', async (c) => {
@@ -1970,6 +1971,43 @@ interface OpenPositionView {
   pnlPct: number | null
 }
 
+/**
+ * overview「最近の約定」用の直近 fill ロード。post_submit 行は side が null
+ * (writer は pre_submit にしか入れない) なので client_order_id で pre_submit と
+ * self-JOIN して side を引く (loadSymbolChart と同方針)。pre_submit が無い古い fill は
+ * realized_pnl の有無から推測 (null=BUY / 非null=SELL)。
+ */
+async function loadRecentFills(
+  db: D1Database,
+  limit: number,
+): Promise<OverviewData['recentTrades']> {
+  const result = await db
+    .prepare(
+      `SELECT ps.id AS id, ps.timestamp AS timestamp, ps.symbol AS symbol,
+         COALESCE(pre.side, CASE WHEN ps.realized_pnl IS NOT NULL THEN 'SELL' ELSE 'BUY' END) AS side,
+         ps.filled_qty AS filledQty, ps.filled_price AS filledPrice,
+         ps.realized_pnl AS realizedPnl, ps.broker_status AS brokerStatus
+       FROM trade_journal AS ps
+       LEFT JOIN trade_journal AS pre
+         ON pre.client_order_id = ps.client_order_id AND pre.trade_event_type = 'pre_submit'
+       WHERE ps.trade_event_type = 'post_submit' AND ps.filled_price IS NOT NULL
+       ORDER BY ps.id DESC
+       LIMIT ?`,
+    )
+    .bind(limit)
+    .all<{
+      id: number
+      timestamp: string
+      symbol: string | null
+      side: string | null
+      filledQty: number | null
+      filledPrice: number | null
+      realizedPnl: number | null
+      brokerStatus: string | null
+    }>()
+  return result.results ?? []
+}
+
 function collectOpenPositions(data: OverviewData): OpenPositionView[] {
   const out: OpenPositionView[] = []
   for (const r of data.positions) {
@@ -2089,7 +2127,7 @@ function renderRecentPanel(data: OverviewData): string {
       <div>
         <table><tbody>
           <tr><th>実行モード</th><td>${dryPill} <span class="muted" style="font-size:11px">(D1 dry_run)</span></td></tr>
-          <tr><th>取引 (trading_enabled)</th><td>${tradingPill}</td></tr>
+          <tr><th>取引 (effective)</th><td>${tradingPill} <span class="muted" style="font-size:11px">(env override 反映後)</span></td></tr>
           <tr><th>VIX レジーム</th><td>${renderVixRegimeCell(data.vixRegime)}</td></tr>
         </tbody></table>
       </div>

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -15,8 +15,10 @@ type DashboardBindings = AppBindings & {
   }
 }
 import { loadGlobalConfigFrom } from '../infrastructure/db/globalConfigLoader'
+import { loadOverviewPanelsCsv, setOverviewPanels } from '../infrastructure/db/globalConfigRepo'
 import { resolveTradingEnabled } from '../trading/runtime/killSwitch'
 import { loadSymbolUniverse, type SymbolUniverse } from '../infrastructure/db/symbolUniverse'
+import type { SymbolCurrency } from '../infrastructure/db/symbolConfigRepo'
 import { escapeHtml, formatSymbolDisplay } from '../shared/format'
 import { createDb } from '../infrastructure/db/tradeJournalRepo'
 import {
@@ -111,7 +113,73 @@ export const dashboard = new Hono<DashboardBindings>()
     c.set('killSwitchState', state)
     await next()
   })
-  .get('/', (c) => c.html(renderLayout(c, 'ダッシュボード', indexBody())))
+  .get('/', async (c) => {
+    if (!c.env.DB) {
+      return c.html(renderLayout(c, 'ダッシュボード', unavailable('DB not bound')))
+    }
+    try {
+      const db = createDb(c.env.DB)
+      const universe = await loadSymbolUniverse(c.env)
+      const allDisplaySymbols = [...universe.allowedSymbols, ...universe.inactiveSymbols]
+      const symbolClient = c.env.SYMBOL_STATE ? new SymbolStateClient(c.env.SYMBOL_STATE) : null
+      const range = parseEquityRange(c.req.query('range'))
+      const [panelsCsv, portfolio, snapshots, positions, strategyPriceMap, recentTrades, vixRegime, global] =
+        await Promise.all([
+          loadOverviewPanelsCsv(db),
+          c.env.PORTFOLIO_STATE
+            ? new PortfolioStateClient(c.env.PORTFOLIO_STATE).getPortfolio().catch(() => null)
+            : Promise.resolve(null),
+          safeLoadPortfolioSnapshots(c.env.DB, range),
+          symbolClient
+            ? Promise.all(
+                allDisplaySymbols.map(async (sym) => {
+                  try {
+                    return { sym, state: await symbolClient.getState(sym), error: null as string | null }
+                  } catch (err) {
+                    return { sym, state: null as SymbolState | null, error: messageOf(err) }
+                  }
+                }),
+              )
+            : Promise.resolve([] as Array<{ sym: string; state: SymbolState | null; error: string | null }>),
+          loadLatestStrategyPrices(c.env.DB, allDisplaySymbols),
+          db
+            .select({
+              id: tradeJournal.id,
+              timestamp: tradeJournal.timestamp,
+              symbol: tradeJournal.symbol,
+              side: tradeJournal.side,
+              filledQty: tradeJournal.filledQty,
+              filledPrice: tradeJournal.filledPrice,
+              realizedPnl: tradeJournal.realizedPnl,
+              brokerStatus: tradeJournal.brokerStatus,
+            })
+            .from(tradeJournal)
+            .where(eq(tradeJournal.tradeEventType, 'post_submit'))
+            .orderBy(desc(tradeJournal.id))
+            .limit(8),
+          c.env.DB
+            ? loadVixRegimeSnapshot(c.env.DB, c.get('requestId')).catch(() => null)
+            : Promise.resolve(null),
+          loadGlobalConfigFrom(c.env, c.get('requestId')),
+        ])
+      const data: OverviewData = {
+        panels: parseOverviewPanels(panelsCsv),
+        portfolio,
+        snapshots,
+        range,
+        positions,
+        strategyPriceMap,
+        recentTrades,
+        vixRegime,
+        dryRun: global.dryRun,
+        tradingEnabled: global.tradingEnabled,
+        universe,
+      }
+      return c.html(renderLayout(c, 'ダッシュボード', overviewBody(data)))
+    } catch (err) {
+      return c.html(renderLayout(c, 'ダッシュボード', unavailable(messageOf(err))))
+    }
+  })
   .get('/positions', async (c) => {
     if (!c.env.DB || !c.env.SYMBOL_STATE) {
       return c.html(renderLayout(c, 'ポートフォリオ', unavailable('DB or SYMBOL_STATE not bound')))
@@ -181,11 +249,29 @@ export const dashboard = new Hono<DashboardBindings>()
     if (!c.env.DB) {
       return c.html(renderLayout(c, '設定', unavailable('DB not bound')))
     }
-    const [global, universe] = await Promise.all([
+    const [global, universe, panelsCsv] = await Promise.all([
       loadGlobalConfigFrom(c.env, c.get('requestId')),
       loadSymbolUniverse(c.env),
+      loadOverviewPanelsCsv(createDb(c.env.DB)),
     ])
-    return c.html(renderLayout(c, '設定', configBody(global, universe)))
+    return c.html(
+      renderLayout(c, '設定', configBody(global, universe, parseOverviewPanels(panelsCsv))),
+    )
+  })
+  // #dashboard-mf-layout: overview パネル ON/OFF を保存。HTML form (checkbox 複数) →
+  // 有効 key を CSV 化して global_config に書き、PRG で /dashboard/config に戻る。
+  .post('/config/overview-panels', rateLimit('ADMIN_WRITE'), async (c) => {
+    if (!c.env.DB) {
+      return c.html(renderLayout(c, '設定', unavailable('DB not bound')))
+    }
+    const form = await c.req.formData()
+    const selected = form
+      .getAll('panels')
+      .map(String)
+      .filter((s) => (ALL_OVERVIEW_PANELS as readonly string[]).includes(s))
+    const csv = Array.from(new Set(selected)).join(',')
+    await setOverviewPanels(createDb(c.env.DB), csv, new Date().toISOString())
+    return c.redirect('/dashboard/config', 303)
   })
   .get('/charts', async (c) => {
     if (!c.env.DB) {
@@ -1264,13 +1350,46 @@ function fmtJst(value: string | Date | null | undefined): string {
 }
 
 const STYLE = `
-  body{font-family:-apple-system,system-ui,sans-serif;margin:0;padding:20px;background:#f5f5f7;color:#1d1d1f}
+  body{font-family:-apple-system,system-ui,sans-serif;margin:0;padding:0;background:#f5f5f7;color:#1d1d1f}
   h1{margin:0 0 16px;font-size:22px}
-  nav{margin-bottom:20px;display:flex;gap:8px;flex-wrap:wrap;align-items:center}
-  nav a{color:#06c;text-decoration:none;padding:4px 10px;border:1px solid #d0d0d5;border-radius:6px;background:#fff}
-  nav a:hover{background:#eef}
-  nav .nav-group{color:#86868b;font-size:11px;text-transform:uppercase;letter-spacing:0.05em;padding:0 4px 0 8px;border-left:1px solid #d0d0d5;margin-left:4px}
-  nav .nav-group:first-of-type{border-left:none;margin-left:0;padding-left:0}
+  /* mf-dashboard 風 shell: 左 sidebar + main */
+  .app{display:flex;min-height:100vh;align-items:stretch}
+  .sidebar{flex:0 0 216px;background:#fff;border-right:1px solid #d0d0d5;padding:16px 12px;display:flex;flex-direction:column;gap:4px;position:sticky;top:0;align-self:flex-start;height:100vh;overflow-y:auto}
+  .sidebar .brand{font-weight:700;font-size:15px;padding:4px 8px 12px;color:#1d1d1f}
+  .sidebar nav{display:flex;flex-direction:column;gap:2px}
+  .sidebar .nav-group{color:#86868b;font-size:11px;text-transform:uppercase;letter-spacing:0.05em;padding:12px 8px 4px}
+  .sidebar .nav-link{color:#1d1d1f;text-decoration:none;padding:7px 10px;border-radius:7px;font-size:13px}
+  .sidebar .nav-link:hover{background:#f0f0f3}
+  .sidebar .nav-link.active{background:#06c;color:#fff;font-weight:600}
+  .main{flex:1;min-width:0;padding:24px}
+  .main .page-title{margin:0 0 16px;font-size:22px}
+  @media(max-width:780px){
+    .app{flex-direction:column}
+    .sidebar{flex:none;width:auto;height:auto;position:static;border-right:none;border-bottom:1px solid #d0d0d5;flex-direction:row;flex-wrap:wrap;align-items:center}
+    .sidebar nav{flex-direction:row;flex-wrap:wrap}
+    .sidebar .nav-group{padding:4px 8px}
+    .main{padding:16px}
+  }
+  /* KPI カード */
+  .kpi-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px;margin-bottom:16px}
+  .kpi-card{background:#fff;border:1px solid #d0d0d5;border-radius:10px;padding:14px}
+  .kpi-label{color:#86868b;font-size:12px;margin-bottom:6px}
+  .kpi-value{font-size:22px;font-weight:700;font-variant-numeric:tabular-nums}
+  .kpi-sub{font-size:12px;margin-top:4px;font-variant-numeric:tabular-nums}
+  /* パネル (カード) */
+  .panel{background:#fff;border:1px solid #d0d0d5;border-radius:10px;padding:16px;margin-bottom:16px}
+  .panel>.panel-title{margin:0 0 12px;font-size:14px;font-weight:700}
+  .panel-row{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+  @media(max-width:780px){.panel-row{grid-template-columns:1fr}}
+  .panel table{border:none;border-radius:0}
+  /* bar (構成比 / movers) */
+  .bar-track{background:#f0f0f3;border-radius:4px;height:8px;overflow:hidden;margin-top:3px}
+  .bar-fill{height:8px;border-radius:4px;background:#06c}
+  .bar-fill.up{background:#057a55}.bar-fill.down{background:#c22}
+  .rank-row{display:flex;justify-content:space-between;gap:8px;padding:4px 0;font-size:13px;font-variant-numeric:tabular-nums}
+  .pill{display:inline-block;padding:1px 8px;border-radius:10px;font-size:11px;font-weight:700}
+  .pill.dry{background:#057a55;color:#fff}.pill.live{background:#c22;color:#fff}
+  .pill.on{background:#057a55;color:#fff}.pill.off{background:#86868b;color:#fff}
   table{border-collapse:collapse;width:100%;background:#fff;border:1px solid #d0d0d5;border-radius:6px;overflow:hidden}
   th,td{padding:8px 10px;text-align:left;border-bottom:1px solid #e5e5ea;font-size:13px;font-variant-numeric:tabular-nums}
   th{background:#fafafa;font-weight:600}
@@ -1298,6 +1417,7 @@ const STYLE = `
 
 function renderLayout(
   c: {
+    req: { path: string }
     env: unknown
     var: { killSwitchState: KillSwitchBannerState | null }
   },
@@ -1305,7 +1425,64 @@ function renderLayout(
   body: string,
 ): string {
   const banner = killSwitchBanner(c.var.killSwitchState)
-  return layout(title, banner + body)
+  return layout(title, banner + body, c.req.path)
+}
+
+/** Sidebar nav 定義 (mf-dashboard 風 shell)。active link は path 完全一致で強調。 */
+const NAV_GROUPS: ReadonlyArray<{
+  label?: string
+  links: ReadonlyArray<{ href: string; text: string; title?: string }>
+}> = [
+  { links: [{ href: '/dashboard', text: 'ホーム' }] },
+  {
+    label: '取引状況',
+    links: [
+      { href: '/dashboard/positions', text: 'ポートフォリオ' },
+      { href: '/dashboard/portfolio', text: '口座サマリ' },
+      { href: '/dashboard/trades', text: '約定履歴' },
+    ],
+  },
+  {
+    label: '戦略・監視',
+    links: [
+      { href: '/dashboard/cron', text: '戦略判定' },
+      { href: '/dashboard/charts', text: 'チャート' },
+      { href: '/dashboard/alerts', text: 'アラート' },
+      { href: '/dashboard/events', text: 'イベント' },
+    ],
+  },
+  {
+    label: '運用',
+    links: [
+      { href: '/dashboard/config', text: '設定' },
+      { href: '/dashboard/symbols', text: '銘柄管理' },
+      { href: '/dashboard/audit', text: '監査ログ' },
+      {
+        href: '/dashboard/broker-probe',
+        text: 'broker 診断',
+        title: 'Webull broker に直接 quote/positions を投げて raw レスポンスを表示する診断ページ',
+      },
+      {
+        href: '/dashboard/webull-token',
+        text: 'Webull token',
+        title: 'Webull x-access-token の状態確認 / 投入 / refresh (#21 Phase B)',
+      },
+    ],
+  },
+]
+
+function renderSidebarNav(activePath?: string): string {
+  return NAV_GROUPS.map((g) => {
+    const head = g.label ? `<div class="nav-group">${esc(g.label)}</div>` : ''
+    const links = g.links
+      .map((l) => {
+        const active = activePath === l.href ? ' active' : ''
+        const t = l.title ? ` title="${esc(l.title)}"` : ''
+        return `<a class="nav-link${active}" href="${l.href}"${t}>${esc(l.text)}</a>`
+      })
+      .join('')
+    return head + links
+  }).join('')
 }
 
 function killSwitchBanner(state: KillSwitchBannerState | null): string {
@@ -1335,7 +1512,7 @@ function killSwitchBanner(state: KillSwitchBannerState | null): string {
   </div>`
 }
 
-function layout(title: string, body: string): string {
+function layout(title: string, body: string, activePath?: string): string {
   return `<!doctype html>
 <html lang="ja">
 <head>
@@ -1345,27 +1522,17 @@ function layout(title: string, body: string): string {
 <style>${STYLE}</style>
 </head>
 <body>
-<h1>Webull Trading — ${esc(title)}</h1>
-<nav>
-  <a href="/dashboard">ホーム</a>
-  <span class="nav-group">取引状況</span>
-  <a href="/dashboard/positions">ポートフォリオ</a>
-  <a href="/dashboard/portfolio">口座サマリ</a>
-  <a href="/dashboard/trades">約定履歴</a>
-  <span class="nav-group">戦略・監視</span>
-  <a href="/dashboard/cron">戦略判定</a>
-  <a href="/dashboard/charts">チャート</a>
-  <a href="/dashboard/alerts">アラート</a>
-  <a href="/dashboard/events">イベント</a>
-  <span class="nav-group">運用</span>
-  <a href="/dashboard/config">設定</a>
-  <a href="/dashboard/symbols">銘柄管理</a>
-  <a href="/dashboard/audit">監査ログ</a>
-  <a href="/dashboard/broker-probe" title="Webull broker に直接 quote/positions を投げて raw レスポンスを表示する診断ページ">broker 診断</a>
-  <a href="/dashboard/webull-token" title="Webull x-access-token の状態確認 / 投入 / refresh (#21 Phase B)">Webull token</a>
-</nav>
-${body}
-<div class="footer">画面生成時刻: ${esc(fmtJst(new Date()))}</div>
+<div class="app">
+  <aside class="sidebar">
+    <div class="brand">Webull Trading</div>
+    <nav>${renderSidebarNav(activePath)}</nav>
+  </aside>
+  <main class="main">
+    <h1 class="page-title">${esc(title)}</h1>
+    ${body}
+    <div class="footer">画面生成時刻: ${esc(fmtJst(new Date()))}</div>
+  </main>
+</div>
 </body>
 </html>`
 }
@@ -1744,31 +1911,209 @@ function parseJsonObject(value: string | null | undefined): unknown {
   }
 }
 
-function indexBody(): string {
-  return `<p>運用者向けダッシュボード (一部 page は write 操作あり、すべての変更は監査ログに記録)。各ページは Cloudflare Access で保護されています。</p>
+// #dashboard-mf-layout: overview パネル定義。設定で ON/OFF (default 全表示)。
+export type OverviewPanel = 'kpi' | 'equity' | 'composition' | 'recent'
+export const ALL_OVERVIEW_PANELS: readonly OverviewPanel[] = ['kpi', 'equity', 'composition', 'recent']
+export const OVERVIEW_PANEL_LABELS: Record<OverviewPanel, string> = {
+  kpi: 'KPI カード (総資産 / 当日損益 / 建玉数 / エクスポージャー)',
+  equity: '資産推移チャート (期間タブ)',
+  composition: '資産構成 + 含み損益ランキング',
+  recent: '最近の約定 + VIX / リスク状態',
+}
 
-<h2 style="font-size:14px;margin:16px 0 4px 0">取引状況</h2>
-<ul>
-  <li><a href="/dashboard/positions">ポートフォリオ</a> — 全銘柄の Durable Object 状態 (保有 / 平均取得単価 / 未約定注文 / クールダウン)</li>
-  <li><a href="/dashboard/portfolio">口座サマリ</a> — 当日始値資産 / 当日実現損益 / ドローダウン / 緊急停止 (kill-switch)</li>
-  <li><a href="/dashboard/trades">約定履歴</a> — <code>trade_journal</code> 直近 (既定 50件、<code>?limit=N</code> で可変、最大 200)</li>
-</ul>
+/** CSV を有効パネル集合へ。不正値は無視、空 (未設定/全部不正) は全表示。 */
+export function parseOverviewPanels(csv: string | null | undefined): Set<OverviewPanel> {
+  const set = new Set<OverviewPanel>()
+  for (const tok of (csv ?? '').split(',').map((s) => s.trim())) {
+    if ((ALL_OVERVIEW_PANELS as readonly string[]).includes(tok)) set.add(tok as OverviewPanel)
+  }
+  return set.size === 0 ? new Set(ALL_OVERVIEW_PANELS) : set
+}
 
-<h2 style="font-size:14px;margin:16px 0 4px 0">戦略・監視</h2>
-<ul>
-  <li><a href="/dashboard/cron">戦略判定</a> — <code>strategy_decision_log</code> 直近 cron tick の銘柄別判定 (<code>?symbol=SOXL</code> / <code>?requestId=...</code> で絞り込み可)</li>
-  <li><a href="/dashboard/charts">チャート</a> — 概要 (エクイティカーブ + ドローダウン) / 取引品質 (PnL 分布 + 統計 + Decision breakdown) / 個別銘柄 (price + SMA50 + entry/exit) を tab 切替</li>
-  <li><a href="/dashboard/alerts">アラート</a> — Slack/Discord に push 通知した critical / warning / info の直近 (#141)。webhook 未設定でも D1 に記録される。</li>
-  <li><a href="/dashboard/events">イベント</a> — <code>earnings_calendar</code> / <code>macro_event_calendar</code> の手動 add / delete (#293)。avoid 用 risk gate のソース。</li>
-</ul>
+interface OverviewData {
+  panels: Set<OverviewPanel>
+  portfolio: {
+    dailyStartEquity: number
+    dailyRealizedPnl: number
+    openExposureUsd: number
+    openExposureJpy: number
+    tradingDisabledUntil: string | null
+    updatedAt: string
+  } | null
+  snapshots: PortfolioEquitySnapshotRow[]
+  range: EquityRange
+  positions: Array<{ sym: string; state: SymbolState | null; error: string | null }>
+  strategyPriceMap: Map<string, { price: number; asOf: string }>
+  recentTrades: Array<{
+    id: number
+    timestamp: string
+    symbol: string | null
+    side: string | null
+    filledQty: number | null
+    filledPrice: number | null
+    realizedPnl: number | null
+    brokerStatus: string | null
+  }>
+  vixRegime: VixRegime | null
+  dryRun: boolean
+  tradingEnabled: boolean
+  universe: SymbolUniverse
+}
 
-<h2 style="font-size:14px;margin:16px 0 4px 0">運用</h2>
-<ul>
-  <li><a href="/dashboard/config">設定</a> — <code>global_config</code> + 有効な <code>symbol_config</code></li>
-  <li><a href="/dashboard/symbols">銘柄管理</a> — <code>symbol_config</code> CRUD (#292)。追加 / 編集 / 有効化切替 / soft delete。</li>
-  <li><a href="/dashboard/audit">監査ログ</a> — 状態変更系 admin POST の before/after 差分 (#274)。actor / endpoint / 日付で絞り込み可。</li>
-  <li><a href="/dashboard/broker-probe">broker 診断</a> — Webull broker へ直接 quote / positions を投げて raw レスポンスを観察 (接続診断用)。</li>
-</ul>`
+/** 開いている建玉 (qty != 0) を評価額・含み損益% 付きで抽出。 */
+interface OpenPositionView {
+  sym: string
+  qty: number
+  currency: SymbolCurrency
+  price: number | null
+  marketValue: number | null
+  pnlPct: number | null
+}
+
+function collectOpenPositions(data: OverviewData): OpenPositionView[] {
+  const out: OpenPositionView[] = []
+  for (const r of data.positions) {
+    const pos = r.state?.position
+    if (!r.state || !pos || pos.qty === 0) continue
+    const webull = r.state.lastQuote
+      ? { price: r.state.lastQuote.price, source: r.state.lastQuote.source, asOf: r.state.lastQuote.asOf ?? r.state.lastQuote.fetchedAt }
+      : null
+    const yahoo = data.strategyPriceMap.get(r.state.symbol) ?? null
+    const quote = pickFreshQuote(webull, yahoo)
+    const price = quote?.price ?? null
+    const pnlPct = price !== null && pos.avgPrice > 0 ? ((price - pos.avgPrice) / pos.avgPrice) * 100 : null
+    out.push({
+      sym: r.state.symbol,
+      qty: pos.qty,
+      currency: data.universe.symbolCurrency[r.state.symbol] ?? 'USD',
+      price,
+      marketValue: price !== null ? pos.qty * price : null,
+      pnlPct,
+    })
+  }
+  return out
+}
+
+function kpiCard(label: string, value: string, sub?: string, subClass?: string): string {
+  const subHtml = sub ? `<div class="kpi-sub ${subClass ?? 'muted'}">${sub}</div>` : ''
+  return `<div class="kpi-card"><div class="kpi-label">${esc(label)}</div><div class="kpi-value">${value}</div>${subHtml}</div>`
+}
+
+function renderKpiPanel(data: OverviewData, open: OpenPositionView[]): string {
+  const p = data.portfolio
+  const dd = p && p.dailyStartEquity > 0 ? (p.dailyRealizedPnl / p.dailyStartEquity) * 100 : null
+  const pnlClass = p == null ? 'muted' : p.dailyRealizedPnl >= 0 ? 'ok' : 'err'
+  const cards = [
+    kpiCard('当日始値資産', p ? fmtNumber(p.dailyStartEquity, 2) : '—', '口座 dailyStartEquity'),
+    kpiCard(
+      '当日実現損益',
+      p ? `<span class="${pnlClass}">${fmtNumber(p.dailyRealizedPnl, 2)}</span>` : '—',
+      dd === null ? undefined : `DD ${fmtNumber(dd, 2)}%`,
+      dd === null ? 'muted' : dd >= 0 ? 'ok' : 'err',
+    ),
+    kpiCard('建玉数', String(open.length), '保有中の銘柄数'),
+    kpiCard(
+      'Open exposure',
+      p ? `${fmtNumber(p.openExposureUsd, 0)}<span class="muted" style="font-size:12px"> USD</span>` : '—',
+      p ? `${fmtNumber(p.openExposureJpy, 0)} JPY` : undefined,
+    ),
+  ].join('')
+  return `<div class="kpi-grid">${cards}</div>`
+}
+
+function renderCompositionPanel(open: OpenPositionView[]): string {
+  if (open.length === 0) {
+    return `<div class="panel"><div class="panel-title">資産構成 / 含み損益ランキング</div><p class="muted">保有中の建玉がありません。</p></div>`
+  }
+  // 通貨内シェアで構成比 bar を正規化 (USD/JPY を混ぜない)。
+  const sumByCcy: Record<string, number> = {}
+  for (const o of open) {
+    if (o.marketValue !== null) sumByCcy[o.currency] = (sumByCcy[o.currency] ?? 0) + Math.abs(o.marketValue)
+  }
+  const composition = [...open]
+    .sort((a, b) => (Math.abs(b.marketValue ?? 0)) - (Math.abs(a.marketValue ?? 0)))
+    .map((o) => {
+      const total = sumByCcy[o.currency] ?? 0
+      const share = o.marketValue !== null && total > 0 ? (Math.abs(o.marketValue) / total) * 100 : 0
+      const valueText = o.marketValue !== null ? `${fmtNumber(o.marketValue, 0)} ${o.currency}` : '—'
+      return `<div class="rank-row"><span>${esc(o.sym)} <span class="muted" style="font-size:11px">${fmtNumber(share, 1)}%</span></span><span>${valueText}</span></div>
+        <div class="bar-track"><div class="bar-fill" style="width:${share.toFixed(1)}%"></div></div>`
+    })
+    .join('')
+  // 含み損益% ランキング (up / down)。
+  const ranked = open.filter((o) => o.pnlPct !== null) as Array<OpenPositionView & { pnlPct: number }>
+  const gainers = [...ranked].filter((o) => o.pnlPct >= 0).sort((a, b) => b.pnlPct - a.pnlPct).slice(0, 5)
+  const losers = [...ranked].filter((o) => o.pnlPct < 0).sort((a, b) => a.pnlPct - b.pnlPct).slice(0, 5)
+  const rankRow = (o: OpenPositionView & { pnlPct: number }) =>
+    `<div class="rank-row"><span>${esc(o.sym)}</span><span class="${o.pnlPct >= 0 ? 'ok' : 'err'}">${fmtNumber(o.pnlPct, 2)}%</span></div>`
+  const rankCol = (title: string, items: Array<OpenPositionView & { pnlPct: number }>) =>
+    `<div><div class="muted" style="font-size:12px;margin-bottom:4px">${esc(title)}</div>${items.length ? items.map(rankRow).join('') : '<p class="muted">—</p>'}</div>`
+  return `<div class="panel">
+    <div class="panel-title">資産構成 / 含み損益ランキング</div>
+    <p class="muted" style="font-size:12px;margin-top:0">構成比は通貨内シェア。ランキングは含み損益% (現在値 vs 平均取得単価)。</p>
+    <div class="panel-row">
+      <div><div class="muted" style="font-size:12px;margin-bottom:4px">構成 (評価額)</div>${composition}</div>
+      <div class="panel-row" style="grid-template-columns:1fr 1fr">${rankCol('上昇', gainers)}${rankCol('下落', losers)}</div>
+    </div>
+  </div>`
+}
+
+function renderRecentPanel(data: OverviewData): string {
+  const trades = data.recentTrades
+    .map((t) => {
+      const sideClass = t.side === 'BUY' ? 'ok' : t.side === 'SELL' ? 'err' : 'muted'
+      const pnl = t.realizedPnl !== null ? formatRealizedPnl(t.realizedPnl) : '<span class="muted">—</span>'
+      return `<tr>
+        <td class="muted" style="font-size:12px">${esc(fmtJst(t.timestamp))}</td>
+        <td><strong>${esc(displaySymbol(t.symbol ?? '—', data.universe))}</strong></td>
+        <td class="${sideClass}">${esc(t.side ?? '—')}</td>
+        <td>${t.filledQty !== null ? esc(t.filledQty) : '—'}</td>
+        <td>${t.filledPrice !== null ? fmtNumber(t.filledPrice, 2) : '—'}</td>
+        <td>${pnl}</td>
+      </tr>`
+    })
+    .join('')
+  const recentTable = data.recentTrades.length
+    ? `<table><thead><tr><th>時刻</th><th>銘柄</th><th>売買</th><th>数量</th><th>約定値</th><th>実損益</th></tr></thead><tbody>${trades}</tbody></table>`
+    : '<p class="muted">約定履歴がありません。</p>'
+  const dryPill = data.dryRun
+    ? '<span class="pill dry">DRY-RUN</span>'
+    : '<span class="pill live">LIVE</span>'
+  const tradingPill = data.tradingEnabled
+    ? '<span class="pill on">取引 ON</span>'
+    : '<span class="pill off">取引 OFF</span>'
+  return `<div class="panel">
+    <div class="panel-title">最近の約定 / リスク状態</div>
+    <div class="panel-row">
+      <div>${recentTable}<div style="margin-top:8px"><a href="/dashboard/trades">約定履歴をすべて見る →</a></div></div>
+      <div>
+        <table><tbody>
+          <tr><th>実行モード</th><td>${dryPill} <span class="muted" style="font-size:11px">(D1 dry_run)</span></td></tr>
+          <tr><th>取引 (trading_enabled)</th><td>${tradingPill}</td></tr>
+          <tr><th>VIX レジーム</th><td>${renderVixRegimeCell(data.vixRegime)}</td></tr>
+        </tbody></table>
+      </div>
+    </div>
+  </div>`
+}
+
+function overviewBody(data: OverviewData): string {
+  const open = collectOpenPositions(data)
+  const sections: string[] = []
+  if (data.panels.has('kpi')) sections.push(renderKpiPanel(data, open))
+  if (data.panels.has('equity')) {
+    sections.push(
+      `<div class="panel">${renderPortfolioEquityChart(data.snapshots, data.range, '/dashboard')}</div>`,
+    )
+  }
+  if (data.panels.has('composition')) sections.push(renderCompositionPanel(open))
+  if (data.panels.has('recent')) sections.push(renderRecentPanel(data))
+  if (sections.length === 0) {
+    sections.push(
+      '<p class="muted">表示パネルが選択されていません。<a href="/dashboard/config">設定</a>でパネルを有効化してください。</p>',
+    )
+  }
+  return sections.join('')
 }
 
 /**
@@ -1990,8 +2335,9 @@ async function safeLoadPortfolioSnapshots(
 function renderPortfolioEquityChart(
   snapshots: PortfolioEquitySnapshotRow[],
   range: EquityRange,
+  basePath = '/dashboard/portfolio',
 ): string {
-  const rangeTabs = renderEquityRangeTabs(range)
+  const rangeTabs = renderEquityRangeTabs(range, basePath)
   if (snapshots.length === 0) {
     return `<h3 style="margin-top:24px">総資産チャート</h3>
     ${rangeTabs}
@@ -2077,7 +2423,7 @@ function renderPortfolioEquityChart(
   <script>${initScript}</script>`
 }
 
-function renderEquityRangeTabs(active: EquityRange): string {
+function renderEquityRangeTabs(active: EquityRange, basePath = '/dashboard/portfolio'): string {
   const options: Array<{ id: EquityRange; label: string }> = [
     { id: '30d', label: '30 日' },
     { id: '90d', label: '90 日' },
@@ -2087,7 +2433,7 @@ function renderEquityRangeTabs(active: EquityRange): string {
   const links = options
     .map((opt) => {
       const cls = opt.id === active ? 'tab tab-active' : 'tab'
-      return `<a class="${cls}" href="/dashboard/portfolio?range=${opt.id}">${opt.label}</a>`
+      return `<a class="${cls}" href="${basePath}?range=${opt.id}">${opt.label}</a>`
     })
     .join(' ')
   return `<div class="tab-strip" style="margin-top:12px">${links}</div>`
@@ -2220,7 +2566,17 @@ function tradesBody(
 function configBody(
   global: Awaited<ReturnType<typeof loadGlobalConfigFrom>>,
   universe: Awaited<ReturnType<typeof loadSymbolUniverse>>,
+  overviewPanels: Set<OverviewPanel>,
 ): string {
+  // #dashboard-mf-layout: overview パネル ON/OFF。POST → PRG redirect (#293 と同型)。
+  const panelForm = `<details open>
+    <summary>ダッシュボード overview パネル表示</summary>
+    <form method="post" action="/dashboard/config/overview-panels" style="margin:8px 0;display:flex;flex-direction:column;gap:6px;max-width:560px">
+      ${ALL_OVERVIEW_PANELS.map((k) => `<label style="font-size:13px"><input type="checkbox" name="panels" value="${k}"${overviewPanels.has(k) ? ' checked' : ''}/> ${esc(OVERVIEW_PANEL_LABELS[k])}</label>`).join('')}
+      <div><button type="submit" style="padding:4px 12px;font-size:13px;background:#06c;color:#fff;border:none;border-radius:6px;cursor:pointer">保存</button></div>
+    </form>
+    <p class="muted" style="font-size:12px"><code>/dashboard</code> の overview に表示するパネル。全て OFF にすると全表示に戻ります。</p>
+  </details>`
   // 列名 (snake_case) は SQL での copy-paste 互換のため英字のまま残し、
   // 日本語説明は別列に分離。これで `UPDATE global_config SET xxx = ...` が
   // そのまま使える。
@@ -2266,7 +2622,8 @@ function configBody(
         </tr>`
     })
     .join('')
-  return `<details open>
+  return `${panelForm}
+  <details open>
     <summary>グローバル設定 (global_config)</summary>
     <table>
       <thead><tr><th>Key</th><th>値</th><th>説明</th><th>詳細</th></tr></thead>

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -280,6 +280,8 @@ describe('dashboard', () => {
     let insertedValues: Record<string, unknown> | undefined
     // setOverviewPanels は db.batch([select(before), insert().values().onConflictDoUpdate()])。
     // select/insert は batch に渡す statement を組むだけ (mock では空 obj)、実 read は batch が返す。
+    // batch 呼び出し自体を spy して原子更新 (read→write 退行) の回帰ガードにする。
+    const batchSpy = vi.fn(async (_stmts: unknown[]) => [[{ value: 'kpi,equity,composition,recent' }], {}])
     vi.mocked(createDb).mockReturnValue({
       select: () => ({ from: () => ({ where: () => ({ limit: () => ({}) }) }) }),
       insert: () => ({
@@ -293,7 +295,7 @@ describe('dashboard', () => {
           }
         },
       }),
-      batch: async () => [[{ value: 'kpi,equity,composition,recent' }], {}],
+      batch: batchSpy,
     } as unknown as ReturnType<typeof createDb>)
     const env = { ...baseEnv, DB: {} as D1Database }
     const app = createApp()
@@ -317,6 +319,9 @@ describe('dashboard', () => {
     // upsert の insert 部の payload も検証 (初回作成時に正しい行が入る)。
     expect(insertedValues).toMatchObject({ id: 'default', overviewPanels: 'kpi,recent' })
     expect(typeof insertedValues?.updatedAt).toBe('string')
+    // 原子更新の回帰ガード: 1 回の batch に before-read + upsert の 2 statement。
+    expect(batchSpy).toHaveBeenCalledTimes(1)
+    expect((batchSpy.mock.calls[0]![0] as unknown[]).length).toBe(2)
   })
 
   it('escapes potentially-unsafe symbol names on config page', async () => {

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -277,20 +277,23 @@ describe('dashboard', () => {
 
   it('saves overview panel selection (303 redirect, CSV deduped + invalid dropped)', async () => {
     let storedCsv: string | undefined
+    let insertedValues: Record<string, unknown> | undefined
+    // setOverviewPanels は db.batch([select(before), insert().values().onConflictDoUpdate()])。
+    // select/insert は batch に渡す statement を組むだけ (mock では空 obj)、実 read は batch が返す。
     vi.mocked(createDb).mockReturnValue({
-      // loadOverviewPanelsCsv (before-read) → value 無し → default fallback。
-      select: () => ({
-        from: () => ({ where: () => ({ limit: async () => [{ value: undefined }] }) }),
-      }),
-      // setOverviewPanels は upsert: insert().values().onConflictDoUpdate()。
+      select: () => ({ from: () => ({ where: () => ({ limit: () => ({}) }) }) }),
       insert: () => ({
-        values: () => ({
-          onConflictDoUpdate: (cfg: { set: { overviewPanels: string } }) => {
-            storedCsv = cfg.set.overviewPanels
-            return Promise.resolve(undefined)
-          },
-        }),
+        values: (vals: Record<string, unknown>) => {
+          insertedValues = vals
+          return {
+            onConflictDoUpdate: (cfg: { set: { overviewPanels: string } }) => {
+              storedCsv = cfg.set.overviewPanels
+              return {}
+            },
+          }
+        },
       }),
+      batch: async () => [[{ value: 'kpi,equity,composition,recent' }], {}],
     } as unknown as ReturnType<typeof createDb>)
     const env = { ...baseEnv, DB: {} as D1Database }
     const app = createApp()
@@ -311,6 +314,9 @@ describe('dashboard', () => {
     expect(res.status).toBe(303)
     expect(res.headers.get('location')).toBe('/dashboard/config')
     expect(storedCsv).toBe('kpi,recent')
+    // upsert の insert 部の payload も検証 (初回作成時に正しい行が入る)。
+    expect(insertedValues).toMatchObject({ id: 'default', overviewPanels: 'kpi,recent' })
+    expect(typeof insertedValues?.updatedAt).toBe('string')
   })
 
   it('escapes potentially-unsafe symbol names on config page', async () => {

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -278,16 +278,19 @@ describe('dashboard', () => {
   it('saves overview panel selection (303 redirect, CSV deduped + invalid dropped)', async () => {
     let storedCsv: string | undefined
     vi.mocked(createDb).mockReturnValue({
+      // loadOverviewPanelsCsv (before-read) → value 無し → default fallback。
       select: () => ({
-        from: () => ({ where: () => ({ limit: async () => [{ id: 'default' }] }) }),
+        from: () => ({ where: () => ({ limit: async () => [{ value: undefined }] }) }),
       }),
-      update: () => ({
-        set: (vals: { overviewPanels: string }) => {
-          storedCsv = vals.overviewPanels
-          return { where: async () => undefined }
-        },
+      // setOverviewPanels は upsert: insert().values().onConflictDoUpdate()。
+      insert: () => ({
+        values: () => ({
+          onConflictDoUpdate: (cfg: { set: { overviewPanels: string } }) => {
+            storedCsv = cfg.set.overviewPanels
+            return Promise.resolve(undefined)
+          },
+        }),
       }),
-      insert: () => ({ values: async () => undefined }),
     } as unknown as ReturnType<typeof createDb>)
     const env = { ...baseEnv, DB: {} as D1Database }
     const app = createApp()
@@ -539,8 +542,8 @@ describe('parseOverviewPanels', () => {
     const all = [...ALL_OVERVIEW_PANELS].sort()
     expect([...parseOverviewPanels('')].sort()).toEqual(all)
     expect([...parseOverviewPanels('x,y')].sort()).toEqual(all)
-    expect(parseOverviewPanels(null).size).toBe(ALL_OVERVIEW_PANELS.length)
-    expect(parseOverviewPanels(undefined).size).toBe(ALL_OVERVIEW_PANELS.length)
+    expect([...parseOverviewPanels(null)].sort()).toEqual(all)
+    expect([...parseOverviewPanels(undefined)].sort()).toEqual(all)
   })
 })
 

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -261,6 +261,55 @@ describe('dashboard', () => {
     expect(body).toContain('SOXL')
   })
 
+  // #dashboard-mf-layout: overview パネル ON/OFF フォーム。createDb mock 未設定 →
+  // loadOverviewPanelsCsv が default fallback → 4 パネルすべて checked で描画。
+  it('renders overview panel toggle form on config page (all checked by default)', async () => {
+    const env = { ...baseEnv, DB: {} as D1Database }
+    const app = createApp()
+    const res = await app.request('/dashboard/config', { headers: authHeader }, env)
+    const body = await res.text()
+    expect(body).toContain('action="/dashboard/config/overview-panels"')
+    for (const k of ['kpi', 'equity', 'composition', 'recent']) {
+      expect(body).toContain(`value="${k}"`)
+    }
+    expect((body.match(/name="panels"[^>]*checked/g) ?? []).length).toBe(4)
+  })
+
+  it('saves overview panel selection (303 redirect, CSV deduped + invalid dropped)', async () => {
+    let storedCsv: string | undefined
+    vi.mocked(createDb).mockReturnValue({
+      select: () => ({
+        from: () => ({ where: () => ({ limit: async () => [{ id: 'default' }] }) }),
+      }),
+      update: () => ({
+        set: (vals: { overviewPanels: string }) => {
+          storedCsv = vals.overviewPanels
+          return { where: async () => undefined }
+        },
+      }),
+      insert: () => ({ values: async () => undefined }),
+    } as unknown as ReturnType<typeof createDb>)
+    const env = { ...baseEnv, DB: {} as D1Database }
+    const app = createApp()
+    const res = await app.request(
+      '/dashboard/config/overview-panels',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams([
+          ['panels', 'kpi'],
+          ['panels', 'recent'],
+          ['panels', 'kpi'],
+          ['panels', 'bogus'],
+        ]).toString(),
+      },
+      env,
+    )
+    expect(res.status).toBe(303)
+    expect(res.headers.get('location')).toBe('/dashboard/config')
+    expect(storedCsv).toBe('kpi,recent')
+  })
+
   it('escapes potentially-unsafe symbol names on config page', async () => {
     vi.mocked(loadSymbolUniverse).mockResolvedValue(
       makeSymbolUniverse({
@@ -474,6 +523,24 @@ describe('dashboard', () => {
     const app = createApp()
     const res = await app.request('/dashboard/alerts', {}, unauthEnv)
     expect(res.status).toBe(401)
+  })
+})
+
+import { parseOverviewPanels, ALL_OVERVIEW_PANELS } from '../../src/routes/dashboard'
+
+describe('parseOverviewPanels', () => {
+  it('parses a valid CSV into the panel set', () => {
+    expect([...parseOverviewPanels('kpi,recent')].sort()).toEqual(['kpi', 'recent'])
+  })
+  it('ignores invalid tokens and whitespace', () => {
+    expect([...parseOverviewPanels(' kpi , bogus , equity ')].sort()).toEqual(['equity', 'kpi'])
+  })
+  it('empty / all-invalid / null / undefined → all panels (fallback)', () => {
+    const all = [...ALL_OVERVIEW_PANELS].sort()
+    expect([...parseOverviewPanels('')].sort()).toEqual(all)
+    expect([...parseOverviewPanels('x,y')].sort()).toEqual(all)
+    expect(parseOverviewPanels(null).size).toBe(ALL_OVERVIEW_PANELS.length)
+    expect(parseOverviewPanels(undefined).size).toBe(ALL_OVERVIEW_PANELS.length)
   })
 })
 


### PR DESCRIPTION
## 概要
ダッシュボードを [hiroppy/mf-dashboard](https://hiroppy.github.io/mf-dashboard/) 風に刷新。

- **左サイドバー shell** を全ページに適用 (上部 flat nav → sidebar、active link 強調)
- **`/dashboard` を overview に作り替え**: 上部 KPI カード / 資産推移チャート (期間タブ) / 資産構成 + 含み損益ランキング / 最近の約定 + リスク状態
- **overview パネルは設定で ON/OFF 可** (デフォルト全表示)
- 既存詳細ページ (positions/portfolio/trades/cron/charts/config/...) は新 shell を継承

## 実装メモ
- ECharts は既存 CDN (`ECHARTS_CDN`) / `renderPortfolioEquityChart` / `renderEquityRangeTabs` を流用。SSR (Hono) のまま、新フレームワーク無し。
- パネル ON/OFF は `global_config.overview_panels` (CSV) に永続。**表示専用設定なので `GlobalConfigSnapshot` / cron 経路には通さず**、dashboard 専用の `loadOverviewPanelsCsv` / `setOverviewPanels` で読み書き (blast radius 最小化)。
- 設定 UI は `/dashboard/config` の checkbox フォーム → `POST /dashboard/config/overview-panels` (PRG redirect、#293 と同型)。
- migration `0021_add_overview_panels.sql` は **drizzle-kit generate で生成** (snapshot/journal 整合、#393 のドリフト回避)。`ALTER TABLE global_config ADD COLUMN overview_panels text NOT NULL DEFAULT 'kpi,equity,composition,recent'`。
- 含み損益ランキングは "前日比" ではなく **含み損益% (現在値 vs 平均取得単価)** で算出 (前日終値データを持たないため正直に labeling)。

## 確認
- typecheck OK / **test 1203 passed** (overview / parseOverviewPanels / config フォーム / 保存 endpoint の追加テスト含む)
- migration はローカル sqlite で ALTER + default backfill 検証済
- staging に deploy して `trading-staging.chanu.co/dashboard` で目視確認予定

## 備考
- このブランチは PR #395 (env DRY_RUN badge 削除) の commit を含みます (同じ layout 領域を触るため土台に取り込み)。#395 は本 PR にスーパーセットされるので、本 PR マージ後に #395 を close するか、#395 を先にマージして本ブランチを rebase してください。
- migration は `pnpm deploy:staging` / production CD (`deploy:production`) が `d1 migrations apply` で自動適用します。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ダッシュボードに概要パネル（KPI／資産／構成／最近の取引）を個別表示・非表示できる設定を追加。選択内容は永続化され、初期表示は KPI, equity, composition, recent。
  * サイドバー＋メインの新レイアウトで選択したパネルを動的に表示。レンジ遷移などの連携も改善。

* **テスト**
  * 概要パネル設定のE2Eテストとパース処理の単体テストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->