### PR TITLE
fix(reconcile): ack ロストした約定を heal してドリフト防止

### DIFF
--- a/src/trading/reconciliation/reconcileFills.ts
+++ b/src/trading/reconciliation/reconcileFills.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, gte, isNull, or, sql } from 'drizzle-orm'
+import { and, asc, eq, gte, isNotNull, isNull, or, sql } from 'drizzle-orm'
 import { alias } from 'drizzle-orm/sqlite-core'
 import type { Env } from '../../config/env'
 import { createDb } from '../../infrastructure/db/tradeJournalRepo'
@@ -105,6 +105,21 @@ const MAX_REPAIR_ATTEMPTS = 5
  * (#139): callers that need to catch up from a longer pause can widen it.
  */
 const DEFAULT_LOOKBACK_MS = 48 * 3_600_000
+
+/**
+ * #drift: submit が例外 (BrokerAuthError 等で ack ロスト) になった post_submit 行は
+ * `submitted` が立たず通常 cohort から漏れる。だが「我々側のエラー = broker 不約定」
+ * とは限らない (auth blip で実は FILLED してることがある)。これを broker 注文履歴で
+ * 照合して state を heal するため、errored 行も短い window で reconcile 対象に含める。
+ *
+ * window を 48h ではなく **30 分**に絞る理由:
+ *   - reconcile cron は 5 分間隔なので、ack ロスト fill は数 tick (= 数分) で拾える。
+ *   - 古い履歴行を再処理しない (手動 sync 後に過去の SELL を再 apply して
+ *     "Cannot SELL without an open position" を誘発する事故を避ける)。
+ *   - pre-acceptance で本当に失敗した errored 行 (買付余力 / 空売り 417 等) は
+ *     notFound のまま 30 分で window から脱落 — broker 照合は bounded。
+ */
+const ERRORED_SUBMIT_LOOKBACK_MS = 30 * 60_000
 
 /**
  * Default cap on rows inspected per call. Keeps a single invocation bounded
@@ -231,6 +246,8 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
   // cooldown window incorrectly.
   const runNow = now()
   const since = new Date(runNow.getTime() - (options.lookbackMs ?? DEFAULT_LOOKBACK_MS)).toISOString()
+  // #drift: ack ロストした errored submit 用の狭い window (default 30 分)。
+  const erroredSince = new Date(runNow.getTime() - ERRORED_SUBMIT_LOOKBACK_MS).toISOString()
   const limit = options.limit ?? DEFAULT_ROW_LIMIT
   // Deep-lookup sweep settings (#139). Default `historyMaxPages=1` preserves
   // the prior single-page behaviour, so cron callers see no change in broker
@@ -316,24 +333,38 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
     .where(
       and(
         eq(tradeJournal.tradeEventType, 'post_submit'),
-        eq(tradeJournal.submitted, true),
-        // Lookback の適用は cohort 別に分かれる (#268):
-        //   - fresh poll cohort (broker_status NULL): broker への問合せが必要
-        //     なので、古い行を毎 tick 引っ張ると broker pressure になる
-        //     (default 48h cap)。
-        //   - repair cohort (broker_status='FILLED' AND state_applied_at NULL):
-        //     broker poll 不要 (broker_status 確認済)、DO RPC のみで軽量。
-        //     **lookback 無視で常に sweep** する。これにより長期保有 fill が
-        //     48h 経過後 aged-out で permanent split-brain になる事故を防ぐ。
-        //     行数爆発は SELECT LIMIT 50 で bounded、永続 fail 行は #228 の
-        //     auto-abandon (MAX_REPAIR_ATTEMPTS=5) で cohort から自動的に外れる。
-        //
-        // `retryStateApply` フラグは残してあるが #268 以降は no-op
-        // (互換性のため signature 維持、将来 admin 側で別 sweep モードに
-        // 再定義する余地)。
         or(
-          and(isNull(tradeJournal.brokerStatus), gte(tradeJournal.timestamp, since)),
-          repairFilter,
+          // 通常 cohort: submit 成功 (submitted=true)。
+          // Lookback の適用は cohort 別に分かれる (#268):
+          //   - fresh poll cohort (broker_status NULL): broker への問合せが必要
+          //     なので、古い行を毎 tick 引っ張ると broker pressure になる
+          //     (default 48h cap)。
+          //   - repair cohort (broker_status='FILLED' AND state_applied_at NULL):
+          //     broker poll 不要 (broker_status 確認済)、DO RPC のみで軽量。
+          //     **lookback 無視で常に sweep** する。これにより長期保有 fill が
+          //     48h 経過後 aged-out で permanent split-brain になる事故を防ぐ。
+          //     行数爆発は SELECT LIMIT 50 で bounded、永続 fail 行は #228 の
+          //     auto-abandon (MAX_REPAIR_ATTEMPTS=5) で cohort から自動的に外れる。
+          //
+          // `retryStateApply` フラグは残してあるが #268 以降は no-op
+          // (互換性のため signature 維持、将来 admin 側で別 sweep モードに
+          // 再定義する余地)。
+          and(
+            eq(tradeJournal.submitted, true),
+            or(
+              and(isNull(tradeJournal.brokerStatus), gte(tradeJournal.timestamp, since)),
+              repairFilter,
+            ),
+          ),
+          // #drift: ack ロストした errored submit (submitted が立たない / error_class
+          // 有り / broker_status 未確定) を **狭い window (30分)** で照合対象に。auth blip
+          // 等で実は FILLED してた注文を broker 履歴から拾って heal する。pre-acceptance
+          // 失敗 (買付余力/空売り 417 等) は notFound のまま window 経過で脱落。
+          and(
+            isNotNull(tradeJournal.errorClass),
+            isNull(tradeJournal.brokerStatus),
+            gte(tradeJournal.timestamp, erroredSince),
+          ),
         ),
       ),
     )

--- a/test/trading/reconciliation/reconcileFills.test.ts
+++ b/test/trading/reconciliation/reconcileFills.test.ts
@@ -1549,4 +1549,71 @@ describe('reconcileFills state-apply marker (issue #142)', () => {
       expect(summary.notFound).toEqual(['coid-missing-deep'])
     })
   })
+
+  // #drift: ack ロストした SELL (submit が例外で記録漏れ) を broker 履歴から拾って
+  // 建玉を close し、実現損益も記録する heal 経路。errored cohort の WHERE は fake db
+  // が無視するので、ここでは「候補に入った errored 由来 SELL 行が正しく apply される」
+  // ことを検証する (cohort 選択自体は SQL レベルの変更)。
+  it('heals a drifted position: applies a found SELL fill (close + realized PnL)', async () => {
+    const row: CandidateRow = {
+      id: 42,
+      clientOrderId: 'coid-sell-lost',
+      symbol: 'TQQQ',
+      side: 'SELL',
+      brokerStatus: null,
+      filledQty: null,
+      filledPrice: null,
+      realizedPnl: null,
+      stateAppliedAt: null,
+      stateApplyAttempts: 0,
+    }
+    const { db, updates } = makeFakeDb([row])
+    vi.mocked(createDb).mockReturnValue(db)
+    vi.mocked(createWebullHttpClient).mockReturnValue(
+      makeWebullStub({
+        'coid-sell-lost': {
+          status: 'FILLED',
+          filled_quantity: '3',
+          limit_price: '81.38',
+          side: 'SELL',
+          symbol: 'TQQQ',
+        },
+      }) as unknown as ReturnType<typeof createWebullHttpClient>,
+    )
+    // DO はまだ 3 株保有 (lost SELL のせいでドリフト)。reconcile が close する。
+    const symbolStub = emptySymbolStateStub()
+    symbolStub.getState = vi.fn(async () => ({
+      symbol: 'TQQQ',
+      position: { qty: 3, avgPrice: 85.25, openedAt: '2026-06-04T16:50:31.472Z' },
+      appliedClientOrderIds: [],
+      pendingOrder: null,
+      lastSignalAt: null,
+      cooldownUntil: null,
+      settledCash: 0,
+      pendingSettlement: [],
+      lastExecutedPrice: null,
+      lastQuote: null,
+      updatedAt: '2026-06-05T00:00:00.000Z',
+    }))
+
+    const summary = await reconcileFills({
+      env: {
+        DB: FAKE_DB_BINDING,
+        SYMBOL_STATE: makeSymbolStateNamespace(symbolStub) as never,
+      } as never,
+      now: () => new Date('2026-06-05T13:35:00.000Z'),
+    })
+
+    expect(summary.inspected).toBe(1)
+    expect(summary.stateApplied).toBe(1)
+    // realized PnL = (81.38 - 85.25) * 3 = -11.61
+    expect(summary.updated).toEqual([
+      { clientOrderId: 'coid-sell-lost', status: 'FILLED', realizedPnl: expect.closeTo(-11.61, 2) },
+    ])
+    expect(symbolStub.recordFillOnce).toHaveBeenCalledWith('TQQQ', 'coid-sell-lost', {
+      side: 'SELL',
+      qty: 3,
+      price: 81.38,
+    })
+  })
 })


### PR DESCRIPTION
## 何を / なぜ

TQQQ の「空売り拒否ループ」の根因はドリフト:
- 6/4 16:45 に BUY 3株が約定 → DO は 3株保有を記録。
- 6/5 13:30 に損切り SELL 3株が **broker で約定($81.38)** したが、**直後に `BrokerAuthError`(token 一時失効)で submit が例外**になり、bot が約定を記録できず **DO が 3株保有のまま残留**。
- 以降「もう無い 3 株」を売り続けて `Cash accounts do not allow short selling`(空売り拒否)を量産。

**なぜ reconcile が自己修復しなかったか**: `reconcileFills` の候補抽出 WHERE が `submitted = true` の行のみを対象にしていた。submit が例外を投げた行は `result` が無く **`submitted` が立たない**ため、最初から照合対象外 → broker 履歴を見に行かず、約定を永久に取りこぼしていた。「我々側のエラー = broker 不約定」とは限らない(ack ロスト)。

## 変更

reconcile の候補 cohort に **errored 行**(`error_class` 有り + `broker_status` 未確定)を追加:
- **狭い 30 分 window**(`ERRORED_SUBMIT_LOOKBACK_MS`)で broker 注文履歴を coid 照合。reconcile cron は 5 分間隔なので ack ロスト fill は数 tick で拾える。
- **FILLED なら state に適用して heal**(建玉 close + 実現損益記録)。
- pre-acceptance で本当に失敗した注文(買付余力 / 空売り 417 等)は notFound のまま 30 分 window 経過で脱落 → broker 照合は bounded。
- window を 48h でなく 30 分に絞る別の理由: **手動 sync 済の古い行を再 apply して `Cannot SELL without an open position` を誘発する事故を回避**(今回 force-sync 済の TQQQ 行は >1日前なので対象外)。

通常 cohort(`submitted=true` の fresh-poll / repair)は不変。

## テスト
`pnpm typecheck` / `pnpm test` → **1272 passed**。追加: 約定済 SELL を broker 履歴から拾い、建玉を close + 実現損益(-$11.61)を記録する heal 経路。

## 補足
- 既存の手動 `sync-holdings`(broker 実保有へ同期)は引き続き止血用に有効。本 PR は **再発防止**(ack ロストを自動 heal)。
- fake db が WHERE を無視する都合上、cohort 選択そのものの単体テストは不可。heal 経路(loop)の正しさを検証。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 取引照合機能を改善し、エラーで失敗した注文をより短い時間窓（30分）で修復できるように対応しました。

* **Tests**
  * 取引記録の欠落から復旧するシナリオのテストケースを追加し、照合の信頼性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->