### PR TITLE
fix(strategy): total_capital_jpy 未設定時は budget sizing を fail-closed (#417 余力不足の主因)

### DIFF
--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -537,7 +537,17 @@ export async function runStrategyCron(
   // #budget-jpy-base-fx: 予算配分は口座(円)単一プール基準。USD 銘柄を「円予算 → USD」
   // 換算するため USD/JPY を 1 回だけ取得 (USD 側に budget 銘柄がある時のみ)。取得失敗
   // /異常値は null → USD budget 銘柄は sizing 側で fail-closed (発注見送り)。
-  const budgetBasisJpy = sanitizeEquity(global.totalCapitalJpy, DEFAULT_EQUITY_JPY)
+  // 予算配分の基準額は実口座総額 (total_capital_jpy)。**null/未設定/非正は DEFAULT に
+  // 倒さず undefined** にする: 幻の資本 (¥1.5M default) で budget% sizing すると小口座で
+  // 過大発注になり Webull 余力不足 (417) を招くため、budget 銘柄を sizing 側で
+  // fail-closed (発注見送り) させる。total_capital_jpy を設定すれば即 sizing 再開
+  // (real-money safety / #417 buying-power)。risk-% sizing 経路の equity 既定は別管理。
+  const budgetBasisJpy =
+    global.totalCapitalJpy != null &&
+    Number.isFinite(global.totalCapitalJpy) &&
+    global.totalCapitalJpy > 0
+      ? global.totalCapitalJpy
+      : undefined
   const usdHasBudgetSymbol = byCurrency.USD.some(
     (s) => universe.symbolBudgetAllocPct[s.toUpperCase()] !== undefined,
   )

--- a/test/trading/strategy/pullbackScheduler.test.ts
+++ b/test/trading/strategy/pullbackScheduler.test.ts
@@ -1567,3 +1567,45 @@ describe('runPullbackScheduler per-symbol lot_size (#symbol-lot-size)', () => {
     expect(aapl?.reason).toMatch(/lot-size-round/)
   })
 })
+
+describe('runPullbackScheduler budget-alloc basis fail-closed (#417 buying-power)', () => {
+  it('fail-closed (no BUY) for a budget symbol when budgetBasisJpy is undefined (total_capital_jpy 未設定)', async () => {
+    // total_capital_jpy=null → runStrategyCron は budgetBasisJpy=undefined を渡す。
+    // 幻の資本で sizing せず発注見送り (過大発注 → Webull 417 を防ぐ)。
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution,
+      symbolLotSizeMap: { AAPL: 1 },
+      symbolBudgetAllocPctMap: { AAPL: 0.35 },
+      budgetBasisJpy: undefined,
+      fxJpyPerSymbolCcy: 150,
+      now: () => now,
+    })
+    expect(summary.buys).toBe(0)
+    expect(execution.calls).toHaveLength(0)
+    const aapl = summary.decisions.find((d) => d.symbol === 'AAPL')
+    expect(aapl?.decision).toBe('REJECT')
+  })
+
+  it('places a BUY for a budget symbol once budgetBasisJpy is a real account total', async () => {
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution,
+      symbolLotSizeMap: { AAPL: 1 },
+      symbolBudgetAllocPctMap: { AAPL: 0.35 },
+      budgetBasisJpy: 1_000_000, // ¥1M × 35% / 150 ≈ $2,333 → 数株
+      fxJpyPerSymbolCcy: 150,
+      now: () => now,
+    })
+    expect(summary.buys).toBe(1)
+    expect(execution.calls).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## 何を / なぜ

production で TQQQ が `Webull 417 Insufficient Buying Power` (decision 605) を出していた。調査すると **production `total_capital_jpy` / `total_capital_usd` が両方 `null`**。

budget 配分 sizing は `budgetBasisJpy = sanitizeEquity(global.totalCapitalJpy, DEFAULT_EQUITY_JPY)` で、`null` だと **既定値 ¥1,500,000 にフォールバック**していた。つまり実口座 (小額) ではなく**幻の ¥1.5M を基準に `budget% × ¥1.5M` で sizing** → max_notional ($500/銘柄) でクランプされても複数銘柄で実余力を超過 → Webull が約定前に 417 で拒否。

実マネー fail-closed の観点で「資本未設定 → 大きな既定値で発注」は危険。

## 修正

`budgetBasisJpy` を `total_capital_jpy` が `null`/非有限/非正のとき **DEFAULT に倒さず `undefined`** にする。`computePullbackSizing` の budget 分岐は既に `budgetBasisJpy` 欠損で fail-closed (発注見送り) するので、**total_capital_jpy を設定するまで budget 銘柄は建たない**。設定すれば即 sizing 再開。

- risk-% sizing 経路の `equity` 既定 (`DEFAULT_EQUITY_*`) は本 PR では不変 (budget 経路のみ厳格化)。
- これは「pool を宣言しなければ budget 発注しない」= 設定レベルの最小 pool ゲート。実余力をブローカーから引く恒久版は別 issue。

## テスト
`pnpm typecheck` / `pnpm test` → **1251 passed**。追加: scheduler で budget 銘柄 + `budgetBasisJpy=undefined` → REJECT、実値 (¥1M) → BUY。sizing 単体の budgetBasisJpy 欠損 fail-closed は既存。

## 運用 (即対応)
production の `total_capital_jpy` (と `total_capital_usd`) を**実口座総額**に設定する必要あり。設定しない限り budget 銘柄は安全側で発注見送り。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 予算配分時に基準資本データが欠損・異常な場合、取引が安全に見送られるよう改善しました。

* **Tests**
  * 予算配分の基準資本処理に関するテストスイートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->