### PR TITLE
fix(risk): Yahoo quote (bid/ask 無し) で spread guard を適用外にして発注を通す (案A, #411)

### DIFF
--- a/src/trading/risk/perSymbolRiskGate.ts
+++ b/src/trading/risk/perSymbolRiskGate.ts
@@ -1,5 +1,6 @@
 /**
- * Per-symbol risk gate (pure).
+ * Per-symbol risk gate (pure, except one observability `console.warn` when the
+ * spread guard is skipped for a bid/ask-less quote source — see gate 4 / #411).
  *
  * 7 つの per-symbol guard を一つの pure function に集約する。manual
  * `/trade/execute` 経路 (TradingService) と cron (`runPullbackScheduler`) の
@@ -9,7 +10,8 @@
  *   1. settled cash (BUY only): notional > settledCash で reject
  *   2. inverse pair (BUY only): inverse 銘柄の建玉が残っていれば reject
  *   3. quote freshness (BUY only / halt fallback): lastQuote.fetchedAt が staleQuoteMs を超えれば reject
- *   4. spread guard (BUY only): bid/ask 欠損 / 異常 / spread% が limit 超で reject
+ *   4. spread guard (BUY only): 異常 / spread% が limit 超で reject。bid/ask 欠損は
+ *      source 次第 — Yahoo 等 bid/ask 非対応 source は適用外で通す、それ以外は fail-closed (issue #411)
  *   5. gap re-eval (BUY only): avgPrice と lastQuote.price の |gap| > gapRejectPct で reject
  *   6. JP 値幅制限 (BUY only): JP 銘柄かつ band 外 limit price で reject
  *   7. (option) cooldown: state.cooldownUntil が未来なら reject
@@ -30,8 +32,19 @@
  */
 import type { QuoteSnapshot, SymbolState } from '../state/types'
 import { inferWebullMarket } from '../../infrastructure/webull/mapper'
+import { YAHOO_QUOTE_SOURCE } from '../../infrastructure/quotes/YahooQuoteClient'
 import { isWithinJpPriceBand } from './jpPriceBand'
 import { computeSpreadPct } from './spreadGuard'
+
+/**
+ * Quote source が構造的に bid/ask を持たない (= spread を計算できない) もの。
+ * Yahoo `/v8/chart` meta は bid/ask を返さない (PR #334 で default 化)。これらの
+ * source で bid/ask 欠損は「異常」ではなく「仕様」なので、spread guard を
+ * **適用外 (skip)** にして発注を通す (degraded but tradeable)。Webull 等 bid/ask を
+ * 返すべき source での欠損は従来通り fail-closed。Webull market-data 復活で
+ * bid/ask が実データになれば本 set を空にして本来運用へ戻す (issue #411 = 案B)。
+ */
+const QUOTE_SOURCES_WITHOUT_BID_ASK: ReadonlySet<string> = new Set([YAHOO_QUOTE_SOURCE])
 
 export interface PerSymbolRiskInput {
   symbol: string
@@ -134,7 +147,8 @@ export function evaluatePerSymbolRisk(
   }
 
   // 5. spread guard (BUY only)。SELL/exit は wide spread でも実行優先。
-  //    bid/ask 欠損は fail-closed (lastQuote 有り前提)。
+  //    bid/ask 欠損は source 次第: Yahoo 等 bid/ask 非対応 source は適用外で通し、
+  //    それ以外 (Webull 等) は fail-closed (issue #411 で恒久対応 = Webull bid/ask)。
   if (side === 'BUY') {
     const spreadReason = evaluateSpreadGate(symbol, state.lastQuote, config.spreadLimits)
     if (spreadReason !== null) {
@@ -180,6 +194,19 @@ function evaluateSpreadGate(
   const bid = lastQuote.bid
   const ask = lastQuote.ask
   if (bid === undefined || ask === undefined) {
+    // 案A (issue #411): bid/ask を構造的に持たない source (Yahoo) では spread を
+    // 適用外にして通す。それ以外 (Webull 等) の欠損は異常なので fail-closed 継続。
+    if (QUOTE_SOURCES_WITHOUT_BID_ASK.has(lastQuote.source)) {
+      // 安全弁を一段緩めるので observability に明示 (構造化ログ)。
+      console.warn(
+        JSON.stringify({
+          event: 'spread_guard_skipped_no_bidask',
+          symbol,
+          source: lastQuote.source,
+        }),
+      )
+      return null
+    }
     return 'spread unknown, bid/ask missing'
   }
   const market = inferWebullMarket(symbol)

--- a/test/trading/risk/perSymbolRiskGate.test.ts
+++ b/test/trading/risk/perSymbolRiskGate.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
   evaluatePerSymbolRisk,
   type PerSymbolRiskConfig,
@@ -199,6 +199,44 @@ describe('evaluatePerSymbolRisk — spread guard', () => {
     )
     expect(decision.approved).toBe(false)
     expect(decision.reasons[0]).toContain('bid/ask missing')
+  })
+
+  it('skips spread guard (approves) when source lacks bid/ask — Yahoo (#411 案A)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const state: SymbolState = {
+        ...emptySymbolState('TQQQ', () => now),
+        // Yahoo feed は bid/ask 無しで price のみ保存する。
+        lastQuote: quote(100, 1_000, { source: 'yahoo-snapshot', bid: undefined, ask: undefined }),
+      }
+      const decision = evaluatePerSymbolRisk(
+        { symbol: 'TQQQ', side: 'BUY', intentPrice: 100, intentNotional: 100, state, now },
+        baseConfig,
+      )
+      expect(decision.approved).toBe(true)
+      expect(decision.reasons).toEqual([])
+      // observability に skip を明示する構造化ログが出る。
+      const logged = warn.mock.calls.map((c) => JSON.parse(c[0] as string))
+      expect(logged).toContainEqual(
+        expect.objectContaining({ event: 'spread_guard_skipped_no_bidask', symbol: 'TQQQ', source: 'yahoo-snapshot' }),
+      )
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('still enforces spread limit when a bid/ask-less source DOES provide bid/ask', () => {
+    // Yahoo source でも bid/ask が来た場合は通常通り spread 判定する (skip は欠損時のみ)。
+    const state: SymbolState = {
+      ...emptySymbolState('TQQQ', () => now),
+      lastQuote: quote(100, 1_000, { source: 'yahoo-snapshot', bid: 99.0, ask: 101.0 }), // spread 2% >> 0.25%
+    }
+    const decision = evaluatePerSymbolRisk(
+      { symbol: 'TQQQ', side: 'BUY', intentPrice: 100, intentNotional: 100, state, now },
+      baseConfig,
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reasons[0]).toContain('spread')
   })
 
   it('approves SELL when spread is wide (exit priority)', () => {

--- a/test/trading/strategy/pullbackScheduler.test.ts
+++ b/test/trading/strategy/pullbackScheduler.test.ts
@@ -413,6 +413,39 @@ describe('runPullbackScheduler per-symbol risk gate (#138 parity)', () => {
     expect(reject?.reason).toContain('bid/ask missing')
   })
 
+  it('places a BUY when bid/ask is missing but the source lacks it (Yahoo, #411 案A)', async () => {
+    // TQQQ 再現: Yahoo feed は price のみで bid/ask 無し → spread guard を適用外に
+    // して通す (fail-closed しない)。console.warn の skip ログは抑制。
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const state: SymbolState = {
+        ...emptySymbolState('AAPL', () => now),
+        lastQuote: {
+          price: 118,
+          asOf: now.toISOString(),
+          fetchedAt: now.toISOString(),
+          source: 'yahoo-snapshot',
+          bid: undefined,
+          ask: undefined,
+        },
+      }
+      const execution = mockExecution()
+      const summary = await runPullbackScheduler({
+        symbols: ['AAPL'],
+        equity: 100_000,
+        barClient: mockBarClient(uptrendBars()),
+        positionStore: makeStore({ AAPL: state }),
+        execution,
+        perSymbolRisk: baseRiskConfig,
+        now: () => now,
+      })
+      expect(summary.buys).toBe(1)
+      expect(execution.calls).toHaveLength(1)
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
   it('rejects BUY when inverseState shows an open position', async () => {
     const inverse: SymbolState = {
       ...emptySymbolState('SQQQ', () => now),


### PR DESCRIPTION
## 何を / なぜ

TQQQ 等が `risk: spread unknown, bid/ask missing` で発注見送りになっていた (decision id 593)。

**原因**: per-symbol risk gate の spread guard は `lastQuote.bid/ask` を使い欠損時 fail-closed する設計だが、quote feed は PR #334 で **YahooQuoteClient を default 化**しており **Yahoo は bid/ask を返さない**。結果 `lastQuote` が price のみで保存され、BUY が spread guard まで到達した銘柄は全て fail-closed → **Yahoo 運用では戦略が一切 entry できない**状態だった。

## 対応 (案A = 暫定)

quote source が構造的に bid/ask を持たない (`yahoo-snapshot`) 場合のみ、spread 判定を**適用外 (skip)** にして発注を通す:

- `QUOTE_SOURCES_WITHOUT_BID_ASK = { 'yahoo-snapshot' }` を判定に追加。
- Webull 等 bid/ask を返すべき source での欠損は**従来通り fail-closed**(異常検知を維持)。
- Yahoo source でも bid/ask が実際に来た場合は通常通り spread limit を評価(skip は欠損時のみ)。
- skip 時は構造化ログ `spread_guard_skipped_no_bidask`(symbol/source)で **observability に明示**(安全弁を一段緩めるため)。
- SELL/exit は元々 spread に関係なく実行優先なので影響なし。

> 安全側の緩和なので、対象 source を Yahoo に限定し、ログで可視化。流動的な US ETF (TQQQ/SOXL 等) の spread は元々極小なので実害は限定的。

## 恒久対応 (案B) → issue #411
price は Yahoo 継続でよいが、**spread 用 bid/ask を Webull quote から取得**(ハイブリッド)、または Webull market-data 安定後に quote feed を Webull へ戻し、この skip 分岐を撤去して fail-closed を本来運用に戻す。`src/index.ts:136` の切り戻し TODO と連動。

## テスト
`pnpm typecheck` / `pnpm test` → **1249 passed**。追加: gate 単体 (Yahoo+欠損→approve & skip ログ / Yahoo でも bid/ask 有れば spread 評価継続 / 非 Yahoo 欠損は fail-closed 維持)、scheduler E2E (Yahoo 欠損で BUY 成立 = TQQQ 再現)。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 特定の価格ソースが bid/ask データをサポートしていない場合、リスク審査をスキップして取引を許可するよう改善しました

* **Tests**
  * リスク審査機能に関する新規テストケースを追加し、各シナリオで正常に動作することを確認しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->