### PR TITLE
feat(sizing): unify budget allocation to single JPY account pool + FX 換算

### DIFF
--- a/src/infrastructure/quotes/fxRate.ts
+++ b/src/infrastructure/quotes/fxRate.ts
@@ -20,6 +20,8 @@ export interface UsdJpyRateOptions {
   timeoutMs?: number
   fetchFn?: typeof fetch
   userAgent?: string
+  /** 構造化ログの追跡 ID (cron tick の requestId を伝搬)。 */
+  requestId?: string
 }
 
 interface YahooChartMetaResponse {
@@ -37,6 +39,7 @@ export async function loadUsdJpyRate(options: UsdJpyRateOptions = {}): Promise<n
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
   const fetchFn = options.fetchFn ?? fetch.bind(globalThis)
   const userAgent = options.userAgent ?? DEFAULT_USER_AGENT
+  const requestId = options.requestId
 
   const url = new URL(`/v8/finance/chart/${encodeURIComponent(FX_SYMBOL)}`, baseUrl)
   url.searchParams.set('interval', '1d')
@@ -51,13 +54,13 @@ export async function loadUsdJpyRate(options: UsdJpyRateOptions = {}): Promise<n
       signal: controller.signal,
     })
     if (!response.ok) {
-      console.warn(JSON.stringify({ event: 'usdjpy_fetch_non_ok', status: response.status }))
+      console.warn(JSON.stringify({ event: 'usdjpy_fetch_non_ok', status: response.status, requestId }))
       return null
     }
     const json = (await response.json()) as YahooChartMetaResponse
     const rate = json.chart?.result?.[0]?.meta?.regularMarketPrice
     if (typeof rate !== 'number' || !Number.isFinite(rate) || rate < MIN_RATE || rate > MAX_RATE) {
-      console.warn(JSON.stringify({ event: 'usdjpy_rate_invalid', rate }))
+      console.warn(JSON.stringify({ event: 'usdjpy_rate_invalid', rate, requestId }))
       return null
     }
     return rate
@@ -66,6 +69,7 @@ export async function loadUsdJpyRate(options: UsdJpyRateOptions = {}): Promise<n
       JSON.stringify({
         event: 'usdjpy_fetch_failed',
         message: error instanceof Error ? error.message : String(error),
+        requestId,
       }),
     )
     return null

