### PR TITLE
feat(dashboard): 買付余力をホーム + 銘柄設定画面に表示 (#415)

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -876,6 +876,38 @@ export const admin = new Hono<AppBindings>()
     })
   })
   /**
+   * #415: 口座買付余力の軽量 JSON。dashboard (ホーム / 銘柄設定) が client-side
+   * fetch して表示する用 (broker/probe と同じく credentials: 'same-origin' で
+   * CF Access cookie を流用)。live token が無い / broker エラーは fail-safe で
+   * `status:'unavailable'` を返し、ページ描画は壊さない。通貨別 buying_power を
+   * そのまま返す (FX 換算はせず、表示側で通貨別に出す)。
+   */
+  .get('/buying-power', async (c) => {
+    c.header('Cache-Control', 'no-store')
+    try {
+      const accessToken = await resolveAccessToken(c.env)
+      const balance = await createWebullReadClient(c.env, { accessToken }).getAccountBalance()
+      const assets = Array.isArray(balance.account_currency_assets) ? balance.account_currency_assets : []
+      const byCurrency = assets.map((a) => ({
+        currency: (a.currency ?? '?').toUpperCase(),
+        buyingPower: Number(a.buying_power),
+        cash: Number(a.cash_balance),
+      }))
+      return c.json({
+        status: 'ok' as const,
+        asOf: new Date().toISOString(),
+        baseCurrency: balance.total_asset_currency ?? null,
+        totalCash: Number(balance.total_cash_balance),
+        byCurrency,
+      })
+    } catch (e) {
+      return c.json({
+        status: 'unavailable' as const,
+        reason: e instanceof Error ? e.message : String(e),
+      })
+    }
+  })
+  /**
    * #21 Phase B: `WebullTokenStateDO` operator endpoints。
    *
    * - GET /webull-token        : 現在の状態 metadata を返す (token plaintext は返却しない)

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -2189,6 +2189,44 @@ function renderRecentPanel(data: OverviewData): string {
   </div>`
 }
 
+/**
+ * 口座買付余力バッジ (#415)。SSR はブロックせず、client-side で `/admin/buying-power`
+ * を fetch して通貨別 buying_power を描画する (broker-probe と同じく CF Access cookie
+ * 流用)。取得失敗は ⚠ 表示でページは壊さない。ホーム / 銘柄設定の両方で使う。
+ */
+function buyingPowerBadge(): string {
+  return `<div id="buying-power-badge" class="panel" style="display:flex;align-items:center;gap:8px;font-size:13px;padding:10px 14px">
+    <strong>買付余力</strong> <span class="muted">読込中…</span>
+  </div>
+  <script>
+  (function () {
+    var el = document.getElementById('buying-power-badge');
+    if (!el) return;
+    fetch('/admin/buying-power', { credentials: 'same-origin' })
+      .then(function (r) { return r.ok ? r.json() : { status: 'unavailable', reason: 'http ' + r.status }; })
+      .then(function (d) {
+        if (!d || d.status !== 'ok') {
+          el.innerHTML = '<strong>買付余力</strong> <span style="color:#c22;font-weight:600">⚠ 取得不可</span>' +
+            ' <span class="muted" style="font-size:11px">' + ((d && d.reason) ? String(d.reason).slice(0, 80) : '') + '</span>';
+          return;
+        }
+        var parts = (d.byCurrency || []).map(function (a) {
+          var bp = Number(a.buyingPower);
+          var sym = a.currency === 'JPY' ? '¥' : (a.currency === 'USD' ? '$' : '');
+          var v = isFinite(bp) ? bp.toLocaleString('ja-JP', { maximumFractionDigits: a.currency === 'JPY' ? 0 : 2 }) : a.buyingPower;
+          var zero = isFinite(bp) && bp <= 0;
+          return '<span style="' + (zero ? 'color:#86868b' : 'font-weight:600') + '">' + a.currency + ' ' + sym + v + '</span>';
+        });
+        el.innerHTML = '<strong>買付余力</strong> ' + (parts.join(' &nbsp;/&nbsp; ') || '—') +
+          ' <span class="muted" style="font-size:11px">(口座 ' + (d.baseCurrency || '') + ' 総現金 ' + Number(d.totalCash).toLocaleString('ja-JP') + ')</span>';
+      })
+      .catch(function () {
+        el.innerHTML = '<strong>買付余力</strong> <span style="color:#c22;font-weight:600">⚠ 取得不可</span>';
+      });
+  })();
+  </script>`
+}
+
 function overviewBody(data: OverviewData): string {
   const open = collectOpenPositions(data)
   const sections: string[] = []
@@ -2205,7 +2243,7 @@ function overviewBody(data: OverviewData): string {
       '<p class="muted">表示パネルが選択されていません。<a href="/dashboard/config">設定</a>でパネルを有効化してください。</p>',
     )
   }
