### PR TITLE
feat(dashboard): cron判定をチャートに重ねる + 入場までの距離/参考外挿の可視化

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -3547,6 +3547,30 @@ function renderDecisionLadder(
   </div>`
 }
 
+/**
+ * チャート判定点クリック時に脇パネルへ挿す HTML を作る (#decision-trace の
+ * グラフ同期)。trace があれば `renderDecisionLadder` をそのまま使い、無ければ
+ * (migration 前 / 一部経路) 出力ボックスだけの最小フォールバックを返す。
+ * チャート側 JS は単に innerHTML へ挿すだけにして、ラダー描画ロジックの
+ * 二重化 (JS 側複製) を避け、ラダー表現の真実源を server に一本化する。
+ */
+export function renderChartDecisionTrace(
+  traceJson: string | null,
+  decision: string,
+  reason: string | null,
+): string {
+  const outputReason = localizeReason(reason) || (reason ?? '-')
+  const ladder = renderDecisionLadder(traceJson, decision, outputReason)
+  if (ladder) return ladder
+  const decUpper = (decision || '').toUpperCase()
+  return `<div><strong>判定トレース</strong>
+    <div class="trace-ladder">
+      <p class="muted" style="margin:4px 0;font-size:12px">この判定にはトレースが保存されていません (旧ログ)。</p>
+      <div class="tl-output tl-out-${esc(decUpper.toLowerCase())}">出力: <strong>${esc(decUpper)}</strong> — ${esc(outputReason)}</div>
+    </div>
+  </div>`
+}
+
 function cronDecisionJson(row: {
   id: number
   timestamp: string
@@ -3892,6 +3916,33 @@ export interface SymbolChartMarker {
   realizedPnl: number | null
 }
 
+/**
+ * チャート上にプロットする「cron 判定イベント」1 件 (#decision-trace 連携)。
+ * 文字ログ (戦略判定テーブル) とグラフを 1 画面で同期させるための要素。
+ * eval 時刻 (`timestamp`) × eval 価格 (`price`) に色分けの点を打ち、点クリックで
+ * `ladderHtml` (= 既存 `renderDecisionLadder` の出力) を脇のパネルに表示する。
+ *
+ * HOLD (保有継続 / 様子見の定常状態) は省き、判定が動いた BUY/SELL/REJECT/ERROR
+ * のみを載せる。価格線・fill ピン・position/preview 線が HOLD 状態は既に表現済み。
+ */
+export interface SymbolChartDecision {
+  /** strategy_decision_log の行 id。点の一意キー兼デバッグ用。 */
+  id: number
+  timestamp: string // ISO UTC (eval 時刻)
+  /** eval 時の評価価格 (= strategy_decision_log.price)。y 位置に使う。 */
+  price: number
+  decision: 'BUY' | 'SELL' | 'REJECT' | 'ERROR'
+  /** 生 reason (英語)。tooltip では localize して表示。 */
+  reason: string | null
+  /**
+   * server-side で事前レンダリングした判定トレース・ラダー HTML
+   * (`renderDecisionLadder` 出力、trace 無し行は最小フォールバック)。
+   * client は click でこの文字列を innerHTML へ挿すだけ (JS 側にラダー描画
+   * ロジックを複製せず単一の真実源を保つ)。値はすべて `esc()` 済みの自前 markup。
+   */
+  ladderHtml: string
+}
+
 export interface SymbolChartPosition {
   /** 平均取得単価 (= 直近 BUY filled_price、partial fill / add は未対応 POC) */
   avgPrice: number
@@ -3929,6 +3980,16 @@ export function computeChartWindowDays(timeStopDays: number): number {
   const dynamic = Math.ceil(timeStopDays * 2 + 4)
   return Math.min(Math.max(dynamic, 14), MAX_WINDOW_DAYS)
 }
+
+/**
+ * チャートに重ねる判定点の上限 (最新側から採用)。payload サイズ (各点が
+ * 事前レンダリングのラダー HTML を持つ) と視認性のガード。HOLD を除いた
+ * BUY/SELL/REJECT/ERROR のみが対象なので通常はこの上限に届かない。
+ */
+const MAX_CHART_DECISIONS = 250
+
+/** チャート判定点として描画する decision 種別 (HOLD は定常状態なので除外)。 */
+const CHART_PLOTTED_DECISIONS: ReadonlySet<string> = new Set(['BUY', 'SELL', 'REJECT', 'ERROR'])
 
 export interface PivotPoint {
   /** ISO UTC timestamp of the daily bar */
@@ -3991,6 +4052,13 @@ export interface SymbolChartData {
   latestCronPrice: number | null
   /** `latestCronPrice` の timestamp (ISO Z)。preview line の to-end 用。null 時 preview 描画スキップ。 */
   latestCronTimestamp: string | null
+  /**
+   * チャートに重ねる cron 判定イベント (BUY/SELL/REJECT/ERROR、HOLD 除外)。
+   * 文字ログ↔グラフ同期用 (#decision-trace)。最新側 `MAX_CHART_DECISIONS` 件まで。
+   * 追加 (additive) フィールドなので optional: 古い fixture / grid payload では
+   * 省略され、レンダラ側は `|| []` で安全に扱う。
+   */
+  decisions?: SymbolChartDecision[]
 }
 
 /**
@@ -4016,14 +4084,22 @@ export async function loadSymbolChart(
       // 取りこぼさない。strftime で右辺を ISO UTC 形式 ("...T...:...Z") に
       // 揃える (default datetime() の空白区切りでは stored ISO と境界がぶれる)。
       .prepare(
-        `SELECT timestamp, price, indicators_json
+        `SELECT id, timestamp, price, decision, reason, indicators_json, trace_json
          FROM strategy_decision_log
          WHERE symbol = ?
            AND timestamp >= strftime('%Y-%m-%dT%H:%M:%fZ', 'now', ?)
          ORDER BY id ASC`,
       )
       .bind(symbol, `-${windowDays} days`)
-      .all<{ timestamp: string; price: number | null; indicators_json: string | null }>(),
+      .all<{
+        id: number
+        timestamp: string
+        price: number | null
+        decision: string | null
+        reason: string | null
+        indicators_json: string | null
+        trace_json: string | null
+      }>(),
     db
       // post_submit 行は side が null (writer は pre_submit にしか side を入れない)。
       // client_order_id で pre_submit と self-JOIN して side を引く。古い fill で
@@ -4067,6 +4143,26 @@ export async function loadSymbolChart(
         low20d: indicators.low20d,
       }
     })
