### PR TITLE
docs(config): total_capital_jpy は budget 単一プール基準であることを明記

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -2778,11 +2778,13 @@ const CONFIG_KEY_META: Record<string, ConfigKeyMeta> = {
   },
   total_capital_usd: {
     label: '運用資本 (USD)',
-    detail: 'US 株に割り当てる運用資金 (ドル)。この金額を元に 1 回のリスク額や保有上限を計算します。',
+    detail:
+      'risk-% sizing (stop 距離ベース) の US 株 equity 基準 (ドル)。budget配分% (budget_alloc_pct) 指定銘柄は通貨に関係なく total_capital_jpy 単一プールを使うため、こちらは不要 (USD risk-% 銘柄がある時のみ設定)。',
   },
   total_capital_jpy: {
-    label: '運用資本 (JPY)',
-    detail: '日本株に割り当てる運用資金 (円)。この金額を元に 1 回のリスク額や保有上限を計算します。',
+    label: '運用資本 (JPY / 口座総額)',
+    detail:
+      '口座の運用資本 (円)。budget配分% (budget_alloc_pct) 指定銘柄は通貨に関係なく **この円総額が単一プール基準** (USD 銘柄も USD/JPY で円換算して sizing、#407)。risk-% sizing の日本株 equity 基準も兼ねる。買付余力 pool ゲートの円換算基準でもある (#415)。',
   },
   max_portfolio_exposure_pct: {
     label: 'portfolio exposure 上限率 (比率)',


### PR DESCRIPTION
## 何を / なぜ

dashboard の config 説明文が #407 (予算配分の円単一プール統一) 前のままで、実態と食い違っていた:

- `total_capital_jpy` の説明が「**日本株に割り当てる**運用資金 (円)」 → だが #407 以降、**budget配分% (`budget_alloc_pct`) 指定銘柄は US 含め通貨に関係なくこの円総額が単一プール基準** (USD は USD/JPY で換算)。買付余力 pool ゲート (#415) の円換算基準でもある。
- production の active 銘柄 (SOXL/SOXS/TQQQ/SQQQ) は全部 budget% なので `total_capital_jpy` で sizing されるのに、説明文だと「USなら total_capital_usd では?」と誤解する (実際に混乱が発生)。

> 本体 (#417 買付余力 pool) のマージ後に積んだ説明文コミットが宙に浮いていたので、main へ入れ直す PR。

## 変更
- `total_capital_jpy`: ラベルを「運用資本 (JPY / 口座総額)」に。説明を「budget配分%銘柄は通貨に関係なくこの円総額が単一プール基準 (USD は FX 換算、#407)、risk-% の日本株 equity 基準も兼ね、買付余力 pool の円換算基準 (#415)」に更新。
- `total_capital_usd`: 「risk-% sizing の US株 equity 基準。budget%銘柄は円プールを使うので不要」と明確化。

設定値・挙動の変更なし (説明文のみ)。`pnpm typecheck` / dashboard test green。