### PR TITLE
feat(risk): 発注前の買付余力 pool ゲート (Webull Account Balance, #415)

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -334,6 +334,15 @@ export interface Env {
 }
 
 
+// #415: Account Balance endpoint path override (append at end)。買付余力 pool
+// pre-trade ゲート用。default v1 `/openapi/account/balance` (JP probe で 200 確認)。
+// `WEBULL_TRADE_VERSION=v2` 運用なら `/openapi/assets/balance` を指定する (同 shape)。
+// 未設定 / 空 / `/` 始まりでない値は fallback (絶対 URL 注入防止)。
+export interface Env {
+  WEBULL_PATH_ACCOUNT_BALANCE?: string
+}
+
+
 // #258: trade/account routes に送る x-version ヘッダ値の env override
 // (append at end)。default 'v1' (= 現行挙動)。新 OpenAPI docs では v2 必須化
 // の方向だが、旧 path も v1 alias で受理されてるので staging で env 切替えて

--- a/src/infrastructure/webull/WebullHttpClient.ts
+++ b/src/infrastructure/webull/WebullHttpClient.ts
@@ -1,6 +1,7 @@
 import type { OrderIntent } from '../../trading/domain/OrderIntent'
 import { BrokerRequestError, brokerErrorForStatus } from '../../shared/errors'
 import type {
+  WebullAccountBalanceDto,
   WebullAccountDto,
   WebullOrderDetailDto,
   WebullOrderHistoryWrapperDto,
@@ -54,6 +55,8 @@ export interface WebullClientEnv {
   WEBULL_PATH_POSITIONS?: string
   WEBULL_PATH_ORDERS_HISTORY?: string
   WEBULL_PATH_ORDERS_PLACE?: string
+  /** #415: Account Balance path override。default `/openapi/account/balance` (v1)。 */
+  WEBULL_PATH_ACCOUNT_BALANCE?: string
   /**
    * #258: trade/account routes に送る x-version ヘッダ値。default 'v1'
    * (= 現行挙動)、'v2' に opt-in 可能。新 docs では v2 推奨だが旧/新 path
@@ -89,6 +92,12 @@ interface WebullHttpClientOptions {
   ordersHistoryPath?: string
   ordersPlacePath?: string
   /**
+   * #415: Account Balance endpoint path。default は v1 `/openapi/account/balance`
+   * (JP probe で 200 確認)。`tradeVersion='v2'` 運用なら `/openapi/assets/balance`
+   * を env で指定する (同 shape を返す)。
+   */
+  accountBalancePath?: string
+  /**
    * #258: trade/account routes に送る x-version ヘッダ値。default 'v1' (= 現行
    * 挙動)、env で 'v2' に opt-in 可能。新 OpenAPI docs では v2 必須化の方向だが
    * v1 でも alias 受理されてるので staging で env 切替えて検証する。
@@ -105,6 +114,7 @@ interface WebullHttpClientOptions {
 const DEFAULT_POSITIONS_PATH = '/openapi/account/positions'
 const DEFAULT_ORDERS_HISTORY_PATH = '/openapi/account/orders/history'
 const DEFAULT_ORDERS_PLACE_PATH = '/openapi/account/orders/place'
+const DEFAULT_ACCOUNT_BALANCE_PATH = '/openapi/account/balance'
 const DEFAULT_TRADE_VERSION = 'v1'
 const DEFAULT_PLACE_ORDER_SCHEMA: PlaceOrderSchemaVersion = 'v1'
 /**
@@ -125,6 +135,7 @@ export class WebullHttpClient {
   private readonly positionsPath: string
   private readonly ordersHistoryPath: string
   private readonly ordersPlacePath: string
+  private readonly accountBalancePath: string
   private readonly tradeVersion: string
   private readonly placeOrderSchema: PlaceOrderSchemaVersion
 
@@ -145,6 +156,7 @@ export class WebullHttpClient {
     this.positionsPath = options.positionsPath ?? DEFAULT_POSITIONS_PATH
     this.ordersHistoryPath = options.ordersHistoryPath ?? DEFAULT_ORDERS_HISTORY_PATH
     this.ordersPlacePath = options.ordersPlacePath ?? DEFAULT_ORDERS_PLACE_PATH
+    this.accountBalancePath = options.accountBalancePath ?? DEFAULT_ACCOUNT_BALANCE_PATH
     this.tradeVersion = options.tradeVersion ?? DEFAULT_TRADE_VERSION
     this.placeOrderSchema = options.placeOrderSchema ?? DEFAULT_PLACE_ORDER_SCHEMA
   }
@@ -155,6 +167,16 @@ export class WebullHttpClient {
 
   async getAccount(): Promise<WebullAccountDto> {
     return this.request<WebullAccountDto>('GET', '/account/profile', {
+      query: { account_id: this.requireAccountId() },
+    })
+  }
+
+  /**
+   * 口座の現金残高・買付余力を取得 (#415)。`account_currency_assets[]` に通貨別
+   * `buying_power` が入る。発注前の共有プール pre-trade ゲートで使う。
+   */
+  async getAccountBalance(): Promise<WebullAccountBalanceDto> {
+    return this.request<WebullAccountBalanceDto>('GET', this.accountBalancePath, {
       query: { account_id: this.requireAccountId() },
     })
   }
@@ -509,6 +531,7 @@ export function createWebullHttpClient(
     positionsPath: trim(env.WEBULL_PATH_POSITIONS),
     ordersHistoryPath: trim(env.WEBULL_PATH_ORDERS_HISTORY),
     ordersPlacePath: trim(env.WEBULL_PATH_ORDERS_PLACE),
+    accountBalancePath: trim(env.WEBULL_PATH_ACCOUNT_BALANCE),
     tradeVersion: validateVersion(env.WEBULL_TRADE_VERSION),
     placeOrderSchema: validateOrderSchema(env.WEBULL_PLACE_ORDER_SCHEMA),
   })

--- a/src/infrastructure/webull/WebullReadClient.ts
+++ b/src/infrastructure/webull/WebullReadClient.ts
@@ -4,6 +4,7 @@ import {
   type WebullHttpClient,
 } from './WebullHttpClient'
 import type {
+  WebullAccountBalanceDto,
   WebullAccountDto,
   WebullOrderDetailDto,
   WebullPositionDto,
@@ -27,6 +28,10 @@ export class WebullReadClient {
 
   getAccount(): Promise<WebullAccountDto> {
     return this.http.getAccount()
+  }
+
+  getAccountBalance(): Promise<WebullAccountBalanceDto> {
+    return this.http.getAccountBalance()
   }
 
   findOrderByClientId(

--- a/src/infrastructure/webull/dto.ts
+++ b/src/infrastructure/webull/dto.ts
@@ -6,6 +6,35 @@ export interface WebullAccountDto {
   status?: string
 }
 
+/**
+ * 口座資産・買付余力 (`/openapi/account/balance` v1 / `/openapi/assets/balance` v2、
+ * #415)。JP 本番 probe で確認した shape:
+ *   { total_asset_currency:'JPY', total_cash_balance:'100000',
+ *     account_currency_assets:[{currency:'JPY', cash_balance, buying_power, ...},
+ *                              {currency:'USD', ...}] }
+ * 数値は全て string-encoded (OpenAPI 共通)。buying_power は **通貨別** に
+ * `account_currency_assets[]` に入る。mapper/reader 側で数値化する。
+ */
+export interface WebullAccountCurrencyAssetDto {
+  currency?: string
+  cash_balance?: string
+  buying_power?: string
+  /** v2 (`/openapi/assets/balance`) のみ。v1 では欠落。 */
+  market_value?: string
+  unrealized_profit_loss?: string
+}
+
+export interface WebullAccountBalanceDto {
+  /** 口座基準通貨 (例 'JPY')。 */
+  total_asset_currency?: string
+  total_cash_balance?: string
+  /** v2 のみ。 */
+  total_market_value?: string
+  total_unrealized_profit_loss?: string
+  /** 通貨別の現金 / 買付余力。POC: JPY + USD。 */
+  account_currency_assets?: WebullAccountCurrencyAssetDto[]
+}
+
 export interface WebullSubscriptionDto {
   subscription_id?: string
   user_id?: string

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -737,6 +737,9 @@ export const admin = new Hono<AppBindings>()
       positionsNew,
       orderHistoryOld,
       orderHistoryNew,
+      balanceAccountV1,
+      balanceAssetsV2,
+      balanceAssetsAccountV2,
     ] = await Promise.all([
       // path は WebullQuoteClient.DEFAULT_QUOTE_PATH と一致:
       // /openapi/market-data/stock/snapshot (× /openapi/quotes/v2/...)。
@@ -791,6 +794,28 @@ export const admin = new Hono<AppBindings>()
         query: { account_id: accountId, page_size: '10' },
         version: 'v2',
       }),
+      // #415 buying-power: Account Balance endpoint の path/version/レスポンス項目を
+      // 確定するための probe (doc: /api-doc/trade/account/account-balance)。positions が
+      // account/*(v1)→assets/*(v2) で drift した実績を踏まえ候補を並列で叩く。どれが
+      // 200 + buying-power フィールドを返すかで本実装の path/version/DTO を決める。
+      probeOnce({
+        method: 'GET',
+        path: '/openapi/account/balance',
+        query: { account_id: accountId },
+        version: 'v1',
+      }),
+      probeOnce({
+        method: 'GET',
+        path: '/openapi/assets/balance',
+        query: { account_id: accountId },
+        version: 'v2',
+      }),
+      probeOnce({
+        method: 'GET',
+        path: '/openapi/assets/account-balance',
+        query: { account_id: accountId },
+        version: 'v2',
+      }),
     ])
 
     // 診断 payload は raw broker レスポンスを含むので browser / 中間 cache に
@@ -826,6 +851,11 @@ export const admin = new Hono<AppBindings>()
       positionsNew,
       orderHistoryOld,
       orderHistoryNew,
+      // #415 buying-power: Account Balance endpoint 候補の probe 結果。どれが 200 +
+      // buying-power フィールドを返すかで本実装の path/version/DTO を確定する。
+      balanceAccountV1,
+      balanceAssetsV2,
+      balanceAssetsAccountV2,
       // Yahoo Finance 経由の同 symbol snapshot (#21 follow-up)。Webull の data-api
       // が応答しない状況での代替経路の生死を可視化する。
       quoteYahoo: quoteYahooResult,

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1687,6 +1687,12 @@ function brokerProbeBody(args: {
 <h2 style="font-size:14px;margin:16px 0 4px 0">quote 結果 (Yahoo Finance) <span class="muted" style="font-size:12px;font-weight:normal">— strategy cron が default で使う source</span></h2>
 <pre id="probe-quote-yahoo" style="background:#f6f6f6;border:1px solid #ddd;border-radius:4px;padding:8px;font-size:12px;overflow:auto;max-height:400px;white-space:pre-wrap;word-break:break-all">(まだ probe 未実行)</pre>
 
+<h2 style="font-size:14px;margin:16px 0 4px 0">買付余力 (buying power) <span class="muted" style="font-size:11px">#415</span></h2>
+<p class="muted" style="font-size:11px;margin:0 0 4px 0">
+  発注前の共有プール pre-trade ゲートが使う口座買付余力。通貨別 <code>buying_power</code> を表示。取得失敗時は cron が当 tick の BUY を全見送り (fail-closed)。
+</p>
+<div id="probe-buying-power" style="background:#f6f6f6;border:1px solid #ddd;border-radius:4px;padding:8px;font-size:13px">(まだ probe 未実行)</div>
+
 <h2 style="font-size:14px;margin:16px 0 4px 0">meta</h2>
 <pre id="probe-meta" style="background:#f6f6f6;border:1px solid #ddd;border-radius:4px;padding:8px;font-size:12px">(まだ probe 未実行)</pre>
 
@@ -1830,6 +1836,7 @@ function brokerProbeBody(args: {
         if (positionsNewRaw) positionsNewRaw.textContent = prettify(body.positionsNew);
         if (orderOldRaw) orderOldRaw.textContent = prettify(body.orderHistoryOld);
         if (orderNewRaw) orderNewRaw.textContent = prettify(body.orderHistoryNew);
+        renderBuyingPower(body);
         renderDriftTable(body);
         metaEl.textContent = JSON.stringify({
           timestamp: body.timestamp,
@@ -1844,6 +1851,46 @@ function brokerProbeBody(args: {
       .finally(function () {
         refreshBtn.disabled = false;
       });
+  }
+
+  // #415: 買付余力を描画。balance probe 候補 (account/balance v1, assets/balance v2)
+  // のうち最初に 200 を返したものを parse し、通貨別 buying_power を出す。
+  // どれも 200 でなければ ⚠ unavailable (= cron は当 tick の BUY を全見送り)。
+  function renderBuyingPower(body) {
+    var el = document.getElementById('probe-buying-power');
+    if (!el) return;
+    var candidates = [
+      { label: '/openapi/account/balance (v1)', section: body.balanceAccountV1 },
+      { label: '/openapi/assets/balance (v2)', section: body.balanceAssetsV2 },
+    ];
+    var hit = null;
+    for (var i = 0; i < candidates.length; i++) {
+      var s = candidates[i].section;
+      if (s && s.phase === 'response' && s.status === 200 && typeof s.bodyTruncated === 'string') {
+        var parsed = null;
+        try { parsed = JSON.parse(s.bodyTruncated); } catch (_) { parsed = null; }
+        if (parsed) { hit = { label: candidates[i].label, body: parsed }; break; }
+      }
+    }
+    if (!hit) {
+      el.innerHTML = '<span style="color:#c22;font-weight:600">⚠ 取得不可 (unavailable)</span> ' +
+        '<span class="muted" style="font-size:11px">— balance endpoint がどれも 200 を返さず。cron は当 tick の BUY を fail-closed で見送ります。</span>';
+      return;
+    }
+    var b = hit.body;
+    var assets = Array.isArray(b.account_currency_assets) ? b.account_currency_assets : [];
+    var rows = assets.map(function (a) {
+      return '<tr><td style="padding:2px 10px 2px 0"><code>' + (a.currency || '?') + '</code></td>' +
+        '<td style="padding:2px 10px;text-align:right;font-variant-numeric:tabular-nums">' + formatNumber(a.buying_power) + '</td>' +
+        '<td style="padding:2px 10px;text-align:right;font-variant-numeric:tabular-nums" class="muted">cash ' + formatNumber(a.cash_balance) + '</td></tr>';
+    }).join('');
+    el.innerHTML =
+      '<div style="margin-bottom:4px"><span style="color:#0a8a0a;font-weight:600">✅ 取得 OK</span> ' +
+      '<span class="muted" style="font-size:11px">via ' + hit.label + ' / 基準通貨 ' + (b.total_asset_currency || '?') +
+      ' / 総現金 ' + formatNumber(b.total_cash_balance) + '</span></div>' +
+      '<table style="font-size:12px;border-collapse:collapse"><thead><tr class="muted">' +
+      '<th style="text-align:left;padding:2px 10px 2px 0">通貨</th><th style="text-align:right;padding:2px 10px">買付余力</th><th></th></tr></thead>' +
+      '<tbody>' + (rows || '<tr><td colspan="3" class="muted">(通貨別資産なし)</td></tr>') + '</tbody></table>';
   }
 
   // drift 比較テーブルを描画。各行は status / msTaken を旧/新 並列表示。
@@ -1864,7 +1911,8 @@ function brokerProbeBody(args: {
     }
     tableBody.innerHTML =
       row('positions', body.positions, body.positionsNew) +
-      row('order history', body.orderHistoryOld, body.orderHistoryNew);
+      row('order history', body.orderHistoryOld, body.orderHistoryNew) +
+      row('account balance', body.balanceAccountV1, body.balanceAssetsV2);
   }
 
   function onPickClick(ev) {

--- a/src/trading/strategy/buyingPower.ts
+++ b/src/trading/strategy/buyingPower.ts
@@ -1,0 +1,119 @@
+// 買付余力の共有プール pre-trade ゲート (#415)。
+//
+// budget 配分は各銘柄を口座共有プール (円) に対する % で sizing するが、発注時に
+// 実際の買付余力を見ていないと、複数銘柄の合算が実余力を超えて Webull が約定前に
+// 417 (Insufficient Buying Power) で拒否する。本モジュールは Webull Account Balance
+// から得た **JPY 基準の買付余力**を 1 tick 分の「台帳 (ledger)」として持ち、scheduler が
+// 発注ごとに残余力を予約 (decrement) して超過注文を pre-trade で reject できるようにする。
+//
+// fail-safe: 余力が取得できない/異常な tick は `unavailable` 台帳にして当 tick の BUY を
+// 全見送り (fail-closed)。誤った余力で過大発注しない。Webull 自体の 417 は最終防壁 (二重)。
+
+import type { WebullAccountBalanceDto } from '../../infrastructure/webull/dto'
+
+/** sizing→fill 間の値動き / 手数料 / 端数を吸収する既定の安全バッファ (1%)。 */
+export const DEFAULT_BUYING_POWER_BUFFER_PCT = 0.01
+
+export interface BuyingPowerLedger {
+  /** `ok` = 余力取得済で予約可能。`unavailable` = 取得失敗 → BUY 全 reject。 */
+  status: 'ok' | 'unavailable'
+  /** 残余力 (JPY 基準、安全バッファ適用後)。`unavailable` 時は 0。 */
+  remainingJpy: number
+  /** 取得時刻 (ISO)。dashboard 表示用。 */
+  asOf: string | null
+  /** 取得元ラベル (例 'webull-balance')。 */
+  source: string
+  /** `unavailable` の理由 (dashboard / log 用)。 */
+  reason?: string
+  /**
+   * `notionalJpy` (JPY 基準) を予約する。`ok` かつ残余力で賄えるなら減算して true、
+   * それ以外は false (= 発注見送り)。非有限/非正の notional も false。
+   */
+  tryReserve(notionalJpy: number): boolean
+  /** 予約後に submit が失敗した時、予約を戻す (他銘柄判定を歪めないため)。 */
+  refund(notionalJpy: number): void
+}
+
+/** 取得失敗 tick 用。常に予約失敗 = 当 tick の BUY を全 fail-closed。 */
+export function createUnavailableBuyingPowerLedger(reason: string): BuyingPowerLedger {
+  return {
+    status: 'unavailable',
+    remainingJpy: 0,
+    asOf: null,
+    source: 'webull-balance',
+    reason,
+    tryReserve() {
+      return false
+    },
+    refund() {
+      /* no-op */
+    },
+  }
+}
+
+/** 取得成功 tick 用。`availableJpy` に安全バッファを掛けた額を残余力の初期値にする。 */
+export function createBuyingPowerLedger(opts: {
+  availableJpy: number
+  asOf: string | null
+  source?: string
+  bufferPct?: number
+}): BuyingPowerLedger {
+  const buffer = opts.bufferPct ?? DEFAULT_BUYING_POWER_BUFFER_PCT
+  const safeBuffer = Number.isFinite(buffer) && buffer >= 0 && buffer < 1 ? buffer : DEFAULT_BUYING_POWER_BUFFER_PCT
+  const base = Number.isFinite(opts.availableJpy) && opts.availableJpy > 0 ? opts.availableJpy : 0
+  const ledger: BuyingPowerLedger = {
+    status: 'ok',
+    remainingJpy: base * (1 - safeBuffer),
+    asOf: opts.asOf,
+    source: opts.source ?? 'webull-balance',
+    tryReserve(notionalJpy: number): boolean {
+      if (!Number.isFinite(notionalJpy) || notionalJpy <= 0) return false
+      if (notionalJpy > ledger.remainingJpy) return false
+      ledger.remainingJpy -= notionalJpy
+      return true
+    },
+    refund(notionalJpy: number): void {
+      if (Number.isFinite(notionalJpy) && notionalJpy > 0) ledger.remainingJpy += notionalJpy
+    },
+  }
+  return ledger
+}
+
+/**
+ * Webull Account Balance から **JPY 基準の合計買付余力**を算出する。`account_currency_assets[]`
+ * の通貨別 `buying_power` を JPY に換算して合算する (USD は `usdJpyRate` で換算)。
+ *
+ * 算出不能なら **null (= 呼び出し側で fail-closed)**:
+ *   - 配列が無い / 空
+ *   - いずれかの buying_power が非有限 / 負 (異常値)
+ *   - USD 等の非 JPY 通貨に余力があるのに `usdJpyRate` が無効 (誤換算で過大発注しない)
+ *   - JPY/USD 以外の通貨に余力がある (未対応通貨は安全側で fail-closed)
+ */
+export function buyingPowerJpyFromBalance(
+  balance: WebullAccountBalanceDto,
+  usdJpyRate: number | null,
+): { jpy: number; byCurrency: Record<string, number> } | null {
+  const assets = balance.account_currency_assets
+  if (!Array.isArray(assets) || assets.length === 0) return null
+  const fxOk = usdJpyRate !== null && Number.isFinite(usdJpyRate) && usdJpyRate > 0
+  let jpy = 0
+  const byCurrency: Record<string, number> = {}
+  for (const asset of assets) {
+    const ccy = (asset.currency ?? '').trim().toUpperCase()
+    const bp = Number(asset.buying_power)
+    if (!Number.isFinite(bp) || bp < 0) return null // 異常値 → fail-closed
+    byCurrency[ccy] = bp
+    if (ccy === 'JPY') {
+      jpy += bp
+    } else if (ccy === 'USD') {
+      if (bp > 0) {
+        if (!fxOk) return null // USD 余力ありだが FX 取得失敗 → fail-closed
+        jpy += bp * (usdJpyRate as number)
+      }
+    } else if (bp > 0) {
+      return null // 未対応通貨に余力 → fail-closed
+    }
+  }
+  if (!Number.isFinite(jpy) || jpy < 0) return null
+  return { jpy, byCurrency }
+}

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -14,6 +14,7 @@ import {
   type DailyBar,
 } from './indicators'
 import { computePullbackSizing } from './pullbackSizing'
+import type { BuyingPowerLedger } from './buyingPower'
 import type { ExecutionResult } from '../domain/ExecutionResult'
 import type { OrderIntent } from '../domain/OrderIntent'
 import {
@@ -81,6 +82,13 @@ export interface PullbackSchedulerOptions {
    * USD で FX 取得失敗時は undefined を渡し、budget 銘柄を fail-closed させる。
    */
   fxJpyPerSymbolCcy?: number
+  /**
+   * 口座買付余力の共有プール台帳 (#415)。指定時、BUY の submit 直前に notional を
+   * JPY 換算して `tryReserve` し、超過 / `unavailable` は pre-trade で reject する
+   * (Webull 417 をローカルで先回り)。runs (USD/JPY) をまたいで同一 ledger を共有
+   * する想定。未指定 (DryRun / legacy / test) は pool ゲート無効。
+   */
+  buyingPower?: BuyingPowerLedger
   /**
    * Per-symbol decision sink。HOLD / BUY / SELL / REJECT / ERROR の各 route で
    * 1 回ずつ呼ばれる。実装は D1 INSERT が典型 (#128)、テストは fake 注入可能。
@@ -767,6 +775,34 @@ export async function runPullbackScheduler(
       }
     }
 
+    // #415: 買付余力 pool ゲート (BUY only)。notional を JPY 換算して共有台帳の残余力と
+    // 突き合わせ、unavailable / 不足は pre-trade で reject (Webull 417 をローカル先回り)。
+    // 減算は約定成立後 (loop は逐次なので check→commit で整合)。SELL/exit は対象外。
+    if (intent.side === 'BUY' && options.buyingPower) {
+      const ledger = options.buyingPower
+      const notionalJpy = intent.notional * (options.fxJpyPerSymbolCcy ?? 1)
+      const insufficient = ledger.status !== 'ok' || notionalJpy > ledger.remainingJpy
+      if (insufficient) {
+        const reason =
+          ledger.status !== 'ok'
+            ? `risk: buying-power unavailable (${ledger.reason ?? 'fetch failed'})`
+            : `risk: insufficient buying power (notionalJpy ${Math.round(notionalJpy)} > remaining ${Math.round(ledger.remainingJpy)})`
+        summary.rejected.push({ symbol: upper, reason })
+        await emitDecision({
+          symbol: upper,
+          decision: 'REJECT',
+          reason,
+          price: indicators.price,
+          indicatorsJson: JSON.stringify(indicators),
+          trace: appendTrace(
+            signal.trace,
+            traceStep('risk.buying_power_pool', false, Math.round(notionalJpy), '<=', Math.round(ledger.remainingJpy), reason),
+          ),
+        })
+        continue
+      }
+    }
+
     const expiresAtMs = now().getTime() + pendingLockTtlMs
     if (!Number.isFinite(expiresAtMs) || expiresAtMs <= now().getTime()) {
       const reason = `invalid expiresAt computed from pendingLockTtlMs: ${pendingLockTtlMs}`
@@ -943,6 +979,8 @@ export async function runPullbackScheduler(
     // Increment counters only after successful execution.
     if (executedIntent.side === 'BUY') {
       summary.buys += 1
+      // #415: 約定した BUY 分の買付余力を共有台帳から減算 (次銘柄の pool 判定に反映)。
+      options.buyingPower?.tryReserve(intent.notional * (options.fxJpyPerSymbolCcy ?? 1))
     } else {
       summary.sells += 1
     }
@@ -1161,6 +1199,7 @@ const TRACE_LABEL_JA: Record<string, string> = {
   'risk.macro_event': 'マクロイベントゲート',
   'risk.per_symbol_gate': '銘柄別リスクゲート',
   'risk.vix_regime': 'VIX レジーム判定',
+  'risk.buying_power_pool': '口座買付余力プール (発注前)',
   'risk.sanity_failed_cooldown': 'sanity_failed cooldown (broker stub 疑い)',
   'broker.submit': '証券会社への発注送信',
   'broker.sell_qty_fallback': 'SELL 数量超過時の broker available qty 再 submit',

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -1,6 +1,13 @@
 import type { Env } from '../../config/env'
 import { YahooBarClient } from '../../infrastructure/quotes/YahooBarClient'
 import { loadUsdJpyRate } from '../../infrastructure/quotes/fxRate'
+import type { WebullAccountBalanceDto } from '../../infrastructure/webull/dto'
+import {
+  buyingPowerJpyFromBalance,
+  createBuyingPowerLedger,
+  createUnavailableBuyingPowerLedger,
+  type BuyingPowerLedger,
+} from './buyingPower'
 import { loadGlobalConfigFrom } from '../../infrastructure/db/globalConfigLoader'
 import { loadSymbolUniverse } from '../../infrastructure/db/symbolUniverse'
 import type { SymbolCurrency } from '../../infrastructure/db/symbolConfigRepo'
@@ -551,9 +558,18 @@ export async function runStrategyCron(
   const usdHasBudgetSymbol = byCurrency.USD.some(
     (s) => universe.symbolBudgetAllocPct[s.toUpperCase()] !== undefined,
   )
-  const usdJpyRate = usdHasBudgetSymbol
-    ? await loadUsdJpyRate({ requestId: options.requestId })
-    : null
+  // USD/JPY は budget 換算に加え、live 時は買付余力 (USD 建て) の JPY 換算にも要る
+  // ので、live ならば取得する (#415)。
+  const needUsdJpy = usdHasBudgetSymbol || liveReadClient !== null
+  const usdJpyRate = needUsdJpy ? await loadUsdJpyRate({ requestId: options.requestId }) : null
+
+  // #415: 発注前の共有プール pre-trade ゲート。live 時のみ Webull の買付余力を取得し
+  // JPY 基準の ledger を作る (runs=USD/JPY をまたいで共有)。取得失敗/異常値は
+  // unavailable 台帳 → 当 tick の BUY 全 fail-closed (誤余力で過大発注しない)。
+  // DryRun (liveReadClient=null) では undefined のまま = scheduler の pool ゲート無効。
+  const buyingPower: BuyingPowerLedger | undefined = liveReadClient
+    ? await resolveBuyingPowerLedger(liveReadClient, usdJpyRate, options.requestId)
+    : undefined
 
   for (const run of runs) {
     analysis.runs.push({
@@ -575,6 +591,7 @@ export async function runStrategyCron(
       symbolBudgetAllocPctMap: universe.symbolBudgetAllocPct,
       budgetBasisJpy,
       fxJpyPerSymbolCcy,
+      buyingPower,
       defaultRule,
       rulesMap,
       riskPerTradePct: scaledRiskPerTradePct,
@@ -669,6 +686,41 @@ function sanitizeEquity(value: number | null | undefined, fallback: number): num
   if (value === null || value === undefined) return fallback
   if (!Number.isFinite(value) || value <= 0) return fallback
   return value
+}
+
+/**
+ * Webull 買付余力を取得し JPY 基準の共有 ledger を作る (#415)。HTTP client が
+ * 内部で transient retry するので、ここでは 1 回呼んで成否を判定する。例外 / parse
+ * 不能 / 異常値 / FX 欠落は **unavailable 台帳** (= 当 tick の BUY 全 fail-closed)。
+ * 構造化ログ (requestId 付き) で取得結果を残す。
+ */
+async function resolveBuyingPowerLedger(
+  readClient: { getAccountBalance(): Promise<WebullAccountBalanceDto> },
+  usdJpyRate: number | null,
+  requestId: string | undefined,
+): Promise<BuyingPowerLedger> {
+  try {
+    const balance = await readClient.getAccountBalance()
+    const bp = buyingPowerJpyFromBalance(balance, usdJpyRate)
+    if (bp === null) {
+      console.warn(
+        JSON.stringify({
+          event: 'buying_power_unavailable',
+          reason: 'balance parse failed / anomaly / missing FX',
+          requestId,
+        }),
+      )
+      return createUnavailableBuyingPowerLedger('balance parse failed / anomaly / missing FX')
+    }
+    console.warn(
+      JSON.stringify({ event: 'buying_power_fetched', jpy: bp.jpy, byCurrency: bp.byCurrency, requestId }),
+    )
+    return createBuyingPowerLedger({ availableJpy: bp.jpy, asOf: new Date().toISOString() })
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error)
+    console.warn(JSON.stringify({ event: 'buying_power_unavailable', reason, requestId }))
+    return createUnavailableBuyingPowerLedger(reason)
+  }
 }
 
 /**

--- a/test/strategy/buyingPower.test.ts
+++ b/test/strategy/buyingPower.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buyingPowerJpyFromBalance,
+  createBuyingPowerLedger,
+  createUnavailableBuyingPowerLedger,
+  DEFAULT_BUYING_POWER_BUFFER_PCT,
+} from '../../src/trading/strategy/buyingPower'
+import type { WebullAccountBalanceDto } from '../../src/infrastructure/webull/dto'
+
+const balance = (assets: Array<{ currency: string; buying_power: string }>): WebullAccountBalanceDto => ({
+  total_asset_currency: 'JPY',
+  account_currency_assets: assets,
+})
+
+describe('buyingPowerJpyFromBalance', () => {
+  it('sums JPY + USD(×fx) buying power into a JPY base', () => {
+    const r = buyingPowerJpyFromBalance(
+      balance([
+        { currency: 'JPY', buying_power: '100000' },
+        { currency: 'USD', buying_power: '200' },
+      ]),
+      150,
+    )
+    expect(r).not.toBeNull()
+    expect(r!.jpy).toBeCloseTo(100000 + 200 * 150, 4) // 130,000
+    expect(r!.byCurrency).toEqual({ JPY: 100000, USD: 200 })
+  })
+
+  it('JPY-only account needs no FX', () => {
+    const r = buyingPowerJpyFromBalance(
+      balance([
+        { currency: 'JPY', buying_power: '100000' },
+        { currency: 'USD', buying_power: '0.00' },
+      ]),
+      null,
+    )
+    expect(r!.jpy).toBe(100000)
+  })
+
+  it('fail-closed (null) when USD buying power > 0 but FX missing', () => {
+    expect(
+      buyingPowerJpyFromBalance(
+        balance([
+          { currency: 'JPY', buying_power: '100000' },
+          { currency: 'USD', buying_power: '200' },
+        ]),
+        null,
+      ),
+    ).toBeNull()
+  })
+
+  it('fail-closed on anomalous (negative / non-finite) buying power', () => {
+    expect(buyingPowerJpyFromBalance(balance([{ currency: 'JPY', buying_power: '-1' }]), 150)).toBeNull()
+    expect(buyingPowerJpyFromBalance(balance([{ currency: 'JPY', buying_power: 'abc' }]), 150)).toBeNull()
+  })
+
+  it('fail-closed on missing / empty asset array', () => {
+    expect(buyingPowerJpyFromBalance({}, 150)).toBeNull()
+    expect(buyingPowerJpyFromBalance({ account_currency_assets: [] }, 150)).toBeNull()
+  })
+
+  it('fail-closed on an unsupported currency with non-zero buying power', () => {
+    expect(
+      buyingPowerJpyFromBalance(balance([{ currency: 'HKD', buying_power: '500' }]), 150),
+    ).toBeNull()
+  })
+})
+
+describe('BuyingPowerLedger', () => {
+  it('reserves down to zero and rejects over-reservation', () => {
+    const l = createBuyingPowerLedger({ availableJpy: 100_000, asOf: '2026-06-05T00:00:00Z', bufferPct: 0 })
+    expect(l.status).toBe('ok')
+    expect(l.remainingJpy).toBe(100_000)
+    expect(l.tryReserve(60_000)).toBe(true)
+    expect(l.remainingJpy).toBe(40_000)
+    expect(l.tryReserve(60_000)).toBe(false) // exceeds remaining
+    expect(l.remainingJpy).toBe(40_000) // unchanged on failed reserve
+    expect(l.tryReserve(40_000)).toBe(true)
+    expect(l.remainingJpy).toBe(0)
+  })
+
+  it('applies the default safety buffer to the initial remaining', () => {
+    const l = createBuyingPowerLedger({ availableJpy: 100_000, asOf: null })
+    expect(l.remainingJpy).toBeCloseTo(100_000 * (1 - DEFAULT_BUYING_POWER_BUFFER_PCT), 4)
+  })
+
+  it('rejects non-finite / non-positive reservations', () => {
+    const l = createBuyingPowerLedger({ availableJpy: 100_000, asOf: null, bufferPct: 0 })
+    expect(l.tryReserve(0)).toBe(false)
+    expect(l.tryReserve(-1)).toBe(false)
+    expect(l.tryReserve(Number.NaN)).toBe(false)
+    expect(l.remainingJpy).toBe(100_000)
+  })
+
+  it('refund restores reserved amount', () => {
+    const l = createBuyingPowerLedger({ availableJpy: 100_000, asOf: null, bufferPct: 0 })
+    l.tryReserve(30_000)
+    l.refund(30_000)
+    expect(l.remainingJpy).toBe(100_000)
+  })
+
+  it('unavailable ledger always rejects reservations (fail-closed)', () => {
+    const l = createUnavailableBuyingPowerLedger('fetch failed')
+    expect(l.status).toBe('unavailable')
+    expect(l.remainingJpy).toBe(0)
+    expect(l.tryReserve(1)).toBe(false)
+    expect(l.reason).toBe('fetch failed')
+  })
+})

--- a/test/trading/strategy/pullbackScheduler.test.ts
+++ b/test/trading/strategy/pullbackScheduler.test.ts
@@ -10,6 +10,10 @@ import type { Execution } from '../../../src/trading/execution/Execution'
 import type { PositionStore } from '../../../src/trading/state/PositionStore'
 import { emptySymbolState, type SymbolState } from '../../../src/trading/state/types'
 import { runPullbackScheduler } from '../../../src/trading/strategy/pullbackScheduler'
+import {
+  createBuyingPowerLedger,
+  createUnavailableBuyingPowerLedger,
+} from '../../../src/trading/strategy/buyingPower'
 import type { DailyBar } from '../../../src/trading/strategy/indicators'
 
 const now = new Date('2026-04-20T14:30:00.000Z')
@@ -1607,5 +1611,90 @@ describe('runPullbackScheduler budget-alloc basis fail-closed (#417 buying-power
     })
     expect(summary.buys).toBe(1)
     expect(execution.calls).toHaveLength(1)
+  })
+})
+
+describe('runPullbackScheduler buying-power pool gate (#415)', () => {
+  it('fail-closed: rejects BUY when the ledger is unavailable (fetch failed)', async () => {
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution,
+      symbolLotSizeMap: { AAPL: 1 },
+      buyingPower: createUnavailableBuyingPowerLedger('fetch failed'),
+      now: () => now,
+    })
+    expect(summary.buys).toBe(0)
+    expect(execution.calls).toHaveLength(0)
+    const aapl = summary.decisions.find((d) => d.symbol === 'AAPL')
+    expect(aapl?.decision).toBe('REJECT')
+    expect(aapl?.reason).toMatch(/buying-power unavailable/)
+  })
+
+  it('places a BUY and decrements the ledger when buying power is sufficient', async () => {
+    const execution = mockExecution()
+    const ledger = createBuyingPowerLedger({ availableJpy: 1_000_000_000, asOf: null, bufferPct: 0 })
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution,
+      symbolLotSizeMap: { AAPL: 1 },
+      fxJpyPerSymbolCcy: 150,
+      buyingPower: ledger,
+      now: () => now,
+    })
+    expect(summary.buys).toBe(1)
+    expect(execution.calls).toHaveLength(1)
+    expect(ledger.remainingJpy).toBeLessThan(1_000_000_000) // 約定分が減算された
+  })
+
+  it('rejects BUY (no execution) when notional exceeds remaining buying power', async () => {
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution,
+      symbolLotSizeMap: { AAPL: 1 },
+      fxJpyPerSymbolCcy: 150,
+      buyingPower: createBuyingPowerLedger({ availableJpy: 1, asOf: null, bufferPct: 0 }),
+      now: () => now,
+    })
+    expect(summary.buys).toBe(0)
+    expect(execution.calls).toHaveLength(0)
+    const aapl = summary.decisions.find((d) => d.symbol === 'AAPL')
+    expect(aapl?.decision).toBe('REJECT')
+    expect(aapl?.reason).toMatch(/insufficient buying power/)
+  })
+
+  it('shared pool covers only the first of two BUYs (sequential decrement)', async () => {
+    // budget mode + symbolCap で notional を 1 銘柄 ≈ ¥49,937 に固定 (fx=1)。
+    // pool ¥60,000 → 1 件目は通り、2 件目は残余力不足で reject。
+    const execution = mockExecution()
+    const ledger = createBuyingPowerLedger({ availableJpy: 60_000, asOf: null, bufferPct: 0 })
+    const summary = await runPullbackScheduler({
+      symbols: ['AAA', 'BBB'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution,
+      symbolLotSizeMap: { AAA: 1, BBB: 1 },
+      symbolBudgetAllocPctMap: { AAA: 1, BBB: 1 },
+      symbolCapMap: { AAA: 50_000, BBB: 50_000 },
+      budgetBasisJpy: 1_000_000,
+      fxJpyPerSymbolCcy: 1,
+      buyingPower: ledger,
+      now: () => now,
+    })
+    expect(summary.buys).toBe(1)
+    expect(execution.calls).toHaveLength(1)
+    const rejected = summary.decisions.filter((d) => d.decision === 'REJECT')
+    expect(rejected.some((d) => /insufficient buying power/.test(d.reason ?? ''))).toBe(true)
   })
 })


### PR DESCRIPTION
## 何を / なぜ

口座共有プールに対する budget% sizing が**発注時に実買付余力を見ておらず**、複数銘柄の合算が余力超過で Webull が `417 Insufficient Buying Power` を返していた (decision 605 TQQQ)。**発注前に実買付余力でゲート**し、417 をローカルで先回り reject する。#415 の恒久対応。

## Phase 0 — probe-first で endpoint 確定 (実施済)
`/admin/broker/probe` に balance 候補を追加し staging 実トークンで実行 → **`GET /openapi/account/balance` (v1) が 200**、`account_currency_assets[]` に**通貨別 `buying_power`** を返すと確認 (`/openapi/assets/balance` v2 も同形、`assets/account-balance` は 404):
```json
{"total_asset_currency":"JPY","total_cash_balance":"100000",
 "account_currency_assets":[{"currency":"JPY","buying_power":"100000",...},{"currency":"USD","buying_power":"0.00",...}]}
```

## 実装
- **client**: `WebullHttpClient.getAccountBalance()` + `WebullAccountBalanceDto` + `WebullReadClient` passthrough。env `WEBULL_PATH_ACCOUNT_BALANCE` (default `/openapi/account/balance`)。
- **`buyingPower.ts`**: `BuyingPowerLedger` (`tryReserve`/`refund`、安全バッファ default 1%) + `buyingPowerJpyFromBalance` (通貨別 buying_power を USD/JPY で **JPY 基準に合算**、異常値/FX欠落/未対応通貨は **fail-closed = null**)。
- **cron** (`runStrategyCron`): live (`dryRun=false`) 時のみ余力取得 (HTTP client が transient retry → 失敗は fail-closed)。JPY 基準 ledger を per-currency runs 間で**共有**。取得失敗/異常は **unavailable 台帳 = 当 tick の BUY 全 fail-closed**、SELL/exit は継続。構造化ログ (`buying_power_fetched`/`unavailable`、requestId 付き)。
- **scheduler** (`pullbackScheduler`): BUY の submit 直前に `notionalJpy = notional × fxJpyPerSymbolCcy` で pool チェック (`unavailable`/不足は pre-trade reject、trace `risk.buying_power_pool`)、**約定後に減算** (loop は逐次なので check→commit で整合)。未指定 (DryRun/legacy/test) は無効。
- **dashboard**: broker-probe ページに**買付余力パネル** (通貨別 buying_power / 基準通貨 / ✅取得OK / ⚠unavailable) + drift テーブルに account balance 行。

## fail-safe / real-money (合意方針)
余力取得失敗/異常値は **fail-closed (当 tick BUY 全停止) + retry** (HTTP client 内蔵)。誤余力での過大発注を回避。Webull 417 も最終防壁 (二重)。USD→JPY 換算は検証済 `loadUsdJpyRate` のみ。安全バッファで sizing→fill 値動き/端数吸収。

## テスト
`pnpm typecheck` / `pnpm test` → **1266 passed**。`buyingPower` 単体 (JPY+USD合算 / FX欠落・異常・未対応通貨で fail-closed / ledger reserve・refund・unavailable)、scheduler (unavailable→reject / 余力十分→BUY+減算 / 不足→reject / 共有プールが 2 銘柄中 1 件のみ通す逐次減算)。

## 運用 (要対応)
1. **production の balance endpoint version を確認**: 本番が `WEBULL_TRADE_VERSION=v2` 運用なら `WEBULL_PATH_ACCOUNT_BALANCE=/openapi/assets/balance` を設定 (v1 運用なら default のままで可)。`/admin/broker/probe` の「買付余力」パネルで✅が出れば OK。
2. これで TQQQ 等は余力超過時に 417 ではなく `risk: insufficient buying power` で pre-trade reject される。

Closes #415。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 口座残高・買付余力の取得に対応し、複数エンドポイントをサポート
  * ダッシュボードの診断画面に「買付余力」セクションを追加
  * 発注前の買付余力チェック機能を実装。複数銘柄にまたがる自動取引での過度な買付を防止

* **Tests**
  * 買付余力計算ロジック・レッジャー予約機能の検証テスト一式を追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->