### PR TITLE
feat(observability): broker-error ログに発注数量 + ¥/$ 両建て金額を併記 (#417 follow-up)

### DIFF
--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -898,7 +898,9 @@ export async function runPullbackScheduler(
           symbol: upper,
           decision: 'ERROR',
           // DB には英語 canonical で保存。表示層 (localizeReason) で日本語化。
-          reason: `broker submit error: ${messageOf(error)}`,
+          // localize は `^broker submit error: ` を prefix match するので、発注内容
+          // (何口 / $ と ¥) は **message の後ろ**に付けて prefix を壊さない (#417)。
+          reason: `broker submit error: ${messageOf(error)} [${describeOrderAmount(intent, options.fxJpyPerSymbolCcy)}]`,
           price: indicators.price,
           trace: appendTrace(signal.trace, traceStep('broker.submit', false, messageOf(error), '==', 'submitted')),
         })
@@ -1154,6 +1156,23 @@ function buildIntent(symbol: string, side: 'BUY' | 'SELL', qty: number, price: n
 
 function messageOf(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
+}
+
+/**
+ * 発注しようとした数量・金額を「何口 / いくら」で人間可読に整形する (#417 follow-up)。
+ * USD 銘柄 (fx>0 かつ !=1) は **$ と ¥ を併記** (notional × USD/JPY)、JPY 銘柄 (fx=1) は ¥、
+ * fx 不明は通貨記号なし。decision log の reason に付けて 417 等の原因切り分けに使う。
+ */
+function describeOrderAmount(intent: OrderIntent, fxJpyPerSymbolCcy: number | undefined): string {
+  const { quantity: qty, price: px, notional } = intent
+  const yen = (n: number) => `¥${Math.round(n).toLocaleString('en-US')}`
+  if (fxJpyPerSymbolCcy !== undefined && Number.isFinite(fxJpyPerSymbolCcy) && fxJpyPerSymbolCcy > 0) {
+    if (fxJpyPerSymbolCcy === 1) {
+      return `発注内容: ${qty}口 @ ${yen(px)} = ${yen(notional)}`
+    }
+    return `発注内容: ${qty}口 @ $${px} = $${notional.toFixed(2)} ≈ ${yen(notional * fxJpyPerSymbolCcy)} (USD/JPY ${fxJpyPerSymbolCcy})`
+  }
+  return `発注内容: ${qty}口 @ ${px} = ${notional} (通貨不明)`
 }
 
 function appendTrace(

--- a/test/trading/strategy/pullbackScheduler.test.ts
+++ b/test/trading/strategy/pullbackScheduler.test.ts
@@ -1698,3 +1698,59 @@ describe('runPullbackScheduler buying-power pool gate (#415)', () => {
     expect(rejected.some((d) => /insufficient buying power/.test(d.reason ?? ''))).toBe(true)
   })
 })
+
+describe('runPullbackScheduler broker-error decision embeds order amount (#417)', () => {
+  it('includes qty + USD/JPY notional in the ERROR reason for a USD symbol', async () => {
+    const throwing: Execution & { calls: unknown[] } = {
+      calls: [],
+      async execute(intent) {
+        ;(throwing.calls as unknown[]).push(intent)
+        throw new BrokerClientError(
+          'Webull request failed permanently with status 417: {"error_code":"OAUTH_OPENAPI_ORDER_BUYING_POWER_NOT_ENOUGH"}',
+          'POST /openapi/account/orders/place',
+          { brokerStatus: 417 },
+        )
+      },
+    }
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution: throwing,
+      symbolLotSizeMap: { AAPL: 1 },
+      fxJpyPerSymbolCcy: 150,
+      now: () => now,
+    })
+    const err = summary.decisions.find((d) => d.decision === 'ERROR')
+    expect(err).toBeDefined()
+    // localize 用の prefix は維持 (発注内容は message の後ろ)。
+    expect(err?.reason).toMatch(/^broker submit error: /)
+    expect(err?.reason).toMatch(/発注内容: \d+口/)
+    expect(err?.reason).toContain('$') // USD notional
+    expect(err?.reason).toContain('¥') // JPY 換算
+    expect(err?.reason).toContain('USD/JPY 150')
+  })
+
+  it('shows ¥ only for a JPY symbol (fx=1)', async () => {
+    const throwing: Execution & { calls: unknown[] } = {
+      calls: [],
+      async execute() {
+        throw new BrokerClientError('boom 417', 'POST /place', { brokerStatus: 417 })
+      },
+    }
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution: throwing,
+      symbolLotSizeMap: { AAPL: 1 },
+      fxJpyPerSymbolCcy: 1,
+      now: () => now,
+    })
+    const err = summary.decisions.find((d) => d.decision === 'ERROR')
+    expect(err?.reason).toMatch(/発注内容: \d+口 @ ¥/)
+    expect(err?.reason).not.toContain('USD/JPY')
+  })
+})


### PR DESCRIPTION
## 何を / なぜ

TQQQ が 417 (Insufficient Buying Power) を出し続けているが、decision ログが `price` しか持たず **何口・いくら (¥と$) 発注しようとしたか不明**で原因切り分けできなかった。

ERROR (broker reject) decision の `reason` に**発注内容を併記**する:
- USD 銘柄 (fx>0 かつ≠1): `発注内容: 2口 @ $84.67 = $169.34 ≈ ¥25,401 (USD/JPY 150.06)`
- JPY 銘柄 (fx=1): `発注内容: 100口 @ ¥1,500 = ¥150,000`
- localize の `^broker submit error: ` prefix を壊さないよう、発注内容は **message の後ろ** `[...]` に付与。

これで 417 が「実際にいくらの注文か」が一目で分かり、ローカル pool 計算と Webull 実余力のズレを切り分けられる。

## テスト
`pnpm typecheck` / `pnpm test` → **1268 passed**。USD 銘柄で `$`+`¥`+`USD/JPY` 併記、JPY 銘柄で `¥` のみ・`USD/JPY` 無しを確認。

## 次の調査
本 PR で出る数量/金額を見て、417 の根因 (USD buying_power=0 で円→ドル自動換算が効いていない疑い) を確定する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * ブローカーの発注エラーメッセージに、発注数量と価格情報を人間可読な形式で追記しました。USD/JPY換算情報も含まれるようになり、エラー時の対応がより容易になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->