### PR TITLE
feat(symbols): per-symbol lot_size (入力必須 + 売買単位未設定は fail-closed)

### DIFF
--- a/drizzle/0025_add_symbol_lot_size.sql
+++ b/drizzle/0025_add_symbol_lot_size.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `symbol_config` ADD `lot_size` integer;

--- a/drizzle/meta/0025_snapshot.json
+++ b/drizzle/meta/0025_snapshot.json
@@ -1,0 +1,1328 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "58876ba3-234c-4dbb-9066-17ad135a5985",
+  "prevId": "e7bd85a6-2210-42b6-8a80-b4a855f730d6",
+  "tables": {
+    "config_audit_log": {
+      "name": "config_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before_json": {
+          "name": "before_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "after_json": {
+          "name": "after_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "config_audit_log_timestamp_id_idx": {
+          "name": "config_audit_log_timestamp_id_idx",
+          "columns": [
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "config_audit_log_actor_timestamp_id_idx": {
+          "name": "config_audit_log_actor_timestamp_id_idx",
+          "columns": [
+            "actor",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "config_audit_log_endpoint_timestamp_id_idx": {
+          "name": "config_audit_log_endpoint_timestamp_id_idx",
+          "columns": [
+            "endpoint",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "config_state_snapshot": {
+      "name": "config_state_snapshot",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "earnings_calendar": {
+      "name": "earnings_calendar",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "earnings_date": {
+          "name": "earnings_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "earnings_calendar_symbol_date_unique": {
+          "name": "earnings_calendar_symbol_date_unique",
+          "columns": [
+            "symbol",
+            "earnings_date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "global_config": {
+      "name": "global_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "trading_enabled": {
+          "name": "trading_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "market_hours_check": {
+          "name": "market_hours_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "max_order_notional": {
+          "name": "max_order_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "max_order_notional_usd": {
+          "name": "max_order_notional_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2000
+        },
+        "max_order_notional_jpy": {
+          "name": "max_order_notional_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100000
+        },
+        "total_capital_usd": {
+          "name": "total_capital_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_capital_jpy": {
+          "name": "total_capital_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_portfolio_exposure_pct": {
+          "name": "max_portfolio_exposure_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.6
+        },
+        "drawdown_kill_threshold": {
+          "name": "drawdown_kill_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.02
+        },
+        "stale_quote_ms": {
+          "name": "stale_quote_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 900000
+        },
+        "gap_reject_pct": {
+          "name": "gap_reject_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.03
+        },
+        "spread_limit_pct_us": {
+          "name": "spread_limit_pct_us",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.0025
+        },
+        "spread_limit_pct_jp": {
+          "name": "spread_limit_pct_jp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.006
+        },
+        "pullback_default_stop_pct": {
+          "name": "pullback_default_stop_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.04
+        },
+        "pullback_default_take_profit_pct": {
+          "name": "pullback_default_take_profit_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.07
+        },
+        "pullback_default_time_stop_days": {
+          "name": "pullback_default_time_stop_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "pullback_default_pullback_max": {
+          "name": "pullback_default_pullback_max",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.03
+        },
+        "pullback_default_pullback_min": {
+          "name": "pullback_default_pullback_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.06
+        },
+        "pullback_default_min_return_50d": {
+          "name": "pullback_default_min_return_50d",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.08
+        },
+        "pullback_default_require_above_sma50": {
+          "name": "pullback_default_require_above_sma50",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "pullback_default_k_atr": {
+          "name": "pullback_default_k_atr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "pullback_default_max_sma50_deviation_pct": {
+          "name": "pullback_default_max_sma50_deviation_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.6
+        },
+        "pullback_default_max_atr_ratio": {
+          "name": "pullback_default_max_atr_ratio",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1.5
+        },
+        "risk_base_per_trade_pct": {
+          "name": "risk_base_per_trade_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.004
+        },
+        "risk_dd_half_threshold": {
+          "name": "risk_dd_half_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.05
+        },
+        "risk_dd_halt_threshold": {
+          "name": "risk_dd_halt_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.1
+        },
+        "vix_warning_threshold": {
+          "name": "vix_warning_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 25
+        },
+        "vix_critical_threshold": {
+          "name": "vix_critical_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "vix_warning_size_scale": {
+          "name": "vix_warning_size_scale",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.5
+        },
+        "overview_panels": {
+          "name": "overview_panels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'kpi,equity,composition,recent'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "global_config_max_order_notional_range": {
+          "name": "global_config_max_order_notional_range",
+          "value": "\"global_config\".\"max_order_notional\" > 0 AND \"global_config\".\"max_order_notional\" <= 10000000"
+        },
+        "global_config_max_order_notional_usd_range": {
+          "name": "global_config_max_order_notional_usd_range",
+          "value": "\"global_config\".\"max_order_notional_usd\" > 0 AND \"global_config\".\"max_order_notional_usd\" <= 1000000"
+        },
+        "global_config_max_order_notional_jpy_range": {
+          "name": "global_config_max_order_notional_jpy_range",
+          "value": "\"global_config\".\"max_order_notional_jpy\" > 0 AND \"global_config\".\"max_order_notional_jpy\" <= 100000000"
+        },
+        "global_config_total_capital_usd_range": {
+          "name": "global_config_total_capital_usd_range",
+          "value": "\"global_config\".\"total_capital_usd\" IS NULL OR \"global_config\".\"total_capital_usd\" > 0"
+        },
+        "global_config_total_capital_jpy_range": {
+          "name": "global_config_total_capital_jpy_range",
+          "value": "\"global_config\".\"total_capital_jpy\" IS NULL OR \"global_config\".\"total_capital_jpy\" > 0"
+        },
+        "global_config_max_portfolio_exposure_pct_range": {
+          "name": "global_config_max_portfolio_exposure_pct_range",
+          "value": "\"global_config\".\"max_portfolio_exposure_pct\" > 0 AND \"global_config\".\"max_portfolio_exposure_pct\" <= 1"
+        },
+        "global_config_drawdown_kill_threshold_range": {
+          "name": "global_config_drawdown_kill_threshold_range",
+          "value": "\"global_config\".\"drawdown_kill_threshold\" >= -1 AND \"global_config\".\"drawdown_kill_threshold\" <= 0"
+        },
+        "global_config_stale_quote_ms_range": {
+          "name": "global_config_stale_quote_ms_range",
+          "value": "\"global_config\".\"stale_quote_ms\" >= 0"
+        },
+        "global_config_gap_reject_pct_range": {
+          "name": "global_config_gap_reject_pct_range",
+          "value": "\"global_config\".\"gap_reject_pct\" >= 0 AND \"global_config\".\"gap_reject_pct\" <= 1"
+        },
+        "global_config_spread_limit_pct_us_range": {
+          "name": "global_config_spread_limit_pct_us_range",
+          "value": "\"global_config\".\"spread_limit_pct_us\" >= 0 AND \"global_config\".\"spread_limit_pct_us\" <= 1"
+        },
+        "global_config_spread_limit_pct_jp_range": {
+          "name": "global_config_spread_limit_pct_jp_range",
+          "value": "\"global_config\".\"spread_limit_pct_jp\" >= 0 AND \"global_config\".\"spread_limit_pct_jp\" <= 1"
+        },
+        "global_config_pullback_default_stop_pct_range": {
+          "name": "global_config_pullback_default_stop_pct_range",
+          "value": "\"global_config\".\"pullback_default_stop_pct\" < 0 AND \"global_config\".\"pullback_default_stop_pct\" >= -1"
+        },
+        "global_config_pullback_default_take_profit_pct_range": {
+          "name": "global_config_pullback_default_take_profit_pct_range",
+          "value": "\"global_config\".\"pullback_default_take_profit_pct\" > 0 AND \"global_config\".\"pullback_default_take_profit_pct\" <= 1"
+        },
+        "global_config_pullback_default_time_stop_days_range": {
+          "name": "global_config_pullback_default_time_stop_days_range",
+          "value": "\"global_config\".\"pullback_default_time_stop_days\" > 0 AND \"global_config\".\"pullback_default_time_stop_days\" <= ?"
+        },
+        "global_config_pullback_default_pullback_max_range": {
+          "name": "global_config_pullback_default_pullback_max_range",
+          "value": "\"global_config\".\"pullback_default_pullback_max\" <= 0 AND \"global_config\".\"pullback_default_pullback_max\" >= -1"
+        },
+        "global_config_pullback_default_pullback_min_range": {
+          "name": "global_config_pullback_default_pullback_min_range",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= 0 AND \"global_config\".\"pullback_default_pullback_min\" >= -1"
+        },
+        "global_config_pullback_default_min_return_50d_range": {
+          "name": "global_config_pullback_default_min_return_50d_range",
+          "value": "\"global_config\".\"pullback_default_min_return_50d\" >= -1 AND \"global_config\".\"pullback_default_min_return_50d\" <= 10"
+        },
+        "global_config_pullback_default_k_atr_range": {
+          "name": "global_config_pullback_default_k_atr_range",
+          "value": "\"global_config\".\"pullback_default_k_atr\" > 0 AND \"global_config\".\"pullback_default_k_atr\" <= 10"
+        },
+        "global_config_pullback_default_pullback_window_order": {
+          "name": "global_config_pullback_default_pullback_window_order",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= \"global_config\".\"pullback_default_pullback_max\""
+        },
+        "global_config_risk_base_per_trade_pct_range": {
+          "name": "global_config_risk_base_per_trade_pct_range",
+          "value": "\"global_config\".\"risk_base_per_trade_pct\" > 0 AND \"global_config\".\"risk_base_per_trade_pct\" <= 1"
+        },
+        "global_config_risk_dd_half_threshold_range": {
+          "name": "global_config_risk_dd_half_threshold_range",
+          "value": "\"global_config\".\"risk_dd_half_threshold\" < 0 AND \"global_config\".\"risk_dd_half_threshold\" >= -1"
+        },
+        "global_config_risk_dd_halt_threshold_range": {
+          "name": "global_config_risk_dd_halt_threshold_range",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" < 0 AND \"global_config\".\"risk_dd_halt_threshold\" >= -1"
+        },
+        "global_config_risk_dd_threshold_order": {
+          "name": "global_config_risk_dd_threshold_order",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" <= \"global_config\".\"risk_dd_half_threshold\""
+        },
+        "global_config_vix_warning_threshold_range": {
+          "name": "global_config_vix_warning_threshold_range",
+          "value": "\"global_config\".\"vix_warning_threshold\" > 0 AND \"global_config\".\"vix_warning_threshold\" <= 200"
+        },
+        "global_config_vix_critical_threshold_range": {
+          "name": "global_config_vix_critical_threshold_range",
+          "value": "\"global_config\".\"vix_critical_threshold\" > 0 AND \"global_config\".\"vix_critical_threshold\" <= 200"
+        },
+        "global_config_vix_threshold_order": {
+          "name": "global_config_vix_threshold_order",
+          "value": "\"global_config\".\"vix_warning_threshold\" <= \"global_config\".\"vix_critical_threshold\""
+        },
+        "global_config_vix_warning_size_scale_range": {
+          "name": "global_config_vix_warning_size_scale_range",
+          "value": "\"global_config\".\"vix_warning_size_scale\" >= 0 AND \"global_config\".\"vix_warning_size_scale\" <= 1"
+        }
+      }
+    },
+    "inverse_pairs": {
+      "name": "inverse_pairs",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inverse": {
+          "name": "inverse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "macro_event_calendar": {
+      "name": "macro_event_calendar",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_time": {
+          "name": "event_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "macro_event_calendar_type_date_unique": {
+          "name": "macro_event_calendar_type_date_unique",
+          "columns": [
+            "event_type",
+            "event_date"
+          ],
+          "isUnique": true
+        },
+        "macro_event_calendar_date_idx": {
+          "name": "macro_event_calendar_date_idx",
+          "columns": [
+            "event_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_emit_log": {
+      "name": "notification_emit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cause": {
+          "name": "cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notification_emit_log_timestamp_id_idx": {
+          "name": "notification_emit_log_timestamp_id_idx",
+          "columns": [
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "notification_emit_log_severity_timestamp_id_idx": {
+          "name": "notification_emit_log_severity_timestamp_id_idx",
+          "columns": [
+            "severity",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "notification_emit_log_event_type_timestamp_id_idx": {
+          "name": "notification_emit_log_event_type_timestamp_id_idx",
+          "columns": [
+            "event_type",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "portfolio_equity_snapshot": {
+      "name": "portfolio_equity_snapshot",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "daily_start_equity_usd": {
+          "name": "daily_start_equity_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_start_equity_jpy": {
+          "name": "daily_start_equity_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_realized_pnl_usd": {
+          "name": "daily_realized_pnl_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_realized_pnl_jpy": {
+          "name": "daily_realized_pnl_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "drawdown_pct": {
+          "name": "drawdown_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "portfolio_equity_snapshot_at_idx": {
+          "name": "portfolio_equity_snapshot_at_idx",
+          "columns": [
+            "snapshot_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "strategy_decision_log": {
+      "name": "strategy_decision_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indicators_json": {
+          "name": "indicators_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "strategy_decision_log_symbol_id_idx": {
+          "name": "strategy_decision_log_symbol_id_idx",
+          "columns": [
+            "symbol",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "strategy_decision_log_coid_idx": {
+          "name": "strategy_decision_log_coid_idx",
+          "columns": [
+            "client_order_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "symbol_config": {
+      "name": "symbol_config",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "market": {
+          "name": "market",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_notional": {
+          "name": "max_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_stop_days_override": {
+          "name": "time_stop_days_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "k_atr_override": {
+          "name": "k_atr_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "budget_alloc_pct": {
+          "name": "budget_alloc_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lot_size": {
+          "name": "lot_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "symbol_config_currency_enum": {
+          "name": "symbol_config_currency_enum",
+          "value": "\"symbol_config\".\"currency\" IN ('USD', 'JPY')"
+        },
+        "symbol_config_time_stop_days_override_range": {
+          "name": "symbol_config_time_stop_days_override_range",
+          "value": "\"symbol_config\".\"time_stop_days_override\" IS NULL OR (\"symbol_config\".\"time_stop_days_override\" >= 1 AND \"symbol_config\".\"time_stop_days_override\" <= ?)"
+        },
+        "symbol_config_k_atr_override_range": {
+          "name": "symbol_config_k_atr_override_range",
+          "value": "\"symbol_config\".\"k_atr_override\" IS NULL OR (\"symbol_config\".\"k_atr_override\" >= 0.5 AND \"symbol_config\".\"k_atr_override\" <= 5.0)"
+        }
+      }
+    },
+    "trade_journal": {
+      "name": "trade_journal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trade_event_type": {
+          "name": "trade_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "strategy_name": {
+          "name": "strategy_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_action": {
+          "name": "signal_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_reason": {
+          "name": "signal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_allowed": {
+          "name": "risk_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_reasons": {
+          "name": "risk_reasons",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "limit_price": {
+          "name": "limit_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notional": {
+          "name": "notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "broker_status": {
+          "name": "broker_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "submitted": {
+          "name": "submitted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_qty": {
+          "name": "filled_qty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_price": {
+          "name": "filled_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "realized_pnl": {
+          "name": "realized_pnl",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hold_days": {
+          "name": "hold_days",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_reason": {
+          "name": "exit_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_applied_at": {
+          "name": "state_applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_error": {
+          "name": "state_apply_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_attempts": {
+          "name": "state_apply_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trading_toggle_history": {
+      "name": "trading_toggle_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before": {
+          "name": "before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "after": {
+          "name": "after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1780576185111,
       "tag": "0024_add_symbol_budget_alloc_pct",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "6",
+      "when": 1780582507641,
+      "tag": "0025_add_symbol_lot_size",
+      "breakpoints": true
     }
   ]
 }

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -121,6 +121,15 @@ export const symbolConfig = sqliteTable(
      * SQLite ALTER 制約で付けず admin parse + 将来 rebuild で担保。
      */
     budgetAllocPct: real('budget_alloc_pct'),
+    /**
+     * 売買単位 (1 注文の最小ロット = 1単元の株数 / ETF の口数)。NULL = 未設定。
+     * **fallback しない**: cron sizing は NULL を fail-closed (発注見送り) として扱う
+     * (誤った blanket 100/1 で過大・過小発注しないため #symbol-lot-size)。US 株/ETF・
+     * JP ETF は通常 1、JP 個別株は 100。フォームは Yahoo `quoteType`/market から推奨値を
+     * プリフィルするが、確定値は手入力必須。range CHECK は SQLite ALTER 制約を避け
+     * admin parse + 将来 rebuild で担保 (budget_alloc_pct と同方針)。
+     */
+    lotSize: integer('lot_size'),
     updatedAt: text('updated_at').notNull(),
   },
   (t) => ({

--- a/src/infrastructure/db/symbolConfigRepo.ts
+++ b/src/infrastructure/db/symbolConfigRepo.ts
@@ -56,6 +56,12 @@ export interface SymbolConfigSnapshot {
    * (= 従来の risk-% sizing)。fixed-% 配分モードの sizing に使う (#budget-alloc)。
    */
   symbolBudgetAllocPct: Record<string, number>
+  /**
+   * symbol → lot_size (売買単位、integer >= 1)。NULL / 不正は map に**含めない**。
+   * 下流 (cron sizing) は map に無い銘柄を fail-closed (発注見送り) 扱いにする
+   * — blanket default に倒さない (#symbol-lot-size)。
+   */
+  symbolLotSize: Record<string, number>
 }
 
 /**
@@ -82,6 +88,7 @@ export async function loadSymbolConfig(
   const symbolTimeStopDaysOverride: Record<string, number> = {}
   const symbolKAtrOverride: Record<string, number> = {}
   const symbolBudgetAllocPct: Record<string, number> = {}
+  const symbolLotSize: Record<string, number> = {}
   for (const row of rows) {
     const symbol = row.symbol.toUpperCase()
     if (row.active) {
@@ -131,6 +138,17 @@ export async function loadSymbolConfig(
     ) {
       symbolBudgetAllocPct[symbol] = row.budgetAllocPct
     }
+    // lot_size は integer >= 1 のみ採用。NULL / 非整数 / <1 は map に出さず
+    // (= 下流 fail-closed)。blanket default に倒さない (#symbol-lot-size)。
+    if (
+      row.lotSize !== null &&
+      row.lotSize !== undefined &&
+      Number.isFinite(row.lotSize) &&
+      Number.isInteger(row.lotSize) &&
+      row.lotSize >= 1
+    ) {
+      symbolLotSize[symbol] = row.lotSize
+    }
   }
   return {
     allowedSymbols,
@@ -143,6 +161,7 @@ export async function loadSymbolConfig(
     symbolTimeStopDaysOverride,
     symbolKAtrOverride,
     symbolBudgetAllocPct,
+    symbolLotSize,
   }
 }
 
@@ -181,6 +200,12 @@ export interface SymbolConfigWriteInput {
    * (#budget-alloc)。
    */
   budgetAllocPct: number | null
+  /**
+   * 売買単位 (integer >= 1)。**入力必須** — admin parse が未入力を弾く。NULL は
+   * 既存行 (migration 前) のみで、cron sizing は NULL を fail-closed 扱いにする
+   * (#symbol-lot-size)。
+   */
+  lotSize: number | null
 }
 
 /**
@@ -208,6 +233,7 @@ export async function insertSymbolConfig(
       timeStopDaysOverride: input.timeStopDaysOverride,
       kAtrOverride: input.kAtrOverride,
       budgetAllocPct: input.budgetAllocPct,
+      lotSize: input.lotSize,
       updatedAt: nowIso,
     })
   } catch (err) {
@@ -252,6 +278,7 @@ export async function updateSymbolConfig(
       timeStopDaysOverride: input.timeStopDaysOverride,
       kAtrOverride: input.kAtrOverride,
       budgetAllocPct: input.budgetAllocPct,
+      lotSize: input.lotSize,
       updatedAt: nowIso,
     })
     .where(eq(symbolConfig.symbol, input.symbol))
@@ -493,6 +520,9 @@ export async function createSymbolPair(
       kAtrOverride: null,
       // regime hedge は片方ずつ建てるので counterpart も同じ予算配分%を継承。
       budgetAllocPct: primary.budgetAllocPct,
+      // インバース対は同じ商品種別 (両方 3x ETF 等) なので売買単位も primary 継承。
+      // 異なる場合は counterpart を個別編集で上書きする (#symbol-lot-size)。
+      lotSize: primary.lotSize,
       updatedAt: nowIso,
     })
     await db.batch([delLink, insCounterpart, insLink])

--- a/src/infrastructure/db/symbolUniverse.ts
+++ b/src/infrastructure/db/symbolUniverse.ts
@@ -41,6 +41,11 @@ export interface SymbolUniverse {
    * fixed-% 予算配分モード (#budget-alloc)。
    */
   symbolBudgetAllocPct: Record<string, number>
+  /**
+   * symbol → lot_size (売買単位、integer >= 1)。NULL は map に不在
+   * (= cron sizing が fail-closed)。blanket default に倒さない (#symbol-lot-size)。
+   */
+  symbolLotSize: Record<string, number>
   inversePairs: Record<string, string>
   source: 'd1'
 }
@@ -72,6 +77,7 @@ export async function loadSymbolUniverse(env: UniverseEnv): Promise<SymbolUniver
     symbolTimeStopDaysOverride: config.symbolTimeStopDaysOverride,
     symbolKAtrOverride: config.symbolKAtrOverride,
     symbolBudgetAllocPct: config.symbolBudgetAllocPct,
+    symbolLotSize: config.symbolLotSize,
     inversePairs: pairs,
     source: 'd1',
   }

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -2113,6 +2113,8 @@ function parseSymbolConfigBody(body: unknown): SymbolConfigWriteInput {
     kAtrOverride?: unknown
     budget_alloc_pct?: unknown
     budgetAllocPct?: unknown
+    lot_size?: unknown
+    lotSize?: unknown
   }
   const symbol = normalizeSymbol(raw.symbol)
   const market = parseMarket(raw.market)
@@ -2150,6 +2152,9 @@ function parseSymbolConfigBody(body: unknown): SymbolConfigWriteInput {
     100,
   )
   const budgetAllocPct = budgetAllocPctRaw === null ? null : budgetAllocPctRaw / 100
+  // 売買単位は **入力必須** (空欄/未指定はエラー)。fallback しない (#symbol-lot-size)。
+  // 整数 1-100000 (JP 個別株=100 / ETF=1 / US=1 を想定、上限は防御的に広め)。
+  const lotSize = parseRequiredIntegerInRange(raw.lot_size ?? raw.lotSize, 'lotSize', 1, 100_000)
   return {
     symbol,
     name,
@@ -2161,7 +2166,41 @@ function parseSymbolConfigBody(body: unknown): SymbolConfigWriteInput {
     timeStopDaysOverride,
     kAtrOverride,
     budgetAllocPct,
+    lotSize,
   }
+}
+
+/**
+ * 必須 integer in [min,max]。空文字 / undefined / null は **エラー** (fallback
+ * しない、#symbol-lot-size)。売買単位 lot_size の受け口。
+ */
+function parseRequiredIntegerInRange(
+  value: unknown,
+  field: string,
+  min: number,
+  max: number,
+): number {
+  const invalid = () => {
+    throw new ValidationError(`${field} is required and must be an integer between ${min} and ${max}`, {
+      field,
+    })
+  }
+  if (value === undefined || value === null) invalid()
+  let parsed: number
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (trimmed === '') invalid()
+    parsed = Number(trimmed)
+  } else if (typeof value === 'number') {
+    parsed = value
+  } else {
+    invalid()
+    return 0 // unreachable (invalid throws), satisfies type checker
+  }
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < min || parsed > max) {
+    invalid()
+  }
+  return parsed
 }
 
 function normalizeSymbol(value: unknown): string {

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -6888,6 +6888,11 @@ function symbolsListBody(args: {
       const maxNotionalCell = r.maxNotional === null
         ? '<span class="muted" title="未設定 = global の MAX_ORDER_NOTIONAL を使用">— (global)</span>'
         : `${esc(r.maxNotional.toLocaleString('ja-JP'))} <span class="muted" style="font-size:11px">${esc(r.currency)}</span>`
+      // 売買単位 (lot_size)。未設定は fail-closed (発注見送り) なので赤字警告で明示。
+      const lotSizeCell =
+        r.lotSize == null
+          ? '<span class="err" title="売買単位が未設定です。設定するまで BUY は発注されません (fail-closed)。編集から入力してください。">⚠ 未設定</span>'
+          : `${esc(String(r.lotSize))} <span class="muted" style="font-size:11px">${r.lotSize === 1 ? '株/口' : '株'}</span>`
       // 予算配分 ladder slider (#budget-alloc): 5%刻み。確定するまで client 側で仮調整、
       // form="symbol-budget-form" で一括 POST。inverse 相手は JS が同期する。
       const allocPctNum = r.budgetAllocPct != null ? Math.round(r.budgetAllocPct * 1000) / 10 : 0
@@ -6920,6 +6925,7 @@ function symbolsListBody(args: {
         <td><strong><span${symStyle}>${esc(r.symbol)}</span></strong></td>
         <td>${esc(r.name ?? '')}</td>
         <td><code style="font-size:11px">${esc(r.market)}/${esc(r.currency)}</code></td>
+        <td>${lotSizeCell}</td>
         <td>${maxNotionalCell}</td>
         <td>${budgetCell}</td>
         <td>${esc(r.notes ?? '')}</td>
@@ -6941,6 +6947,7 @@ function symbolsListBody(args: {
       <th>銘柄</th>
       <th>銘柄名</th>
       <th>市場/通貨</th>
+      <th>売買単位</th>
       <th>1注文上限</th>
       <th>予算配分</th>
       <th>メモ</th>
@@ -7210,6 +7217,7 @@ function symbolFormBody(args: SymbolFormArgs): string {
   const currencyValue = row?.currency ?? 'USD'
   const activeChecked = (row?.active ?? true) ? ' checked' : ''
   const maxNotionalValue = row?.maxNotional === null || row?.maxNotional === undefined ? '' : String(row.maxNotional)
+  const lotSizeValue = row?.lotSize === null || row?.lotSize === undefined ? '' : String(row.lotSize)
   const notesValue = row?.notes ?? ''
   const timeStopDaysOverrideValue =
     row?.timeStopDaysOverride === null || row?.timeStopDaysOverride === undefined
@@ -7304,6 +7312,13 @@ function symbolFormBody(args: SymbolFormArgs): string {
       <input type="hidden" name="active" value="false">
       <input type="checkbox" name="active" value="true"${activeChecked}> 取引対象として有効
     </label>
+    <label>売買単位 <span class="muted" style="font-size:11px">(lot_size)</span></label>
+    <div>
+      <input type="number" name="lot_size" id="symbol-form-lot-size" value="${esc(lotSizeValue)}" required step="1" min="1" max="100000" placeholder="必須: 1注文の最小単位" style="padding:6px;width:160px">
+      <span class="muted" style="font-size:12px;margin-left:6px">株/口 (1単元)</span>
+      <span id="symbol-form-lot-suggest" class="muted" style="font-size:11px;margin-left:6px"></span>
+      <p class="muted" style="margin:4px 0 0;font-size:11px"><strong>入力必須</strong> (fallback しません)。1 注文の最小発注数 = 1単元の株数/口数。<strong>JP 個別株は通常 100、ETF (1570/1357 等) と US 株は 1</strong>。未設定の銘柄は cron が発注を見送ります (fail-closed)。Yahoo から銘柄を選ぶと種別 (ETF/個別株) に応じた推奨値を自動入力します (確定は手入力で上書き可)。</p>
+    </div>
     <label>1注文上限 <span class="muted" style="font-size:11px">(max_notional)</span></label>
     <div>
       <input type="number" name="max_notional" value="${esc(maxNotionalValue)}" step="0.01" min="0.01" placeholder="空欄で global default を使用" style="padding:6px;width:160px">
@@ -7412,8 +7427,25 @@ function symbolFormBody(args: SymbolFormArgs): string {
       if (m.market && marketSel) marketSel.value = m.market;
       if (m.currency && currencySel) currencySel.value = m.currency;
       if (m.currency) window.syncSymbolFormCurrencyUnits(m.currency);
+      window.suggestLotSizeFromMatch(m);
       window.hideSymbolSuggest();
       if (symInput) symInput.focus();
+    };
+    // Yahoo quoteType + market から売買単位の推奨値を自動入力する。
+    // ETF → 1 口、JP 個別株 (EQUITY) → 100 株、US 個別株 → 1 株。あくまで推奨で、
+    // operator が手入力で上書き可能 (確定は手入力必須・fail-closed なので #symbol-lot-size)。
+    window.suggestLotSizeFromMatch = function (m) {
+      var lotInput = document.getElementById('symbol-form-lot-size');
+      var hint = document.getElementById('symbol-form-lot-suggest');
+      if (!lotInput) return;
+      var qt = (m.quoteType || '').toUpperCase();
+      var mkt = (m.market || 'US').toUpperCase();
+      var suggested = qt === 'ETF' ? 1 : (mkt === 'JP' ? 100 : 1);
+      lotInput.value = String(suggested);
+      if (hint) {
+        var kind = qt === 'ETF' ? 'ETF' : (mkt === 'JP' ? 'JP 個別株' : 'US 株');
+        hint.textContent = '推奨: ' + suggested + ' (' + kind + ')。要確認';
+      }
     };
     // インバース銘柄欄: 同じ Yahoo suggest だが pick は inverse 入力だけを埋める
     // (主銘柄の name/market/currency は上書きしない)。

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -6888,11 +6888,13 @@ function symbolsListBody(args: {
       const maxNotionalCell = r.maxNotional === null
         ? '<span class="muted" title="未設定 = global の MAX_ORDER_NOTIONAL を使用">— (global)</span>'
         : `${esc(r.maxNotional.toLocaleString('ja-JP'))} <span class="muted" style="font-size:11px">${esc(r.currency)}</span>`
-      // 売買単位 (lot_size)。未設定は fail-closed (発注見送り) なので赤字警告で明示。
-      const lotSizeCell =
-        r.lotSize == null
-          ? '<span class="err" title="売買単位が未設定です。設定するまで BUY は発注されません (fail-closed)。編集から入力してください。">⚠ 未設定</span>'
-          : `${esc(String(r.lotSize))} <span class="muted" style="font-size:11px">${r.lotSize === 1 ? '株/口' : '株'}</span>`
+      // 売買単位 (lot_size)。未設定・不正値 (NULL/0/負/非整数) は cron sizing が
+      // fail-closed (発注見送り) するので、一覧でも同じ判定で赤字警告を出す
+      // (loadSymbolConfig の採用条件 = integer>=1 と揃える、CodeRabbit #409)。
+      const lotSizeValid = Number.isInteger(r.lotSize) && (r.lotSize as number) >= 1
+      const lotSizeCell = !lotSizeValid
+        ? '<span class="err" title="売買単位が未設定または不正です。設定するまで BUY は発注されません (fail-closed)。編集から入力してください。">⚠ 未設定</span>'
+        : `${esc(String(r.lotSize))} <span class="muted" style="font-size:11px">${r.lotSize === 1 ? '株/口' : '株'}</span>`
       // 予算配分 ladder slider (#budget-alloc): 5%刻み。確定するまで client 側で仮調整、
       // form="symbol-budget-form" で一括 POST。inverse 相手は JS が同期する。
       const allocPctNum = r.budgetAllocPct != null ? Math.round(r.budgetAllocPct * 1000) / 10 : 0

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -53,11 +53,19 @@ export interface PullbackSchedulerOptions {
   riskPerTradePct?: number
   pendingLockTtlMs?: number
   /**
-   * Exchange lot size for this run (e.g. 100 for TSE). Default 1. Applied
-   * uniformly to all symbols in this invocation — callers running mixed
-   * markets should invoke the scheduler once per lot-size.
+   * @deprecated Run 単位の一律 lot。後方互換のため残置 (test 用)。production の
+   * `runStrategyCron` は渡さず `symbolLotSizeMap` を使う。symbol が map にも
+   * これにも無ければ fail-closed (#symbol-lot-size)。
    */
   lotSize?: number
+  /**
+   * symbol → lot_size (売買単位、integer >= 1)。`lotSize` (run 単位) より優先。
+   * **この map を渡した時点で lot 必須モードになる**: map に該当 symbol が無い
+   * BUY は fail-closed (発注見送り) — blanket default に倒さない (#symbol-lot-size)。
+   * production (`runStrategyCron`) は常にこれを渡す。map も `lotSize` も渡さない
+   * legacy caller のみ従来の lot=1 に倒す (旧 unit test 後方互換)。
+   */
+  symbolLotSizeMap?: Record<string, number>
   /**
    * symbol → budget_alloc_pct (0<pct<=1)。指定 symbol は fixed-% 配分 sizing
    * (口座(円)単一プールに対する割合) に切替わる (#budget-jpy-base-fx)。
@@ -448,6 +456,36 @@ export async function runPullbackScheduler(
     let intent: OrderIntent
     if (signal.action === 'BUY') {
       const rule = strategy.resolveRule(upper)
+      // 売買単位は per-symbol map を優先。production (`runStrategyCron`) は常に
+      // `symbolLotSizeMap` を渡す (空でも) ので、**map にあるのに該当 symbol が
+      // 無い = lot_size 未設定 → fail-closed** (発注見送り、#symbol-lot-size)。
+      // 誤った blanket lot で過大/過小発注しない。`symbolLotSizeMap` も
+      // `lotSize` も一切渡さない legacy caller (旧 unit test 等) のみ従来の lot=1。
+      const resolvedLotSize =
+        options.symbolLotSizeMap?.[upper] ??
+        options.lotSize ??
+        (options.symbolLotSizeMap === undefined ? 1 : undefined)
+      if (
+        resolvedLotSize === undefined ||
+        !Number.isFinite(resolvedLotSize) ||
+        !Number.isInteger(resolvedLotSize) ||
+        resolvedLotSize < 1
+      ) {
+        const reason = `sizing rejected: missing-lot-size (symbol ${upper} has no lot_size configured, entry ${indicators.price})`
+        summary.rejected.push({ symbol: upper, reason })
+        await emitDecision({
+          symbol: upper,
+          decision: 'REJECT',
+          reason,
+          price: indicators.price,
+          indicatorsJson: JSON.stringify(indicators),
+          trace: appendTrace(
+            signal.trace,
+            traceStep('sizing.lot_size_configured', false, undefined, undefined, undefined, 'missing-lot-size'),
+          ),
+        })
+        continue
+      }
       const sizing = computePullbackSizing({
         equity: options.equity,
         entryPrice: indicators.price,
@@ -456,7 +494,7 @@ export async function runPullbackScheduler(
         baselineAtr20: indicators.baselineAtr20,
         symbolCap: options.symbolCapMap?.[upper],
         riskPerTradePct: options.riskPerTradePct,
-        lotSize: options.lotSize,
+        lotSize: resolvedLotSize,
         kAtr: rule.kAtr,
         budgetAllocPct: options.symbolBudgetAllocPctMap?.[upper],
         budgetBasisJpy: options.budgetBasisJpy,
@@ -464,7 +502,7 @@ export async function runPullbackScheduler(
       })
       if (sizing.quantity <= 0) {
         const reason = buildSizingRejectReason(sizing, {
-          lotSize: options.lotSize ?? 1,
+          lotSize: resolvedLotSize,
           entryPrice: indicators.price,
         })
         summary.rejected.push({ symbol: upper, reason })
@@ -507,7 +545,7 @@ export async function runPullbackScheduler(
           // warning: qty を `floor(qty * scale / lot) * lot` で lot に揃える。
           // lot=1 の US 株は単純な floor、lot=100 の JP 株は単元未満で 0 になり得る。
           // 結果が 0 になった場合は次の `scaledQuantity <= 0` reject で拾う。
-          const lot = options.lotSize ?? 1
+          const lot = resolvedLotSize
           const rawScaled = sizing.quantity * options.vixDecision.sizeScale
           scaledQuantity = lot > 1
             ? Math.floor(rawScaled / lot) * lot
@@ -1112,6 +1150,7 @@ function labelJa(label: string): string {
 
 const TRACE_LABEL_JA: Record<string, string> = {
   'sizing.quantity_positive': '発注数量が1株/1単元以上ある',
+  'sizing.lot_size_configured': '売買単位 (lot_size) が設定済み',
   'scheduler.price_valid': '株価が有効',
   'scheduler.notional_valid': '発注金額が有効',
   'scheduler.sell_position_exists': '売却対象の建玉がある',

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -42,7 +42,8 @@ import { runPullbackScheduler, type PullbackDecisionTrace, type PullbackRunSumma
 
 const DEFAULT_EQUITY_USD = 10_000
 const DEFAULT_EQUITY_JPY = 1_500_000
-const JP_LOT_SIZE = 100
+// 売買単位は per-symbol (symbol_config.lot_size) で持つ。未設定銘柄は scheduler
+// 側で fail-closed (発注見送り) — blanket default に倒さない (#symbol-lot-size)。
 
 /**
  * sanity_failed cooldown window (ms)。直近この期間内に同 symbol で broker
@@ -122,7 +123,6 @@ export interface StrategyCronAnalysis {
   runs: Array<{
     currency: SymbolCurrency
     equity: number
-    lotSize: number
     symbols: string[]
   }>
   decisions: PullbackDecisionTrace[]
@@ -518,12 +518,11 @@ export async function runStrategyCron(
   // sub-run ごとに独立した summary が `vix` を持つので、aggregate もそれと
   // 揃えておく。`emptySummary()` は `vix` を埋めないので明示的に上書きする。
   const summary: PullbackRunSummary = { ...emptySummary(), vix: vixDecision }
-  const runs: Array<{ currency: SymbolCurrency; equity: number; lotSize: number; symbols: string[] }> = []
+  const runs: Array<{ currency: SymbolCurrency; equity: number; symbols: string[] }> = []
   if (byCurrency.USD.length > 0) {
     runs.push({
       currency: 'USD',
       equity: sanitizeEquity(global.totalCapitalUsd, DEFAULT_EQUITY_USD),
-      lotSize: 1,
       symbols: byCurrency.USD,
     })
   }
@@ -531,7 +530,6 @@ export async function runStrategyCron(
     runs.push({
       currency: 'JPY',
       equity: sanitizeEquity(global.totalCapitalJpy, DEFAULT_EQUITY_JPY),
-      lotSize: JP_LOT_SIZE,
       symbols: byCurrency.JPY,
     })
   }
@@ -551,7 +549,6 @@ export async function runStrategyCron(
     analysis.runs.push({
       currency: run.currency,
       equity: run.equity,
-      lotSize: run.lotSize,
       symbols: run.symbols,
     })
     // JPY 銘柄は fx=1。USD 銘柄は usdJpyRate (null なら undefined → budget 銘柄 fail-closed)。
@@ -560,7 +557,7 @@ export async function runStrategyCron(
     const sub = await runPullbackScheduler({
       symbols: run.symbols,
       equity: run.equity,
-      lotSize: run.lotSize,
+      symbolLotSizeMap: universe.symbolLotSize,
       barClient,
       positionStore,
       execution,

--- a/test/helpers/configFixtures.ts
+++ b/test/helpers/configFixtures.ts
@@ -57,6 +57,7 @@ export function makeSymbolUniverse(overrides: Partial<SymbolUniverse> = {}): Sym
     symbolTimeStopDaysOverride: {},
     symbolKAtrOverride: {},
     symbolBudgetAllocPct: {},
+    symbolLotSize: { SOXL: 1, SOXS: 1 },
     inversePairs: {},
     source: 'd1',
     ...overrides,

--- a/test/infrastructure/db/symbolConfigRepo.test.ts
+++ b/test/infrastructure/db/symbolConfigRepo.test.ts
@@ -233,6 +233,7 @@ const writeInput = (symbol: string): SymbolConfigWriteInput => ({
   timeStopDaysOverride: null,
   kAtrOverride: null,
   budgetAllocPct: null,
+  lotSize: 1,
 })
 
 describe('setInversePair', () => {

--- a/test/routes/admin.test.ts
+++ b/test/routes/admin.test.ts
@@ -1140,6 +1140,7 @@ describe('POST /admin/orders/sync-holdings', () => {
       symbolTimeStopDaysOverride: {},
       symbolKAtrOverride: {},
       symbolBudgetAllocPct: {},
+      symbolLotSize: {},
       inversePairs: {},
       source: 'd1',
     })

--- a/test/routes/dashboardSymbolsCrud.test.ts
+++ b/test/routes/dashboardSymbolsCrud.test.ts
@@ -154,6 +154,7 @@ function fakeDb(initial: SymbolConfigRow[]) {
               timeStopDaysOverride: (v.timeStopDaysOverride as number | null) ?? null,
               kAtrOverride: (v.kAtrOverride as number | null) ?? null,
               budgetAllocPct: (v.budgetAllocPct as number | null) ?? null,
+              lotSize: (v.lotSize as number | null) ?? null,
               updatedAt: String(v.updatedAt ?? ''),
             })
           }
@@ -209,6 +210,7 @@ function row(overrides: Partial<SymbolConfigRow> = {}): SymbolConfigRow {
     timeStopDaysOverride: null,
     kAtrOverride: null,
     budgetAllocPct: null,
+    lotSize: 1,
     updatedAt: '2026-04-23T00:00:00.000Z',
     ...overrides,
   }
@@ -258,6 +260,7 @@ describe('dashboard symbol_config CRUD UI (#292)', () => {
       currency: 'USD',
       active: 'true',
       max_notional: '1500',
+      lot_size: '1',
       notes: '',
     })
     const res = await app.request(
@@ -308,6 +311,7 @@ describe('dashboard symbol_config CRUD UI (#292)', () => {
       currency: 'USD',
       active: 'true',
       max_notional: '3000',
+      lot_size: '1',
       notes: 'bumped',
     })
     const res = await app.request(
@@ -403,6 +407,42 @@ describe('dashboard symbol_config CRUD UI (#292)', () => {
     expect(deletes).toHaveLength(0)
   })
 
+  // --- lot_size 入力必須 (#symbol-lot-size) ---
+  it('validation: rejects missing / empty / non-integer lot_size with 400 (required, no fallback)', async () => {
+    const db = fakeDb([])
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const app = createApp()
+
+    const post = (extra: Record<string, string>) =>
+      app.request(
+        '/admin/symbol-config',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...authHeader },
+          body: new URLSearchParams({
+            symbol: 'TQQQ',
+            market: 'US',
+            currency: 'USD',
+            active: 'true',
+            ...extra,
+          }).toString(),
+        },
+        { ...baseEnv, DB: {} as D1Database },
+      )
+
+    // lot_size 欄が無い → 400 (fallback しない)
+    expect((await post({})).status).toBe(400)
+    // 空文字 → 400
+    expect((await post({ lot_size: '' })).status).toBe(400)
+    // 0 / 負 / 非整数 → 400
+    expect((await post({ lot_size: '0' })).status).toBe(400)
+    expect((await post({ lot_size: '-1' })).status).toBe(400)
+    expect((await post({ lot_size: '1.5' })).status).toBe(400)
+
+    // どれも insert は走っていない (fail-closed)
+    expect(db.inserts.filter((i) => i.table === 'symbol_config')).toHaveLength(0)
+  })
+
   // --- Validation ---
   it('validation: rejects empty symbol / unknown market / negative max_notional with 400', async () => {
     const db = fakeDb([])
@@ -490,6 +530,7 @@ describe('dashboard symbol_config CRUD UI (#292)', () => {
           market: 'US',
           currency: 'USD',
           active: 'true',
+          lot_size: '1',
         }).toString(),
       },
       { ...baseEnv, DB: {} as D1Database },
@@ -515,6 +556,7 @@ describe('dashboard symbol_config CRUD UI (#292)', () => {
           market: 'US',
           currency: 'USD',
           active: true,
+          lot_size: 1,
         }),
       },
       { ...baseEnv, DB: {} as D1Database },
@@ -630,6 +672,7 @@ describe('dashboard symbol_config CRUD UI (#292)', () => {
       currency: 'USD',
       active: 'true',
       max_notional: '2000',
+      lot_size: '1',
       time_stop_days_override: '5',
       k_atr_override: '3.0',
     })
@@ -664,6 +707,7 @@ describe('dashboard symbol_config CRUD UI (#292)', () => {
       currency: 'USD',
       active: 'true',
       max_notional: '1000',
+      lot_size: '1',
       time_stop_days_override: '',
       k_atr_override: '',
     })
@@ -757,6 +801,7 @@ describe('dashboard symbol_config CRUD UI (#292)', () => {
       currency: 'USD',
       active: 'true',
       max_notional: '2000',
+      lot_size: '1',
       time_stop_days_override: '7',
       k_atr_override: '2.5',
     })
@@ -839,6 +884,7 @@ describe('dashboard symbol_config CRUD UI (#292)', () => {
       currency: 'USD',
       active: 'true',
       max_notional: '500',
+      lot_size: '1',
       inverse_symbol: 'soxs',
       // Yahoo pick 由来の counterpart メタ (一覧でインバース側の銘柄名を出す #315)
       inverse_name: 'Direxion Daily Semiconductor Bear 3X Shares',
@@ -863,6 +909,8 @@ describe('dashboard symbol_config CRUD UI (#292)', () => {
     expect(soxs.name).toBe('Direxion Daily Semiconductor Bear 3X Shares')
     expect(soxs.market).toBe('US')
     expect(soxs.currency).toBe('USD')
+    // counterpart は同じ商品種別なので売買単位を primary 継承 (#symbol-lot-size)
+    expect(soxs.lotSize).toBe(1)
     // inverse_pairs リンクが書かれる
     expect(db.inserts.some((i) => i.table === 'inverse_pairs')).toBe(true)
   })
@@ -876,6 +924,7 @@ describe('dashboard symbol_config CRUD UI (#292)', () => {
       market: 'JP',
       currency: 'JPY',
       active: 'true',
+      lot_size: '1', // 1570 (日経レバ ETF) は 1口
       budget_alloc_pct: '40', // 40% → 0.4
     })
     const res = await app.request(
@@ -978,6 +1027,7 @@ describe('dashboard symbol_config CRUD UI (#292)', () => {
       market: 'US',
       currency: 'USD',
       active: 'true',
+      lot_size: '1',
       inverse_symbol: 'SOXL',
     })
     const res = await app.request(

--- a/test/routes/dashboardSymbolsCrud.test.ts
+++ b/test/routes/dashboardSymbolsCrud.test.ts
@@ -248,6 +248,21 @@ describe('dashboard symbol_config CRUD UI (#292)', () => {
     expect(body).toContain('有効 1 / 無効 1')
   })
 
+  it('list flags NULL / invalid lot_size as ⚠ 未設定 (matches runtime fail-closed, CodeRabbit #409)', async () => {
+    const db = fakeDb([
+      row({ symbol: 'AAA', lotSize: null }), // 未設定
+      row({ symbol: 'BBB', lotSize: 0 }), // 不正値 (実行系は fail-closed)
+      row({ symbol: 'CCC', lotSize: 100 }), // 正常
+    ])
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const app = createApp()
+    const res = await app.request('/dashboard/symbols', { headers: authHeader }, { ...baseEnv, DB: {} as D1Database })
+    const body = await res.text()
+    // NULL も 0 も警告。正常な 100 は数値表示。
+    expect((body.match(/⚠ 未設定/g) ?? []).length).toBe(2)
+    expect(body).toMatch(/100 <span class="muted"[^>]*>株<\/span>/)
+  })
+
   // --- POST add ---
   it('POST /admin/symbol-config inserts row + writes audit row, redirects 303', async () => {
     const db = fakeDb([])

--- a/test/trading/strategy/pullbackScheduler.test.ts
+++ b/test/trading/strategy/pullbackScheduler.test.ts
@@ -1474,3 +1474,63 @@ describe('runPullbackScheduler per-symbol rule override (#316)', () => {
     expect(soxl?.reason ?? '').not.toMatch(/time-stop hit/)
   })
 })
+
+describe('runPullbackScheduler per-symbol lot_size (#symbol-lot-size)', () => {
+  it('fail-closed (no BUY) when symbolLotSizeMap is provided but the symbol is absent', async () => {
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution,
+      // map は渡すが AAPL を含めない → lot_size 未設定扱い → 発注見送り。
+      symbolLotSizeMap: { SOXL: 1 },
+      now: () => now,
+    })
+
+    expect(summary.buys).toBe(0)
+    expect(execution.calls).toHaveLength(0)
+    const aapl = summary.decisions.find((d) => d.symbol === 'AAPL')
+    expect(aapl?.decision).toBe('REJECT')
+    expect(aapl?.reason).toMatch(/missing-lot-size/)
+    expect(summary.rejected).toContainEqual(
+      expect.objectContaining({ symbol: 'AAPL', reason: expect.stringMatching(/missing-lot-size/) }),
+    )
+  })
+
+  it('places a BUY when the symbol has a lot_size in the map', async () => {
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution,
+      symbolLotSizeMap: { AAPL: 1 },
+      now: () => now,
+    })
+
+    expect(summary.buys).toBe(1)
+    expect(execution.calls).toHaveLength(1)
+  })
+
+  it('rounds a JP-style lot=100 symbol down to a whole unit (single-unit-or-zero)', async () => {
+    // lot=100 で equity が 1 単元に届かない → lot-size-round で 0 株 reject。
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution,
+      symbolLotSizeMap: { AAPL: 100 },
+      now: () => now,
+    })
+
+    expect(summary.buys).toBe(0)
+    const aapl = summary.decisions.find((d) => d.symbol === 'AAPL')
+    expect(aapl?.decision).toBe('REJECT')
+    expect(aapl?.reason).toMatch(/lot-size-round/)
+  })
+})


### PR DESCRIPTION
## 何を / なぜ

`1570` (日経レバ ETF) が小口座で永久に発注できなかった。原因は **売買単位を per-symbol で持っておらず、JP 個別株の単元 100 を全 JPY 銘柄に一律適用**していたこと (`JP_LOT_SIZE = 100`)。1570 は **ETF で売買単位 1口**なのに「1単元 = 100口 ≈ ¥746万」を要求 → `lot-size-round` で 0 株却下になっていた (decision id 585, `raw qty 1 < lot 100, entry 74620`)。

売買単位を `symbol_config.lot_size` として **per-symbol** に持たせ、**入力必須 + 未設定は fail-closed**（誤った blanket lot で過大/過小発注しない）にする。

> 方針: Yahoo v8 API には売買単位フィールドが無く `instrumentType`(ETF/EQUITY) のみ取れる。よって lot は **手入力必須**とし、Yahoo の種別から**推奨値をプリフィル**するに留める（確定は人間）。

## 変更

- **schema**: `symbol_config.lot_size INTEGER` (nullable, DB CHECK なし = clean `ALTER ADD COLUMN`。`budget_alloc_pct` と同方針)。migration `0025_add_symbol_lot_size`。
- **repo / universe**: `symbolLotSize` map を pass-through。`loadSymbolConfig` は integer>=1 のみ採用 (NULL/不正は map 不在 = 下流 fail-closed)。インバース対の counterpart は同じ商品種別なので **primary の lot を継承**。
- **scheduler** (`pullbackScheduler`): per-symbol lot を解決。**`symbolLotSizeMap` を渡した時点で lot 必須モード**になり、該当 symbol が無い BUY は `missing-lot-size` で **fail-closed (発注見送り)**。blanket default に倒さない。map も `lotSize` も渡さない legacy caller のみ従来 `lot=1` (後方互換)。
- **cron** (`runStrategyCron`): `JP_LOT_SIZE` 一律 lot を撤去、`universe.symbolLotSize` を scheduler に配線。production は常に map を渡すので、DB で lot 未設定の active 銘柄は自動的に発注見送り。
- **admin**: `lot_size` を**入力必須** (`parseRequiredIntegerInRange`、未入力/空/0/負/非整数は 400、fallback しない)。
- **dashboard**: 銘柄フォームに **必須 lot 欄** + Yahoo `quoteType`/market からの**推奨値プリフィル** (ETF→1 / JP個別株→100 / US→1、手入力で上書き可)。銘柄一覧に **売買単位列** (未設定は `⚠ 未設定` を赤字で表示し fail-closed を明示)。

## fail-safe / real-money
- 未設定銘柄は **trade しない** (silent な 100/1 default を入れない)。誤 lot による過大発注を防ぐ。
- 既存の per-currency 上限 / exposure gate / budget 配分は不変。

## 運用注意 (migration 後)
既存 active 銘柄は `lot_size` が NULL になるため、**lot を設定するまで BUY は発注見送り (fail-closed)**。各銘柄を編集して売買単位を入力すること (1570/1357・US 株/ETF → 1、JP 個別株 → 100)。

## テスト
`pnpm typecheck` / `pnpm test` → **1245 passed**。migration は local D1 で apply 済。追加: lot 入力必須 (未入力/空/0/負/非整数→400・insert 無し)、counterpart の lot 継承、scheduler の `missing-lot-size` fail-closed・`lot=100` の単元未満 round・map 設定時の BUY 成立。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 銘柄ごとに売買単位（ロットサイズ）を設定・管理できるようになりました
  * 管理画面で売買単位の表示・編集が可能になりました
  * 銘柄選択時に推奨売買単位が自動入力されます（ETF=1、日本株=100、米国株=1）

* **改善**
  * 売買単位が未設定の場合、発注を見送る仕様に統一しました
  * 戦略実行時に銘柄ごとの売買単位を正確に反映するようになりました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->