### PR TITLE
feat(sizing): per-symbol fixed-% budget allocation

### DIFF
--- a/drizzle/0024_add_symbol_budget_alloc_pct.sql
+++ b/drizzle/0024_add_symbol_budget_alloc_pct.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `symbol_config` ADD `budget_alloc_pct` real;

--- a/drizzle/meta/0024_snapshot.json
+++ b/drizzle/meta/0024_snapshot.json
@@ -1,0 +1,1321 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e7bd85a6-2210-42b6-8a80-b4a855f730d6",
+  "prevId": "86dea85f-6a2e-40dd-b74d-e83dc935ea14",
+  "tables": {
+    "config_audit_log": {
+      "name": "config_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before_json": {
+          "name": "before_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "after_json": {
+          "name": "after_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "config_audit_log_timestamp_id_idx": {
+          "name": "config_audit_log_timestamp_id_idx",
+          "columns": [
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "config_audit_log_actor_timestamp_id_idx": {
+          "name": "config_audit_log_actor_timestamp_id_idx",
+          "columns": [
+            "actor",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "config_audit_log_endpoint_timestamp_id_idx": {
+          "name": "config_audit_log_endpoint_timestamp_id_idx",
+          "columns": [
+            "endpoint",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "config_state_snapshot": {
+      "name": "config_state_snapshot",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "earnings_calendar": {
+      "name": "earnings_calendar",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "earnings_date": {
+          "name": "earnings_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "earnings_calendar_symbol_date_unique": {
+          "name": "earnings_calendar_symbol_date_unique",
+          "columns": [
+            "symbol",
+            "earnings_date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "global_config": {
+      "name": "global_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "trading_enabled": {
+          "name": "trading_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "market_hours_check": {
+          "name": "market_hours_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "max_order_notional": {
+          "name": "max_order_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "max_order_notional_usd": {
+          "name": "max_order_notional_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2000
+        },
+        "max_order_notional_jpy": {
+          "name": "max_order_notional_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100000
+        },
+        "total_capital_usd": {
+          "name": "total_capital_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_capital_jpy": {
+          "name": "total_capital_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_portfolio_exposure_pct": {
+          "name": "max_portfolio_exposure_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.6
+        },
+        "drawdown_kill_threshold": {
+          "name": "drawdown_kill_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.02
+        },
+        "stale_quote_ms": {
+          "name": "stale_quote_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 900000
+        },
+        "gap_reject_pct": {
+          "name": "gap_reject_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.03
+        },
+        "spread_limit_pct_us": {
+          "name": "spread_limit_pct_us",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.0025
+        },
+        "spread_limit_pct_jp": {
+          "name": "spread_limit_pct_jp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.006
+        },
+        "pullback_default_stop_pct": {
+          "name": "pullback_default_stop_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.04
+        },
+        "pullback_default_take_profit_pct": {
+          "name": "pullback_default_take_profit_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.07
+        },
+        "pullback_default_time_stop_days": {
+          "name": "pullback_default_time_stop_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "pullback_default_pullback_max": {
+          "name": "pullback_default_pullback_max",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.03
+        },
+        "pullback_default_pullback_min": {
+          "name": "pullback_default_pullback_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.06
+        },
+        "pullback_default_min_return_50d": {
+          "name": "pullback_default_min_return_50d",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.08
+        },
+        "pullback_default_require_above_sma50": {
+          "name": "pullback_default_require_above_sma50",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "pullback_default_k_atr": {
+          "name": "pullback_default_k_atr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "pullback_default_max_sma50_deviation_pct": {
+          "name": "pullback_default_max_sma50_deviation_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.6
+        },
+        "pullback_default_max_atr_ratio": {
+          "name": "pullback_default_max_atr_ratio",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1.5
+        },
+        "risk_base_per_trade_pct": {
+          "name": "risk_base_per_trade_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.004
+        },
+        "risk_dd_half_threshold": {
+          "name": "risk_dd_half_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.05
+        },
+        "risk_dd_halt_threshold": {
+          "name": "risk_dd_halt_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.1
+        },
+        "vix_warning_threshold": {
+          "name": "vix_warning_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 25
+        },
+        "vix_critical_threshold": {
+          "name": "vix_critical_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "vix_warning_size_scale": {
+          "name": "vix_warning_size_scale",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.5
+        },
+        "overview_panels": {
+          "name": "overview_panels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'kpi,equity,composition,recent'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "global_config_max_order_notional_range": {
+          "name": "global_config_max_order_notional_range",
+          "value": "\"global_config\".\"max_order_notional\" > 0 AND \"global_config\".\"max_order_notional\" <= 10000000"
+        },
+        "global_config_max_order_notional_usd_range": {
+          "name": "global_config_max_order_notional_usd_range",
+          "value": "\"global_config\".\"max_order_notional_usd\" > 0 AND \"global_config\".\"max_order_notional_usd\" <= 1000000"
+        },
+        "global_config_max_order_notional_jpy_range": {
+          "name": "global_config_max_order_notional_jpy_range",
+          "value": "\"global_config\".\"max_order_notional_jpy\" > 0 AND \"global_config\".\"max_order_notional_jpy\" <= 100000000"
+        },
+        "global_config_total_capital_usd_range": {
+          "name": "global_config_total_capital_usd_range",
+          "value": "\"global_config\".\"total_capital_usd\" IS NULL OR \"global_config\".\"total_capital_usd\" > 0"
+        },
+        "global_config_total_capital_jpy_range": {
+          "name": "global_config_total_capital_jpy_range",
+          "value": "\"global_config\".\"total_capital_jpy\" IS NULL OR \"global_config\".\"total_capital_jpy\" > 0"
+        },
+        "global_config_max_portfolio_exposure_pct_range": {
+          "name": "global_config_max_portfolio_exposure_pct_range",
+          "value": "\"global_config\".\"max_portfolio_exposure_pct\" > 0 AND \"global_config\".\"max_portfolio_exposure_pct\" <= 1"
+        },
+        "global_config_drawdown_kill_threshold_range": {
+          "name": "global_config_drawdown_kill_threshold_range",
+          "value": "\"global_config\".\"drawdown_kill_threshold\" >= -1 AND \"global_config\".\"drawdown_kill_threshold\" <= 0"
+        },
+        "global_config_stale_quote_ms_range": {
+          "name": "global_config_stale_quote_ms_range",
+          "value": "\"global_config\".\"stale_quote_ms\" >= 0"
+        },
+        "global_config_gap_reject_pct_range": {
+          "name": "global_config_gap_reject_pct_range",
+          "value": "\"global_config\".\"gap_reject_pct\" >= 0 AND \"global_config\".\"gap_reject_pct\" <= 1"
+        },
+        "global_config_spread_limit_pct_us_range": {
+          "name": "global_config_spread_limit_pct_us_range",
+          "value": "\"global_config\".\"spread_limit_pct_us\" >= 0 AND \"global_config\".\"spread_limit_pct_us\" <= 1"
+        },
+        "global_config_spread_limit_pct_jp_range": {
+          "name": "global_config_spread_limit_pct_jp_range",
+          "value": "\"global_config\".\"spread_limit_pct_jp\" >= 0 AND \"global_config\".\"spread_limit_pct_jp\" <= 1"
+        },
+        "global_config_pullback_default_stop_pct_range": {
+          "name": "global_config_pullback_default_stop_pct_range",
+          "value": "\"global_config\".\"pullback_default_stop_pct\" < 0 AND \"global_config\".\"pullback_default_stop_pct\" >= -1"
+        },
+        "global_config_pullback_default_take_profit_pct_range": {
+          "name": "global_config_pullback_default_take_profit_pct_range",
+          "value": "\"global_config\".\"pullback_default_take_profit_pct\" > 0 AND \"global_config\".\"pullback_default_take_profit_pct\" <= 1"
+        },
+        "global_config_pullback_default_time_stop_days_range": {
+          "name": "global_config_pullback_default_time_stop_days_range",
+          "value": "\"global_config\".\"pullback_default_time_stop_days\" > 0 AND \"global_config\".\"pullback_default_time_stop_days\" <= ?"
+        },
+        "global_config_pullback_default_pullback_max_range": {
+          "name": "global_config_pullback_default_pullback_max_range",
+          "value": "\"global_config\".\"pullback_default_pullback_max\" <= 0 AND \"global_config\".\"pullback_default_pullback_max\" >= -1"
+        },
+        "global_config_pullback_default_pullback_min_range": {
+          "name": "global_config_pullback_default_pullback_min_range",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= 0 AND \"global_config\".\"pullback_default_pullback_min\" >= -1"
+        },
+        "global_config_pullback_default_min_return_50d_range": {
+          "name": "global_config_pullback_default_min_return_50d_range",
+          "value": "\"global_config\".\"pullback_default_min_return_50d\" >= -1 AND \"global_config\".\"pullback_default_min_return_50d\" <= 10"
+        },
+        "global_config_pullback_default_k_atr_range": {
+          "name": "global_config_pullback_default_k_atr_range",
+          "value": "\"global_config\".\"pullback_default_k_atr\" > 0 AND \"global_config\".\"pullback_default_k_atr\" <= 10"
+        },
+        "global_config_pullback_default_pullback_window_order": {
+          "name": "global_config_pullback_default_pullback_window_order",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= \"global_config\".\"pullback_default_pullback_max\""
+        },
+        "global_config_risk_base_per_trade_pct_range": {
+          "name": "global_config_risk_base_per_trade_pct_range",
+          "value": "\"global_config\".\"risk_base_per_trade_pct\" > 0 AND \"global_config\".\"risk_base_per_trade_pct\" <= 1"
+        },
+        "global_config_risk_dd_half_threshold_range": {
+          "name": "global_config_risk_dd_half_threshold_range",
+          "value": "\"global_config\".\"risk_dd_half_threshold\" < 0 AND \"global_config\".\"risk_dd_half_threshold\" >= -1"
+        },
+        "global_config_risk_dd_halt_threshold_range": {
+          "name": "global_config_risk_dd_halt_threshold_range",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" < 0 AND \"global_config\".\"risk_dd_halt_threshold\" >= -1"
+        },
+        "global_config_risk_dd_threshold_order": {
+          "name": "global_config_risk_dd_threshold_order",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" <= \"global_config\".\"risk_dd_half_threshold\""
+        },
+        "global_config_vix_warning_threshold_range": {
+          "name": "global_config_vix_warning_threshold_range",
+          "value": "\"global_config\".\"vix_warning_threshold\" > 0 AND \"global_config\".\"vix_warning_threshold\" <= 200"
+        },
+        "global_config_vix_critical_threshold_range": {
+          "name": "global_config_vix_critical_threshold_range",
+          "value": "\"global_config\".\"vix_critical_threshold\" > 0 AND \"global_config\".\"vix_critical_threshold\" <= 200"
+        },
+        "global_config_vix_threshold_order": {
+          "name": "global_config_vix_threshold_order",
+          "value": "\"global_config\".\"vix_warning_threshold\" <= \"global_config\".\"vix_critical_threshold\""
+        },
+        "global_config_vix_warning_size_scale_range": {
+          "name": "global_config_vix_warning_size_scale_range",
+          "value": "\"global_config\".\"vix_warning_size_scale\" >= 0 AND \"global_config\".\"vix_warning_size_scale\" <= 1"
+        }
+      }
+    },
+    "inverse_pairs": {
+      "name": "inverse_pairs",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inverse": {
+          "name": "inverse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "macro_event_calendar": {
+      "name": "macro_event_calendar",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_time": {
+          "name": "event_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "macro_event_calendar_type_date_unique": {
+          "name": "macro_event_calendar_type_date_unique",
+          "columns": [
+            "event_type",
+            "event_date"
+          ],
+          "isUnique": true
+        },
+        "macro_event_calendar_date_idx": {
+          "name": "macro_event_calendar_date_idx",
+          "columns": [
+            "event_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_emit_log": {
+      "name": "notification_emit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cause": {
+          "name": "cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notification_emit_log_timestamp_id_idx": {
+          "name": "notification_emit_log_timestamp_id_idx",
+          "columns": [
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "notification_emit_log_severity_timestamp_id_idx": {
+          "name": "notification_emit_log_severity_timestamp_id_idx",
+          "columns": [
+            "severity",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "notification_emit_log_event_type_timestamp_id_idx": {
+          "name": "notification_emit_log_event_type_timestamp_id_idx",
+          "columns": [
+            "event_type",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "portfolio_equity_snapshot": {
+      "name": "portfolio_equity_snapshot",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "daily_start_equity_usd": {
+          "name": "daily_start_equity_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_start_equity_jpy": {
+          "name": "daily_start_equity_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_realized_pnl_usd": {
+          "name": "daily_realized_pnl_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_realized_pnl_jpy": {
+          "name": "daily_realized_pnl_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "drawdown_pct": {
+          "name": "drawdown_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "portfolio_equity_snapshot_at_idx": {
+          "name": "portfolio_equity_snapshot_at_idx",
+          "columns": [
+            "snapshot_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "strategy_decision_log": {
+      "name": "strategy_decision_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indicators_json": {
+          "name": "indicators_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "strategy_decision_log_symbol_id_idx": {
+          "name": "strategy_decision_log_symbol_id_idx",
+          "columns": [
+            "symbol",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "strategy_decision_log_coid_idx": {
+          "name": "strategy_decision_log_coid_idx",
+          "columns": [
+            "client_order_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "symbol_config": {
+      "name": "symbol_config",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "market": {
+          "name": "market",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_notional": {
+          "name": "max_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_stop_days_override": {
+          "name": "time_stop_days_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "k_atr_override": {
+          "name": "k_atr_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "budget_alloc_pct": {
+          "name": "budget_alloc_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "symbol_config_currency_enum": {
+          "name": "symbol_config_currency_enum",
+          "value": "\"symbol_config\".\"currency\" IN ('USD', 'JPY')"
+        },
+        "symbol_config_time_stop_days_override_range": {
+          "name": "symbol_config_time_stop_days_override_range",
+          "value": "\"symbol_config\".\"time_stop_days_override\" IS NULL OR (\"symbol_config\".\"time_stop_days_override\" >= 1 AND \"symbol_config\".\"time_stop_days_override\" <= ?)"
+        },
+        "symbol_config_k_atr_override_range": {
+          "name": "symbol_config_k_atr_override_range",
+          "value": "\"symbol_config\".\"k_atr_override\" IS NULL OR (\"symbol_config\".\"k_atr_override\" >= 0.5 AND \"symbol_config\".\"k_atr_override\" <= 5.0)"
+        }
+      }
+    },
+    "trade_journal": {
+      "name": "trade_journal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trade_event_type": {
+          "name": "trade_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "strategy_name": {
+          "name": "strategy_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_action": {
+          "name": "signal_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_reason": {
+          "name": "signal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_allowed": {
+          "name": "risk_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_reasons": {
+          "name": "risk_reasons",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "limit_price": {
+          "name": "limit_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notional": {
+          "name": "notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "broker_status": {
+          "name": "broker_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "submitted": {
+          "name": "submitted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_qty": {
+          "name": "filled_qty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_price": {
+          "name": "filled_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "realized_pnl": {
+          "name": "realized_pnl",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hold_days": {
+          "name": "hold_days",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_reason": {
+          "name": "exit_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_applied_at": {
+          "name": "state_applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_error": {
+          "name": "state_apply_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_attempts": {
+          "name": "state_apply_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trading_toggle_history": {
+      "name": "trading_toggle_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before": {
+          "name": "before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "after": {
+          "name": "after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1780572943376,
       "tag": "0023_drop_bucket_columns",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "6",
+      "when": 1780576185111,
+      "tag": "0024_add_symbol_budget_alloc_pct",
+      "breakpoints": true
     }
   ]
 }

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -114,6 +114,13 @@ export const symbolConfig = sqliteTable(
      * 高ボラ銘柄で stop を緩めるケース用 (#316)。
      */
     kAtrOverride: real('k_atr_override'),
+    /**
+     * 予算配分 fraction (NULL = 従来の risk-% sizing、0<pct<=1)。指定されると
+     * fixed-% 配分モードで `notional = min(total_capital * pct, max_notional)` で
+     * sizing する (#budget-alloc)。小口座で高額レバ ETF を建てる用。range CHECK は
+     * SQLite ALTER 制約で付けず admin parse + 将来 rebuild で担保。
+     */
+    budgetAllocPct: real('budget_alloc_pct'),
     updatedAt: text('updated_at').notNull(),
   },
   (t) => ({

--- a/src/infrastructure/db/symbolConfigRepo.ts
+++ b/src/infrastructure/db/symbolConfigRepo.ts
@@ -287,6 +287,29 @@ export async function toggleSymbolActive(
 }
 
 /**
+ * budget_alloc_pct だけを更新する focused update (#budget-alloc ラダー調整用)。
+ * `pct` は fraction (0<pct<=1) or null (= risk-% sizing に戻す)。存在しなければ null。
+ * before/after を返し caller が audit / inverse 同期に使う。
+ */
+export async function updateBudgetAllocPct(
+  db: DrizzleD1Database,
+  symbol: string,
+  pct: number | null,
+  nowIso: string,
+): Promise<{ before: SymbolConfigRow; after: SymbolConfigRow } | null> {
+  const before = await findSymbolConfig(db, symbol)
+  if (before === null) return null
+  const beforeSnapshot: SymbolConfigRow = { ...before }
+  await db
+    .update(symbolConfig)
+    .set({ budgetAllocPct: pct, updatedAt: nowIso })
+    .where(eq(symbolConfig.symbol, symbol))
+  const after = await findSymbolConfig(db, symbol)
+  if (after === null) return null
+  return { before: beforeSnapshot, after }
+}
+
+/**
  * Hard delete。inactive (active=false) 行のみ削除可、active 行は削除拒否
  * ({ rejected: 'still_active' } 返却)。
  *

--- a/src/infrastructure/db/symbolConfigRepo.ts
+++ b/src/infrastructure/db/symbolConfigRepo.ts
@@ -300,6 +300,10 @@ export async function updateBudgetAllocPct(
   const before = await findSymbolConfig(db, symbol)
   if (before === null) return null
   const beforeSnapshot: SymbolConfigRow = { ...before }
+  // 同値なら UPDATE しない (updatedAt だけ無監査で進むのを防ぐ、CodeRabbit #405)。
+  if ((before.budgetAllocPct ?? null) === (pct ?? null)) {
+    return { before: beforeSnapshot, after: beforeSnapshot }
+  }
   await db
     .update(symbolConfig)
     .set({ budgetAllocPct: pct, updatedAt: nowIso })

--- a/src/infrastructure/db/symbolConfigRepo.ts
+++ b/src/infrastructure/db/symbolConfigRepo.ts
@@ -51,6 +51,11 @@ export interface SymbolConfigSnapshot {
    * 高ボラ銘柄で ATR stop を緩めたい時に使う (#316)。
    */
   symbolKAtrOverride: Record<string, number>
+  /**
+   * symbol → budget_alloc_pct (fraction 0<pct<=1)。NULL は map に含めない
+   * (= 従来の risk-% sizing)。fixed-% 配分モードの sizing に使う (#budget-alloc)。
+   */
+  symbolBudgetAllocPct: Record<string, number>
 }
 
 /**
@@ -76,6 +81,7 @@ export async function loadSymbolConfig(
   const symbolNotes: Record<string, string> = {}
   const symbolTimeStopDaysOverride: Record<string, number> = {}
   const symbolKAtrOverride: Record<string, number> = {}
+  const symbolBudgetAllocPct: Record<string, number> = {}
   for (const row of rows) {
     const symbol = row.symbol.toUpperCase()
     if (row.active) {
@@ -115,6 +121,16 @@ export async function loadSymbolConfig(
     ) {
       symbolKAtrOverride[symbol] = row.kAtrOverride
     }
+    // budget_alloc_pct は 0<pct<=1 のみ採用 (範囲外 / NaN は無視 = risk sizing)。
+    if (
+      row.budgetAllocPct !== null &&
+      row.budgetAllocPct !== undefined &&
+      Number.isFinite(row.budgetAllocPct) &&
+      row.budgetAllocPct > 0 &&
+      row.budgetAllocPct <= 1
+    ) {
+      symbolBudgetAllocPct[symbol] = row.budgetAllocPct
+    }
   }
   return {
     allowedSymbols,
@@ -126,6 +142,7 @@ export async function loadSymbolConfig(
     symbolNotes,
     symbolTimeStopDaysOverride,
     symbolKAtrOverride,
+    symbolBudgetAllocPct,
   }
 }
 
@@ -159,6 +176,11 @@ export interface SymbolConfigWriteInput {
    * 高ボラ銘柄で ATR stop を緩める (#316)。
    */
   kAtrOverride: number | null
+  /**
+   * 予算配分 fraction (NULL = risk-% sizing、0<pct<=1)。fixed-% 配分モード
+   * (#budget-alloc)。
+   */
+  budgetAllocPct: number | null
 }
 
 /**
@@ -185,6 +207,7 @@ export async function insertSymbolConfig(
       notes: input.notes,
       timeStopDaysOverride: input.timeStopDaysOverride,
       kAtrOverride: input.kAtrOverride,
+      budgetAllocPct: input.budgetAllocPct,
       updatedAt: nowIso,
     })
   } catch (err) {
@@ -228,6 +251,7 @@ export async function updateSymbolConfig(
       notes: input.notes,
       timeStopDaysOverride: input.timeStopDaysOverride,
       kAtrOverride: input.kAtrOverride,
+      budgetAllocPct: input.budgetAllocPct,
       updatedAt: nowIso,
     })
     .where(eq(symbolConfig.symbol, input.symbol))
@@ -440,6 +464,8 @@ export async function createSymbolPair(
       notes: null,
       timeStopDaysOverride: null,
       kAtrOverride: null,
+      // regime hedge は片方ずつ建てるので counterpart も同じ予算配分%を継承。
+      budgetAllocPct: primary.budgetAllocPct,
       updatedAt: nowIso,
     })
     await db.batch([delLink, insCounterpart, insLink])

--- a/src/infrastructure/db/symbolUniverse.ts
+++ b/src/infrastructure/db/symbolUniverse.ts
@@ -36,6 +36,11 @@ export interface SymbolUniverse {
    * global_config.pullback_default_k_atr を使う (fall-through、#316)。
    */
   symbolKAtrOverride: Record<string, number>
+  /**
+   * symbol → budget_alloc_pct (0<pct<=1)。空 map のキーは従来の risk-% sizing。
+   * fixed-% 予算配分モード (#budget-alloc)。
+   */
+  symbolBudgetAllocPct: Record<string, number>
   inversePairs: Record<string, string>
   source: 'd1'
 }
@@ -66,6 +71,7 @@ export async function loadSymbolUniverse(env: UniverseEnv): Promise<SymbolUniver
     symbolNotes: config.symbolNotes,
     symbolTimeStopDaysOverride: config.symbolTimeStopDaysOverride,
     symbolKAtrOverride: config.symbolKAtrOverride,
+    symbolBudgetAllocPct: config.symbolBudgetAllocPct,
     inversePairs: pairs,
     source: 'd1',
   }

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -33,7 +33,9 @@ import {
   findSymbolConfig,
   insertSymbolConfig,
   hardDeleteSymbol,
+  loadInversePairs,
   toggleSymbolActive,
+  updateBudgetAllocPct,
   updateSymbolConfig,
   type SymbolConfigWriteInput,
 } from '../infrastructure/db/symbolConfigRepo'
@@ -1507,6 +1509,62 @@ export const admin = new Hono<AppBindings>()
     )
     if (isForm) return c.redirect('/dashboard/symbols', 303)
     return c.json({ symbol: symbolPath, deleted: true })
+  })
+  /**
+   * 予算配分% の一括更新 (#budget-alloc ラダー)。一覧の各 slider が
+   * `pct_<SYMBOL>` field を送り、「確定」押下で全銘柄まとめて更新する
+   * (確定するまでは client 側で仮調整)。値は % (0-100)、空 / 0 → NULL
+   * (= risk-% sizing)。インバース対は片側でも UI が同期するので両側送られる
+   * 想定だが、server 側でも相手を同値に揃える防御を入れる (JS off 耐性)。
+   */
+  .post('/symbol-config/budget-alloc', rateLimit('ADMIN_WRITE'), async (c) => {
+    if (!c.env.DB) {
+      throw new ValidationError('DB binding is not configured', { field: 'env' })
+    }
+    const isForm = isFormContentType(c.req.header('content-type'))
+    const db = createDb(c.env.DB)
+    const now = new Date().toISOString()
+    const form = await c.req.formData()
+    const inverse = await loadInversePairs(db)
+    // pct_<SYMBOL> を集約 (大文字正規化、% → fraction、空/0 → null)。
+    const desired = new Map<string, number | null>()
+    for (const [key, raw] of form.entries()) {
+      if (!key.startsWith('pct_')) continue
+      const sym = normalizeSymbol(key.slice(4))
+      const s = String(raw).trim()
+      if (s === '') {
+        desired.set(sym, null)
+        continue
+      }
+      const pctNum = Number(s)
+      if (!Number.isFinite(pctNum) || pctNum < 0 || pctNum > 100) {
+        throw new ValidationError(`budget_alloc_pct for ${sym} must be 0..100`, { field: 'budget_alloc_pct' })
+      }
+      desired.set(sym, pctNum <= 0 ? null : pctNum / 100)
+    }
+    // インバース対の同値同期 (両側 desired にある場合は UI 値を尊重、片側のみなら相手も揃える)。
+    for (const [sym, pct] of [...desired.entries()]) {
+      const inv = inverse[sym]
+      if (inv && !desired.has(inv)) desired.set(inv, pct)
+    }
+    let updated = 0
+    for (const [sym, pct] of desired.entries()) {
+      const res = await updateBudgetAllocPct(db, sym, pct, now)
+      if (res === null) continue
+      const beforeFrac = res.before.budgetAllocPct ?? null
+      if (beforeFrac !== pct) {
+        updated += 1
+        await writeAuditLog(
+          c,
+          '/admin/symbol-config/budget-alloc',
+          `symbol=${sym}`,
+          { budgetAllocPct: beforeFrac },
+          { budgetAllocPct: pct },
+        )
+      }
+    }
+    if (isForm) return c.redirect('/dashboard/symbols', 303)
+    return c.json({ updated })
   })
   /**
    * symbol search (live autocomplete + form auto-fill 用)。

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -2053,6 +2053,8 @@ function parseSymbolConfigBody(body: unknown): SymbolConfigWriteInput {
     timeStopDaysOverride?: unknown
     k_atr_override?: unknown
     kAtrOverride?: unknown
+    budget_alloc_pct?: unknown
+    budgetAllocPct?: unknown
   }
   const symbol = normalizeSymbol(raw.symbol)
   const market = parseMarket(raw.market)
@@ -2079,6 +2081,15 @@ function parseSymbolConfigBody(body: unknown): SymbolConfigWriteInput {
     0.5,
     5.0,
   )
+  // 予算配分: form は **% (0<pct<=100)** で送る。fraction (0<pct<=1) に変換して保存
+  // (#budget-alloc)。空 / undefined → NULL (= 従来の risk-% sizing)。範囲外は 400。
+  const budgetAllocPctRaw = parseOptionalNumberInRange(
+    raw.budget_alloc_pct ?? raw.budgetAllocPct,
+    'budgetAllocPct',
+    0.0001,
+    100,
+  )
+  const budgetAllocPct = budgetAllocPctRaw === null ? null : budgetAllocPctRaw / 100
   return {
     symbol,
     name,
@@ -2089,6 +2100,7 @@ function parseSymbolConfigBody(body: unknown): SymbolConfigWriteInput {
     notes,
     timeStopDaysOverride,
     kAtrOverride,
+    budgetAllocPct,
   }
 }
 
@@ -2291,6 +2303,7 @@ function symbolConfigSnapshot(row: SymbolConfigRow): Record<string, unknown> {
     notes: row.notes,
     timeStopDaysOverride: row.timeStopDaysOverride,
     kAtrOverride: row.kAtrOverride,
+    budgetAllocPct: row.budgetAllocPct,
     updatedAt: row.updatedAt,
   }
 }

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -2139,12 +2139,14 @@ function parseSymbolConfigBody(body: unknown): SymbolConfigWriteInput {
     0.5,
     5.0,
   )
-  // 予算配分: form は **% (0<pct<=100)** で送る。fraction (0<pct<=1) に変換して保存
-  // (#budget-alloc)。空 / undefined → NULL (= 従来の risk-% sizing)。範囲外は 400。
+  // 予算配分: form は **% (0.1<=pct<=100)** で送る。fraction (0.001<=pct<=1) に変換して
+  // 保存 (#budget-alloc)。空 / undefined → NULL (= 従来の risk-% sizing)。下限は UI の
+  // 表示丸め (0.1% 刻み) / slider (5% 刻み) と揃え、sub-0.1% の保持崩れを防ぐ
+  // (CodeRabbit #405)。範囲外は 400。
   const budgetAllocPctRaw = parseOptionalNumberInRange(
     raw.budget_alloc_pct ?? raw.budgetAllocPct,
     'budgetAllocPct',
-    0.0001,
+    0.1,
     100,
   )
   const budgetAllocPct = budgetAllocPctRaw === null ? null : budgetAllocPctRaw / 100

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -6893,7 +6893,7 @@ function symbolsListBody(args: {
       const allocPctNum = r.budgetAllocPct != null ? Math.round(r.budgetAllocPct * 1000) / 10 : 0
       const budgetCell = `<div style="display:flex;align-items:center;gap:6px;min-width:170px">
           <input type="range" name="pct_${esc(r.symbol)}" form="symbol-budget-form" min="0" max="100" step="5" value="${allocPctNum}"
-            data-symbol="${esc(r.symbol)}"${inverse ? ` data-inverse="${esc(inverse)}"` : ''}
+            data-symbol="${esc(r.symbol)}" data-currency="${esc(r.currency)}"${inverse ? ` data-inverse="${esc(inverse)}"` : ''}
             oninput="window.onBudgetSlide(this)" style="width:110px;vertical-align:middle">
           <span id="budget-label-${esc(r.symbol)}" class="muted" style="font-size:12px;width:42px;text-align:right;font-variant-numeric:tabular-nums">${allocPctNum === 0 ? 'risk' : allocPctNum + '%'}</span>
         </div>`
@@ -6934,7 +6934,8 @@ function symbolsListBody(args: {
       </tr>`
     })
     .join('')
-  return `${errorBanner}${filterBar}${headerBar}
+  const budgetMeter = renderBudgetMeter(computeBudgetUsage(rows, inversePairs))
+  return `${errorBanner}${filterBar}${headerBar}${budgetMeter}
   <table>
     <thead><tr>
       <th style="width:28px" title="インバース対のツリー表記"></th>
@@ -6979,8 +6980,80 @@ const BUDGET_LADDER_JS = `
     var note = document.getElementById('symbol-budget-dirty');
     if (bar) bar.style.display = 'flex';
     if (note) note.textContent = Object.keys(window.__budgetDirty).length + ' 銘柄を変更中';
+    window.__recomputeBudgetMeter();
+  };
+  // 同時建玉ベースの予算使用率を全 slider から再計算してメーターを再描画。
+  // インバース対は max を 1 回だけ計上 (片側のみ建つため)。
+  window.__recomputeBudgetMeter = function () {
+    var box = document.getElementById('symbol-budget-meter');
+    if (!box) return;
+    var sliders = document.querySelectorAll('input[name^="pct_"]');
+    var bySym = {};
+    sliders.forEach(function (s) {
+      var v = Number(s.value);
+      if (v > 0) bySym[s.getAttribute('data-symbol')] = { ccy: s.getAttribute('data-currency'), pct: v, inv: s.getAttribute('data-inverse') };
+    });
+    var usage = {};
+    var counted = {};
+    Object.keys(bySym).forEach(function (sym) {
+      var e = bySym[sym];
+      if (e.inv) {
+        var key = [sym, e.inv].sort().join('|');
+        if (counted[key]) return;
+        counted[key] = true;
+        var invPct = bySym[e.inv] ? bySym[e.inv].pct : 0;
+        usage[e.ccy] = (usage[e.ccy] || 0) + Math.max(e.pct, invPct);
+      } else {
+        usage[e.ccy] = (usage[e.ccy] || 0) + e.pct;
+      }
+    });
+    var ccys = ['USD', 'JPY'].filter(function (c) { return (usage[c] || 0) > 0; });
+    if (ccys.length === 0) { box.style.display = 'none'; box.innerHTML = ''; return; }
+    var html = '<div class="muted" style="font-size:11px;margin-bottom:4px">インバース対は片側のみ建つため max を 1 回計上。total_capital に対する最大同時コミット率。</div>';
+    ccys.forEach(function (ccy) {
+      var used = usage[ccy] || 0;
+      var w = Math.min(100, used);
+      var color = used > 100 ? '#c22' : used > 80 ? '#b25000' : '#057a55';
+      html += '<div data-ccy="' + ccy + '" style="margin:2px 0">'
+        + '<div style="display:flex;justify-content:space-between;font-size:12px"><span>' + ccy + ' 予算使用率 (同時建玉ベース)</span>'
+        + '<span style="font-variant-numeric:tabular-nums;color:' + color + '">' + used.toFixed(0) + '% / 100%' + (used > 100 ? ' ⚠超過' : '') + '</span></div>'
+        + '<div class="bar-track" style="height:8px"><div class="bar-fill" style="width:' + w.toFixed(0) + '%;background:' + color + '"></div></div></div>';
+    });
+    box.className = 'panel';
+    box.style.cssText = 'margin:0 0 12px;padding:10px 12px';
+    box.innerHTML = html;
+    box.style.display = 'block';
   };
 `
+
+/**
+ * #budget-alloc: 同時建玉ベースの予算使用率メーター (per currency)。slider 変更で
+ * JS が live 更新する (id 固定の bar / label を書き換え)。0 通貨は出さない。
+ */
+function renderBudgetMeter(usage: Record<string, number>): string {
+  const currencies = ['USD', 'JPY'].filter((c) => (usage[c] ?? 0) > 0)
+  if (currencies.length === 0) {
+    // 何も配分が無くても JS が後で表示できるよう箱だけ用意 (初期 hidden)。
+    return `<div id="symbol-budget-meter" style="display:none;margin:0 0 12px"></div>`
+  }
+  const bar = (ccy: string) => {
+    const used = usage[ccy] ?? 0
+    const w = Math.min(100, used)
+    const over = used > 100
+    const color = over ? '#c22' : used > 80 ? '#b25000' : '#057a55'
+    return `<div data-ccy="${ccy}" style="margin:2px 0">
+        <div style="display:flex;justify-content:space-between;font-size:12px">
+          <span>${ccy} 予算使用率 (同時建玉ベース)</span>
+          <span class="budget-meter-val" style="font-variant-numeric:tabular-nums;color:${color}">${used.toFixed(0)}% / 100%${over ? ' ⚠超過' : ''}</span>
+        </div>
+        <div class="bar-track" style="height:8px"><div class="budget-meter-fill bar-fill" style="width:${w.toFixed(0)}%;background:${color}"></div></div>
+      </div>`
+  }
+  return `<div id="symbol-budget-meter" class="panel" style="margin:0 0 12px;padding:10px 12px">
+    <div class="muted" style="font-size:11px;margin-bottom:4px">インバース対は片側のみ建つため max を 1 回計上。total_capital に対する最大同時コミット率。</div>
+    ${currencies.map(bar).join('')}
+  </div>`
+}
 
 /** 予算配分 ladder の確定 / 取消 バー。slider は form attr で此処の form に紐づく。 */
 function budgetLadderControls(): string {
@@ -6992,6 +7065,37 @@ function budgetLadderControls(): string {
     <a href="/dashboard/symbols" style="padding:5px 12px;text-decoration:none;border:1px solid #d0d0d5;border-radius:6px;font-size:13px">取消</a>
     <button type="submit" form="symbol-budget-form" style="padding:5px 14px;background:#06c;color:#fff;border:none;border-radius:6px;cursor:pointer;font-size:13px">確定して保存</button>
   </div>`
+}
+
+/**
+ * #budget-alloc: 同時建玉ベースの予算使用率 (per currency, %)。
+ * インバース対は同時に片方しか建たないので max(両側) で1回だけ計上、
+ * standalone と別ペアは加算。total_capital に対する「最大同時コミット率」。
+ */
+export function computeBudgetUsage(
+  rows: Array<{ symbol: string; currency: string; budgetAllocPct: number | null }>,
+  inversePairs: Record<string, string>,
+): Record<string, number> {
+  const pctBySym = new Map<string, { currency: string; pct: number }>()
+  for (const r of rows) {
+    const pct = r.budgetAllocPct != null && r.budgetAllocPct > 0 ? r.budgetAllocPct * 100 : 0
+    if (pct > 0) pctBySym.set(r.symbol.toUpperCase(), { currency: r.currency, pct })
+  }
+  const usage: Record<string, number> = {}
+  const countedPair = new Set<string>()
+  for (const [sym, { currency, pct }] of pctBySym) {
+    const inv = inversePairs[sym]
+    if (inv) {
+      const key = [sym, inv].sort().join('|')
+      if (countedPair.has(key)) continue
+      countedPair.add(key)
+      const invPct = pctBySym.get(inv)?.pct ?? 0
+      usage[currency] = (usage[currency] ?? 0) + Math.max(pct, invPct)
+    } else {
+      usage[currency] = (usage[currency] ?? 0) + pct
+    }
+  }
+  return usage
 }
 
 /**

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -6934,8 +6934,7 @@ function symbolsListBody(args: {
       </tr>`
     })
     .join('')
-  const budgetMeter = renderBudgetMeter(computeBudgetUsage(rows, inversePairs))
-  return `${errorBanner}${filterBar}${headerBar}${budgetMeter}
+  return `${errorBanner}${filterBar}${headerBar}
   <table>
     <thead><tr>
       <th style="width:28px" title="インバース対のツリー表記"></th>
@@ -6985,8 +6984,8 @@ const BUDGET_LADDER_JS = `
   // 同時建玉ベースの予算使用率を全 slider から再計算してメーターを再描画。
   // インバース対は max を 1 回だけ計上 (片側のみ建つため)。
   window.__recomputeBudgetMeter = function () {
-    var box = document.getElementById('symbol-budget-meter');
-    if (!box) return;
+    var barMeter = document.getElementById('symbol-budget-bar-meter');
+    if (!barMeter) return;
     var sliders = document.querySelectorAll('input[name^="pct_"]');
     var bySym = {};
     sliders.forEach(function (s) {
@@ -7008,65 +7007,18 @@ const BUDGET_LADDER_JS = `
       }
     });
     var ccys = ['USD', 'JPY'].filter(function (c) { return (usage[c] || 0) > 0; });
-    // sticky バー内のコンパクトゲージ (確定ボタン横)。
-    var barMeter = document.getElementById('symbol-budget-bar-meter');
-    if (barMeter) {
-      barMeter.innerHTML = ccys.map(function (ccy) {
-        var u = usage[ccy] || 0;
-        var w = Math.min(100, u);
-        var col = u > 100 ? '#c22' : u > 80 ? '#b25000' : '#057a55';
-        return '<span style="display:inline-flex;align-items:center;gap:5px;font-size:12px">'
-          + '<span class="muted">' + ccy + '</span>'
-          + '<span class="bar-track" style="display:inline-block;width:70px;height:8px;vertical-align:middle"><span class="bar-fill" style="display:block;width:' + w.toFixed(0) + '%;height:8px;background:' + col + '"></span></span>'
-          + '<span style="font-variant-numeric:tabular-nums;color:' + col + '">' + u.toFixed(0) + '%' + (u > 100 ? '⚠' : '') + '</span></span>';
-      }).join('');
-    }
-    if (ccys.length === 0) { box.style.display = 'none'; box.innerHTML = ''; return; }
-    var html = '<div class="muted" style="font-size:11px;margin-bottom:4px">インバース対は片側のみ建つため max を 1 回計上。total_capital に対する最大同時コミット率。</div>';
-    ccys.forEach(function (ccy) {
-      var used = usage[ccy] || 0;
-      var w = Math.min(100, used);
-      var color = used > 100 ? '#c22' : used > 80 ? '#b25000' : '#057a55';
-      html += '<div data-ccy="' + ccy + '" style="margin:2px 0">'
-        + '<div style="display:flex;justify-content:space-between;font-size:12px"><span>' + ccy + ' 予算使用率 (同時建玉ベース)</span>'
-        + '<span style="font-variant-numeric:tabular-nums;color:' + color + '">' + used.toFixed(0) + '% / 100%' + (used > 100 ? ' ⚠超過' : '') + '</span></div>'
-        + '<div class="bar-track" style="height:8px"><div class="bar-fill" style="width:' + w.toFixed(0) + '%;background:' + color + '"></div></div></div>';
-    });
-    box.className = 'panel';
-    box.style.cssText = 'margin:0 0 12px;padding:10px 12px';
-    box.innerHTML = html;
-    box.style.display = 'block';
+    // sticky バー内のコンパクトゲージ (確定ボタン横、同時建玉ベース)。
+    barMeter.innerHTML = ccys.map(function (ccy) {
+      var u = usage[ccy] || 0;
+      var w = Math.min(100, u);
+      var col = u > 100 ? '#c22' : u > 80 ? '#b25000' : '#057a55';
+      return '<span title="同時建玉ベースの予算使用率 (インバース対は max を1回計上)" style="display:inline-flex;align-items:center;gap:5px;font-size:12px">'
+        + '<span class="muted">' + ccy + '</span>'
+        + '<span class="bar-track" style="display:inline-block;width:70px;height:8px;vertical-align:middle"><span class="bar-fill" style="display:block;width:' + w.toFixed(0) + '%;height:8px;background:' + col + '"></span></span>'
+        + '<span style="font-variant-numeric:tabular-nums;color:' + col + '">' + u.toFixed(0) + '%' + (u > 100 ? '⚠' : '') + '</span></span>';
+    }).join('');
   };
 `
-
-/**
- * #budget-alloc: 同時建玉ベースの予算使用率メーター (per currency)。slider 変更で
- * JS が live 更新する (id 固定の bar / label を書き換え)。0 通貨は出さない。
- */
-function renderBudgetMeter(usage: Record<string, number>): string {
-  const currencies = ['USD', 'JPY'].filter((c) => (usage[c] ?? 0) > 0)
-  if (currencies.length === 0) {
-    // 何も配分が無くても JS が後で表示できるよう箱だけ用意 (初期 hidden)。
-    return `<div id="symbol-budget-meter" style="display:none;margin:0 0 12px"></div>`
-  }
-  const bar = (ccy: string) => {
-    const used = usage[ccy] ?? 0
-    const w = Math.min(100, used)
-    const over = used > 100
-    const color = over ? '#c22' : used > 80 ? '#b25000' : '#057a55'
-    return `<div data-ccy="${ccy}" style="margin:2px 0">
-        <div style="display:flex;justify-content:space-between;font-size:12px">
-          <span>${ccy} 予算使用率 (同時建玉ベース)</span>
-          <span class="budget-meter-val" style="font-variant-numeric:tabular-nums;color:${color}">${used.toFixed(0)}% / 100%${over ? ' ⚠超過' : ''}</span>
-        </div>
-        <div class="bar-track" style="height:8px"><div class="budget-meter-fill bar-fill" style="width:${w.toFixed(0)}%;background:${color}"></div></div>
-      </div>`
-  }
-  return `<div id="symbol-budget-meter" class="panel" style="margin:0 0 12px;padding:10px 12px">
-    <div class="muted" style="font-size:11px;margin-bottom:4px">インバース対は片側のみ建つため max を 1 回計上。total_capital に対する最大同時コミット率。</div>
-    ${currencies.map(bar).join('')}
-  </div>`
-}
 
 /** 予算配分 ladder の確定 / 取消 バー。slider は form attr で此処の form に紐づく。 */
 function budgetLadderControls(): string {

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -7008,6 +7008,19 @@ const BUDGET_LADDER_JS = `
       }
     });
     var ccys = ['USD', 'JPY'].filter(function (c) { return (usage[c] || 0) > 0; });
+    // sticky バー内のコンパクトゲージ (確定ボタン横)。
+    var barMeter = document.getElementById('symbol-budget-bar-meter');
+    if (barMeter) {
+      barMeter.innerHTML = ccys.map(function (ccy) {
+        var u = usage[ccy] || 0;
+        var w = Math.min(100, u);
+        var col = u > 100 ? '#c22' : u > 80 ? '#b25000' : '#057a55';
+        return '<span style="display:inline-flex;align-items:center;gap:5px;font-size:12px">'
+          + '<span class="muted">' + ccy + '</span>'
+          + '<span class="bar-track" style="display:inline-block;width:70px;height:8px;vertical-align:middle"><span class="bar-fill" style="display:block;width:' + w.toFixed(0) + '%;height:8px;background:' + col + '"></span></span>'
+          + '<span style="font-variant-numeric:tabular-nums;color:' + col + '">' + u.toFixed(0) + '%' + (u > 100 ? '⚠' : '') + '</span></span>';
+      }).join('');
+    }
     if (ccys.length === 0) { box.style.display = 'none'; box.innerHTML = ''; return; }
     var html = '<div class="muted" style="font-size:11px;margin-bottom:4px">インバース対は片側のみ建つため max を 1 回計上。total_capital に対する最大同時コミット率。</div>';
     ccys.forEach(function (ccy) {
@@ -7061,6 +7074,7 @@ function budgetLadderControls(): string {
   <div id="symbol-budget-bar" style="position:sticky;bottom:0;margin-top:12px;padding:10px 12px;background:#fff;border:1px solid #d0d0d5;border-radius:8px;display:none;align-items:center;gap:12px;box-shadow:0 -2px 8px rgba(0,0,0,0.06)">
     <strong style="font-size:13px">予算配分の変更（未確定）</strong>
     <span id="symbol-budget-dirty" class="muted" style="font-size:12px"></span>
+    <span id="symbol-budget-bar-meter" style="display:flex;gap:14px;align-items:center"></span>
     <span style="flex:1"></span>
     <a href="/dashboard/symbols" style="padding:5px 12px;text-decoration:none;border:1px solid #d0d0d5;border-radius:6px;font-size:13px">取消</a>
     <button type="submit" form="symbol-budget-form" style="padding:5px 14px;background:#06c;color:#fff;border:none;border-radius:6px;cursor:pointer;font-size:13px">確定して保存</button>

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -7086,6 +7086,11 @@ function symbolFormBody(args: SymbolFormArgs): string {
   const kAtrPlaceholder = globalDefaults
     ? `空欄で global default (${globalDefaults.kAtr}) を使用`
     : '空欄で global default を使用'
+  // 予算配分は DB に fraction (0..1) 保存、表示は % (×100)。
+  const budgetAllocPctValue =
+    row?.budgetAllocPct === null || row?.budgetAllocPct === undefined
+      ? ''
+      : String(Math.round(row.budgetAllocPct * 1000) / 10)
   const symbolField =
     mode === 'edit'
       ? `<input type="text" name="symbol" value="${esc(symbolValue)}" readonly style="padding:6px;background:#eee">
@@ -7167,6 +7172,12 @@ function symbolFormBody(args: SymbolFormArgs): string {
       <input type="number" name="max_notional" value="${esc(maxNotionalValue)}" step="0.01" min="0.01" placeholder="空欄で global default を使用" style="padding:6px;width:160px">
       <span class="muted" style="font-size:12px;margin-left:6px"><span id="symbol-form-max-notional-unit">${esc(currencyValue)}</span> / 1 発注</span>
       <p class="muted" style="margin:4px 0 0;font-size:11px">空欄 → global の <code>max_order_notional_<span id="symbol-form-max-notional-global-key">${currencyValue.toLowerCase()}</span></code> を使用。設定値は per-symbol cap として global より優先。</p>
+    </div>
+    <label>予算配分 <span class="muted" style="font-size:11px">(%)</span></label>
+    <div>
+      <input type="number" name="budget_alloc_pct" value="${esc(budgetAllocPctValue)}" step="0.1" min="0.1" max="100" placeholder="空欄で risk-% sizing" style="padding:6px;width:160px">
+      <span class="muted" style="font-size:12px;margin-left:6px">% of 総資本</span>
+      <p class="muted" style="margin:4px 0 0;font-size:11px">指定すると <strong>1 注文 = 総資本 (<code>total_capital</code>) × この%</strong> で sizing (risk-% sizing を bypass)。小口座で高額レバ ETF を建てる用。上限は <code>min(予算×%, 1注文上限)</code>。空欄なら従来の risk-% sizing。</p>
     </div>
     <label>保有上限 <span class="muted" style="font-size:11px">(time_stop_days)</span></label>
     <div>

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -7012,10 +7012,10 @@ const BUDGET_LADDER_JS = `
       var u = usage[ccy] || 0;
       var w = Math.min(100, u);
       var col = u > 100 ? '#c22' : u > 80 ? '#b25000' : '#057a55';
-      return '<span title="同時建玉ベースの予算使用率 (インバース対は max を1回計上)" style="display:inline-flex;align-items:center;gap:5px;font-size:12px">'
-        + '<span class="muted">' + ccy + '</span>'
-        + '<span class="bar-track" style="display:inline-block;width:70px;height:8px;vertical-align:middle"><span class="bar-fill" style="display:block;width:' + w.toFixed(0) + '%;height:8px;background:' + col + '"></span></span>'
-        + '<span style="font-variant-numeric:tabular-nums;color:' + col + '">' + u.toFixed(0) + '%' + (u > 100 ? '⚠' : '') + '</span></span>';
+      return '<span title="同時建玉ベースの予算使用率 (インバース対は max を1回計上)" style="display:flex;align-items:center;gap:6px;font-size:12px;flex:1;min-width:0">'
+        + '<span class="muted" style="white-space:nowrap">' + ccy + '</span>'
+        + '<span class="bar-track" style="flex:1;min-width:40px;height:8px"><span class="bar-fill" style="display:block;width:' + w.toFixed(0) + '%;height:8px;background:' + col + '"></span></span>'
+        + '<span style="font-variant-numeric:tabular-nums;color:' + col + ';white-space:nowrap">' + u.toFixed(0) + '%' + (u > 100 ? '⚠' : '') + '</span></span>';
     }).join('');
   };
 `
@@ -7025,9 +7025,8 @@ function budgetLadderControls(): string {
   return `<form id="symbol-budget-form" method="post" action="/admin/symbol-config/budget-alloc"></form>
   <div id="symbol-budget-bar" style="position:sticky;bottom:0;margin-top:12px;padding:10px 12px;background:#fff;border:1px solid #d0d0d5;border-radius:8px;display:none;align-items:center;gap:12px;box-shadow:0 -2px 8px rgba(0,0,0,0.06)">
     <strong style="font-size:13px">予算配分の変更（未確定）</strong>
-    <span id="symbol-budget-dirty" class="muted" style="font-size:12px"></span>
-    <span id="symbol-budget-bar-meter" style="display:flex;gap:14px;align-items:center"></span>
-    <span style="flex:1"></span>
+    <span id="symbol-budget-dirty" class="muted" style="font-size:12px;white-space:nowrap"></span>
+    <span id="symbol-budget-bar-meter" style="display:flex;gap:14px;align-items:center;flex:1"></span>
     <a href="/dashboard/symbols" style="padding:5px 12px;text-decoration:none;border:1px solid #d0d0d5;border-radius:6px;font-size:13px">取消</a>
     <button type="submit" form="symbol-budget-form" style="padding:5px 14px;background:#06c;color:#fff;border:none;border-radius:6px;cursor:pointer;font-size:13px">確定して保存</button>
   </div>`

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -6888,6 +6888,15 @@ function symbolsListBody(args: {
       const maxNotionalCell = r.maxNotional === null
         ? '<span class="muted" title="未設定 = global の MAX_ORDER_NOTIONAL を使用">— (global)</span>'
         : `${esc(r.maxNotional.toLocaleString('ja-JP'))} <span class="muted" style="font-size:11px">${esc(r.currency)}</span>`
+      // 予算配分 ladder slider (#budget-alloc): 5%刻み。確定するまで client 側で仮調整、
+      // form="symbol-budget-form" で一括 POST。inverse 相手は JS が同期する。
+      const allocPctNum = r.budgetAllocPct != null ? Math.round(r.budgetAllocPct * 1000) / 10 : 0
+      const budgetCell = `<div style="display:flex;align-items:center;gap:6px;min-width:170px">
+          <input type="range" name="pct_${esc(r.symbol)}" form="symbol-budget-form" min="0" max="100" step="5" value="${allocPctNum}"
+            data-symbol="${esc(r.symbol)}"${inverse ? ` data-inverse="${esc(inverse)}"` : ''}
+            oninput="window.onBudgetSlide(this)" style="width:110px;vertical-align:middle">
+          <span id="budget-label-${esc(r.symbol)}" class="muted" style="font-size:12px;width:42px;text-align:right;font-variant-numeric:tabular-nums">${allocPctNum === 0 ? 'risk' : allocPctNum + '%'}</span>
+        </div>`
       // ツリー表記 (#315): 対を縦線で連結。上段は中央→下端に縦線 + 中央で右へ横棒
       // (┌)、下段は上端→中央に縦線 + 中央で右へ横棒 (└)。隣接行で左の縦線が
       // 行境界を跨いで連結し、1 本の bracket に見える。線は相手 edit へのリンク。
@@ -6912,6 +6921,7 @@ function symbolsListBody(args: {
         <td>${esc(r.name ?? '')}</td>
         <td><code style="font-size:11px">${esc(r.market)}/${esc(r.currency)}</code></td>
         <td>${maxNotionalCell}</td>
+        <td>${budgetCell}</td>
         <td>${esc(r.notes ?? '')}</td>
         <td class="muted" style="font-size:11px">${esc(dateOnly)}</td>
         <td>
@@ -6932,12 +6942,56 @@ function symbolsListBody(args: {
       <th>銘柄名</th>
       <th>市場/通貨</th>
       <th>1注文上限</th>
+      <th>予算配分</th>
       <th>メモ</th>
       <th>更新日</th>
       <th>操作</th>
     </tr></thead>
     <tbody>${tbody}</tbody>
-  </table>`
+  </table>
+  ${budgetLadderControls()}
+  <script>${BUDGET_LADDER_JS}</script>`
+}
+
+// #budget-alloc ladder の client JS: slider 移動でラベル更新 + インバース相手の
+// slider を同値に同期 + 「未確定」バーを表示。保存は確定ボタン押下の form POST のみ
+// (即保存しない = 確定するまで仮)。
+const BUDGET_LADDER_JS = `
+  window.__budgetDirty = {};
+  window.__fmtBudget = function (v) { return Number(v) <= 0 ? 'risk' : v + '%'; };
+  window.__setBudgetSlider = function (sym, v) {
+    var sl = document.querySelector('input[name="pct_' + sym + '"]');
+    var lb = document.getElementById('budget-label-' + sym);
+    if (sl) sl.value = v;
+    if (lb) lb.textContent = window.__fmtBudget(v);
+  };
+  window.onBudgetSlide = function (el) {
+    var sym = el.getAttribute('data-symbol');
+    var inv = el.getAttribute('data-inverse');
+    var v = el.value;
+    var lb = document.getElementById('budget-label-' + sym);
+    if (lb) lb.textContent = window.__fmtBudget(v);
+    // インバース対は同値に同期 (#315 regime hedge)。相手 slider が一覧に在れば揃える。
+    if (inv) window.__setBudgetSlider(inv, v);
+    window.__budgetDirty[sym] = true;
+    if (inv) window.__budgetDirty[inv] = true;
+    var bar = document.getElementById('symbol-budget-bar');
+    var note = document.getElementById('symbol-budget-dirty');
+    if (bar) bar.style.display = 'flex';
+    if (note) note.textContent = Object.keys(window.__budgetDirty).length + ' 銘柄を変更中';
+  };
+`
+
+/** 予算配分 ladder の確定 / 取消 バー。slider は form attr で此処の form に紐づく。 */
+function budgetLadderControls(): string {
+  return `<form id="symbol-budget-form" method="post" action="/admin/symbol-config/budget-alloc"></form>
+  <div id="symbol-budget-bar" style="position:sticky;bottom:0;margin-top:12px;padding:10px 12px;background:#fff;border:1px solid #d0d0d5;border-radius:8px;display:none;align-items:center;gap:12px;box-shadow:0 -2px 8px rgba(0,0,0,0.06)">
+    <strong style="font-size:13px">予算配分の変更（未確定）</strong>
+    <span id="symbol-budget-dirty" class="muted" style="font-size:12px"></span>
+    <span style="flex:1"></span>
+    <a href="/dashboard/symbols" style="padding:5px 12px;text-decoration:none;border:1px solid #d0d0d5;border-radius:6px;font-size:13px">取消</a>
+    <button type="submit" form="symbol-budget-form" style="padding:5px 14px;background:#06c;color:#fff;border:none;border-radius:6px;cursor:pointer;font-size:13px">確定して保存</button>
+  </div>`
 }
 
 /**

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -6950,6 +6950,17 @@ function symbolsListBody(args: {
     <tbody>${tbody}</tbody>
   </table>
   ${budgetLadderControls()}
+  ${safeJsonScript(
+    '__budgetBaseline',
+    rows
+      .filter((r) => r.budgetAllocPct != null && r.budgetAllocPct > 0)
+      .map((r) => ({
+        s: r.symbol.toUpperCase(),
+        ccy: r.currency,
+        pct: Math.round((r.budgetAllocPct as number) * 1000) / 10,
+        inv: inversePairs[r.symbol.toUpperCase()] ?? null,
+      })),
+  )}
   <script>${BUDGET_LADDER_JS}</script>`
 }
 
@@ -6986,11 +6997,18 @@ const BUDGET_LADDER_JS = `
   window.__recomputeBudgetMeter = function () {
     var barMeter = document.getElementById('symbol-budget-bar-meter');
     if (!barMeter) return;
-    var sliders = document.querySelectorAll('input[name^="pct_"]');
+    // 全銘柄の baseline 配分から開始し、表示中 slider の現在値で上書きする。
+    // filter で非表示の銘柄の配分が meter から欠落しないようにするため (CodeRabbit #405)。
     var bySym = {};
+    (window.__budgetBaseline || []).forEach(function (b) {
+      if (b.pct > 0) bySym[b.s] = { ccy: b.ccy, pct: b.pct, inv: b.inv };
+    });
+    var sliders = document.querySelectorAll('input[name^="pct_"]');
     sliders.forEach(function (s) {
+      var sym = s.getAttribute('data-symbol');
       var v = Number(s.value);
-      if (v > 0) bySym[s.getAttribute('data-symbol')] = { ccy: s.getAttribute('data-currency'), pct: v, inv: s.getAttribute('data-inverse') };
+      if (v > 0) bySym[sym] = { ccy: s.getAttribute('data-currency'), pct: v, inv: s.getAttribute('data-inverse') };
+      else delete bySym[sym]; // 0 にした表示中銘柄は除外 (baseline 値で復活させない)
     });
     var usage = {};
     var counted = {};

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -59,6 +59,12 @@ export interface PullbackSchedulerOptions {
    */
   lotSize?: number
   /**
+   * symbol → budget_alloc_pct (0<pct<=1)。指定 symbol は fixed-% 配分 sizing
+   * (notional = min(equity * pct, symbolCap)) に切替わる (#budget-alloc)。
+   * 未指定 symbol は従来の risk-% sizing。
+   */
+  symbolBudgetAllocPctMap?: Record<string, number>
+  /**
    * Per-symbol decision sink。HOLD / BUY / SELL / REJECT / ERROR の各 route で
    * 1 回ずつ呼ばれる。実装は D1 INSERT が典型 (#128)、テストは fake 注入可能。
    * 呼び出し側が失敗を throw しないのが前提 (logging failure isolation)。
@@ -443,6 +449,7 @@ export async function runPullbackScheduler(
         riskPerTradePct: options.riskPerTradePct,
         lotSize: options.lotSize,
         kAtr: rule.kAtr,
+        budgetAllocPct: options.symbolBudgetAllocPctMap?.[upper],
       })
       if (sizing.quantity <= 0) {
         const reason = buildSizingRejectReason(sizing, {

--- a/src/trading/strategy/pullbackSizing.ts
+++ b/src/trading/strategy/pullbackSizing.ts
@@ -78,10 +78,18 @@ export function computePullbackSizing(input: PullbackSizingInput): PullbackSizin
   let stopDistance: number | undefined
   let riskBudget: number | undefined
 
-  if (input.budgetAllocPct !== undefined && input.budgetAllocPct > 0) {
+  if (input.budgetAllocPct !== undefined) {
     // === fixed-% 予算配分モード (#budget-alloc) ===
     // notional = min(equity * pct, symbolCap)。risk-% / ATR floor は使わない。
     // 小口座で高額レバ ETF を「予算の N%」で建てるための path。
+    //
+    // budgetAllocPct が「指定済み」なら厳密検証して fail-closed。NaN / <=0 / >1 の
+    // 不正値で risk-% にフォールバックすると想定外サイジングになるため (CodeRabbit
+    // #405)、ここで 0 qty 返却して止める (loadSymbolConfig は 0<pct<=1 のみ通すが
+    // 二重防御)。
+    if (!Number.isFinite(input.budgetAllocPct) || input.budgetAllocPct <= 0 || input.budgetAllocPct > 1) {
+      return { quantity: 0, notional: 0, capped: true, capReason: 'insufficient-risk-budget' }
+    }
     if (!Number.isFinite(input.entryPrice) || input.entryPrice <= 0) {
       return { quantity: 0, notional: 0, capped: true, capReason: 'invalid-stop' }
     }

--- a/src/trading/strategy/pullbackSizing.ts
+++ b/src/trading/strategy/pullbackSizing.ts
@@ -8,6 +8,13 @@ export interface PullbackSizingInput {
   baselineAtr20: number
   /** Optional symbol-specific absolute notional cap. */
   symbolCap?: number
+  /**
+   * Per-symbol budget allocation fraction of NAV (0..1)。指定されると **fixed-%
+   * 配分モード**になり risk-% / ATR floor を bypass して
+   * `notional = min(equity * budgetAllocPct, symbolCap)` で sizing する (#budget-alloc)。
+   * 小口座で risk-% sizing が 0 株になる高額レバ ETF 用。NULL は従来の risk sizing。
+   */
+  budgetAllocPct?: number
   /** Risk fraction of NAV per trade. Default 0.004 (0.4%). */
   riskPerTradePct?: number
   /** ATR floor ratio. If atr20 < baselineAtr20 * this, size is halved. Default 0.5. */
@@ -65,37 +72,65 @@ export function computePullbackSizing(input: PullbackSizingInput): PullbackSizin
   if (!Number.isFinite(input.kAtr) || input.kAtr <= 0) {
     throw new Error(`computePullbackSizing: kAtr must be a positive finite number, got ${input.kAtr}`)
   }
-  const pctStop = Math.abs(input.entryPrice * input.stopPct)
-  // vol-adaptive: kAtr * atr20。atr20=0 (post-halt/gap) は pct stop が floor。
-  const atrStop = input.atr20 > 0 ? input.kAtr * input.atr20 : 0
-  const stopDistance = atrStop > pctStop ? atrStop : pctStop
-
-  if (!Number.isFinite(stopDistance) || stopDistance <= 0) {
-    return { quantity: 0, notional: 0, capped: true, capReason: 'invalid-stop', stopDistance }
-  }
-
-  const riskBudget = input.equity * riskPct
-  if (!Number.isFinite(riskBudget) || riskBudget <= 0) {
-    return { quantity: 0, notional: 0, capped: true, capReason: 'insufficient-risk-budget', stopDistance, riskBudget }
-  }
-
-  let quantity = Math.floor(riskBudget / stopDistance)
+  let quantity: number
   let capped = false
   let capReason: PullbackSizingResult['capReason']
+  let stopDistance: number | undefined
+  let riskBudget: number | undefined
 
-  if (input.baselineAtr20 > 0 && input.atr20 < input.baselineAtr20 * atrFloor) {
-    quantity = Math.floor(quantity / 2)
-    capped = true
-    capReason = 'atr-floor'
+  if (input.budgetAllocPct !== undefined && input.budgetAllocPct > 0) {
+    // === fixed-% 予算配分モード (#budget-alloc) ===
+    // notional = min(equity * pct, symbolCap)。risk-% / ATR floor は使わない。
+    // 小口座で高額レバ ETF を「予算の N%」で建てるための path。
+    if (!Number.isFinite(input.entryPrice) || input.entryPrice <= 0) {
+      return { quantity: 0, notional: 0, capped: true, capReason: 'invalid-stop' }
+    }
+    const rawNotional = input.equity * input.budgetAllocPct
+    if (!Number.isFinite(rawNotional) || rawNotional <= 0) {
+      return { quantity: 0, notional: 0, capped: true, capReason: 'insufficient-risk-budget' }
+    }
+    let target = rawNotional
+    // %優先・絶対上限は安全弁: min(予算×%, symbolCap)。
+    if (input.symbolCap !== undefined && target > input.symbolCap) {
+      target = input.symbolCap
+      capped = true
+      capReason = 'symbol-cap'
+    }
+    quantity = Math.floor(target / input.entryPrice)
+  } else {
+    // === 従来の risk-% sizing ===
+    const pctStop = Math.abs(input.entryPrice * input.stopPct)
+    // vol-adaptive: kAtr * atr20。atr20=0 (post-halt/gap) は pct stop が floor。
+    const atrStop = input.atr20 > 0 ? input.kAtr * input.atr20 : 0
+    stopDistance = atrStop > pctStop ? atrStop : pctStop
+
+    if (!Number.isFinite(stopDistance) || stopDistance <= 0) {
+      return { quantity: 0, notional: 0, capped: true, capReason: 'invalid-stop', stopDistance }
+    }
+
+    riskBudget = input.equity * riskPct
+    if (!Number.isFinite(riskBudget) || riskBudget <= 0) {
+      return { quantity: 0, notional: 0, capped: true, capReason: 'insufficient-risk-budget', stopDistance, riskBudget }
+    }
+
+    quantity = Math.floor(riskBudget / stopDistance)
+
+    if (input.baselineAtr20 > 0 && input.atr20 < input.baselineAtr20 * atrFloor) {
+      quantity = Math.floor(quantity / 2)
+      capped = true
+      capReason = 'atr-floor'
+    }
+
+    let notionalRisk = quantity * input.entryPrice
+    if (input.symbolCap !== undefined && notionalRisk > input.symbolCap) {
+      quantity = Math.floor(input.symbolCap / input.entryPrice)
+      notionalRisk = quantity * input.entryPrice
+      capped = true
+      capReason = 'symbol-cap'
+    }
   }
 
   let notional = quantity * input.entryPrice
-  if (input.symbolCap !== undefined && notional > input.symbolCap) {
-    quantity = Math.floor(input.symbolCap / input.entryPrice)
-    notional = quantity * input.entryPrice
-    capped = true
-    capReason = 'symbol-cap'
-  }
 
   // Exchange lot-size rounding (e.g. TSE 100-share lots). Must run AFTER all
   // other caps so we don't round up back over symbolCap. If the round-down

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -551,6 +551,7 @@ export async function runStrategyCron(
       positionStore,
       execution,
       symbolCapMap: universe.symbolMaxNotional,
+      symbolBudgetAllocPctMap: universe.symbolBudgetAllocPct,
       defaultRule,
       rulesMap,
       riskPerTradePct: scaledRiskPerTradePct,

--- a/test/helpers/configFixtures.ts
+++ b/test/helpers/configFixtures.ts
@@ -56,6 +56,7 @@ export function makeSymbolUniverse(overrides: Partial<SymbolUniverse> = {}): Sym
     symbolNotes: {},
     symbolTimeStopDaysOverride: {},
     symbolKAtrOverride: {},
+    symbolBudgetAllocPct: {},
     inversePairs: {},
     source: 'd1',
     ...overrides,

--- a/test/infrastructure/db/symbolConfigRepo.test.ts
+++ b/test/infrastructure/db/symbolConfigRepo.test.ts
@@ -134,8 +134,45 @@ import {
   setInversePair,
   deleteInversePairsForSymbol,
   createSymbolPair,
+  updateBudgetAllocPct,
   type SymbolConfigWriteInput,
 } from '../../../src/infrastructure/db/symbolConfigRepo'
+
+describe('updateBudgetAllocPct', () => {
+  // findSymbolConfig は select().from().where().limit()。update().set().where() の
+  // 呼び出し有無を記録する最小 mock。
+  function fakeDb2(current: number | null) {
+    let updates = 0
+    const sel = () => ({
+      from: () => sel(),
+      where: () => sel(),
+      limit: async () => [{ symbol: 'SOXL', budgetAllocPct: current }],
+    })
+    const db = {
+      select: () => sel(),
+      update: () => ({ set: () => ({ where: async () => { updates += 1 } }) }),
+    }
+    return { db: db as unknown as Parameters<typeof updateBudgetAllocPct>[0], updates: () => updates }
+  }
+
+  it('skips UPDATE when value is unchanged (no updatedAt bump, CodeRabbit #405)', async () => {
+    const f = fakeDb2(0.4)
+    await updateBudgetAllocPct(f.db, 'SOXL', 0.4, 't')
+    expect(f.updates()).toBe(0)
+  })
+
+  it('issues UPDATE when value changes', async () => {
+    const f = fakeDb2(0.4)
+    await updateBudgetAllocPct(f.db, 'SOXL', 0.5, 't')
+    expect(f.updates()).toBe(1)
+  })
+
+  it('null↔null is a no-op', async () => {
+    const f = fakeDb2(null)
+    await updateBudgetAllocPct(f.db, 'SOXL', null, 't')
+    expect(f.updates()).toBe(0)
+  })
+})
 
 // setInversePair / deleteInversePairsForSymbol / createSymbolPair 用の最小 mock。
 // insert().values() / delete().where() は即実行で Promise を返し、batch は待つだけ。

--- a/test/infrastructure/db/symbolConfigRepo.test.ts
+++ b/test/infrastructure/db/symbolConfigRepo.test.ts
@@ -195,6 +195,7 @@ const writeInput = (symbol: string): SymbolConfigWriteInput => ({
   notes: null,
   timeStopDaysOverride: null,
   kAtrOverride: null,
+  budgetAllocPct: null,
 })
 
 describe('setInversePair', () => {

--- a/test/routes/admin.test.ts
+++ b/test/routes/admin.test.ts
@@ -1139,6 +1139,7 @@ describe('POST /admin/orders/sync-holdings', () => {
       symbolNotes: {},
       symbolTimeStopDaysOverride: {},
       symbolKAtrOverride: {},
+      symbolBudgetAllocPct: {},
       inversePairs: {},
       source: 'd1',
     })

--- a/test/routes/dashboardSymbolsCrud.test.ts
+++ b/test/routes/dashboardSymbolsCrud.test.ts
@@ -153,6 +153,7 @@ function fakeDb(initial: SymbolConfigRow[]) {
               notes: (v.notes as string | null) ?? null,
               timeStopDaysOverride: (v.timeStopDaysOverride as number | null) ?? null,
               kAtrOverride: (v.kAtrOverride as number | null) ?? null,
+              budgetAllocPct: (v.budgetAllocPct as number | null) ?? null,
               updatedAt: String(v.updatedAt ?? ''),
             })
           }
@@ -207,6 +208,7 @@ function row(overrides: Partial<SymbolConfigRow> = {}): SymbolConfigRow {
     notes: null,
     timeStopDaysOverride: null,
     kAtrOverride: null,
+    budgetAllocPct: null,
     updatedAt: '2026-04-23T00:00:00.000Z',
     ...overrides,
   }
@@ -863,6 +865,46 @@ describe('dashboard symbol_config CRUD UI (#292)', () => {
     expect(soxs.currency).toBe('USD')
     // inverse_pairs リンクが書かれる
     expect(db.inserts.some((i) => i.table === 'inverse_pairs')).toBe(true)
+  })
+
+  it('POST persists budget_alloc_pct as a fraction (% input ÷ 100)', async () => {
+    const db = fakeDb([])
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const app = createApp()
+    const form = new URLSearchParams({
+      symbol: '1570',
+      market: 'JP',
+      currency: 'JPY',
+      active: 'true',
+      budget_alloc_pct: '40', // 40% → 0.4
+    })
+    const res = await app.request(
+      '/admin/symbol-config',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: form.toString(),
+      },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    expect(res.status).toBe(303)
+    const inserted = db.inserts.find((i) => i.table === 'symbol_config')!
+    expect(inserted.values.budgetAllocPct).toBeCloseTo(0.4, 6)
+  })
+
+  it('edit form shows 予算配分 (%) field', async () => {
+    const db = fakeDb([row({ symbol: 'SOXL', budgetAllocPct: 0.4 })])
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const app = createApp()
+    const res = await app.request(
+      '/dashboard/symbols/SOXL/edit',
+      { headers: authHeader },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    const body = await res.text()
+    expect(body).toContain('name="budget_alloc_pct"')
+    // fraction 0.4 → 表示は 40 (%)
+    expect(body).toMatch(/name="budget_alloc_pct"[^>]*value="40"/)
   })
 
   it('new form inputs carry password-manager opt-out (data-1p-ignore)', async () => {

--- a/test/routes/dashboardSymbolsCrud.test.ts
+++ b/test/routes/dashboardSymbolsCrud.test.ts
@@ -907,6 +907,53 @@ describe('dashboard symbol_config CRUD UI (#292)', () => {
     expect(body).toMatch(/name="budget_alloc_pct"[^>]*value="40"/)
   })
 
+  it('list renders budget-allocation ladder slider + confirm button (tentative until 確定)', async () => {
+    const db = fakeDb([row({ symbol: 'SOXL', budgetAllocPct: 0.4 })])
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const app = createApp()
+    const res = await app.request('/dashboard/symbols', { headers: authHeader }, { ...baseEnv, DB: {} as D1Database })
+    const body = await res.text()
+    // slider が form="symbol-budget-form" に紐づき、現在値 40 が反映
+    expect(body).toContain('name="pct_SOXL"')
+    expect(body).toContain('form="symbol-budget-form"')
+    expect(body).toMatch(/name="pct_SOXL"[^>]*value="40"/)
+    // 確定ボタン (即保存しない)
+    expect(body).toContain('確定して保存')
+    expect(body).toContain('action="/admin/symbol-config/budget-alloc"')
+  })
+
+  it('bulk budget-alloc POST converts % → fraction (÷100), 303', async () => {
+    let lastSetPct: number | null | undefined
+    // chain mock: from() は await で [] (loadInversePairs)、where().limit() で
+    // SOXL 行 (findSymbolConfig)、update().set().where() で set 値を捕捉。
+    const chain: Record<string, unknown> = {}
+    chain.from = () => chain
+    chain.where = () => chain
+    chain.limit = async () => [{ symbol: 'SOXL', budgetAllocPct: null }]
+    chain.then = (resolve: (v: unknown[]) => unknown) => Promise.resolve([]).then(resolve)
+    vi.mocked(createDb).mockReturnValue({
+      select: () => chain,
+      update: () => ({
+        set: (vals: { budgetAllocPct: number | null }) => ({
+          where: async () => {
+            lastSetPct = vals.budgetAllocPct
+          },
+        }),
+      }),
+      insert: () => ({ values: async () => undefined }),
+    } as never)
+    const app = createApp()
+    const form = new URLSearchParams({ pct_SOXL: '40' })
+    const res = await app.request(
+      '/admin/symbol-config/budget-alloc',
+      { method: 'POST', headers: { 'content-type': 'application/x-www-form-urlencoded' }, body: form.toString() },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    expect(res.status).toBe(303)
+    expect(res.headers.get('location')).toBe('/dashboard/symbols')
+    expect(lastSetPct).toBeCloseTo(0.4, 6)
+  })
+
   it('new form inputs carry password-manager opt-out (data-1p-ignore)', async () => {
     const db = fakeDb([])
     vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)

--- a/test/routes/dashboardSymbolsCrud.test.ts
+++ b/test/routes/dashboardSymbolsCrud.test.ts
@@ -1014,7 +1014,47 @@ describe('dashboard symbol_config CRUD UI (#292)', () => {
   })
 })
 
-import { orderRowsByPair, assignPairColors, pairRoles } from '../../src/routes/dashboard'
+import { orderRowsByPair, assignPairColors, pairRoles, computeBudgetUsage } from '../../src/routes/dashboard'
+
+describe('#budget-alloc computeBudgetUsage (concurrent-position meter)', () => {
+  const rec = (symbol: string, currency: string, budgetAllocPct: number | null) => ({ symbol, currency, budgetAllocPct })
+
+  it('counts an inverse pair once via max (only one side held at a time)', () => {
+    // SOXL 40% / SOXS 40% (synced) → pair contributes 40, not 80.
+    const usage = computeBudgetUsage(
+      [rec('SOXL', 'USD', 0.4), rec('SOXS', 'USD', 0.4)],
+      { SOXL: 'SOXS', SOXS: 'SOXL' },
+    )
+    expect(usage.USD).toBeCloseTo(40, 6)
+  })
+
+  it('uses max when the two sides differ', () => {
+    const usage = computeBudgetUsage(
+      [rec('SOXL', 'USD', 0.4), rec('SOXS', 'USD', 0.2)],
+      { SOXL: 'SOXS', SOXS: 'SOXL' },
+    )
+    expect(usage.USD).toBeCloseTo(40, 6)
+  })
+
+  it('adds standalone symbols and separate pairs; groups by currency', () => {
+    const usage = computeBudgetUsage(
+      [
+        rec('SOXL', 'USD', 0.4), rec('SOXS', 'USD', 0.4), // pair → 40
+        rec('TQQQ', 'USD', 0.3), rec('SQQQ', 'USD', 0.3), // pair → 30
+        rec('AAPL', 'USD', 0.1), // standalone → 10
+        rec('1570', 'JPY', 0.5), rec('1357', 'JPY', 0.5), // JPY pair → 50
+      ],
+      { SOXL: 'SOXS', SOXS: 'SOXL', TQQQ: 'SQQQ', SQQQ: 'TQQQ', '1570': '1357', '1357': '1570' },
+    )
+    expect(usage.USD).toBeCloseTo(80, 6) // 40+30+10
+    expect(usage.JPY).toBeCloseTo(50, 6)
+  })
+
+  it('ignores null / 0 allocations', () => {
+    const usage = computeBudgetUsage([rec('SOXL', 'USD', null), rec('AAPL', 'USD', 0)], {})
+    expect(usage.USD).toBeUndefined()
+  })
+})
 
 describe('#315 inverse-pair list grouping', () => {
   const r = (symbol: string): SymbolConfigRow => row({ symbol, name: symbol })

--- a/test/strategy/pullbackSizing.test.ts
+++ b/test/strategy/pullbackSizing.test.ts
@@ -209,4 +209,13 @@ describe('computePullbackSizing — fixed-% budget allocation (#budget-alloc)', 
     const result = computePullbackSizing(baseInput())
     expect(result.quantity).toBe(100) // 従来通り
   })
+
+  it('fail-closed (qty 0) on invalid budgetAllocPct instead of risk-% fallback (CodeRabbit #405)', () => {
+    // budgetAllocPct が指定済みだが範囲外 (>1) / NaN / <=0 → 0 qty で止める。
+    for (const bad of [1.5, 0, -0.1, Number.NaN]) {
+      const result = computePullbackSizing(baseInput({ budgetAllocPct: bad }))
+      expect(result.quantity).toBe(0)
+      expect(result.capped).toBe(true)
+    }
+  })
 })

--- a/test/strategy/pullbackSizing.test.ts
+++ b/test/strategy/pullbackSizing.test.ts
@@ -157,3 +157,56 @@ describe('computePullbackSizing', () => {
     expect(() => computePullbackSizing(baseInput({ kAtr: Number.NaN }))).toThrow(/kAtr/)
   })
 })
+
+describe('computePullbackSizing — fixed-% budget allocation (#budget-alloc)', () => {
+  it('sizes by notional = equity * budgetAllocPct (bypasses risk-% / ATR floor)', () => {
+    // 総資本 100k の 40% = 40,000 を price 35,000 で → floor(40000/35000) = 1 株。
+    const result = computePullbackSizing(
+      baseInput({ equity: 100_000, entryPrice: 35_000, budgetAllocPct: 0.4, atr20: 5000, baselineAtr20: 1000 }),
+    )
+    expect(result.quantity).toBe(1)
+    expect(result.notional).toBe(35_000)
+    // risk-% なら floor(400 / stop) = 0 株のはず。budget-alloc で 1 株建つ。
+    expect(result.capped).toBe(false)
+  })
+
+  it('clamps to symbolCap when budget*pct exceeds it (min semantics)', () => {
+    // 40% = 40,000 だが symbolCap 30,000 → min。floor(30000/10000)=3。
+    const result = computePullbackSizing(
+      baseInput({ equity: 100_000, entryPrice: 10_000, budgetAllocPct: 0.4, symbolCap: 30_000 }),
+    )
+    expect(result.quantity).toBe(3)
+    expect(result.notional).toBe(30_000)
+    expect(result.capReason).toBe('symbol-cap')
+  })
+
+  it('uses budget pct even when below symbolCap (% wins, abs is only a ceiling)', () => {
+    // 20% = 20,000 < symbolCap 50,000 → 予算% を採用。floor(20000/10000)=2。
+    const result = computePullbackSizing(
+      baseInput({ equity: 100_000, entryPrice: 10_000, budgetAllocPct: 0.2, symbolCap: 50_000 }),
+    )
+    expect(result.quantity).toBe(2)
+    expect(result.notional).toBe(20_000)
+  })
+
+  it('respects lot size in budget-alloc mode', () => {
+    // 40% = 40,000、price 100、lot 100 → floor(400/100)*100 = 400。
+    const result = computePullbackSizing(
+      baseInput({ equity: 100_000, entryPrice: 100, budgetAllocPct: 0.4, lotSize: 100 }),
+    )
+    expect(result.quantity).toBe(400)
+  })
+
+  it('rejects (qty 0) when budget*pct is too small for one share', () => {
+    // 1% = 1,000 だが price 35,000 → floor(1000/35000)=0。
+    const result = computePullbackSizing(
+      baseInput({ equity: 100_000, entryPrice: 35_000, budgetAllocPct: 0.01 }),
+    )
+    expect(result.quantity).toBe(0)
+  })
+
+  it('falls back to risk-% sizing when budgetAllocPct is undefined', () => {
+    const result = computePullbackSizing(baseInput())
+    expect(result.quantity).toBe(100) // 従来通り
+  })
+})


### PR DESCRIPTION
## 概要
小口座（¥100k 等）では risk-0.4% sizing が高額レバ ETF（1570 ≈¥35k/口 等）で **0 株**になる。対処として **per-symbol の予算配分%** sizing を追加。

`symbol_config.budget_alloc_pct` を設定した銘柄は **`notional = min(総資本 × pct, max_notional)`** で sizing（risk-% を bypass）。未設定銘柄は従来の risk-% sizing のまま。

## 設計（合意済み）
- **%の持ち方**: 銘柄ごとの割当%（per-symbol）
- **総予算の基準**: `total_capital_{jpy,usd}`（cron の run.equity = sanitized total_capital）
- **優先順**: %優先・`max_notional` は安全弁（**min** セマンティクス）
- **risk%との関係**: %指定銘柄は risk-0.4%/ATR floor を bypass（小口座 0 株問題の回避）

## 変更
- `pullbackSizing.computePullbackSizing`: `budgetAllocPct` 指定時に fixed-% 配分ブランチ
- schema: `symbol_config.budget_alloc_pct`（**migration 0024**、ALTER ADD COLUMN）
- repo/universe/scheduler/cron に per-symbol map を配線
- 連動登録の counterpart は primary の % を継承（regime hedge は片方ずつ建てるため）
- dashboard 銘柄フォームに「**予算配分 (%)**」欄（% 入力 → fraction 保存、admin parse で /100、0<pct≤100 を 400 validation）

## テスト
- typecheck OK / **test 1224 passed**
- 追加: sizing（%配分・symbolCap clamp・lot・0株reject・risk fallback）/ フォーム（% → fraction 保存・edit 表示）
- migration 0024 を **D1 local 全 chain apply で検証**（列存在確認）

## 使い方（1570/1357 例、¥100k 口座）
1. `total_capital_jpy` を 100000 に設定
2. 1570 登録時に 予算配分 = 40 → 1357 も 40% 継承。1 注文 = ¥40,000（min(40k, max_notional)）
3. risk-0.4% で 0 株だった高額 ETF が建つように

## 備考
- #402（symbol management overhaul）merge 後の main を base にした単独 PR。migration 0024 は新規列追加のみ（破壊なし）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ダッシュボードに「予算配分（%）」スライダーとシンボル編集の％入力を追加。UIで個別/一括設定でき、未確定変更は下部バーで確認・送信可能。
  * 管理画面に一括POSTエンドポイントを追加し、インバース対の補完やバリデーション（0.1–100%）をサポート。サブシステムに配分マップを注入。
  * 予算配分モードを反映する固定%サイジングと予算使用率計算を導出関数として追加。
* **Chores**
  * シンボル設定に予算配分カラムを追加するDBマイグレーションを導入。
* **テスト**
  * 新機能に対応する単体・統合テストを追加・更新。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->