+  // 判定点 (文字ログ↔グラフ同期 #decision-trace): HOLD を除く BUY/SELL/REJECT/
+  // ERROR を eval 時刻 × eval 価格でチャートに重ねる。各点はクリック時に出す
+  // ラダー HTML を server-side で事前レンダリング (renderDecisionLadder 流用)。
+  // 最新側 MAX_CHART_DECISIONS 件に cap (各点が HTML を持つため payload ガード)。
+  const decisions: SymbolChartDecision[] = logs
+    .filter(
+      (r) =>
+        r.price !== null &&
+        Number.isFinite(Number(r.price)) &&
+        CHART_PLOTTED_DECISIONS.has((r.decision ?? '').toUpperCase()),
+    )
+    .map((r) => ({
+      id: r.id,
+      timestamp: r.timestamp,
+      price: Number(r.price),
+      decision: (r.decision ?? '').toUpperCase() as SymbolChartDecision['decision'],
+      reason: r.reason,
+      ladderHtml: renderChartDecisionTrace(r.trace_json, r.decision ?? '', r.reason),
+    }))
+    .slice(-MAX_CHART_DECISIONS)
   const markers: SymbolChartMarker[] = (fillsResult.results ?? [])
     .filter((r) => r.filled_price !== null)
     .map((r) => ({
@@ -4162,6 +4258,7 @@ export async function loadSymbolChart(
     intradayBars: intradayBars,
     latestCronPrice,
     latestCronTimestamp,
+    decisions,
   }
 }
 
@@ -4780,7 +4877,7 @@ export function computeZoomRange(
   }
 }
 
-interface ChartsBodySymbol {
+export interface ChartsBodySymbol {
   tab: 'symbol'
   focusSymbol: string | null
   symbolChart: SymbolChartData | null
@@ -4958,7 +5055,7 @@ function renderQualityTab(args: ChartsBodyQuality): string {
   <script>${initScript}</script>`
 }
 
-function renderSymbolTab(args: ChartsBodySymbol): string {
+export function renderSymbolTab(args: ChartsBodySymbol): string {
   const noData =
     args.symbolChart === null ||
     args.symbolChart.points.length === 0
@@ -5271,6 +5368,27 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
           realizedPnl: m.realizedPnl, qty: m.qty, fillTimestamp: m.timestamp,
           label: { show: showLabel, formatter: m.price.toFixed(2) + pnlLabel, color: '#c22', position: 'bottom', distance: 6, fontSize: 11 },
           itemStyle: { color: '#c22' },
+        };
+      });
+
+      // 判定点 (#decision-trace のグラフ同期): cron の判定イベント (HOLD を除く
+      // BUY/SELL/REJECT/ERROR) を eval 時刻 × eval 価格に色分けでプロットする。
+      // 点クリックで脇パネルに判定トレース・ラダー (server 事前レンダリング HTML)
+      // を出し、文字ログとグラフを 1 画面で同期させる。category mode では eval
+      // 時刻を最近接 ohlc index に snap (markPoint と同じ手法、xForTimestamp 流用)。
+      // 色は取引品質タブの DECISION_COLORS と揃える。
+      var DECISION_COLORS = { BUY: '#057a55', SELL: '#1471a8', REJECT: '#b25000', ERROR: '#c22' };
+      var DECISION_LABEL_JA = { BUY: '買い', SELL: '売り', REJECT: '見送り', ERROR: 'エラー' };
+      function escHtml(s) {
+        return String(s == null ? '' : s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+      }
+      var decisionList = sc.decisions || [];
+      var decisionPoints = decisionList.map(function (d) {
+        var color = DECISION_COLORS[d.decision] || '#888';
+        return {
+          value: [xForTimestamp(d.timestamp), d.price],
+          decision: d.decision, reason: d.reason, evalTs: d.timestamp, ladderHtml: d.ladderHtml,
+          itemStyle: { color: color, borderColor: '#fff', borderWidth: 1 },
         };
       });
 
@@ -5703,9 +5821,54 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
             },
             silent: true, emphasis: { disabled: true }, z: 7,
           }] : []),
+          // 判定点 scatter: cron 判定イベントを価格チャートに重ねる。z を最前面に
+          // 寄せて (candle z:5 / 線 z:6-8 より上) クリック可能にする。REJECT/ERROR
+          // (= 弾かれた点) は少し大きくして「なぜ買えなかったか」を目立たせる。
+          // tooltip は item trigger で decision + reason 要約 (詳細は click→ラダー)。
+          ...(decisionPoints.length > 0 ? [{
+            name: '判定', type: 'scatter', data: decisionPoints,
+            symbol: 'circle',
+            symbolSize: function (val, p) {
+              var dec = p && p.data ? p.data.decision : '';
+              return (dec === 'REJECT' || dec === 'ERROR') ? 13 : 9;
+            },
+            z: 11, emphasis: { scale: 1.6 }, cursor: 'pointer',
+            tooltip: {
+              trigger: 'item',
+              formatter: function (p) {
+                var d = p.data;
+                var ja = DECISION_LABEL_JA[d.decision] || d.decision;
+                var price = Array.isArray(d.value) ? Number(d.value[1]).toFixed(2) : '';
+                var rsn = d.reason ? '<div style="font-size:11px;max-width:280px;white-space:normal">' + escHtml(d.reason) + '</div>' : '';
+                return '<div style="font-weight:600">' + escHtml(ja) + ' (' + escHtml(d.decision) + ') @ ' + price + '</div>'
+                  + '<div style="font-size:11px">' + jstLabelSec(d.evalTs) + '</div>'
+                  + rsn
+                  + '<div style="font-size:10px;color:#888;margin-top:2px">クリックで判定トレース表示</div>';
+              },
+            },
+          }] : []),
         ],
       });
       window.addEventListener('resize', function () { symChart.resize(); });
+
+      // 判定点クリック → 脇パネルにその判定の判定トレース・ラダーを表示する
+      // (文字ログ↔グラフ同期の肝)。ladderHtml は server 側で renderDecisionLadder
+      // により事前レンダリング済み (全値 esc 済みの自前 markup) なので innerHTML
+      // へ挿すだけ。JS 側にラダー描画ロジックを複製しない。
+      var tracePanel = document.getElementById('decision-trace-panel');
+      function showDecisionTrace(d) {
+        if (!tracePanel || !d) return;
+        tracePanel.innerHTML = d.ladderHtml || '';
+      }
+      symChart.on('click', function (p) {
+        if (p && p.seriesName === '判定' && p.data && p.data.ladderHtml != null) {
+          showDecisionTrace(p.data);
+          if (tracePanel) tracePanel.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+        }
+      });
+      // 初期表示: 最新の判定点のトレースを開いておく。操作前から log↔graph が
+      // 結びついた状態 (= 直近に何が起きたか) を一目で見せる。
+      if (decisionPoints.length > 0) showDecisionTrace(decisionPoints[decisionPoints.length - 1]);
 
       // visible 範囲 (zoom 後の x 軸) 内の candle high/low / markers / position
       // 線を集めて y 軸 range を再計算。zoom out / preset 切替で「縦に空白が
@@ -5914,7 +6077,11 @@ function renderSymbolTab(args: ChartsBodySymbol): string {
   return `${renderSymbolPickerForTab(args)}
   ${renderCurrentIndicatorsBadge(args.symbolChart)}
   <div id="symbol-chart" style="width:100%;height:460px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;margin-top:12px"></div>
+  ${renderDecisionPlotCaption(args.symbolChart)}
   ${renderZoomPresetButtons(args.symbolChart)}
+  <div id="decision-trace-panel" class="reason-panel" style="margin-top:10px">
+    <p class="muted" style="font-size:12px;margin:0">判定点 (●) をクリックすると、その判定が通った採用ロジックのトレースがここに表示されます。</p>
+  </div>
   ${renderStrategyParamsPanel(args.strategyParams)}
   ${safeJsonScript('__chartData', {
     symbolChart: symbolChartPayload,
@@ -6019,14 +6186,17 @@ export function renderGridTab(args: ChartsBodyGrid): string {
   // "番号-会社名" を入れている (US は symbol そのまま) — tooltip header
   // (`sc.displayName || sc.symbol`) で読まれる。
   const payload = {
-    charts: args.charts.map((c) => ({
-      symbol: c.symbol,
-      chart: c.chart
-        ? { ...c.chart, displayName: displaySymbol(c.chart.symbol, args.universe) }
-        : null,
-      error: c.error,
-      displayName: displaySymbol(c.symbol, args.universe),
-    })),
+    charts: args.charts.map((c) => {
+      // grid の mini chart は判定点を描かないので、ラダー HTML を持つ
+      // decisions は payload から落としてサイズを抑える (個別銘柄タブ専用)。
+      const lean = c.chart ? (({ decisions: _omit, ...rest }) => rest)(c.chart) : null
+      return {
+        symbol: c.symbol,
+        chart: lean ? { ...lean, displayName: displaySymbol(c.chart!.symbol, args.universe) } : null,
+        error: c.error,
+        displayName: displaySymbol(c.symbol, args.universe),
+      }
+    }),
     zoomFromMs: args.zoom ? args.zoom.from.getTime() : null,
     zoomToMs: args.zoom ? args.zoom.to.getTime() : null,
   }
@@ -6896,6 +7066,29 @@ export function renderZoomPresetButtons(chart: SymbolChartData | null): string {
  * 撤去 (15m chart の y軸を引き伸ばさないため) した代替表示。最新の cron-eval
  * point から取得し、null は em-dash (—) で fallback。
  */
+/**
+ * 判定点プロットの凡例 + 件数キャプション (#decision-trace のグラフ同期)。
+ * decisions が空なら空文字。最新 `MAX_CHART_DECISIONS` 件に達していれば
+ * truncation を明示する (silent cap を避ける)。色は chart 側 DECISION_COLORS
+ * および取引品質タブと揃える。
+ */
+export function renderDecisionPlotCaption(chart: SymbolChartData | null): string {
+  const decisions = chart?.decisions ?? []
+  if (decisions.length === 0) return ''
+  const dot = (color: string, label: string): string =>
+    `<span style="display:inline-flex;align-items:center;gap:4px;margin-right:12px"><span style="width:9px;height:9px;border-radius:50%;background:${color};box-shadow:0 0 0 1px #fff,0 0 0 2px ${color}"></span>${esc(label)}</span>`
+  const capped =
+    decisions.length >= MAX_CHART_DECISIONS
+      ? ` <span class="muted">(直近 ${MAX_CHART_DECISIONS} 件まで表示)</span>`
+      : ''
+  return `<p class="muted" style="font-size:12px;margin:6px 0 2px">
+    ● は cron の判定イベント。点をクリックすると下に判定トレースが出ます (文字ログとグラフを同期)。HOLD (保有継続 / 様子見) は省略。${capped}
+  </p>
+  <div style="font-size:12px;margin:0 0 4px">
+    ${dot('#057a55', '買い (BUY)')}${dot('#1471a8', '売り (SELL)')}${dot('#b25000', '見送り (REJECT)')}${dot('#c22', 'エラー (ERROR)')}
+  </div>`
+}
+
 export function renderCurrentIndicatorsBadge(chart: SymbolChartData | null): string {
   if (!chart) return ''
   // 最新の indicator 付き point を末尾から探す (Yahoo filler は indicators null)

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -5357,6 +5357,18 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
         pullbackUpperXY.some(function (xy) { return xy[1] != null; }) &&
         pullbackLowerXY.some(function (xy) { return xy[1] != null; });
 
+      // 押し目ゾーン端までの距離ラベル (#entry-distance): 「入場ライン」独立線は
+      // 廃止し、既存の上端/下端点線に「あと −X.X% ($Y)」を付与する。現価格は
+      // latestCronPrice (直近 strategy 評価値) 基準。過熱/トレンド等で実際に入場
+      // できない件は下の「入場まで」パネルが説明する (ここは純粋な価格距離)。
+      function bandEdgeLabel(name, edgeY) {
+        if (!Number.isFinite(edgeY) || sc.latestCronPrice == null || !(sc.latestCronPrice > 0)) return name;
+        var mv = (edgeY - sc.latestCronPrice) / sc.latestCronPrice;
+        return name + ' あと ' + (mv >= 0 ? '+' : '') + (mv * 100).toFixed(1) + '% ($' + edgeY.toFixed(2) + ')';
+      }
+      var pullbackUpperLabel = bandEdgeLabel('押し目上端', bandUpperY);
+      var pullbackLowerLabel = bandEdgeLabel('押し目下端', bandLowerY);
+
       // 価格トレンド線 (server-side で daily close の linear regression fit)。
       // 旧仕様の「上値抵抗線 / 下値支持線」上下 2 本は、ローソク足の上下を
       // flat に走り「価格の中心を辿る trend」という user 期待と乖離していた
@@ -5610,26 +5622,6 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
         }
       }
 
-      // 入場ライン (#entry-distance): 今 BUY が成立する最寄り価格を水平線で。
-      // 「あと価格がどこまで動けば入場か」をチャート上で直接見せる。価格非依存
-      // ゲートが塞ぐ局面は server 側で entryLine=null にしてあるので描かない。
-      var entryLineXY = null;
-      var entryLineLabel = '';
-      if (data.entryLine && data.entryLine.price != null && sc.points.length > 0) {
-        var elPrice = data.entryLine.price;
-        extraYValues.push(elPrice);
-        var elFromMs = new Date(sc.points[0].timestamp).getTime();
-        var elToMs = sc.latestCronTimestamp != null
-          ? new Date(sc.latestCronTimestamp).getTime()
-          : new Date(sc.points[sc.points.length - 1].timestamp).getTime();
-        if (Number.isFinite(elFromMs) && Number.isFinite(elToMs)) {
-          entryLineXY = toCategoryXY(densifyHorizontalLine(elPrice, elFromMs, elToMs, ohlcTimestamps));
-          var elMove = data.entryLine.priceMove;
-          var elPct = elMove == null ? '' : ' (' + (elMove >= 0 ? '+' : '') + (elMove * 100).toFixed(1) + '%)';
-          entryLineLabel = '入場ライン ' + elPrice.toFixed(2) + elPct;
-        }
-      }
-
       // 参考 価格外挿線 (#entry-distance のグラフ表現): 直近ペースを未来へ延ばした
       // 点線。category 軸に未来スロットを足して描く。**予測ではなく外挿** なので
       // 点線 + "参考" 明記。entryPrice が無い (価格非依存ブロック) 局面は server 側で
@@ -5871,6 +5863,8 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
               lineStyle: { width: 1, color: 'rgba(255, 140, 0, 0.55)', type: 'dashed' },
               itemStyle: { color: 'rgba(255, 140, 0, 0.55)' },
               symbol: 'none', z: 2,
+              // 入場まで距離を右端ラベルに (旧「入場ライン」線の代替)。
+              endLabel: { show: true, formatter: pullbackUpperLabel, color: '#b25000', fontSize: 10 },
             },
             {
               name: '押し目下端',
@@ -5879,6 +5873,7 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
               lineStyle: { width: 1, color: 'rgba(255, 140, 0, 0.55)', type: 'dashed' },
               itemStyle: { color: 'rgba(255, 140, 0, 0.55)' },
               symbol: 'none', z: 2,
+              endLabel: { show: true, formatter: pullbackLowerLabel, color: '#b25000', fontSize: 10 },
             },
           ]),
           // 価格トレンド (linear regression, 直近 30 日 daily close fit)。
@@ -6011,13 +6006,6 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
           // 入場ライン (#entry-distance): 今 BUY が成立する最寄り価格。cyan 実線 +
           // endLabel で「入場ライン $Y (−X.X%)」。現価格との差がチャート上の縦の
           // 隙間として直感的に読める。z:9 で価格線群より前面、判定点 (z:11) より背面。
-          ...(entryLineXY ? [{
-            name: entryLineLabel, type: 'line', data: entryLineXY,
-            lineStyle: { width: 1.6, color: '#0891b2', type: 'solid' }, symbol: 'none',
-            itemStyle: { color: '#0891b2' },
-            endLabel: { show: true, formatter: entryLineLabel, color: '#0891b2', fontSize: 11 },
-            silent: true, emphasis: { disabled: true }, z: 9,
-          }] : []),
           // 参考 価格外挿線: 直近ペースの未来延長 (点線)。予測ではない (legend / 注記)。
           // 交差点 (= 入場ライン到達) には pin を立てる。
           ...(projLineXY ? [{
@@ -6195,9 +6183,9 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
           pushIfFinite(pVirtualAvg * (1 + sc.rules.stopPct));
           pushIfFinite(pVirtualAvg * (1 + sc.rules.takeProfitPct));
         }
-        // 入場ライン (#entry-distance) は chart 全幅に引くので常に visible。
-        // y 範囲に含めて、価格から離れていても枠外に消えないようにする。
-        if (data.entryLine && data.entryLine.price != null) pushIfFinite(data.entryLine.price);
+        // 押し目ゾーン上端 (= 入場まで距離ラベルを載せた線) を y 範囲に含めて
+        // ラベルが枠外に切れないようにする。下端は広がりすぎ防止のため含めない。
+        if (Number.isFinite(bandUpperY)) pushIfFinite(bandUpperY);
         // 参考 価格外挿線の末尾価格も含める (未来スロットに描くので zoom 右端で visible)。
         if (projEndPrice != null) pushIfFinite(projEndPrice);
         if (visibleY.length === 0) return;
@@ -6290,22 +6278,13 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
   // chart payload に displayName を注入。client 側の chart title / tooltip header
   // は `sc.displayName || sc.symbol` で読む (US 銘柄は displayName === symbol)。
   // evalIndicators は buyability を server で算出済みなので client へは送らない
-  // (入場ライン価格だけ別途 entryLine で渡す)。
+  // (入場までの距離は押し目ゾーン端ラベル / 外挿線で表現)。
   const symbolChartPayload = args.symbolChart
     ? (({ evalIndicators: _omit, ...rest }) => ({
         ...rest,
         displayName: displaySymbol(args.symbolChart!.symbol, args.universe),
       }))(args.symbolChart)
     : null
-  // 入場ライン (#entry-distance): 今 BUY が成立する最寄り価格。価格非依存ゲートが
-  // 塞いでいる時 (entryPrice null) は線を引かない (panel が理由を説明)。
-  const entryLine =
-    args.buyability?.current && args.buyability.current.entryPrice !== null
-      ? {
-          price: args.buyability.current.entryPrice,
-          priceMove: args.buyability.current.priceMove,
-        }
-      : null
   // 参考 価格外挿線 (#entry-distance のグラフ表現)。直近ペースを未来へ延ばした
   // 「予測ではない外挿」。client は category 軸に未来スロットを足して描く。
   const projection = args.buyability?.projection ?? null
@@ -6321,7 +6300,6 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
   ${renderStrategyParamsPanel(args.strategyParams)}
   ${safeJsonScript('__chartData', {
     symbolChart: symbolChartPayload,
-    entryLine,
     projection,
     zoomFromMs: args.zoom ? args.zoom.from.getTime() : null,
     zoomToMs: args.zoom ? args.zoom.to.getTime() : null,

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -5630,6 +5630,53 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
         }
       }
 
+      // 参考 価格外挿線 (#entry-distance のグラフ表現): 直近ペースを未来へ延ばした
+      // 点線。category 軸に未来スロットを足して描く。**予測ではなく外挿** なので
+      // 点線 + "参考" 明記。entryPrice が無い (価格非依存ブロック) 局面は server 側で
+      // projection=null になり描かれない。time 軸 fallback は POC では描画しない。
+      var projLineXY = null;
+      var projCrossPoint = null;
+      var projZoomEndIndex = null;
+      var projEndPrice = null;
+      (function () {
+        var proj = data.projection;
+        if (!proj || !Number.isFinite(proj.lastPrice) || !Number.isFinite(proj.slopePerStep)) return;
+        if (!useCategoryAxis || ohlcMs.length < 2) return;
+        var dayMs = 24 * 3600 * 1000;
+        var lastBarMs = ohlcMs[ohlcMs.length - 1];
+        // 1 営業日あたりの bar 本数を直近 1 日のスロット数で近似。
+        var barsPerDay = 0;
+        for (var bi = ohlcMs.length - 1; bi >= 0; bi -= 1) {
+          if (lastBarMs - ohlcMs[bi] <= dayMs) barsPerDay += 1; else break;
+        }
+        barsPerDay = Math.max(1, barsPerDay);
+        // 未来スロットの timestamp 間隔 (直近 bar の平均間隔)。
+        var span = barsPerDay > 1 ? (lastBarMs - ohlcMs[ohlcMs.length - barsPerDay]) / (barsPerDay - 1) : 3600000;
+        if (!Number.isFinite(span) || span <= 0) span = 3600000;
+        // 描く未来日数: 交差 (なければ horizon) を 1〜5 営業日に clamp し、履歴に
+        // 対して過大にならないようにする。
+        var rawDays = proj.crossingSteps != null ? proj.crossingSteps : proj.horizonSteps;
+        var drawDays = Math.min(Math.max(Math.ceil(rawDays), 1), 5);
+        var drawBars = Math.max(barsPerDay, Math.round(drawDays * barsPerDay));
+        var startIdx = categories.length - 1;
+        for (var k = 1; k <= drawBars; k += 1) {
+          categories.push(new Date(lastBarMs + k * span).toISOString());
+        }
+        var endIdx = startIdx + drawBars;
+        projEndPrice = proj.lastPrice + proj.slopePerStep * (drawBars / barsPerDay);
+        projLineXY = [[startIdx, proj.lastPrice], [endIdx, projEndPrice]];
+        extraYValues.push(proj.lastPrice, projEndPrice);
+        if (proj.entryPrice != null) extraYValues.push(proj.entryPrice);
+        // 交差点 marker (描画範囲内のときだけ pin を出す)。
+        if (proj.crossingSteps != null && proj.entryPrice != null) {
+          var crossBars = Math.round(proj.crossingSteps * barsPerDay);
+          if (crossBars >= 0 && crossBars <= drawBars) {
+            projCrossPoint = { coord: [startIdx + crossBars, proj.entryPrice], value: proj.entryPrice };
+          }
+        }
+        projZoomEndIndex = endIdx;
+      })();
+
       // ECharts の scale:true は markLine を yAxis range に含めないため、
       // TP / stop が data 範囲外だと枠の外で見えなくなる。data 全体 +
       // position lines + markers を考慮した explicit min/max + padding。
@@ -5679,6 +5726,12 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
         }
         return { startValue: data.zoomFromMs, endValue: data.zoomToMs };
       })();
+      // 外挿線を初期表示に収める: category mode で右端 (endValue) を外挿末尾まで
+      // 広げる (未来スロットを足したぶん)。startValue は据え置きなので履歴 + 外挿が
+      // 同時に見える。
+      if (projZoomEndIndex != null && useCategoryAxis && dzInitial.endValue != null) {
+        dzInitial.endValue = Math.min(projZoomEndIndex, categories.length - 1);
+      }
       // dataZoom slider 両端ラベルも JST で表示 (default だと UTC date string)。
       // category mode では labelFormatter に category 値 (= ISO timestamp 文字列)
       // が渡されるので jstLabel に直接通せばよい (内部で Date(value) parse)。
@@ -5965,6 +6018,22 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
             endLabel: { show: true, formatter: entryLineLabel, color: '#0891b2', fontSize: 11 },
             silent: true, emphasis: { disabled: true }, z: 9,
           }] : []),
+          // 参考 価格外挿線: 直近ペースの未来延長 (点線)。予測ではない (legend / 注記)。
+          // 交差点 (= 入場ライン到達) には pin を立てる。
+          ...(projLineXY ? [{
+            name: '参考 価格外挿 (予測ではない)', type: 'line', data: projLineXY,
+            lineStyle: { width: 1.4, color: '#0891b2', type: 'dotted', opacity: 0.85 }, symbol: 'none',
+            itemStyle: { color: '#0891b2' },
+            silent: true, emphasis: { disabled: true }, z: 8,
+            markPoint: projCrossPoint ? {
+              symbol: 'pin', symbolSize: 30,
+              data: [{
+                coord: projCrossPoint.coord, value: projCrossPoint.value,
+                itemStyle: { color: '#0891b2' },
+                label: { show: true, formatter: '参考\\n到達', color: '#fff', fontSize: 9, lineHeight: 11 },
+              }],
+            } : undefined,
+          }] : []),
           // 判定点 scatter: cron 判定イベントを価格チャートに重ねる。z を最前面に
           // 寄せて (candle z:5 / 線 z:6-8 より上) クリック可能にする。REJECT/ERROR
           // (= 弾かれた点) は少し大きくして「なぜ買えなかったか」を目立たせる。
@@ -6129,6 +6198,8 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
         // 入場ライン (#entry-distance) は chart 全幅に引くので常に visible。
         // y 範囲に含めて、価格から離れていても枠外に消えないようにする。
         if (data.entryLine && data.entryLine.price != null) pushIfFinite(data.entryLine.price);
+        // 参考 価格外挿線の末尾価格も含める (未来スロットに描くので zoom 右端で visible)。
+        if (projEndPrice != null) pushIfFinite(projEndPrice);
         if (visibleY.length === 0) return;
         var rawMin = Math.min.apply(null, visibleY);
         var rawMax = Math.max.apply(null, visibleY);
@@ -6235,6 +6306,9 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
           priceMove: args.buyability.current.priceMove,
         }
       : null
+  // 参考 価格外挿線 (#entry-distance のグラフ表現)。直近ペースを未来へ延ばした
+  // 「予測ではない外挿」。client は category 軸に未来スロットを足して描く。
+  const projection = args.buyability?.projection ?? null
   return `${renderSymbolPickerForTab(args)}
   ${renderCurrentIndicatorsBadge(args.symbolChart)}
   <div id="symbol-chart" style="width:100%;height:460px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;margin-top:12px"></div>
@@ -6248,6 +6322,7 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
   ${safeJsonScript('__chartData', {
     symbolChart: symbolChartPayload,
     entryLine,
+    projection,
     zoomFromMs: args.zoom ? args.zoom.from.getTime() : null,
     zoomToMs: args.zoom ? args.zoom.to.getTime() : null,
   })}

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -5653,9 +5653,9 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
         // 未来スロットの timestamp 間隔 (直近 bar の平均間隔)。
         var span = barsPerDay > 1 ? (lastBarMs - ohlcMs[ohlcMs.length - barsPerDay]) / (barsPerDay - 1) : 3600000;
         if (!Number.isFinite(span) || span <= 0) span = 3600000;
-        // 描く未来日数: 交差 (なければ horizon) を 1〜5 営業日に clamp し、履歴に
-        // 対して過大にならないようにする。
-        var rawDays = proj.crossingSteps != null ? proj.crossingSteps : proj.horizonSteps;
+        // 描く未来日数: 交差ありはその近辺まで、交差なし (向きだけ見せる) は短めに
+        // して未来の空白が過大にならないようにする。1〜5 営業日に clamp。
+        var rawDays = proj.crossingSteps != null ? proj.crossingSteps : Math.min(proj.horizonSteps, 3);
         var drawDays = Math.min(Math.max(Math.ceil(rawDays), 1), 5);
         var drawBars = Math.max(barsPerDay, Math.round(drawDays * barsPerDay));
         var startIdx = categories.length - 1;

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -47,6 +47,16 @@ import {
 } from '../infrastructure/db/portfolioEquitySnapshotRepo'
 import type { PortfolioEquitySnapshotRow } from '../infrastructure/db/schema'
 import type { VixRegime } from '../trading/risk/vixRegimeFilter'
+import {
+  buildBuyabilityView,
+  type BuyabilityView,
+  type EntryGateStatus,
+  type EvalIndicatorPoint,
+} from '../trading/strategy/entryDistance'
+import type {
+  PullbackIndicators,
+  SymbolRule,
+} from '../trading/strategy/strategies/PullbackUptrendStrategy'
 import { and, asc, desc, eq, gte, lte } from 'drizzle-orm'
 import { PortfolioStateClient } from '../trading/state/PortfolioStateClient'
 import { SymbolStateClient } from '../trading/state/SymbolStateClient'
@@ -380,6 +390,8 @@ export const dashboard = new Hono<DashboardBindings>()
         minReturn50d: global.pullbackDefaultMinReturn50d,
         requireAboveSma50: global.pullbackDefaultRequireAboveSma50,
         kAtr: global.pullbackDefaultKAtr,
+        maxSma50DeviationPct: global.pullbackDefaultMaxSma50DeviationPct,
+        maxAtrRatio: global.pullbackDefaultMaxAtrRatio,
       }
       const rules: SymbolChartRules = {
         pullbackMax: strategyParams.pullbackMax,
@@ -387,6 +399,22 @@ export const dashboard = new Hono<DashboardBindings>()
         stopPct: strategyParams.stopPct,
         takeProfitPct: strategyParams.takeProfitPct,
         timeStopDays: strategyParams.timeStopDays,
+      }
+      // 入場距離 (#entry-distance): entry ゲートの閾値は global default のみ
+      // (pullbackMax/Min・minReturn50d・過熱・ボラに per-symbol override は無い)。
+      // entryDistance は entry 系フィールドだけ使うが、SymbolRule は exit 系も
+      // 要求するので global から full rule を組む。
+      const entryRule: SymbolRule = {
+        stopPct: strategyParams.stopPct,
+        takeProfitPct: strategyParams.takeProfitPct,
+        timeStopDays: strategyParams.timeStopDays,
+        pullbackMax: strategyParams.pullbackMax,
+        pullbackMin: strategyParams.pullbackMin,
+        minReturn50d: strategyParams.minReturn50d,
+        requireAboveSma50: strategyParams.requireAboveSma50,
+        kAtr: strategyParams.kAtr,
+        maxSma50DeviationPct: strategyParams.maxSma50DeviationPct,
+        maxAtrRatio: strategyParams.maxAtrRatio,
       }
       // SymbolStateDO の position が ground truth (avgPrice / openedAt が
       // partial fill / position add も反映済)。trade_journal からの derive は
@@ -400,6 +428,9 @@ export const dashboard = new Hono<DashboardBindings>()
       // - 7 日は cron / 押し目 / 直近 fill 確認に最適な daily-trader の窓
       // - lastTimestamp 基準なので休場や POC 開始直後でも broken にならない
       const zoom = computeZoomRange(zoomFrom, zoomTo, symbolChart)
+      const buyability = symbolChart?.evalIndicators?.length
+        ? buildBuyabilityView(symbolChart.evalIndicators, entryRule)
+        : null
       return c.html(
         renderLayout(
           c,
@@ -412,6 +443,7 @@ export const dashboard = new Hono<DashboardBindings>()
             strategyParams,
             zoom,
             universe,
+            buyability,
           }),
         ),
       )
@@ -4059,6 +4091,12 @@ export interface SymbolChartData {
    * 省略され、レンダラ側は `|| []` で安全に扱う。
    */
   decisions?: SymbolChartDecision[]
+  /**
+   * 入場距離 (#entry-distance) 計算用の、直近 (日次ユニーク) 評価指標列。
+   * 各 cron 評価の完全な `PullbackIndicators` を時系列昇順で保持。route 側で
+   * full rule と合わせて `buildBuyabilityView` に渡す。additive で optional。
+   */
+  evalIndicators?: EvalIndicatorPoint[]
 }
 
 /**
@@ -4163,6 +4201,24 @@ export async function loadSymbolChart(
       ladderHtml: renderChartDecisionTrace(r.trace_json, r.decision ?? '', r.reason),
     }))
     .slice(-MAX_CHART_DECISIONS)
+
+  // 入場距離 (#entry-distance) 用: 完全な指標を JST 日ごと最後の評価で集約し
+  // 直近 MAX_EVAL_INDICATOR_DAYS 日を残す。日次集約は sma50/high20d/return50d が
+  // 日次指標であり、5 分 cron の intraday 重複を除いて「入場までの距離推移」を
+  // きれいに見せるため。Map は挿入順 (= 日の初出順 = 時系列) を保ち、同日キーは
+  // 後続 (= その日の最後の評価) で値が上書きされる。
+  const evalByDay = new Map<string, EvalIndicatorPoint>()
+  for (const r of logs) {
+    const indicators = parseFullIndicators(r.indicators_json)
+    if (!indicators) continue
+    const dayKey = jstDayKey(r.timestamp)
+    if (!dayKey) continue
+    evalByDay.set(dayKey, { timestamp: r.timestamp, indicators })
+  }
+  const evalIndicators: EvalIndicatorPoint[] = Array.from(evalByDay.values()).slice(
+    -MAX_EVAL_INDICATOR_DAYS,
+  )
+
   const markers: SymbolChartMarker[] = (fillsResult.results ?? [])
     .filter((r) => r.filled_price !== null)
     .map((r) => ({
@@ -4259,6 +4315,7 @@ export async function loadSymbolChart(
     latestCronPrice,
     latestCronTimestamp,
     decisions,
+    evalIndicators,
   }
 }
 
@@ -4775,6 +4832,57 @@ function parseIndicators(indicatorsJson: string | null): ExtractedIndicators {
 }
 
 /**
+ * indicators_json から完全な `PullbackIndicators` を取り出す (#entry-distance)。
+ * 入場距離計算は price/sma50/return50d/high20d/atr20/baselineAtr20 の全部が要る。
+ * 1 つでも欠けて / 非有限なら null (= その評価日は距離計算に使わない)。
+ */
+function parseFullIndicators(indicatorsJson: string | null): PullbackIndicators | null {
+  if (!indicatorsJson) return null
+  let obj: Record<string, unknown>
+  try {
+    obj = JSON.parse(indicatorsJson) as Record<string, unknown>
+  } catch {
+    return null
+  }
+  const num = (v: unknown): number | null =>
+    typeof v === 'number' && Number.isFinite(v) ? v : null
+  const price = num(obj.price)
+  const sma50 = num(obj.sma50)
+  const return50d = num(obj.return50d)
+  const high20d = num(obj.high20d)
+  const atr20 = num(obj.atr20)
+  const baselineAtr20 = num(obj.baselineAtr20)
+  if (
+    price === null ||
+    sma50 === null ||
+    return50d === null ||
+    high20d === null ||
+    atr20 === null ||
+    baselineAtr20 === null
+  ) {
+    return null
+  }
+  return { price, sma50, return50d, high20d, atr20, baselineAtr20 }
+}
+
+/** 入場距離計算に残す日次ユニーク評価の最大日数 (直近側)。 */
+const MAX_EVAL_INDICATOR_DAYS = 20
+
+const JST_DAY_FMT = new Intl.DateTimeFormat('en-CA', {
+  timeZone: 'Asia/Tokyo',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+})
+
+/** ISO UTC timestamp を JST 日付キー ('YYYY-MM-DD') に。不正なら null。 */
+function jstDayKey(iso: string): string | null {
+  const t = new Date(iso).getTime()
+  if (!Number.isFinite(t)) return null
+  return JST_DAY_FMT.format(new Date(t))
+}
+
+/**
  * `<script>...</script>` 内に埋め込む JSON を XSS 安全にする。
  * ブラウザは `</script>` を「文字列の中でも」script 終端と解釈するので、
  * `<` を unicode escape して中和する。
@@ -4825,6 +4933,10 @@ export interface StrategyParamsSnapshot {
   minReturn50d: number
   requireAboveSma50: boolean
   kAtr: number
+  /** 過熱ガード閾値 `(price-sma50)/sma50` 上限 (#entry-distance / #overextension)。 */
+  maxSma50DeviationPct: number
+  /** ボラ過熱ガード閾値 `atr20/baselineAtr20` 上限。 */
+  maxAtrRatio: number
 }
 
 /**
@@ -4887,6 +4999,8 @@ export interface ChartsBodySymbol {
   zoom: { from: Date; to: Date } | null
   /** symbol picker / chart title を JP 銘柄向け 番号-会社名 形式に整形するための universe。 */
   universe?: SymbolUniverse | null
+  /** 入場距離ビュー (#entry-distance)。「入場まであと/いつ頃」の描画用。null = データ無し。 */
+  buyability?: BuyabilityView | null
 }
 
 /**
@@ -5496,6 +5610,26 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
         }
       }
 
+      // 入場ライン (#entry-distance): 今 BUY が成立する最寄り価格を水平線で。
+      // 「あと価格がどこまで動けば入場か」をチャート上で直接見せる。価格非依存
+      // ゲートが塞ぐ局面は server 側で entryLine=null にしてあるので描かない。
+      var entryLineXY = null;
+      var entryLineLabel = '';
+      if (data.entryLine && data.entryLine.price != null && sc.points.length > 0) {
+        var elPrice = data.entryLine.price;
+        extraYValues.push(elPrice);
+        var elFromMs = new Date(sc.points[0].timestamp).getTime();
+        var elToMs = sc.latestCronTimestamp != null
+          ? new Date(sc.latestCronTimestamp).getTime()
+          : new Date(sc.points[sc.points.length - 1].timestamp).getTime();
+        if (Number.isFinite(elFromMs) && Number.isFinite(elToMs)) {
+          entryLineXY = toCategoryXY(densifyHorizontalLine(elPrice, elFromMs, elToMs, ohlcTimestamps));
+          var elMove = data.entryLine.priceMove;
+          var elPct = elMove == null ? '' : ' (' + (elMove >= 0 ? '+' : '') + (elMove * 100).toFixed(1) + '%)';
+          entryLineLabel = '入場ライン ' + elPrice.toFixed(2) + elPct;
+        }
+      }
+
       // ECharts の scale:true は markLine を yAxis range に含めないため、
       // TP / stop が data 範囲外だと枠の外で見えなくなる。data 全体 +
       // position lines + markers を考慮した explicit min/max + padding。
@@ -5821,6 +5955,16 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
             },
             silent: true, emphasis: { disabled: true }, z: 7,
           }] : []),
+          // 入場ライン (#entry-distance): 今 BUY が成立する最寄り価格。cyan 実線 +
+          // endLabel で「入場ライン $Y (−X.X%)」。現価格との差がチャート上の縦の
+          // 隙間として直感的に読める。z:9 で価格線群より前面、判定点 (z:11) より背面。
+          ...(entryLineXY ? [{
+            name: entryLineLabel, type: 'line', data: entryLineXY,
+            lineStyle: { width: 1.6, color: '#0891b2', type: 'solid' }, symbol: 'none',
+            itemStyle: { color: '#0891b2' },
+            endLabel: { show: true, formatter: entryLineLabel, color: '#0891b2', fontSize: 11 },
+            silent: true, emphasis: { disabled: true }, z: 9,
+          }] : []),
           // 判定点 scatter: cron 判定イベントを価格チャートに重ねる。z を最前面に
           // 寄せて (candle z:5 / 線 z:6-8 より上) クリック可能にする。REJECT/ERROR
           // (= 弾かれた点) は少し大きくして「なぜ買えなかったか」を目立たせる。
@@ -5982,6 +6126,9 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
           pushIfFinite(pVirtualAvg * (1 + sc.rules.stopPct));
           pushIfFinite(pVirtualAvg * (1 + sc.rules.takeProfitPct));
         }
+        // 入場ライン (#entry-distance) は chart 全幅に引くので常に visible。
+        // y 範囲に含めて、価格から離れていても枠外に消えないようにする。
+        if (data.entryLine && data.entryLine.price != null) pushIfFinite(data.entryLine.price);
         if (visibleY.length === 0) return;
         var rawMin = Math.min.apply(null, visibleY);
         var rawMax = Math.max.apply(null, visibleY);
@@ -6071,12 +6218,27 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
   `
   // chart payload に displayName を注入。client 側の chart title / tooltip header
   // は `sc.displayName || sc.symbol` で読む (US 銘柄は displayName === symbol)。
+  // evalIndicators は buyability を server で算出済みなので client へは送らない
+  // (入場ライン価格だけ別途 entryLine で渡す)。
   const symbolChartPayload = args.symbolChart
-    ? { ...args.symbolChart, displayName: displaySymbol(args.symbolChart.symbol, args.universe) }
+    ? (({ evalIndicators: _omit, ...rest }) => ({
+        ...rest,
+        displayName: displaySymbol(args.symbolChart!.symbol, args.universe),
+      }))(args.symbolChart)
     : null
+  // 入場ライン (#entry-distance): 今 BUY が成立する最寄り価格。価格非依存ゲートが
+  // 塞いでいる時 (entryPrice null) は線を引かない (panel が理由を説明)。
+  const entryLine =
+    args.buyability?.current && args.buyability.current.entryPrice !== null
+      ? {
+          price: args.buyability.current.entryPrice,
+          priceMove: args.buyability.current.priceMove,
+        }
+      : null
   return `${renderSymbolPickerForTab(args)}
   ${renderCurrentIndicatorsBadge(args.symbolChart)}
   <div id="symbol-chart" style="width:100%;height:460px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;margin-top:12px"></div>
+  ${renderBuyabilityPanel(args.buyability ?? null)}
   ${renderDecisionPlotCaption(args.symbolChart)}
   ${renderZoomPresetButtons(args.symbolChart)}
   <div id="decision-trace-panel" class="reason-panel" style="margin-top:10px">
@@ -6085,6 +6247,7 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
   ${renderStrategyParamsPanel(args.strategyParams)}
   ${safeJsonScript('__chartData', {
     symbolChart: symbolChartPayload,
+    entryLine,
     zoomFromMs: args.zoom ? args.zoom.from.getTime() : null,
     zoomToMs: args.zoom ? args.zoom.to.getTime() : null,
   })}
@@ -6187,9 +6350,12 @@ export function renderGridTab(args: ChartsBodyGrid): string {
   // (`sc.displayName || sc.symbol`) で読まれる。
   const payload = {
     charts: args.charts.map((c) => {
-      // grid の mini chart は判定点を描かないので、ラダー HTML を持つ
-      // decisions は payload から落としてサイズを抑える (個別銘柄タブ専用)。
-      const lean = c.chart ? (({ decisions: _omit, ...rest }) => rest)(c.chart) : null
+      // grid の mini chart は判定点 / 入場距離を描かないので、ラダー HTML を持つ
+      // decisions と evalIndicators は payload から落としてサイズを抑える
+      // (どちらも個別銘柄タブ専用)。
+      const lean = c.chart
+        ? (({ decisions: _omitD, evalIndicators: _omitE, ...rest }) => rest)(c.chart)
+        : null
       return {
         symbol: c.symbol,
         chart: lean ? { ...lean, displayName: displaySymbol(c.chart!.symbol, args.universe) } : null,
@@ -6943,6 +7109,8 @@ const STRATEGY_DEFAULTS: StrategyParamsSnapshot = {
   minReturn50d: 0.08,
   requireAboveSma50: true,
   kAtr: 2.0,
+  maxSma50DeviationPct: 0.6,
+  maxAtrRatio: 1.5,
 }
 
 /**
@@ -7066,6 +7234,142 @@ export function renderZoomPresetButtons(chart: SymbolChartData | null): string {
  * 撤去 (15m chart の y軸を引き伸ばさないため) した代替表示。最新の cron-eval
  * point から取得し、null は em-dash (—) で fallback。
  */
+const JST_MD_FMT = new Intl.DateTimeFormat('ja-JP', {
+  timeZone: 'Asia/Tokyo',
+  month: 'numeric',
+  day: 'numeric',
+})
+
+/** % 表示 (符号付き)。0.123 → "+12.3%"。 */
+function fmtPctSigned(v: number): string {
+  return `${v >= 0 ? '+' : ''}${(v * 100).toFixed(1)}%`
+}
+
+/** 入場ゲートの「現在値 op 閾値」を人間可読に整形 (#entry-distance)。 */
+function fmtGateValue(g: EntryGateStatus): string {
+  const op = ` ${g.operator} `
+  switch (g.key) {
+    case 'trend':
+    case 'overextension':
+    case 'pullback_shallow':
+    case 'pullback_deep':
+      return `${fmtPctSigned(g.actual)}${op}${fmtPctSigned(g.threshold)}`
+    case 'above_sma50':
+      return `$${g.actual.toFixed(2)}${op}$${g.threshold.toFixed(2)} (SMA50)`
+    case 'volatility':
+      return `${g.actual.toFixed(2)}×${op}${g.threshold.toFixed(2)}×`
+    case 'high20d_valid':
+      return `$${g.actual.toFixed(2)}${op}0`
+  }
+}
+
+/**
+ * 「入場まで あとどれくらい / いつ頃」パネル (#entry-distance)。
+ * - 結論 (buyable / 価格であと X% / 価格では不可+ボトルネック)
+ * - 距離の推移 (mini bar、縮小/拡大トレンド)
+ * - 参考 ETA (外挿・非予測の注記つき)
+ * - 全ゲートの現在値 vs 閾値チェックリスト
+ * buyability / current が無ければ空文字。
+ */
+export function renderBuyabilityPanel(buyability: BuyabilityView | null): string {
+  if (!buyability || !buyability.current) return ''
+  const cur = buyability.current
+
+  // --- 結論 ---
+  let headline: string
+  let headColor: string
+  if (cur.buyable) {
+    headline =
+      '現在 入場条件を充足（cron 評価では BUY 候補。実発注は資金 / 単元など発注側ゲート次第）'
+    headColor = '#057a55'
+  } else if (cur.entryPrice !== null && cur.priceMove !== null) {
+    const dir = cur.priceMove < 0 ? '下落' : '上昇'
+    const binding = cur.bindingGate ? ` ／ ボトルネック: ${esc(cur.bindingGate.labelJa)}` : ''
+    headline = `入場まで: あと 価格 <strong>${fmtPctSigned(cur.priceMove)}</strong>（$${cur.entryPrice.toFixed(2)} 到達 = ${dir}）${binding}`
+    headColor = '#b25000'
+  } else {
+    const g = cur.bindingGate
+    const why = g
+      ? g.priceDependent
+        ? '押し目ゾーンと過熱上限が同時に成立しない局面です。'
+        : 'この指標が条件を満たすまでは、価格がどこでも入場しません。'
+      : ''
+    headline = g
+      ? `価格を動かすだけでは入場不可 — ボトルネック: <strong>${esc(g.labelJa)}</strong>（現在 ${esc(fmtGateValue(g))} 不成立）。${why}`
+      : '入場条件 評価不可'
+    headColor = '#c22'
+  }
+
+  // --- 距離の推移 (mini bars) ---
+  const movePts = buyability.series.filter(
+    (p): p is typeof p & { priceMove: number } => p.priceMove !== null,
+  )
+  const recent = movePts.slice(-8)
+  let trendBlock = ''
+  if (recent.length > 0) {
+    const maxGap = Math.max(...recent.map((p) => Math.abs(p.priceMove)), 1e-9)
+    const bars = recent
+      .map((p, i) => {
+        const gap = Math.abs(p.priceMove)
+        const w = Math.max(2, Math.round((gap / maxGap) * 90))
+        const last = i === recent.length - 1
+        const color = last ? headColor : '#c9c9cf'
+        const md = JST_MD_FMT.format(new Date(p.timestamp))
+        return `<div style="display:flex;align-items:center;gap:6px;font-size:11px;line-height:1.5">
+          <span style="width:34px;color:#86868b;text-align:right">${esc(md)}</span>
+          <span style="display:inline-block;height:8px;width:${w}px;background:${color};border-radius:2px"></span>
+          <span style="font-variant-numeric:tabular-nums">${fmtPctSigned(p.priceMove)}</span>
+        </div>`
+      })
+      .join('')
+    const trendLabel =
+      buyability.trend === 'closing'
+        ? '<span style="color:#057a55">縮小中（入場に近づいている）</span>'
+        : buyability.trend === 'widening'
+          ? '<span style="color:#b25000">拡大中（入場から遠ざかっている）</span>'
+          : buyability.trend === 'flat'
+            ? '<span class="muted">横ばい</span>'
+            : '<span class="muted">判定不能</span>'
+    trendBlock = `<div style="margin-top:8px"><strong>距離の推移</strong>(入場までの価格距離)：${trendLabel}
+      <div style="margin-top:4px">${bars}</div></div>`
+  } else {
+    trendBlock = `<div style="margin-top:8px" class="muted">距離の推移: 価格距離が算出できる評価日がありません（価格非依存ゲートが要因）。</div>`
+  }
+
+  // --- 参考 ETA ---
+  let etaBlock = ''
+  if (buyability.etaTradingDays !== null && buyability.trend === 'closing') {
+    const days = Math.max(1, Math.ceil(buyability.etaTradingDays))
+    etaBlock = `<div style="margin-top:8px"><strong>参考 ETA</strong>: このペースが続けば 約 ${days} 営業日
+      <div class="muted" style="font-size:11px">⚠ 外挿の参考値・予測ではない（相場が逆行すれば遠のく / 押し目バンドも日々動く）</div></div>`
+  }
+
+  // --- ゲートチェックリスト ---
+  const gateRows = cur.gates
+    .map((g) => {
+      const ok = g.passed
+      const binding = cur.bindingGate?.key === g.key
+      const mark = ok ? '✅' : '❌'
+      const bg = ok ? '#f1f8f4' : '#fdf0f0'
+      const border = binding ? 'border-left:3px solid #c22;' : 'border-left:3px solid transparent;'
+      const tag = binding ? ' <span style="color:#c22;font-weight:600">◀ ボトルネック</span>' : ''
+      return `<div style="display:flex;align-items:baseline;gap:8px;padding:3px 8px;background:${bg};${border}border-radius:4px;font-size:12px;flex-wrap:wrap">
+        <span>${mark}</span><span>${esc(g.labelJa)}</span>
+        <span style="color:#555;font-variant-numeric:tabular-nums">${esc(fmtGateValue(g))}</span>${tag}
+      </div>`
+    })
+    .join('')
+
+  return `<div class="reason-panel" style="margin-top:10px;max-width:720px">
+    <div style="font-size:13px;color:${headColor};margin-bottom:6px">${headline}</div>
+    ${trendBlock}
+    ${etaBlock}
+    <div style="margin-top:10px"><strong>入場ゲート</strong>(全条件。閾値は global 既定)
+      <div style="margin-top:4px;display:flex;flex-direction:column;gap:3px">${gateRows}</div>
+    </div>
+  </div>`
+}
+
 /**
  * 判定点プロットの凡例 + 件数キャプション (#decision-trace のグラフ同期)。
  * decisions が空なら空文字。最新 `MAX_CHART_DECISIONS` 件に達していれば

--- a/src/trading/strategy/entryDistance.ts
+++ b/src/trading/strategy/entryDistance.ts
@@ -214,10 +214,92 @@ export interface BuyabilityView {
    * 参考値**。縮小傾向が無い / 点が足りない / 価格非依存ブロック時は null。
    */
   etaTradingDays: number | null
+  /**
+   * チャートに描く「参考の価格外挿線」(#entry-distance のグラフ表現)。直近価格の
+   * 線形フィットを未来へ延ばした傾き + 入場ライン到達 (交差) 情報。**予測ではなく
+   * 外挿**。entryPrice が無い (価格非依存ブロック) / 点が足りない時は null。
+   */
+  projection: EntryProjection | null
+}
+
+export interface EntryProjection {
+  /** 直近評価の価格 (外挿の起点)。 */
+  lastPrice: number
+  /** 1 評価ステップ (≈ 1 営業日) あたりの価格変化 (線形フィット傾き)。 */
+  slopePerStep: number
+  /** 入場ライン価格 (= EntryDistance.entryPrice)。交差判定の対象。 */
+  entryPrice: number
+  /** 外挿の向きが entryPrice に近づいているか。 */
+  approaching: boolean
+  /** 外挿価格が entryPrice に到達するまでの推定ステップ (営業日)。離反 / 横ばいは null。 */
+  crossingSteps: number | null
+  /** 外挿線を描く長さ (ステップ)。交差ありはその近辺まで、無ければ既定ホライズン。 */
+  horizonSteps: number
 }
 
 /** ETA / trend 判定に使う直近評価日数 (日次ユニーク)。 */
 const TREND_WINDOW = 5
+
+/** 外挿線を描く既定ホライズン (営業日)。交差が無くても向きを見せる長さ。 */
+const MAX_PROJECTION_STEPS = 10
+
+/**
+ * y 列の最小二乗傾き (x = 0,1,2,...)。点が 2 未満 / 退化なら null。
+ */
+function linregSlope(ys: number[]): number | null {
+  const n = ys.length
+  if (n < 2) return null
+  let sx = 0
+  let sy = 0
+  let sxx = 0
+  let sxy = 0
+  for (let i = 0; i < n; i += 1) {
+    sx += i
+    sy += ys[i]!
+    sxx += i * i
+    sxy += i * ys[i]!
+  }
+  const denom = n * sxx - sx * sx
+  if (denom === 0) return null
+  return (n * sxy - sx * sy) / denom
+}
+
+/**
+ * チャート用の「参考 価格外挿線」を組み立てる (#entry-distance のグラフ表現)。
+ * 直近 `TREND_WINDOW` 日の価格を線形フィットして傾きを取り、入場ライン
+ * (current.entryPrice) との交差ステップを出す。**予測ではなく外挿**。
+ * entryPrice が無い (価格非依存ブロック) / 価格点 < 2 なら null。
+ */
+export function buildEntryProjection(
+  evals: EvalIndicatorPoint[],
+  current: EntryDistance,
+): EntryProjection | null {
+  if (current.entryPrice === null) return null
+  const prices = evals
+    .slice(-TREND_WINDOW)
+    .map((e) => e.indicators.price)
+    .filter((p) => Number.isFinite(p))
+  if (prices.length < 2) return null
+  const slope = linregSlope(prices)
+  const lastPrice = prices[prices.length - 1]!
+  if (slope === null || !Number.isFinite(lastPrice)) return null
+  const entryPrice = current.entryPrice
+
+  let crossingSteps: number | null = null
+  let approaching = false
+  if (Math.abs(slope) > 1e-9) {
+    const k = (entryPrice - lastPrice) / slope
+    if (k > 0 && Number.isFinite(k)) {
+      crossingSteps = k
+      approaching = true
+    }
+  }
+  const horizonSteps =
+    crossingSteps !== null
+      ? Math.min(Math.max(Math.ceil(crossingSteps), 1), MAX_PROJECTION_STEPS)
+      : MAX_PROJECTION_STEPS
+  return { lastPrice, slopePerStep: slope, entryPrice, approaching, crossingSteps, horizonSteps }
+}
 
 export interface EvalIndicatorPoint {
   timestamp: string
@@ -230,7 +312,7 @@ export interface EvalIndicatorPoint {
  */
 export function buildBuyabilityView(evals: EvalIndicatorPoint[], rule: SymbolRule): BuyabilityView {
   if (evals.length === 0) {
-    return { current: null, series: [], trend: 'unknown', etaTradingDays: null }
+    return { current: null, series: [], trend: 'unknown', etaTradingDays: null, projection: null }
   }
   const series: BuyabilityDistancePoint[] = evals.map((e) => {
     const d = computeEntryDistance(e.indicators, rule)
@@ -243,8 +325,9 @@ export function buildBuyabilityView(evals: EvalIndicatorPoint[], rule: SymbolRul
   const recent = series.slice(-TREND_WINDOW).filter((p) => p.priceMove !== null)
   const gaps = recent.map((p) => Math.abs(p.priceMove as number))
   const { trend, etaTradingDays } = estimateTrendAndEta(gaps)
+  const projection = buildEntryProjection(evals, current)
 
-  return { current, series, trend, etaTradingDays }
+  return { current, series, trend, etaTradingDays, projection }
 }
 
 /**
@@ -254,22 +337,9 @@ export function buildBuyabilityView(evals: EvalIndicatorPoint[], rule: SymbolRul
  */
 function estimateTrendAndEta(gaps: number[]): { trend: BuyabilityTrend; etaTradingDays: number | null } {
   if (gaps.length < 2) return { trend: 'unknown', etaTradingDays: null }
-  const n = gaps.length
-  // x = 0..n-1, y = gaps
-  let sx = 0
-  let sy = 0
-  let sxx = 0
-  let sxy = 0
-  for (let i = 0; i < n; i += 1) {
-    sx += i
-    sy += gaps[i]!
-    sxx += i * i
-    sxy += i * gaps[i]!
-  }
-  const denom = n * sxx - sx * sx
-  if (denom === 0) return { trend: 'flat', etaTradingDays: null }
-  const slope = (n * sxy - sx * sy) / denom
-  const lastGap = gaps[n - 1]!
+  const slope = linregSlope(gaps)
+  if (slope === null) return { trend: 'flat', etaTradingDays: null }
+  const lastGap = gaps[gaps.length - 1]!
   // ほぼ横ばい (1 評価あたり 0.05% 未満の変化) は flat 扱い。
   const FLAT_EPS = 0.0005
   if (Math.abs(slope) < FLAT_EPS) return { trend: 'flat', etaTradingDays: null }

--- a/src/trading/strategy/entryDistance.ts
+++ b/src/trading/strategy/entryDistance.ts
@@ -1,0 +1,281 @@
+import type { PullbackIndicators, SymbolRule } from './strategies/PullbackUptrendStrategy'
+
+/**
+ * 「入場まであとどれくらい / いつ頃」可視化のための前向き距離計算
+ * (#entry-distance)。`PullbackUptrendStrategy.entryDecision` の 7 ゲート連鎖を
+ * **判定ではなく距離として**評価する:
+ *
+ *  - 各ゲートの現在値 vs 閾値 (checklist 用)
+ *  - 最初に不成立になるゲート (= cron が見送る理由 = ボトルネック)
+ *  - **今 BUY が成立する最寄り価格** (= 価格依存ゲートの交差区間のうち現価格に
+ *    最も近い点)。価格非依存ゲート (トレンド / ボラ / high20d) が塞いでいる間は
+ *    どんな価格でも入場できないので null。
+ *
+ * trace (#decision-trace) は early-exit で「最初に落ちたゲートまで」しか持たず、
+ * 「あと価格がどれだけ動けば入場か」を出せない。本モジュールは全ゲートを
+ * 評価して前向きの距離を出す点が異なる。entryDecision とゲート式・順序・
+ * 既定値を一致させること (drift したら誤った入場ラインを描く)。
+ */
+
+export type EntryGateKey =
+  | 'trend'
+  | 'above_sma50'
+  | 'overextension'
+  | 'volatility'
+  | 'high20d_valid'
+  | 'pullback_shallow'
+  | 'pullback_deep'
+
+export interface EntryGateStatus {
+  key: EntryGateKey
+  labelJa: string
+  passed: boolean
+  /** ゲートが比較する指標の現在値 (ゲート固有の単位)。 */
+  actual: number
+  /** 比較先の閾値。 */
+  threshold: number
+  /** 人間可読の比較演算子 (例 '>', '<=')。 */
+  operator: string
+  /**
+   * 現在価格に依存するゲートか (= 価格が動けば成否が変わりうる)。
+   * trend / volatility / high20d_valid は価格非依存 (指標自体が変わらないと不変)。
+   */
+  priceDependent: boolean
+}
+
+export interface EntryDistance {
+  buyable: boolean
+  gates: EntryGateStatus[]
+  /** 最初に不成立になったゲート (= 見送りの直接要因)。buyable なら null。 */
+  bindingGate: EntryGateStatus | null
+  /**
+   * 今 BUY が成立する最寄り価格。価格依存ゲートの交差区間のうち現価格に最も
+   * 近い点。価格非依存ゲートが塞いでいる / 価格区間が空 (構造的に同時成立不可)
+   * の場合は null (= 価格を動かすだけでは入場できない)。
+   */
+  entryPrice: number | null
+  /** 現価格→entryPrice の符号付き変化率 ((entryPrice - price) / price)。負 = 下落が必要。null = entryPrice null 時。 */
+  priceMove: number | null
+}
+
+const GATE_LABEL_JA: Record<EntryGateKey, string> = {
+  trend: 'トレンド (直近騰落率)',
+  above_sma50: 'SMA50 より上',
+  overextension: '過熱していない (SMA50 乖離)',
+  volatility: 'ボラ過熱でない (ATR比)',
+  high20d_valid: '直近高値が有効',
+  pullback_shallow: '押し目が浅すぎない',
+  pullback_deep: '押し目が深すぎない',
+}
+
+const NEG_INF = Number.NEGATIVE_INFINITY
+const POS_INF = Number.POSITIVE_INFINITY
+
+/**
+ * 単一スナップショットの入場距離。`entryDecision` と同じゲート式・順序で評価する。
+ */
+export function computeEntryDistance(ind: PullbackIndicators, rule: SymbolRule): EntryDistance {
+  const { price, sma50, return50d, high20d, atr20, baselineAtr20 } = ind
+  const sma50Deviation = sma50 > 0 ? (price - sma50) / sma50 : 0
+  const atrRatio = baselineAtr20 > 0 ? atr20 / baselineAtr20 : 0
+  const pullback = high20d > 0 ? (price - high20d) / high20d : 0
+
+  const gates: EntryGateStatus[] = [
+    {
+      key: 'trend',
+      labelJa: GATE_LABEL_JA.trend,
+      passed: return50d > rule.minReturn50d,
+      actual: return50d,
+      threshold: rule.minReturn50d,
+      operator: '>',
+      priceDependent: false,
+    },
+    {
+      key: 'above_sma50',
+      labelJa: GATE_LABEL_JA.above_sma50,
+      // requireAboveSma50=false なら常に通過 (entryDecision と同じ)
+      passed: !rule.requireAboveSma50 || price > sma50,
+      actual: price,
+      threshold: sma50,
+      operator: '>',
+      priceDependent: rule.requireAboveSma50,
+    },
+    {
+      key: 'overextension',
+      labelJa: GATE_LABEL_JA.overextension,
+      passed: sma50Deviation <= rule.maxSma50DeviationPct,
+      actual: sma50Deviation,
+      threshold: rule.maxSma50DeviationPct,
+      operator: '<=',
+      priceDependent: true,
+    },
+    {
+      key: 'volatility',
+      labelJa: GATE_LABEL_JA.volatility,
+      passed: atrRatio <= rule.maxAtrRatio,
+      actual: atrRatio,
+      threshold: rule.maxAtrRatio,
+      operator: '<=',
+      priceDependent: false,
+    },
+    {
+      key: 'high20d_valid',
+      labelJa: GATE_LABEL_JA.high20d_valid,
+      passed: high20d > 0,
+      actual: high20d,
+      threshold: 0,
+      operator: '>',
+      priceDependent: false,
+    },
+    {
+      key: 'pullback_shallow',
+      labelJa: GATE_LABEL_JA.pullback_shallow,
+      passed: pullback <= rule.pullbackMax,
+      actual: pullback,
+      threshold: rule.pullbackMax,
+      operator: '<=',
+      priceDependent: true,
+    },
+    {
+      key: 'pullback_deep',
+      labelJa: GATE_LABEL_JA.pullback_deep,
+      passed: pullback >= rule.pullbackMin,
+      actual: pullback,
+      threshold: rule.pullbackMin,
+      operator: '>=',
+      priceDependent: true,
+    },
+  ]
+
+  const bindingGate = gates.find((g) => !g.passed) ?? null
+  const buyable = bindingGate === null
+
+  const entryPrice = resolveNearestEntryPrice(ind, rule, gates)
+  const priceMove = entryPrice !== null && price > 0 ? (entryPrice - price) / price : null
+
+  return { buyable, gates, bindingGate, entryPrice, priceMove }
+}
+
+/**
+ * 価格依存ゲートをすべて満たす価格区間の中で、現価格に最も近い点を返す。
+ * 価格非依存ゲート (トレンド / ボラ / high20d) が 1 つでも落ちていれば、価格を
+ * 動かしても入場できないので null。区間が空 (band が SMA50 帯と交わらない等)
+ * でも null。
+ */
+function resolveNearestEntryPrice(
+  ind: PullbackIndicators,
+  rule: SymbolRule,
+  gates: EntryGateStatus[],
+): number | null {
+  // 価格非依存ゲートが落ちている間は、いくら価格が動いても入場不可。
+  const priceIndependentBlocked = gates.some((g) => !g.priceDependent && !g.passed)
+  if (priceIndependentBlocked) return null
+
+  const { sma50, high20d } = ind
+  if (high20d <= 0) return null
+
+  // band: [high20d*(1+pullbackMin), high20d*(1+pullbackMax)]
+  // pullbackMin < pullbackMax < 0 (例 -0.06 < -0.03) なので下端 < 上端。
+  const bandLow = high20d * (1 + rule.pullbackMin)
+  const bandHigh = high20d * (1 + rule.pullbackMax)
+
+  // above_sma50 (require 時のみ下限): price > sma50
+  const sma50Low = rule.requireAboveSma50 ? sma50 : NEG_INF
+  // overextension 上限: price <= sma50*(1+maxSma50DeviationPct)
+  const overextHigh = sma50 > 0 ? sma50 * (1 + rule.maxSma50DeviationPct) : POS_INF
+
+  const low = Math.max(bandLow, sma50Low)
+  const high = Math.min(bandHigh, overextHigh)
+  if (low > high) return null // 同時成立する価格が存在しない (構造的にブロック)
+
+  // 現価格に最も近い区間内の点 (= 最小の値動きで入場する価格)。
+  const clamped = Math.min(Math.max(ind.price, low), high)
+  return Number.isFinite(clamped) ? clamped : null
+}
+
+export interface BuyabilityDistancePoint {
+  timestamp: string
+  /** 現価格→最寄り入場価格の符号付き変化率。価格非依存ゲートが塞ぐ評価日は null。 */
+  priceMove: number | null
+  buyable: boolean
+}
+
+export type BuyabilityTrend = 'closing' | 'widening' | 'flat' | 'unknown'
+
+export interface BuyabilityView {
+  /** 最新評価の入場距離。評価ログが無ければ null。 */
+  current: EntryDistance | null
+  /** 直近 (日次ユニーク) の距離推移。時系列昇順。 */
+  series: BuyabilityDistancePoint[]
+  /** 距離が縮小 (入場に近づく) / 拡大 / 横ばい / 判定不能。 */
+  trend: BuyabilityTrend
+  /**
+   * 参考 ETA (営業日)。直近の距離縮小ペースの線形外挿。**予測ではなく外挿の
+   * 参考値**。縮小傾向が無い / 点が足りない / 価格非依存ブロック時は null。
+   */
+  etaTradingDays: number | null
+}
+
+/** ETA / trend 判定に使う直近評価日数 (日次ユニーク)。 */
+const TREND_WINDOW = 5
+
+export interface EvalIndicatorPoint {
+  timestamp: string
+  indicators: PullbackIndicators
+}
+
+/**
+ * 直近の評価指標列から入場距離ビューを組み立てる。`evals` は時系列昇順
+ * (日次ユニーク推奨) を想定。
+ */
+export function buildBuyabilityView(evals: EvalIndicatorPoint[], rule: SymbolRule): BuyabilityView {
+  if (evals.length === 0) {
+    return { current: null, series: [], trend: 'unknown', etaTradingDays: null }
+  }
+  const series: BuyabilityDistancePoint[] = evals.map((e) => {
+    const d = computeEntryDistance(e.indicators, rule)
+    return { timestamp: e.timestamp, priceMove: d.priceMove, buyable: d.buyable }
+  })
+  const current = computeEntryDistance(evals[evals.length - 1]!.indicators, rule)
+
+  // trend / ETA は「価格距離 (priceMove) が定義される評価日」のみで判定する。
+  // 価格非依存ブロック日 (priceMove=null) は対象外。
+  const recent = series.slice(-TREND_WINDOW).filter((p) => p.priceMove !== null)
+  const gaps = recent.map((p) => Math.abs(p.priceMove as number))
+  const { trend, etaTradingDays } = estimateTrendAndEta(gaps)
+
+  return { current, series, trend, etaTradingDays }
+}
+
+/**
+ * 連続する「入場までの距離 (絶対値)」列から、縮小/拡大トレンドと参考 ETA を出す。
+ * 線形最小二乗で傾きを取り、負 (縮小) なら gap/|slope| を ETA とする。
+ * gap の単位は分数 (例 0.018 = 1.8%)、index は評価ステップ (≈ 1 営業日)。
+ */
+function estimateTrendAndEta(gaps: number[]): { trend: BuyabilityTrend; etaTradingDays: number | null } {
+  if (gaps.length < 2) return { trend: 'unknown', etaTradingDays: null }
+  const n = gaps.length
+  // x = 0..n-1, y = gaps
+  let sx = 0
+  let sy = 0
+  let sxx = 0
+  let sxy = 0
+  for (let i = 0; i < n; i += 1) {
+    sx += i
+    sy += gaps[i]!
+    sxx += i * i
+    sxy += i * gaps[i]!
+  }
+  const denom = n * sxx - sx * sx
+  if (denom === 0) return { trend: 'flat', etaTradingDays: null }
+  const slope = (n * sxy - sx * sy) / denom
+  const lastGap = gaps[n - 1]!
+  // ほぼ横ばい (1 評価あたり 0.05% 未満の変化) は flat 扱い。
+  const FLAT_EPS = 0.0005
+  if (Math.abs(slope) < FLAT_EPS) return { trend: 'flat', etaTradingDays: null }
+  if (slope >= 0) return { trend: 'widening', etaTradingDays: null }
+  // 縮小中: 現 gap を縮小ペースで割って 0 到達までのステップ数。
+  const eta = lastGap / -slope
+  if (!Number.isFinite(eta) || eta <= 0) return { trend: 'closing', etaTradingDays: null }
+  return { trend: 'closing', etaTradingDays: eta }
+}

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -1974,6 +1974,20 @@ describe('renderSymbolTab — 判定点 scatter + click-to-trace の配線', () 
     const html = renderSymbolTab(symbolArgs([], null))
     expect(html).toContain('"entryLine":null')
   })
+
+  it('projection があれば payload に外挿情報を載せる (参考 価格外挿線)', () => {
+    const view = buildBuyabilityView(
+      [99.5, 99, 98.5, 98].map((price, i) => ({
+        timestamp: `2026-06-0${i + 1}T14:00:00.000Z`,
+        indicators: indFor({ price }),
+      })),
+      TEST_DEFAULT_RULE,
+    )
+    const html = renderSymbolTab(symbolArgs([], view))
+    expect(html).toContain('"projection"')
+    expect(html).toContain('"slopePerStep"')
+    expect(html).toContain('参考 価格外挿') // 外挿線 series 名 (配線確認)
+  })
 })
 
 describe('renderBuyabilityPanel (入場まで あとどれくらい / いつ頃)', () => {

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -1958,21 +1958,22 @@ describe('renderSymbolTab — 判定点 scatter + click-to-trace の配線', () 
     expect(html).toContain('decision-trace-panel')
   })
 
-  it('buyability に entryPrice があれば payload の entryLine + 入場パネルを出す', () => {
-    // price 99 / high20d 100 → band 上端 97 まで下落が必要 (entryPrice 97)
+  it('buyability があれば 入場パネル + 押し目ゾーン端の距離ラベルを配線する', () => {
     const view = buildBuyabilityView(
       [{ timestamp: '2026-06-06T14:00:00.000Z', indicators: indFor({ price: 99 }) }],
       TEST_DEFAULT_RULE,
     )
     const html = renderSymbolTab(symbolArgs([], view))
-    expect(html).toContain('"entryLine"')
-    expect(html).toContain('"price":97') // band 上端
     expect(html).toContain('入場まで') // パネル headline
+    // 入場ライン独立線は廃止 → 押し目ゾーン端に距離ラベルを載せる
+    expect(html).toContain("bandEdgeLabel('押し目上端'")
+    expect(html).toContain("bandEdgeLabel('押し目下端'")
+    expect(html).not.toContain('"entryLine"') // 独立 entryLine payload は無い
   })
 
-  it('buyability が null なら entryLine も null', () => {
+  it('buyability が null なら projection も null', () => {
     const html = renderSymbolTab(symbolArgs([], null))
-    expect(html).toContain('"entryLine":null')
+    expect(html).toContain('"projection":null')
   })
 
   it('projection があれば payload に外挿情報を載せる (参考 価格外挿線)', () => {

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -1002,6 +1002,8 @@ const DEFAULT_PARAMS: StrategyParamsSnapshot = {
   minReturn50d: 0.08,
   requireAboveSma50: true,
   kAtr: 2.0,
+  maxSma50DeviationPct: 0.6,
+  maxAtrRatio: 1.5,
 }
 
 /** Count cells flagged as 変更済 (title attr ベースで識別、凡例 ⚠ と分離)。 */
@@ -1804,12 +1806,23 @@ describe('renderCurrentIndicatorsBadge', () => {
 })
 
 import {
+  renderBuyabilityPanel,
   renderChartDecisionTrace,
   renderDecisionPlotCaption,
   renderSymbolTab,
   type ChartsBodySymbol,
   type SymbolChartDecision,
 } from '../../src/routes/dashboard'
+import { buildBuyabilityView, type EvalIndicatorPoint } from '../../src/trading/strategy/entryDistance'
+import {
+  TEST_DEFAULT_RULE,
+  type PullbackIndicators,
+} from '../../src/trading/strategy/strategies/PullbackUptrendStrategy'
+
+// TEST_DEFAULT_RULE: band = high20d×[0.94, 0.97], sma50 floor。
+function indFor(overrides: Partial<PullbackIndicators>): PullbackIndicators {
+  return { price: 95, sma50: 90, return50d: 0.12, high20d: 100, atr20: 1, baselineAtr20: 1, ...overrides }
+}
 
 describe('renderChartDecisionTrace (チャート判定点クリック時のラダー HTML)', () => {
   it('trace があれば renderDecisionLadder のラダーを返す', () => {
@@ -1891,8 +1904,12 @@ describe('renderSymbolTab — 判定点 scatter + click-to-trace の配線', () 
     stopPct: -0.08, takeProfitPct: 0.07, timeStopDays: 10,
     pullbackMax: -0.03, pullbackMin: -0.15, minReturn50d: 0,
     requireAboveSma50: true, kAtr: 2,
+    maxSma50DeviationPct: 0.6, maxAtrRatio: 1.5,
   }
-  function symbolArgs(decisions: SymbolChartDecision[]): ChartsBodySymbol {
+  function symbolArgs(
+    decisions: SymbolChartDecision[],
+    buyability?: ChartsBodySymbol['buyability'],
+  ): ChartsBodySymbol {
     return {
       tab: 'symbol',
       focusSymbol: 'TQQQ',
@@ -1908,6 +1925,7 @@ describe('renderSymbolTab — 判定点 scatter + click-to-trace の配線', () 
       availableSymbols: ['TQQQ'],
       strategyParams: baseParams,
       zoom: null,
+      buyability: buyability ?? null,
     }
   }
 
@@ -1938,6 +1956,68 @@ describe('renderSymbolTab — 判定点 scatter + click-to-trace の配線', () 
     expect(html).toContain('"decisions":[]')
     // placeholder パネルは常に描画
     expect(html).toContain('decision-trace-panel')
+  })
+
+  it('buyability に entryPrice があれば payload の entryLine + 入場パネルを出す', () => {
+    // price 99 / high20d 100 → band 上端 97 まで下落が必要 (entryPrice 97)
+    const view = buildBuyabilityView(
+      [{ timestamp: '2026-06-06T14:00:00.000Z', indicators: indFor({ price: 99 }) }],
+      TEST_DEFAULT_RULE,
+    )
+    const html = renderSymbolTab(symbolArgs([], view))
+    expect(html).toContain('"entryLine"')
+    expect(html).toContain('"price":97') // band 上端
+    expect(html).toContain('入場まで') // パネル headline
+  })
+
+  it('buyability が null なら entryLine も null', () => {
+    const html = renderSymbolTab(symbolArgs([], null))
+    expect(html).toContain('"entryLine":null')
+  })
+})
+
+describe('renderBuyabilityPanel (入場まで あとどれくらい / いつ頃)', () => {
+  function viewFromPrices(prices: number[]): ReturnType<typeof buildBuyabilityView> {
+    const evals: EvalIndicatorPoint[] = prices.map((price, i) => ({
+      timestamp: `2026-06-0${i + 1}T14:00:00.000Z`,
+      indicators: indFor({ price }),
+    }))
+    return buildBuyabilityView(evals, TEST_DEFAULT_RULE)
+  }
+
+  it('null / current 無しなら空文字', () => {
+    expect(renderBuyabilityPanel(null)).toBe('')
+  })
+
+  it('価格があと下落で入場 → 「入場まで あと 価格」+ 到達価格 + ゲート表', () => {
+    const html = renderBuyabilityPanel(viewFromPrices([99]))
+    expect(html).toContain('入場まで')
+    expect(html).toContain('あと 価格')
+    expect(html).toContain('97.00') // band 上端 = 到達価格
+    expect(html).toContain('入場ゲート')
+    expect(html).toContain('◀ ボトルネック') // 不成立ゲートを明示
+  })
+
+  it('全条件充足なら「入場条件を充足」', () => {
+    const html = renderBuyabilityPanel(viewFromPrices([95]))
+    expect(html).toContain('入場条件を充足')
+  })
+
+  it('価格非依存ブロック (トレンド不足) は「価格を動かすだけでは入場不可」', () => {
+    const view = buildBuyabilityView(
+      [{ timestamp: '2026-06-06T14:00:00.000Z', indicators: indFor({ return50d: 0.02 }) }],
+      TEST_DEFAULT_RULE,
+    )
+    const html = renderBuyabilityPanel(view)
+    expect(html).toContain('価格を動かすだけでは入場不可')
+    expect(html).toContain('トレンド')
+  })
+
+  it('距離が縮小していれば 縮小中 + 参考ETA (非予測注記つき)', () => {
+    const html = renderBuyabilityPanel(viewFromPrices([99.5, 99, 98.5, 98, 97.5]))
+    expect(html).toContain('縮小中')
+    expect(html).toContain('参考 ETA')
+    expect(html).toContain('予測ではない')
   })
 })
 

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -1803,6 +1803,144 @@ describe('renderCurrentIndicatorsBadge', () => {
   })
 })
 
+import {
+  renderChartDecisionTrace,
+  renderDecisionPlotCaption,
+  renderSymbolTab,
+  type ChartsBodySymbol,
+  type SymbolChartDecision,
+} from '../../src/routes/dashboard'
+
+describe('renderChartDecisionTrace (チャート判定点クリック時のラダー HTML)', () => {
+  it('trace があれば renderDecisionLadder のラダーを返す', () => {
+    const trace = JSON.stringify([
+      { label: 'guard.pending_order_absent', label_ja: '発注中でない', passed: true },
+      {
+        label: 'risk.overextension',
+        label_ja: '過熱していない',
+        passed: false,
+        actual: 0.4,
+        operator: '<=',
+        threshold: 0.2,
+      },
+    ])
+    const html = renderChartDecisionTrace(trace, 'REJECT', 'overextension guard')
+    expect(html).toContain('判定トレース')
+    expect(html).toContain('発注中でない')
+    expect(html).toContain('過熱していない')
+    expect(html).toContain('◀ 採用') // 最後のステップに採用矢印
+    expect(html).toContain('tl-out-reject') // 出力ボックス (REJECT 色)
+  })
+
+  it('trace 無し (旧ログ) は出力ボックスのみのフォールバック (◀ 採用 なし)', () => {
+    const html = renderChartDecisionTrace(null, 'REJECT', 'overextension guard')
+    expect(html).toContain('トレースが保存されていません')
+    expect(html).toContain('tl-out-reject')
+    expect(html).toContain('出力: <strong>REJECT</strong>')
+    expect(html).not.toContain('◀ 採用')
+  })
+
+  it('壊れた trace JSON もフォールバックに落ちる (throw しない)', () => {
+    const html = renderChartDecisionTrace('not-json', 'ERROR', 'boom')
+    expect(html).toContain('トレースが保存されていません')
+    expect(html).toContain('tl-out-error')
+  })
+})
+
+describe('renderDecisionPlotCaption (判定点プロットの凡例 + 件数)', () => {
+  function chartWith(decisions: SymbolChartDecision[]): SymbolChartData {
+    return {
+      symbol: 'TQQQ',
+      points: [{ timestamp: '2026-06-06T14:00:00.000Z', price: 80, sma50: null, high20d: null, low20d: null }],
+      markers: [], position: null,
+      rules: { pullbackMax: -0.03, pullbackMin: -0.15, stopPct: -0.08, takeProfitPct: 0.07, timeStopDays: 10 },
+      trendLine: null, intradayBars: [],
+      latestCronPrice: null, latestCronTimestamp: null,
+      decisions,
+    }
+  }
+  const oneDecision: SymbolChartDecision = {
+    id: 1, timestamp: '2026-06-06T14:00:00.000Z', price: 80,
+    decision: 'REJECT', reason: 'overextension', ladderHtml: '<div>x</div>',
+  }
+
+  it('chart null / decisions 無し / 空配列なら空文字', () => {
+    expect(renderDecisionPlotCaption(null)).toBe('')
+    expect(renderDecisionPlotCaption(chartWith([]))).toBe('')
+  })
+
+  it('decisions があれば凡例 + HOLD 省略の説明を出す', () => {
+    const html = renderDecisionPlotCaption(chartWith([oneDecision]))
+    expect(html).toContain('買い (BUY)')
+    expect(html).toContain('売り (SELL)')
+    expect(html).toContain('見送り (REJECT)')
+    expect(html).toContain('エラー (ERROR)')
+    expect(html).toContain('HOLD')
+    expect(html).toContain('クリック')
+  })
+
+  it('上限 (250) に達したら truncation を明示 (silent cap を避ける)', () => {
+    const many = Array.from({ length: 250 }, (_, i) => ({ ...oneDecision, id: i + 1 }))
+    const html = renderDecisionPlotCaption(chartWith(many))
+    expect(html).toContain('直近 250 件まで表示')
+  })
+})
+
+describe('renderSymbolTab — 判定点 scatter + click-to-trace の配線', () => {
+  const baseParams = {
+    stopPct: -0.08, takeProfitPct: 0.07, timeStopDays: 10,
+    pullbackMax: -0.03, pullbackMin: -0.15, minReturn50d: 0,
+    requireAboveSma50: true, kAtr: 2,
+  }
+  function symbolArgs(decisions: SymbolChartDecision[]): ChartsBodySymbol {
+    return {
+      tab: 'symbol',
+      focusSymbol: 'TQQQ',
+      symbolChart: {
+        symbol: 'TQQQ',
+        points: [{ timestamp: '2026-06-06T14:00:00.000Z', price: 80, sma50: 70, high20d: 90, low20d: 60 }],
+        markers: [], position: null,
+        rules: { pullbackMax: -0.03, pullbackMin: -0.15, stopPct: -0.08, takeProfitPct: 0.07, timeStopDays: 10 },
+        trendLine: null, intradayBars: [],
+        latestCronPrice: 80, latestCronTimestamp: '2026-06-06T14:00:00.000Z',
+        decisions,
+      },
+      availableSymbols: ['TQQQ'],
+      strategyParams: baseParams,
+      zoom: null,
+    }
+  }
+
+  it('decisions があれば scatter series + trace panel + 埋込ラダーを配線する', () => {
+    const html = renderSymbolTab(symbolArgs([
+      {
+        id: 1, timestamp: '2026-06-06T14:00:00.000Z', price: 80,
+        decision: 'REJECT', reason: 'overextension',
+        ladderHtml: '<div>LADDER_EMBED_MARKER</div>',
+      },
+    ]))
+    expect(html).toContain("type: 'scatter'")
+    expect(html).toContain("name: '判定'")
+    expect(html).toContain('decision-trace-panel')
+    expect(html).toContain('showDecisionTrace')
+    // 各点の ladderHtml が payload に埋め込まれている (safeJsonScript で < は
+    // < に escape されるが marker テキストは残る)
+    expect(html).toContain('LADDER_EMBED_MARKER')
+    // 凡例キャプションも出る
+    expect(html).toContain('見送り (REJECT)')
+  })
+
+  it('decisions が無ければ凡例は出ず payload も空 (scatter JS は静的に常駐 / runtime で 0 件描画)', () => {
+    const html = renderSymbolTab(symbolArgs([]))
+    // 凡例キャプションは decisions があるときだけ出す
+    expect(html).not.toContain('見送り (REJECT)')
+    // payload の decisions は空配列 (= runtime で scatter 0 点)
+    expect(html).toContain('"decisions":[]')
+    // placeholder パネルは常に描画
+    expect(html).toContain('decision-trace-panel')
+  })
+})
+
 import { renderZoomPresetButtons } from '../../src/routes/dashboard'
 
 describe('renderZoomPresetButtons', () => {

--- a/test/trading/strategy/entryDistance.test.ts
+++ b/test/trading/strategy/entryDistance.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildBuyabilityView,
+  buildEntryProjection,
   computeEntryDistance,
   type EvalIndicatorPoint,
 } from '../../../src/trading/strategy/entryDistance'
@@ -136,5 +137,54 @@ describe('buildBuyabilityView', () => {
   it('最新が buyable なら current.buyable true', () => {
     const v = buildBuyabilityView(evalsFromPrices([99, 98, 97, 96, 95]), RULE)
     expect(v.current?.buyable).toBe(true)
+  })
+})
+
+describe('buildEntryProjection (参考 価格外挿線)', () => {
+  function evalsFromPrices(prices: number[]): EvalIndicatorPoint[] {
+    return prices.map((price, i) => ({
+      timestamp: `2026-06-0${i + 1}T14:00:00.000Z`,
+      indicators: ind({ price }),
+    }))
+  }
+
+  it('entryPrice が無い (トレンドブロック) なら null', () => {
+    const evals = [{ timestamp: 't', indicators: ind({ return50d: 0.02 }) }]
+    const current = computeEntryDistance(evals[0]!.indicators, RULE)
+    expect(buildEntryProjection(evals, current)).toBeNull()
+  })
+
+  it('価格点が 1 つだけなら null (傾き不能)', () => {
+    const evals = evalsFromPrices([99])
+    const current = computeEntryDistance(evals[0]!.indicators, RULE)
+    expect(buildEntryProjection(evals, current)).toBeNull()
+  })
+
+  it('入場ラインへ向かって下落中 → approaching true + crossingSteps 正値', () => {
+    const evals = evalsFromPrices([99, 98.5, 98, 97.5]) // band 上端 97 へ降下
+    const current = computeEntryDistance(evals[evals.length - 1]!.indicators, RULE)
+    const p = buildEntryProjection(evals, current)
+    expect(p).not.toBeNull()
+    expect(p!.entryPrice).toBeCloseTo(97, 6)
+    expect(p!.slopePerStep).toBeLessThan(0)
+    expect(p!.approaching).toBe(true)
+    expect(p!.crossingSteps).not.toBeNull()
+    expect(p!.crossingSteps!).toBeGreaterThan(0)
+  })
+
+  it('入場ラインから離れていく (上昇中) → approaching false + crossingSteps null', () => {
+    const evals = evalsFromPrices([97.5, 98, 98.5, 99]) // band 上端 97 から上へ
+    const current = computeEntryDistance(evals[evals.length - 1]!.indicators, RULE)
+    const p = buildEntryProjection(evals, current)
+    expect(p).not.toBeNull()
+    expect(p!.approaching).toBe(false)
+    expect(p!.crossingSteps).toBeNull()
+    expect(p!.horizonSteps).toBeGreaterThan(0)
+  })
+
+  it('buildBuyabilityView にも projection が乗る', () => {
+    const v = buildBuyabilityView(evalsFromPrices([99, 98.5, 98, 97.5]), RULE)
+    expect(v.projection).not.toBeNull()
+    expect(v.projection!.approaching).toBe(true)
   })
 })

--- a/test/trading/strategy/entryDistance.test.ts
+++ b/test/trading/strategy/entryDistance.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildBuyabilityView,
+  computeEntryDistance,
+  type EvalIndicatorPoint,
+} from '../../../src/trading/strategy/entryDistance'
+import {
+  TEST_DEFAULT_RULE,
+  type PullbackIndicators,
+} from '../../../src/trading/strategy/strategies/PullbackUptrendStrategy'
+
+// TEST_DEFAULT_RULE: minReturn50d 0.08 / requireAboveSma50 true /
+// maxSma50DeviationPct 0.6 / maxAtrRatio 1.5 / pullbackMax -0.03 / pullbackMin -0.06
+const RULE = TEST_DEFAULT_RULE
+
+function ind(overrides: Partial<PullbackIndicators>): PullbackIndicators {
+  return {
+    price: 95,
+    sma50: 90,
+    return50d: 0.12,
+    high20d: 100, // band = [94, 97]
+    atr20: 1,
+    baselineAtr20: 1,
+    ...overrides,
+  }
+}
+
+describe('computeEntryDistance', () => {
+  it('全ゲート通過 → buyable、entryPrice = 現価格、priceMove 0', () => {
+    const d = computeEntryDistance(ind({ price: 95 }), RULE)
+    expect(d.buyable).toBe(true)
+    expect(d.bindingGate).toBeNull()
+    expect(d.entryPrice).toBeCloseTo(95, 6)
+    expect(d.priceMove).toBeCloseTo(0, 6)
+  })
+
+  it('押し目が浅すぎ (価格が band 上端より上) → band 上端まで下落が必要', () => {
+    const d = computeEntryDistance(ind({ price: 99 }), RULE) // pullback -0.01 > -0.03
+    expect(d.buyable).toBe(false)
+    expect(d.bindingGate?.key).toBe('pullback_shallow')
+    expect(d.entryPrice).toBeCloseTo(97, 6) // high20d 100 * (1 + -0.03)
+    expect(d.priceMove).toBeLessThan(0) // 下落が必要
+    expect(d.priceMove).toBeCloseTo((97 - 99) / 99, 6)
+  })
+
+  it('押し目が深すぎ (価格が band 下端より下) → band 下端まで上昇が必要', () => {
+    const d = computeEntryDistance(ind({ price: 92 }), RULE) // pullback -0.08 < -0.06
+    expect(d.buyable).toBe(false)
+    expect(d.bindingGate?.key).toBe('pullback_deep')
+    expect(d.entryPrice).toBeCloseTo(94, 6) // high20d 100 * (1 + -0.06)
+    expect(d.priceMove).toBeGreaterThan(0) // 上昇が必要
+  })
+
+  it('トレンド不足 (価格非依存) → entryPrice null (価格を動かしても入場不可)', () => {
+    const d = computeEntryDistance(ind({ return50d: 0.02 }), RULE)
+    expect(d.buyable).toBe(false)
+    expect(d.bindingGate?.key).toBe('trend')
+    expect(d.entryPrice).toBeNull()
+    expect(d.priceMove).toBeNull()
+  })
+
+  it('ボラ過熱 (価格非依存) → binding=volatility、entryPrice null', () => {
+    const d = computeEntryDistance(ind({ atr20: 3, baselineAtr20: 1 }), RULE) // ratio 3 > 1.5
+    expect(d.bindingGate?.key).toBe('volatility')
+    expect(d.entryPrice).toBeNull()
+  })
+
+  it('過熱と押し目 band が両立しない → binding=overextension、entryPrice null', () => {
+    // sma50 50 / high20d 100: band [94,97] だが過熱上限は 50*1.6=80。
+    // 価格で同時成立できないので「価格を動かすだけでは入場不可」。
+    const d = computeEntryDistance(ind({ sma50: 50, price: 95, high20d: 100 }), RULE)
+    expect(d.bindingGate?.key).toBe('overextension')
+    expect(d.entryPrice).toBeNull()
+  })
+
+  it('過熱が上限を価格距離として制約する (band 上端 > 過熱上限のとき過熱上限を採る)', () => {
+    // sma50 95, high20d 100: band [94,97]、過熱上限 95*(1+0.05)=99.75 (緩めた rule)。
+    // ここでは過熱が緩いので band 上端 97 が entry。過熱が band 内に食い込むケースを
+    // 作るため maxSma50DeviationPct を絞る。
+    const tightRule = { ...RULE, maxSma50DeviationPct: 0.005 } // 上限 95*1.005=95.475
+    const d = computeEntryDistance(ind({ sma50: 95, price: 99, high20d: 100 }), tightRule)
+    // band [94,97] ∩ (>95) ∩ (<=95.475) = [95, 95.475] → 現価格99 に最も近い点 95.475
+    expect(d.entryPrice).toBeCloseTo(95.475, 3)
+  })
+
+  it('ゲート列は entryDecision と同じ 7 ゲート', () => {
+    const d = computeEntryDistance(ind({}), RULE)
+    expect(d.gates.map((g) => g.key)).toEqual([
+      'trend',
+      'above_sma50',
+      'overextension',
+      'volatility',
+      'high20d_valid',
+      'pullback_shallow',
+      'pullback_deep',
+    ])
+  })
+})
+
+describe('buildBuyabilityView', () => {
+  function evalsFromPrices(prices: number[]): EvalIndicatorPoint[] {
+    return prices.map((price, i) => ({
+      timestamp: `2026-06-0${i + 1}T14:00:00.000Z`,
+      indicators: ind({ price }),
+    }))
+  }
+
+  it('空なら current null / trend unknown', () => {
+    const v = buildBuyabilityView([], RULE)
+    expect(v.current).toBeNull()
+    expect(v.trend).toBe('unknown')
+    expect(v.etaTradingDays).toBeNull()
+  })
+
+  it('距離が縮小していく → trend closing + 参考ETA 正値', () => {
+    // 99.5→97.5 と band 上端 97 に近づく (priceMove の絶対値が縮小)
+    const v = buildBuyabilityView(evalsFromPrices([99.5, 99, 98.5, 98, 97.5]), RULE)
+    expect(v.trend).toBe('closing')
+    expect(v.etaTradingDays).not.toBeNull()
+    expect(v.etaTradingDays!).toBeGreaterThan(0)
+    expect(v.current?.buyable).toBe(false)
+  })
+
+  it('距離が拡大していく → trend widening + ETA null', () => {
+    const v = buildBuyabilityView(evalsFromPrices([97.5, 98, 98.5, 99, 99.5]), RULE)
+    expect(v.trend).toBe('widening')
+    expect(v.etaTradingDays).toBeNull()
+  })
+
+  it('距離が横ばい → trend flat + ETA null', () => {
+    const v = buildBuyabilityView(evalsFromPrices([99, 99, 99, 99, 99]), RULE)
+    expect(v.trend).toBe('flat')
+    expect(v.etaTradingDays).toBeNull()
+  })
+
+  it('最新が buyable なら current.buyable true', () => {
+    const v = buildBuyabilityView(evalsFromPrices([99, 98, 97, 96, 95]), RULE)
+    expect(v.current?.buyable).toBe(true)
+  })
+})


### PR DESCRIPTION
## 概要

個別銘柄チャート (`/dashboard/charts?tab=symbol`) を「文字ログ」と同期した1画面にし、さらに**「あとどれくらい・いつ頃で入場できるか」**を前向きに可視化する。#435 (判定トレース・ラダー) の続き。

### 1. cron 判定をチャートに重ねる (文字ログ↔グラフ同期)
- BUY/SELL/REJECT/ERROR を eval 時刻×評価価格に色分けプロット (HOLD は定常状態なので省略)
- 点クリック → その判定の判定トレース・ラダー (#435 の `renderDecisionLadder` を server 事前レンダリングで再利用) を脇パネルに表示
- ホバー → reason 要約 tooltip

### 2. 入場までの距離 (`entryDistance.ts` 純モジュール + テスト)
- `entryDecision` の 7 ゲート連鎖を**距離として**評価。真のボトルネック (過熱/ボラ/トレンド/押し目) を特定
- 「入場まで」パネル: 結論・全ゲートのチェックリスト (現在値 vs 閾値)・距離の推移 (縮小/拡大)・参考ETA
- 押し目ゾーン上端/下端の点線に「あと −X.X% ($Y)」距離ラベル (独立線は重複のため廃止)

### 3. 参考 価格外挿線 (チャート上)
- 直近ペースを未来スロットへ延ばした点線 + 入場ライン到達ピン。**予測ではなく外挿**(点線・"参考"明記)
- 価格ターゲットが無い (過熱/トレンドで構造的ブロック) 時は描かない

## scope
- dashboard 可視化のみ。取引ロジック・発注経路・safety invariant は不変 (fail-closed のまま)
- 入場ゲート閾値は global_config (entry ゲートに per-symbol override は無し)

## test
- `pnpm typecheck` / 全 1325 tests green
- `entryDistance` 純関数 18 ケース、dashboard レンダリング配線テスト追加

## staging 確認済 (trading-staging.chanu.co)
- AAPL: 押し目バンド待ち (上端 あと −2.9% $305.99)、外挿は上昇=遠ざかる向き
- SOXL: 過熱でブロック (価格を動かすだけでは入場不可)
- SOXS: トレンド不足でブロック

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * チャートに売買戦略判定（BUY/SELL/REJECT/ERROR）を同期表示
  * 入場まで必要な価格変動距離をパーセンテージと価格で表示
  * 参考価格の外挿線を描画可能に
  * 判定点クリックで判定根拠パネルを表示
  * 過熱度・ボラティリティ監視用の新規パラメータを追加
  * チャートズーム中のy軸表示精度を向上

<!-- end of auto-generated comment: release notes by coderabbit.ai -->