### PR TITLE
ci(release): 本番リリースPRの「Update Branch」を自動化

### DIFF
--- a/.github/workflows/production-release-pr.yml
+++ b/.github/workflows/production-release-pr.yml
@@ -153,3 +153,49 @@ jobs:
             title="$(TZ=Asia/Tokyo date '+🚀リリース%Y-%m-%d %H:%M:%S')"
             gh pr create --base production --head release/production --title "$title" --body-file release-pr-body.md
           fi
+
+      # production は release マージ毎に merge commit を積んで main と分岐するため、
+      # production ルールセットの strict (branch up-to-date 必須) が release PR に
+      # 毎回 "Update branch" を要求する。ここで GitHub の update-branch API を自動で
+      # 叩いて branch を base 最新に揃え、operator が手で押す手間を無くす。
+      # マージ自体は承認ゲートとして手動のまま (本ステップは更新のみ、merge はしない)。
+      - name: Auto-update release PR branch (skip manual "Update branch")
+        if: steps.production_delta.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PRODUCTION_RELEASE_TOKEN }}
+        run: |
+          pr_number="$(gh pr list \
+            --base production \
+            --head release/production \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')"
+          if [ -z "$pr_number" ]; then
+            echo "::notice::no open release PR; nothing to update."
+            exit 0
+          fi
+
+          # mergeStateStatus が BEHIND の間だけ update-branch を叩く。GitHub の
+          # mergeability 計算は非同期なので UNKNOWN は数秒待って再評価。BEHIND 以外
+          # (CLEAN / BLOCKED=要レビュー 等) になったら最新化済みとみなして終了。
+          attempt=1
+          while [ "$attempt" -le 6 ]; do
+            state="$(gh pr view "$pr_number" --json mergeStateStatus --jq '.mergeStateStatus' 2>/dev/null || echo UNKNOWN)"
+            case "$state" in
+              BEHIND)
+                echo "::notice::release PR #$pr_number is BEHIND; calling update-branch."
+                gh api -X PUT "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}/update-branch" >/dev/null 2>&1 || true
+                sleep 5
+                ;;
+              UNKNOWN)
+                echo "mergeability still computing; waiting."
+                sleep 5
+                ;;
+              *)
+                echo "::notice::release PR #$pr_number not behind (state=$state); branch is up to date."
+                exit 0
+                ;;
+            esac
+            attempt=$((attempt + 1))
+          done
+          echo "::notice::update-branch not confirmed after retries; operator may need to click Update branch once."


### PR DESCRIPTION
## 何を / なぜ

本番リリース PR(`release/production` → `production`)を merge するたびに、毎回手動で **Update Branch** を押す必要があった。

**原因**: `production` ブランチの ruleset に `required_status_checks.strict_required_status_checks_policy: true`(= branch を base 最新に揃えてからでないと merge 不可)が設定されている。一方 production は release マージ毎に merge commit(`Merge pull request …` / `Merge branch 'production' into release/production`)を積み、これらが `main` に乗らないため **release PR が常に "BEHIND"** になり、strict が毎回 Update Branch を要求していた。

## 変更

`production-release-pr.yml` に **update-branch を自動実行するステップ**を追加:
- release PR の `mergeStateStatus` を見て、**`BEHIND` の間だけ** GitHub `PUT /pulls/{n}/update-branch` を叩いて base 最新に揃える。
- `BEHIND` 以外(`CLEAN` / `BLOCKED`=要レビュー 等)になったら最新化済みとして終了。`UNKNOWN`(mergeability 計算中)は数秒待って再評価。
- 既存の force-push / PR 作成ロジックは不変。`has_changes == 'true'` のときだけ動く。

これで **operator の手動 Update Branch が不要**になり、release PR は「承認 + Merge」だけで本番リリースできる(**merge 自体は承認ゲートとして手動のまま**)。strict / 必須レビュー / preflight / linear history は全て維持。

## 注意
- このワークフロー変更は **main にマージされて以降の push から有効**(workflow は default branch のものが実行されるため)。
- `PRODUCTION_RELEASE_TOKEN` には既存どおり `contents:write` + `pull_requests:write` が必要(update-branch も同スコープで動作)。