--- a/src/infrastructure/quotes/fxRate.ts
+++ b/src/infrastructure/quotes/fxRate.ts
@@ -1,0 +1,75 @@
+// USD/JPY スポットレート取得 (#budget-jpy-base-fx)。予算配分を口座(円)単一プールで
+// 扱うため、USD 銘柄の「目標円 → USD notional」換算に使う。
+//
+// Yahoo `/v8/finance/chart/USDJPY=X` の `meta.regularMarketPrice` を読む
+// (YahooBarClient と同 endpoint / UA 規約)。実マネー sizing に効くので **fail-safe**:
+// fetch 失敗・非有限・サニティレンジ外は `null` を返し (throw しない)、呼び出し側で
+// USD 予算銘柄を fail-closed (発注しない) させる。誤レートでの過大発注を防ぐ。
+
+const DEFAULT_BASE_URL = 'https://query1.finance.yahoo.com'
+const DEFAULT_TIMEOUT_MS = 5_000
+const DEFAULT_USER_AGENT = 'Mozilla/5.0'
+const FX_SYMBOL = 'USDJPY=X'
+// USD/JPY の妥当レンジ。歴史的に 75〜160 程度。異常値 (0 / 桁違い / 取り違え) を弾く
+// 安全マージンとして広めに 50〜500 を採用。範囲外は誤データとみなし null。
+const MIN_RATE = 50
+const MAX_RATE = 500
+
+export interface UsdJpyRateOptions {
+  baseUrl?: string
+  timeoutMs?: number
+  fetchFn?: typeof fetch
+  userAgent?: string
+}
+
+interface YahooChartMetaResponse {
+  chart?: {
+    result?: Array<{ meta?: { regularMarketPrice?: number } }>
+  }
+}
+
+/**
+ * USD/JPY (1 USD = N JPY) の最新レートを返す。取得不能 / 異常値は `null`。
+ * 例外は投げない (cron / sizing 経路を巻き添えにしない fail-safe)。
+ */
+export async function loadUsdJpyRate(options: UsdJpyRateOptions = {}): Promise<number | null> {
+  const baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '')
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  const fetchFn = options.fetchFn ?? fetch.bind(globalThis)
+  const userAgent = options.userAgent ?? DEFAULT_USER_AGENT
+
+  const url = new URL(`/v8/finance/chart/${encodeURIComponent(FX_SYMBOL)}`, baseUrl)
+  url.searchParams.set('interval', '1d')
+  url.searchParams.set('range', '5d')
+
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const response = await fetchFn(url.href, {
+      method: 'GET',
+      headers: { Accept: 'application/json', 'User-Agent': userAgent },
+      signal: controller.signal,
+    })
+    if (!response.ok) {
+      console.warn(JSON.stringify({ event: 'usdjpy_fetch_non_ok', status: response.status }))
+      return null
+    }
+    const json = (await response.json()) as YahooChartMetaResponse
+    const rate = json.chart?.result?.[0]?.meta?.regularMarketPrice
+    if (typeof rate !== 'number' || !Number.isFinite(rate) || rate < MIN_RATE || rate > MAX_RATE) {
+      console.warn(JSON.stringify({ event: 'usdjpy_rate_invalid', rate }))
+      return null
+    }
+    return rate
+  } catch (error) {
+    console.warn(
+      JSON.stringify({
+        event: 'usdjpy_fetch_failed',
+        message: error instanceof Error ? error.message : String(error),
+      }),
+    )
+    return null
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -6893,7 +6893,7 @@ function symbolsListBody(args: {
       const allocPctNum = r.budgetAllocPct != null ? Math.round(r.budgetAllocPct * 1000) / 10 : 0
       const budgetCell = `<div style="display:flex;align-items:center;gap:6px;min-width:170px">
           <input type="range" name="pct_${esc(r.symbol)}" form="symbol-budget-form" min="0" max="100" step="5" value="${allocPctNum}"
-            data-symbol="${esc(r.symbol)}" data-currency="${esc(r.currency)}"${inverse ? ` data-inverse="${esc(inverse)}"` : ''}
+            data-symbol="${esc(r.symbol)}"${inverse ? ` data-inverse="${esc(inverse)}"` : ''}
             oninput="window.onBudgetSlide(this)" style="width:110px;vertical-align:middle">
           <span id="budget-label-${esc(r.symbol)}" class="muted" style="font-size:12px;width:42px;text-align:right;font-variant-numeric:tabular-nums">${allocPctNum === 0 ? 'risk' : allocPctNum + '%'}</span>
         </div>`
@@ -6956,7 +6956,6 @@ function symbolsListBody(args: {
       .filter((r) => r.budgetAllocPct != null && r.budgetAllocPct > 0)
       .map((r) => ({
         s: r.symbol.toUpperCase(),
-        ccy: r.currency,
         pct: Math.round((r.budgetAllocPct as number) * 1000) / 10,
         inv: inversePairs[r.symbol.toUpperCase()] ?? null,
       })),
@@ -7001,16 +7000,17 @@ const BUDGET_LADDER_JS = `
     // filter で非表示の銘柄の配分が meter から欠落しないようにするため (CodeRabbit #405)。
     var bySym = {};
     (window.__budgetBaseline || []).forEach(function (b) {
-      if (b.pct > 0) bySym[b.s] = { ccy: b.ccy, pct: b.pct, inv: b.inv };
+      if (b.pct > 0) bySym[b.s] = { pct: b.pct, inv: b.inv };
     });
     var sliders = document.querySelectorAll('input[name^="pct_"]');
     sliders.forEach(function (s) {
       var sym = s.getAttribute('data-symbol');
       var v = Number(s.value);
-      if (v > 0) bySym[sym] = { ccy: s.getAttribute('data-currency'), pct: v, inv: s.getAttribute('data-inverse') };
+      if (v > 0) bySym[sym] = { pct: v, inv: s.getAttribute('data-inverse') };
       else delete bySym[sym]; // 0 にした表示中銘柄は除外 (baseline 値で復活させない)
     });
-    var usage = {};
+    // 口座(円)単一プールに対する使用率を 1 本で合算。インバース対は max を1回計上。
+    var used = 0;
     var counted = {};
     Object.keys(bySym).forEach(function (sym) {
       var e = bySym[sym];
@@ -7019,22 +7019,18 @@ const BUDGET_LADDER_JS = `
         if (counted[key]) return;
         counted[key] = true;
         var invPct = bySym[e.inv] ? bySym[e.inv].pct : 0;
-        usage[e.ccy] = (usage[e.ccy] || 0) + Math.max(e.pct, invPct);
+        used += Math.max(e.pct, invPct);
       } else {
-        usage[e.ccy] = (usage[e.ccy] || 0) + e.pct;
+        used += e.pct;
       }
     });
-    var ccys = ['USD', 'JPY'].filter(function (c) { return (usage[c] || 0) > 0; });
-    // sticky バー内のコンパクトゲージ (確定ボタン横、同時建玉ベース)。
-    barMeter.innerHTML = ccys.map(function (ccy) {
-      var u = usage[ccy] || 0;
-      var w = Math.min(100, u);
-      var col = u > 100 ? '#c22' : u > 80 ? '#b25000' : '#057a55';
-      return '<span title="同時建玉ベースの予算使用率 (インバース対は max を1回計上)" style="display:flex;align-items:center;gap:6px;font-size:12px;flex:1;min-width:0">'
-        + '<span class="muted" style="white-space:nowrap">' + ccy + '</span>'
-        + '<span class="bar-track" style="flex:1;min-width:40px;height:8px"><span class="bar-fill" style="display:block;width:' + w.toFixed(0) + '%;height:8px;background:' + col + '"></span></span>'
-        + '<span style="font-variant-numeric:tabular-nums;color:' + col + ';white-space:nowrap">' + u.toFixed(0) + '%' + (u > 100 ? '⚠' : '') + '</span></span>';
-    }).join('');
+    if (used <= 0) { barMeter.innerHTML = ''; return; }
+    var w = Math.min(100, used);
+    var col = used > 100 ? '#c22' : used > 80 ? '#b25000' : '#057a55';
+    barMeter.innerHTML = '<span title="同時建玉ベースの口座(円)予算使用率 (インバース対は max を1回計上)" style="display:flex;align-items:center;gap:6px;font-size:12px;flex:1;min-width:0">'
+      + '<span class="muted" style="white-space:nowrap">口座予算</span>'
+      + '<span class="bar-track" style="flex:1;min-width:40px;height:8px"><span class="bar-fill" style="display:block;width:' + w.toFixed(0) + '%;height:8px;background:' + col + '"></span></span>'
+      + '<span style="font-variant-numeric:tabular-nums;color:' + col + ';white-space:nowrap">' + used.toFixed(0) + '% / 100%' + (used > 100 ? ' ⚠超過' : '') + '</span></span>';
   };
 `
 
@@ -7051,34 +7047,34 @@ function budgetLadderControls(): string {
 }
 
 /**
- * #budget-alloc: 同時建玉ベースの予算使用率 (per currency, %)。
- * インバース対は同時に片方しか建たないので max(両側) で1回だけ計上、
- * standalone と別ペアは加算。total_capital に対する「最大同時コミット率」。
+ * #budget-jpy-base-fx: 同時建玉ベースの口座(円)予算使用率 (単一 %)。
+ * budget_alloc_pct は通貨に関係なく「口座(円)全体に対する割合」なので、通貨で分けず
+ * 1 本に合算する。インバース対は同時に片方しか建たないので max(両側) で1回だけ計上、
+ * standalone と別ペアは加算 = 「口座に対する最大同時コミット率 (%)」。
  */
 export function computeBudgetUsage(
-  rows: Array<{ symbol: string; currency: string; budgetAllocPct: number | null }>,
+  rows: Array<{ symbol: string; budgetAllocPct: number | null }>,
   inversePairs: Record<string, string>,
-): Record<string, number> {
-  const pctBySym = new Map<string, { currency: string; pct: number }>()
+): number {
+  const pctBySym = new Map<string, number>()
   for (const r of rows) {
     const pct = r.budgetAllocPct != null && r.budgetAllocPct > 0 ? r.budgetAllocPct * 100 : 0
-    if (pct > 0) pctBySym.set(r.symbol.toUpperCase(), { currency: r.currency, pct })
+    if (pct > 0) pctBySym.set(r.symbol.toUpperCase(), pct)
   }
-  const usage: Record<string, number> = {}
+  let used = 0
   const countedPair = new Set<string>()
-  for (const [sym, { currency, pct }] of pctBySym) {
+  for (const [sym, pct] of pctBySym) {
     const inv = inversePairs[sym]
     if (inv) {
       const key = [sym, inv].sort().join('|')
       if (countedPair.has(key)) continue
       countedPair.add(key)
-      const invPct = pctBySym.get(inv)?.pct ?? 0
-      usage[currency] = (usage[currency] ?? 0) + Math.max(pct, invPct)
+      used += Math.max(pct, pctBySym.get(inv) ?? 0)
     } else {
-      usage[currency] = (usage[currency] ?? 0) + pct
+      used += pct
     }
   }
-  return usage
+  return used
 }
 
 /**
@@ -7317,8 +7313,8 @@ function symbolFormBody(args: SymbolFormArgs): string {
     <label>予算配分 <span class="muted" style="font-size:11px">(%)</span></label>
     <div>
       <input type="number" name="budget_alloc_pct" value="${esc(budgetAllocPctValue)}" step="0.1" min="0.1" max="100" placeholder="空欄で risk-% sizing" style="padding:6px;width:160px">
-      <span class="muted" style="font-size:12px;margin-left:6px">% of 総資本</span>
-      <p class="muted" style="margin:4px 0 0;font-size:11px">指定すると <strong>1 注文 = 総資本 (<code>total_capital</code>) × この%</strong> で sizing (risk-% sizing を bypass)。小口座で高額レバ ETF を建てる用。上限は <code>min(予算×%, 1注文上限)</code>。空欄なら従来の risk-% sizing。</p>
+      <span class="muted" style="font-size:12px;margin-left:6px">% of 口座(円)</span>
+      <p class="muted" style="margin:4px 0 0;font-size:11px">指定すると <strong>1 注文 = 口座総額 (<code>total_capital_jpy</code>) × この%</strong> で sizing (risk-% を bypass)。USD 銘柄は USD/JPY レートで自動換算 (レート取得失敗時は発注見送り = fail-closed)。上限は <code>min(予算×%, 1注文上限)</code>。空欄なら従来の risk-% sizing。</p>
     </div>
     <label>保有上限 <span class="muted" style="font-size:11px">(time_stop_days)</span></label>
     <div>

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -60,10 +60,19 @@ export interface PullbackSchedulerOptions {
   lotSize?: number
   /**
    * symbol → budget_alloc_pct (0<pct<=1)。指定 symbol は fixed-% 配分 sizing
-   * (notional = min(equity * pct, symbolCap)) に切替わる (#budget-alloc)。
+   * (口座(円)単一プールに対する割合) に切替わる (#budget-jpy-base-fx)。
    * 未指定 symbol は従来の risk-% sizing。
    */
   symbolBudgetAllocPctMap?: Record<string, number>
+  /**
+   * 予算配分の基準額 = 口座総額 (円、`total_capital_jpy`)。budget 銘柄の sizing 基準。
+   */
+  budgetBasisJpy?: number
+  /**
+   * この run の symbol 通貨 1 単位 = 何円か (JPY run=1、USD run=USD/JPY レート)。
+   * USD で FX 取得失敗時は undefined を渡し、budget 銘柄を fail-closed させる。
+   */
+  fxJpyPerSymbolCcy?: number
   /**
    * Per-symbol decision sink。HOLD / BUY / SELL / REJECT / ERROR の各 route で
    * 1 回ずつ呼ばれる。実装は D1 INSERT が典型 (#128)、テストは fake 注入可能。
@@ -450,6 +459,8 @@ export async function runPullbackScheduler(
         lotSize: options.lotSize,
         kAtr: rule.kAtr,
         budgetAllocPct: options.symbolBudgetAllocPctMap?.[upper],
+        budgetBasisJpy: options.budgetBasisJpy,
+        fxJpyPerSymbolCcy: options.fxJpyPerSymbolCcy,
       })
       if (sizing.quantity <= 0) {
         const reason = buildSizingRejectReason(sizing, {

--- a/src/trading/strategy/pullbackSizing.ts
+++ b/src/trading/strategy/pullbackSizing.ts
@@ -9,12 +9,25 @@ export interface PullbackSizingInput {
   /** Optional symbol-specific absolute notional cap. */
   symbolCap?: number
   /**
-   * Per-symbol budget allocation fraction of NAV (0..1)。指定されると **fixed-%
-   * 配分モード**になり risk-% / ATR floor を bypass して
-   * `notional = min(equity * budgetAllocPct, symbolCap)` で sizing する (#budget-alloc)。
+   * Per-symbol budget allocation fraction (0..1)。指定されると **fixed-% 配分モード**に
+   * なり risk-% / ATR floor を bypass して、**口座(円)単一プール**に対する割合で sizing
+   * する (#budget-jpy-base-fx)。
+   *   targetSymbolCcy = (budgetBasisJpy * budgetAllocPct) / fxJpyPerSymbolCcy
+   *   notional = min(targetSymbolCcy, symbolCap) → floor(/price) → lot
    * 小口座で risk-% sizing が 0 株になる高額レバ ETF 用。NULL は従来の risk sizing。
    */
   budgetAllocPct?: number
+  /**
+   * 予算配分モードの基準額 = 口座総額 (円)。`total_capital_jpy` を流用。
+   * budgetAllocPct 指定時に必須 (finite>0 でなければ fail-closed)。
+   */
+  budgetBasisJpy?: number
+  /**
+   * 1 単位の symbol 通貨 = 何円か (JPY 銘柄=1、USD 銘柄=USD/JPY レート)。
+   * budgetAllocPct 指定時に必須 (finite>0 でなければ fail-closed)。USD で FX 取得
+   * 失敗 (null) のときは呼び出し側が未指定にして fail-closed させる。
+   */
+  fxJpyPerSymbolCcy?: number
   /** Risk fraction of NAV per trade. Default 0.004 (0.4%). */
   riskPerTradePct?: number
   /** ATR floor ratio. If atr20 < baselineAtr20 * this, size is halved. Default 0.5. */
@@ -79,26 +92,38 @@ export function computePullbackSizing(input: PullbackSizingInput): PullbackSizin
   let riskBudget: number | undefined
 
   if (input.budgetAllocPct !== undefined) {
-    // === fixed-% 予算配分モード (#budget-alloc) ===
-    // notional = min(equity * pct, symbolCap)。risk-% / ATR floor は使わない。
-    // 小口座で高額レバ ETF を「予算の N%」で建てるための path。
+    // === fixed-% 予算配分モード (#budget-jpy-base-fx) ===
+    // 口座(円)単一プールに対する割合で sizing。risk-% / ATR floor は使わない。
+    //   targetSymbolCcy = (budgetBasisJpy * pct) / fxJpyPerSymbolCcy
+    //   notional = min(targetSymbolCcy, symbolCap)
+    // 小口座で高額レバ ETF を「口座の N%」で建てるための path。
     //
-    // budgetAllocPct が「指定済み」なら厳密検証して fail-closed。NaN / <=0 / >1 の
-    // 不正値で risk-% にフォールバックすると想定外サイジングになるため (CodeRabbit
-    // #405)、ここで 0 qty 返却して止める (loadSymbolConfig は 0<pct<=1 のみ通すが
-    // 二重防御)。
+    // budgetAllocPct / budgetBasisJpy / fxJpyPerSymbolCcy のいずれかが不正なら
+    // **fail-closed (0 qty)**。risk-% へ fallback すると想定外サイジングになるため、
+    // また USD で FX 取得失敗 (fxJpyPerSymbolCcy 未指定/非有限) のときも発注しない。
     if (!Number.isFinite(input.budgetAllocPct) || input.budgetAllocPct <= 0 || input.budgetAllocPct > 1) {
+      return { quantity: 0, notional: 0, capped: true, capReason: 'insufficient-risk-budget' }
+    }
+    if (
+      input.budgetBasisJpy === undefined ||
+      !Number.isFinite(input.budgetBasisJpy) ||
+      input.budgetBasisJpy <= 0 ||
+      input.fxJpyPerSymbolCcy === undefined ||
+      !Number.isFinite(input.fxJpyPerSymbolCcy) ||
+      input.fxJpyPerSymbolCcy <= 0
+    ) {
       return { quantity: 0, notional: 0, capped: true, capReason: 'insufficient-risk-budget' }
     }
     if (!Number.isFinite(input.entryPrice) || input.entryPrice <= 0) {
       return { quantity: 0, notional: 0, capped: true, capReason: 'invalid-stop' }
     }
-    const rawNotional = input.equity * input.budgetAllocPct
-    if (!Number.isFinite(rawNotional) || rawNotional <= 0) {
+    // 口座円 × pct を symbol 通貨に換算 (JPY 銘柄は fx=1 で素通り)。
+    const targetSymbolCcy = (input.budgetBasisJpy * input.budgetAllocPct) / input.fxJpyPerSymbolCcy
+    if (!Number.isFinite(targetSymbolCcy) || targetSymbolCcy <= 0) {
       return { quantity: 0, notional: 0, capped: true, capReason: 'insufficient-risk-budget' }
     }
-    let target = rawNotional
-    // %優先・絶対上限は安全弁: min(予算×%, symbolCap)。
+    let target = targetSymbolCcy
+    // %優先・絶対上限は安全弁: min(換算後 target, symbolCap)。
     if (input.symbolCap !== undefined && target > input.symbolCap) {
       target = input.symbolCap
       capped = true

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -1,5 +1,6 @@
 import type { Env } from '../../config/env'
 import { YahooBarClient } from '../../infrastructure/quotes/YahooBarClient'
+import { loadUsdJpyRate } from '../../infrastructure/quotes/fxRate'
 import { loadGlobalConfigFrom } from '../../infrastructure/db/globalConfigLoader'
 import { loadSymbolUniverse } from '../../infrastructure/db/symbolUniverse'
 import type { SymbolCurrency } from '../../infrastructure/db/symbolConfigRepo'
@@ -535,6 +536,15 @@ export async function runStrategyCron(
     })
   }
 
+  // #budget-jpy-base-fx: 予算配分は口座(円)単一プール基準。USD 銘柄を「円予算 → USD」
+  // 換算するため USD/JPY を 1 回だけ取得 (USD 側に budget 銘柄がある時のみ)。取得失敗
+  // /異常値は null → USD budget 銘柄は sizing 側で fail-closed (発注見送り)。
+  const budgetBasisJpy = sanitizeEquity(global.totalCapitalJpy, DEFAULT_EQUITY_JPY)
+  const usdHasBudgetSymbol = byCurrency.USD.some(
+    (s) => universe.symbolBudgetAllocPct[s.toUpperCase()] !== undefined,
+  )
+  const usdJpyRate = usdHasBudgetSymbol ? await loadUsdJpyRate() : null
+
   for (const run of runs) {
     analysis.runs.push({
       currency: run.currency,
@@ -542,6 +552,8 @@ export async function runStrategyCron(
       lotSize: run.lotSize,
       symbols: run.symbols,
     })
+    // JPY 銘柄は fx=1。USD 銘柄は usdJpyRate (null なら undefined → budget 銘柄 fail-closed)。
+    const fxJpyPerSymbolCcy = run.currency === 'JPY' ? 1 : (usdJpyRate ?? undefined)
     const decisionDb = strategyDecisionDbOrUndefined(env)
     const sub = await runPullbackScheduler({
       symbols: run.symbols,
@@ -552,6 +564,8 @@ export async function runStrategyCron(
       execution,
       symbolCapMap: universe.symbolMaxNotional,
       symbolBudgetAllocPctMap: universe.symbolBudgetAllocPct,
+      budgetBasisJpy,
+      fxJpyPerSymbolCcy,
       defaultRule,
       rulesMap,
       riskPerTradePct: scaledRiskPerTradePct,

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -543,7 +543,9 @@ export async function runStrategyCron(
   const usdHasBudgetSymbol = byCurrency.USD.some(
     (s) => universe.symbolBudgetAllocPct[s.toUpperCase()] !== undefined,
   )
-  const usdJpyRate = usdHasBudgetSymbol ? await loadUsdJpyRate() : null
+  const usdJpyRate = usdHasBudgetSymbol
+    ? await loadUsdJpyRate({ requestId: options.requestId })
+    : null
 
   for (const run of runs) {
     analysis.runs.push({

--- a/test/infrastructure/quotes/fxRate.test.ts
+++ b/test/infrastructure/quotes/fxRate.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest'
+import { loadUsdJpyRate } from '../../../src/infrastructure/quotes/fxRate'
+
+function fakeFetch(body: unknown, ok = true, status = 200): typeof fetch {
+  return vi.fn(async () => ({
+    ok,
+    status,
+    json: async () => body,
+  })) as unknown as typeof fetch
+}
+
+const chart = (price: unknown) => ({ chart: { result: [{ meta: { regularMarketPrice: price } }] } })
+
+describe('loadUsdJpyRate', () => {
+  it('returns the regularMarketPrice when valid', async () => {
+    const rate = await loadUsdJpyRate({ fetchFn: fakeFetch(chart(150.25)) })
+    expect(rate).toBeCloseTo(150.25, 4)
+  })
+
+  it('returns null on out-of-range rate (sanity guard)', async () => {
+    expect(await loadUsdJpyRate({ fetchFn: fakeFetch(chart(5)) })).toBeNull() // < 50
+    expect(await loadUsdJpyRate({ fetchFn: fakeFetch(chart(9999)) })).toBeNull() // > 500
+    expect(await loadUsdJpyRate({ fetchFn: fakeFetch(chart(0)) })).toBeNull()
+  })
+
+  it('returns null on non-finite / missing price', async () => {
+    expect(await loadUsdJpyRate({ fetchFn: fakeFetch(chart('abc')) })).toBeNull()
+    expect(await loadUsdJpyRate({ fetchFn: fakeFetch(chart(undefined)) })).toBeNull()
+    expect(await loadUsdJpyRate({ fetchFn: fakeFetch({}) })).toBeNull()
+  })
+
+  it('returns null on non-OK response', async () => {
+    expect(await loadUsdJpyRate({ fetchFn: fakeFetch(chart(150), false, 429) })).toBeNull()
+  })
+
+  it('returns null (does not throw) when fetch rejects', async () => {
+    const fetchFn = vi.fn(async () => {
+      throw new Error('network down')
+    }) as unknown as typeof fetch
+    await expect(loadUsdJpyRate({ fetchFn })).resolves.toBeNull()
+  })
+})

--- a/test/infrastructure/quotes/fxRate.test.ts
+++ b/test/infrastructure/quotes/fxRate.test.ts
@@ -39,4 +39,26 @@ describe('loadUsdJpyRate', () => {
     }) as unknown as typeof fetch
     await expect(loadUsdJpyRate({ fetchFn })).resolves.toBeNull()
   })
+
+  it('includes requestId in every structured failure log (CodeRabbit #407)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      // non-ok
+      await loadUsdJpyRate({ requestId: 'req-1', fetchFn: fakeFetch(chart(150), false, 429) })
+      // invalid rate
+      await loadUsdJpyRate({ requestId: 'req-2', fetchFn: fakeFetch(chart(0)) })
+      // fetch reject
+      const rejectFetch = vi.fn(async () => {
+        throw new Error('boom')
+      }) as unknown as typeof fetch
+      await loadUsdJpyRate({ requestId: 'req-3', fetchFn: rejectFetch })
+
+      const events = warn.mock.calls.map((c) => JSON.parse(c[0] as string))
+      expect(events.find((e) => e.event === 'usdjpy_fetch_non_ok')?.requestId).toBe('req-1')
+      expect(events.find((e) => e.event === 'usdjpy_rate_invalid')?.requestId).toBe('req-2')
+      expect(events.find((e) => e.event === 'usdjpy_fetch_failed')?.requestId).toBe('req-3')
+    } finally {
+      warn.mockRestore()
+    }
+  })
 })

--- a/test/routes/dashboardSymbolsCrud.test.ts
+++ b/test/routes/dashboardSymbolsCrud.test.ts
@@ -1016,43 +1016,34 @@ describe('dashboard symbol_config CRUD UI (#292)', () => {
 
 import { orderRowsByPair, assignPairColors, pairRoles, computeBudgetUsage } from '../../src/routes/dashboard'
 
-describe('#budget-alloc computeBudgetUsage (concurrent-position meter)', () => {
-  const rec = (symbol: string, currency: string, budgetAllocPct: number | null) => ({ symbol, currency, budgetAllocPct })
+describe('#budget-jpy-base-fx computeBudgetUsage (single account % meter)', () => {
+  const rec = (symbol: string, budgetAllocPct: number | null) => ({ symbol, budgetAllocPct })
 
   it('counts an inverse pair once via max (only one side held at a time)', () => {
     // SOXL 40% / SOXS 40% (synced) → pair contributes 40, not 80.
-    const usage = computeBudgetUsage(
-      [rec('SOXL', 'USD', 0.4), rec('SOXS', 'USD', 0.4)],
-      { SOXL: 'SOXS', SOXS: 'SOXL' },
-    )
-    expect(usage.USD).toBeCloseTo(40, 6)
+    expect(computeBudgetUsage([rec('SOXL', 0.4), rec('SOXS', 0.4)], { SOXL: 'SOXS', SOXS: 'SOXL' })).toBeCloseTo(40, 6)
   })
 
   it('uses max when the two sides differ', () => {
-    const usage = computeBudgetUsage(
-      [rec('SOXL', 'USD', 0.4), rec('SOXS', 'USD', 0.2)],
-      { SOXL: 'SOXS', SOXS: 'SOXL' },
-    )
-    expect(usage.USD).toBeCloseTo(40, 6)
+    expect(computeBudgetUsage([rec('SOXL', 0.4), rec('SOXS', 0.2)], { SOXL: 'SOXS', SOXS: 'SOXL' })).toBeCloseTo(40, 6)
   })
 
-  it('adds standalone symbols and separate pairs; groups by currency', () => {
-    const usage = computeBudgetUsage(
+  it('sums standalone + separate pairs across currencies into one account % (FX-agnostic)', () => {
+    // 口座(円)に対する割合なので通貨混在でも 1 本に合算: 40 + 30 + 10 + 50 = 130 (超過)。
+    const used = computeBudgetUsage(
       [
-        rec('SOXL', 'USD', 0.4), rec('SOXS', 'USD', 0.4), // pair → 40
-        rec('TQQQ', 'USD', 0.3), rec('SQQQ', 'USD', 0.3), // pair → 30
-        rec('AAPL', 'USD', 0.1), // standalone → 10
-        rec('1570', 'JPY', 0.5), rec('1357', 'JPY', 0.5), // JPY pair → 50
+        rec('SOXL', 0.4), rec('SOXS', 0.4), // pair → 40
+        rec('TQQQ', 0.3), rec('SQQQ', 0.3), // pair → 30
+        rec('AAPL', 0.1), // standalone → 10
+        rec('1570', 0.5), rec('1357', 0.5), // JP pair → 50
       ],
       { SOXL: 'SOXS', SOXS: 'SOXL', TQQQ: 'SQQQ', SQQQ: 'TQQQ', '1570': '1357', '1357': '1570' },
     )
-    expect(usage.USD).toBeCloseTo(80, 6) // 40+30+10
-    expect(usage.JPY).toBeCloseTo(50, 6)
+    expect(used).toBeCloseTo(130, 6)
   })
 
-  it('ignores null / 0 allocations', () => {
-    const usage = computeBudgetUsage([rec('SOXL', 'USD', null), rec('AAPL', 'USD', 0)], {})
-    expect(usage.USD).toBeUndefined()
+  it('ignores null / 0 allocations (returns 0)', () => {
+    expect(computeBudgetUsage([rec('SOXL', null), rec('AAPL', 0)], {})).toBe(0)
   })
 })
 

--- a/test/strategy/pullbackSizing.test.ts
+++ b/test/strategy/pullbackSizing.test.ts
@@ -158,51 +158,58 @@ describe('computePullbackSizing', () => {
   })
 })
 
-describe('computePullbackSizing — fixed-% budget allocation (#budget-alloc)', () => {
-  it('sizes by notional = equity * budgetAllocPct (bypasses risk-% / ATR floor)', () => {
-    // 総資本 100k の 40% = 40,000 を price 35,000 で → floor(40000/35000) = 1 株。
+describe('computePullbackSizing — fixed-% budget allocation, JPY account + FX (#budget-jpy-base-fx)', () => {
+  it('JPY symbol (fx=1): notional = budgetBasisJpy * pct (bypasses risk-% / ATR floor)', () => {
+    // 口座 ¥100k の 40% = ¥40,000 を price ¥35,000 (JPY 銘柄) で → floor(40000/35000)=1。
     const result = computePullbackSizing(
-      baseInput({ equity: 100_000, entryPrice: 35_000, budgetAllocPct: 0.4, atr20: 5000, baselineAtr20: 1000 }),
+      baseInput({ entryPrice: 35_000, budgetAllocPct: 0.4, budgetBasisJpy: 100_000, fxJpyPerSymbolCcy: 1, atr20: 5000, baselineAtr20: 1000 }),
     )
     expect(result.quantity).toBe(1)
     expect(result.notional).toBe(35_000)
-    // risk-% なら floor(400 / stop) = 0 株のはず。budget-alloc で 1 株建つ。
     expect(result.capped).toBe(false)
   })
 
-  it('clamps to symbolCap when budget*pct exceeds it (min semantics)', () => {
-    // 40% = 40,000 だが symbolCap 30,000 → min。floor(30000/10000)=3。
+  it('USD symbol: converts JPY budget via USD/JPY (¥100k×40% / 150 = $266.7 → floor($/price))', () => {
+    // ¥40,000 / 150 = $266.67 を USD price $50 で → floor(266.67/50)=5。
     const result = computePullbackSizing(
-      baseInput({ equity: 100_000, entryPrice: 10_000, budgetAllocPct: 0.4, symbolCap: 30_000 }),
+      baseInput({ entryPrice: 50, budgetAllocPct: 0.4, budgetBasisJpy: 100_000, fxJpyPerSymbolCcy: 150 }),
+    )
+    expect(result.quantity).toBe(5)
+  })
+
+  it('clamps to symbolCap when converted target exceeds it (min semantics)', () => {
+    // JPY 銘柄、¥40,000 だが symbolCap ¥30,000 → min。floor(30000/10000)=3。
+    const result = computePullbackSizing(
+      baseInput({ entryPrice: 10_000, budgetAllocPct: 0.4, budgetBasisJpy: 100_000, fxJpyPerSymbolCcy: 1, symbolCap: 30_000 }),
     )
     expect(result.quantity).toBe(3)
-    expect(result.notional).toBe(30_000)
     expect(result.capReason).toBe('symbol-cap')
   })
 
-  it('uses budget pct even when below symbolCap (% wins, abs is only a ceiling)', () => {
-    // 20% = 20,000 < symbolCap 50,000 → 予算% を採用。floor(20000/10000)=2。
-    const result = computePullbackSizing(
-      baseInput({ equity: 100_000, entryPrice: 10_000, budgetAllocPct: 0.2, symbolCap: 50_000 }),
-    )
-    expect(result.quantity).toBe(2)
-    expect(result.notional).toBe(20_000)
-  })
-
   it('respects lot size in budget-alloc mode', () => {
-    // 40% = 40,000、price 100、lot 100 → floor(400/100)*100 = 400。
+    // ¥40,000、price ¥100、lot 100 → floor(400/100)*100 = 400。
     const result = computePullbackSizing(
-      baseInput({ equity: 100_000, entryPrice: 100, budgetAllocPct: 0.4, lotSize: 100 }),
+      baseInput({ entryPrice: 100, budgetAllocPct: 0.4, budgetBasisJpy: 100_000, fxJpyPerSymbolCcy: 1, lotSize: 100 }),
     )
     expect(result.quantity).toBe(400)
   })
 
-  it('rejects (qty 0) when budget*pct is too small for one share', () => {
-    // 1% = 1,000 だが price 35,000 → floor(1000/35000)=0。
+  it('fail-closed (qty 0) when FX is missing for a USD symbol (fxJpyPerSymbolCcy undefined)', () => {
+    // USD 銘柄で USD/JPY 取得失敗 → budgetBasisJpy はあるが fx 未指定 → 発注見送り。
     const result = computePullbackSizing(
-      baseInput({ equity: 100_000, entryPrice: 35_000, budgetAllocPct: 0.01 }),
+      baseInput({ entryPrice: 50, budgetAllocPct: 0.4, budgetBasisJpy: 100_000 }),
     )
     expect(result.quantity).toBe(0)
+    expect(result.capped).toBe(true)
+  })
+
+  it('fail-closed when budgetBasisJpy missing/invalid', () => {
+    for (const bad of [undefined, 0, -1, Number.NaN]) {
+      const result = computePullbackSizing(
+        baseInput({ entryPrice: 100, budgetAllocPct: 0.4, budgetBasisJpy: bad as number | undefined, fxJpyPerSymbolCcy: 1 }),
+      )
+      expect(result.quantity).toBe(0)
+    }
   })
 
   it('falls back to risk-% sizing when budgetAllocPct is undefined', () => {
@@ -210,10 +217,11 @@ describe('computePullbackSizing — fixed-% budget allocation (#budget-alloc)', 
     expect(result.quantity).toBe(100) // 従来通り
   })
 
-  it('fail-closed (qty 0) on invalid budgetAllocPct instead of risk-% fallback (CodeRabbit #405)', () => {
-    // budgetAllocPct が指定済みだが範囲外 (>1) / NaN / <=0 → 0 qty で止める。
+  it('fail-closed (qty 0) on invalid budgetAllocPct instead of risk-% fallback', () => {
     for (const bad of [1.5, 0, -0.1, Number.NaN]) {
-      const result = computePullbackSizing(baseInput({ budgetAllocPct: bad }))
+      const result = computePullbackSizing(
+        baseInput({ budgetAllocPct: bad, budgetBasisJpy: 100_000, fxJpyPerSymbolCcy: 1 }),
+      )
       expect(result.quantity).toBe(0)
       expect(result.capped).toBe(true)
     }


### PR DESCRIPTION
## 何を / なぜ

予算配分%（#405）は per-currency（`total_capital_usd` / `total_capital_jpy` を別プール、cron も通貨別 run、メーターも USD/JPY 別ゲージ）だった。だが運用者の口座は **¥100k の単一プール**で、Webull JP は USD 銘柄も**円決済（自動 FX）**で買える。USD/JPY と分かれたスライダーは実態と合わず不便だった。

`budget_alloc_pct` を **口座(円)全体に対する割合**に統一し、スライダー・メーターを**円建て1本**に。USD 銘柄は sizing 時のみ USD/JPY で円→USD 換算して株数を算出する。

## 変更

- **`src/infrastructure/quotes/fxRate.ts`** (新規): `loadUsdJpyRate()` — Yahoo `USDJPY=X` の最新値。finite かつ 50–500 レンジ内でなければ `null`、fetch 失敗も `null`（throw しない fail-safe）。
- **`pullbackSizing.ts`**: budget 分岐の基準を `equity` → `budgetBasisJpy` + `fxJpyPerSymbolCcy`（JPY=1 / USD=USDJPY）。`targetSymbolCcy = budgetBasisJpy × pct / fx`。**`budgetBasisJpy` / `fx` が finite>0 でなければ fail-closed（0 qty）** → USD で FX=null はここで止まる。
- **`runStrategyCron.ts`**: USD 予算銘柄がある時のみ `loadUsdJpyRate` を tick で 1 回取得。各 run に `budgetBasisJpy = sanitize(totalCapitalJpy)`、`fxJpyPerSymbolCcy = run.currency==='JPY' ? 1 : (usdjpy ?? undefined)` を配線。
- **`pullbackScheduler.ts`**: `budgetBasisJpy` / `fxJpyPerSymbolCcy` を `computePullbackSizing` に渡す。
- **`dashboard.ts`**: `computeBudgetUsage` を per-currency Record → 単一 number（口座%、pair は max でdedup）。メーター/ゲージを**口座予算1本**（80%→橙 / 100%→赤⚠超過）、slider 文言を「口座(円)%」に。

## スコープ外（不変）
per-currency の他ゲート（`max_order_notional_*` / exposure gate / cron 通貨別 run）はそのまま。`total_capital_usd` は budget 用途から外れるだけで USD risk-% sizing / exposure では残置。

## fail-safe / real-money
FX は実マネー sizing に効くため、**異常値レンジ弾き + 取得失敗時 fail-closed** を厳守（誤レートで過大発注を防止）。JPY 銘柄は FX 非依存。

## テスト
`pnpm typecheck` / `pnpm test` → **1240 passed**。FX helper 単体（レンジ/null/throwしない）、sizing の JPY(fx=1) / USD換算(fx=150→$266→5株) / FX欠落 fail-closed / symbolCap clamp / lot、`computeBudgetUsage` 単一値化を追加。

依存: #405（`budget_alloc_pct` 列）マージ済 main を base。migration 不要。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * USD/JPY スポットレートの自動取得を追加

* **改善**
  * 予算配分ロジックを通貨別から円口座の単一プールへ統一
  * 予算メーターを複数ゲージから単一の口座割合ゲージに変更
  * 銘柄追加/編集の説明文を「総資本」→「口座(円)」表現へ更新
  * FX 未取得や無効時は安全に発注を抑制する挙動を導入

* **テスト**
  * レート取得・予算配分・サイズ算出のテストを追加／更新
<!-- end of auto-generated comment: release notes by coderabbit.ai -->