-  return sections.join('')
+  return buyingPowerBadge() + sections.join('')
 }
 
 /**
@@ -6877,7 +6915,9 @@ function symbolsListBody(args: {
   filter: SymbolsListFilter
 }): string {
   const { rows, inversePairs = {}, errorCode = null, errorSymbol = null, filter } = args
-  const errorBanner = renderSymbolErrorBanner(errorCode, errorSymbol)
+  // #415: 買付余力バッジをページ最上部に (全 return が ${errorBanner} を先頭に持つので
+  // ここに前置すると一覧・空・フィルタ 0 件の全ケースで表示される)。
+  const errorBanner = buyingPowerBadge() + renderSymbolErrorBanner(errorCode, errorSymbol)
   const filtered = applySymbolsListFilter(rows, filter)
   const activeCount = rows.filter((r) => r.active).length
   const inactiveCount = rows.length - activeCount

--- a/test/routes/adminBuyingPower.test.ts
+++ b/test/routes/adminBuyingPower.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp } from '../../src/app'
+import * as readClientMod from '../../src/infrastructure/webull/WebullReadClient'
+import * as tokenMod from '../../src/infrastructure/webull/resolveAccessToken'
+
+const baseEnv = {
+  ACCESS_DEV_BYPASS_USER: 'admin',
+  DRY_RUN: 'true',
+  TRADING_ENABLED: 'false',
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('GET /admin/buying-power (#415)', () => {
+  it('401s without Access JWT', async () => {
+    const res = await createApp().request(
+      '/admin/buying-power',
+      {},
+      { DRY_RUN: 'true', TRADING_ENABLED: 'false' },
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it('returns parsed per-currency buying power (status ok)', async () => {
+    vi.spyOn(tokenMod, 'resolveAccessToken').mockResolvedValue('tok')
+    vi.spyOn(readClientMod, 'createWebullReadClient').mockReturnValue({
+      async getAccountBalance() {
+        return {
+          total_asset_currency: 'JPY',
+          total_cash_balance: '100000',
+          account_currency_assets: [
+            { currency: 'JPY', cash_balance: '100000', buying_power: '100000' },
+            { currency: 'USD', cash_balance: '3.50', buying_power: '500.00' },
+          ],
+        }
+      },
+    } as never)
+    const res = await createApp().request('/admin/buying-power', { headers: {} }, baseEnv)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.status).toBe('ok')
+    expect(body.baseCurrency).toBe('JPY')
+    expect(body.totalCash).toBe(100000)
+    expect(body.byCurrency).toEqual([
+      { currency: 'JPY', buyingPower: 100000, cash: 100000 },
+      { currency: 'USD', buyingPower: 500, cash: 3.5 },
+    ])
+  })
+
+  it('fail-safe: status unavailable (still 200) when balance fetch throws', async () => {
+    vi.spyOn(tokenMod, 'resolveAccessToken').mockResolvedValue('tok')
+    vi.spyOn(readClientMod, 'createWebullReadClient').mockReturnValue({
+      async getAccountBalance() {
+        throw new Error('boom 500')
+      },
+    } as never)
+    const res = await createApp().request('/admin/buying-power', { headers: {} }, baseEnv)
+    expect(res.status).toBe(200) // 常に 200、成否は status フィールドで判定 (ページを壊さない)
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.status).toBe('unavailable')
+    expect(String(body.reason)).toContain('boom 500')
+  })
+})

--- a/test/routes/dashboardSymbolsCrud.test.ts
+++ b/test/routes/dashboardSymbolsCrud.test.ts
@@ -246,6 +246,9 @@ describe('dashboard symbol_config CRUD UI (#292)', () => {
     expect(body).not.toContain('/admin/symbol-config/SOXL/delete')
     // counts (post-cleanup format)
     expect(body).toContain('有効 1 / 無効 1')
+    // #415: 買付余力バッジ (client-side fetch) がページに含まれる
+    expect(body).toContain('buying-power-badge')
+    expect(body).toContain('/admin/buying-power')
   })
 
   it('list flags NULL / invalid lot_size as ⚠ 未設定 (matches runtime fail-closed, CodeRabbit #409)', async () => {


### PR DESCRIPTION
## 何を / なぜ

買付余力が broker-probe 診断画面でしか見えなかった。運用中によく見る **ホーム(`/dashboard`)** と **銘柄設定(`/dashboard/symbols`)** にも表示してほしい、という要望に対応。

## 変更
- **`GET /admin/buying-power`**(新規・軽量 JSON): `resolveAccessToken` → `getAccountBalance` → 通貨別 `buying_power` / `cash` を返す。token 無し・broker エラーは **fail-safe で `status:'unavailable'`**(常に 200、`status` で成否)→ ページ描画は壊さない。`Cache-Control: no-store`。FX 換算はせず通貨別をそのまま返す(表示側で `JPY ¥… / USD $…`)。
- **dashboard**: `buyingPowerBadge()` をホーム / 銘柄設定の最上部に追加。SSR はブロックせず **client-side fetch**(broker-probe と同じく CF Access cookie 流用)。取得成功で通貨別 buying_power、失敗で `⚠ 取得不可` を表示。
- 既存 broker-probe 画面の買付余力パネルはそのまま。

## テスト
`pnpm typecheck` / `pnpm test` → **1271 passed**。`/admin/buying-power` の ok(通貨別 parse)/ unavailable(throw時 fail-safe)/ 401(no Access)、symbols ページに badge 描画を確認。

運用挙動の変更なし(表示のみ。発注/sizing には影響しない)。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ダッシュボード上部に買付余力バッジを常時表示。新しい管理エンドポイントで購買力と現金残高を通貨別に取得可能に。データ取得失敗時も警告表示でページは継続して動作。

* **Tests**
  * 買付余力取得機能と表示の包括的なテストを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->