### PR TITLE
feat: merge inverse-pair budget sliders into one shared control

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -7594,6 +7594,13 @@ function symbolsListBody(args: {
   const ordered = orderRowsByPair(filtered, inversePairs)
   const pairColor = assignPairColors(ordered, inversePairs)
   const roles = pairRoles(ordered, inversePairs)
+  // 共有 slider の初期値計算用 (対の max を採るため両側の % を引けるように)。
+  const pctOf = new Map(
+    ordered.map((r) => [
+      r.symbol.toUpperCase(),
+      r.budgetAllocPct != null ? Math.round(r.budgetAllocPct * 1000) / 10 : 0,
+    ]),
+  )
   const tbody = ordered
     .map((r) => {
       const inactive = !r.active
@@ -7626,14 +7633,26 @@ function symbolsListBody(args: {
         ? '<span class="err" title="売買単位が未設定または不正です。設定するまで BUY は発注されません (fail-closed)。編集から入力してください。">⚠ 未設定</span>'
         : `${esc(String(r.lotSize))} <span class="muted" style="font-size:11px">${r.lotSize === 1 ? '株/口' : '株'}</span>`
       // 予算配分 ladder slider (#budget-alloc): 5%刻み。確定するまで client 側で仮調整、
-      // form="symbol-budget-form" で一括 POST。inverse 相手は JS が同期する。
-      const allocPctNum = r.budgetAllocPct != null ? Math.round(r.budgetAllocPct * 1000) / 10 : 0
-      const budgetCell = `<div style="display:flex;align-items:center;gap:6px;min-width:170px">
+      // form="symbol-budget-form" で一括 POST。両側表示中のインバース対は 1 本の共有
+      // slider (rowspan=2) に統合する — 同時に建つのは片側のみで予算消費は 1 回分
+      // なのに、2 本並ぶと倍取られているように見えるため。初期値は両側の max、
+      // POST に載らない相手側は server が同値同期する (admin #budget-alloc)。
+      const allocPctNum =
+        role === 'top'
+          ? Math.max(pctOf.get(sym) ?? 0, pctOf.get(inverse!.toUpperCase()) ?? 0)
+          : (pctOf.get(sym) ?? 0)
+      const sliderHtml = `<div style="display:flex;align-items:center;gap:6px;min-width:170px">
           <input type="range" name="pct_${esc(r.symbol)}" form="symbol-budget-form" min="0" max="100" step="5" value="${allocPctNum}"
             data-symbol="${esc(r.symbol)}"${inverse ? ` data-inverse="${esc(inverse)}"` : ''}
             oninput="window.onBudgetSlide(this)" style="width:110px;vertical-align:middle">
           <span id="budget-label-${esc(r.symbol)}" class="muted" style="font-size:12px;width:42px;text-align:right;font-variant-numeric:tabular-nums">${allocPctNum === 0 ? 'risk' : allocPctNum + '%'}</span>
         </div>`
+      const budgetTd =
+        role === 'bottom'
+          ? ''
+          : role === 'top'
+            ? `<td rowspan="2" style="vertical-align:middle">${sliderHtml}<div class="muted" style="font-size:11px;margin-top:2px">ペア共通 — 建玉は片側のみ、予算消費は1回分</div></td>`
+            : `<td>${sliderHtml}</td>`
       // ツリー表記 (#315): 対を縦線で連結。上段は中央→下端に縦線 + 中央で右へ横棒
       // (┌)、下段は上端→中央に縦線 + 中央で右へ横棒 (└)。隣接行で左の縦線が
       // 行境界を跨いで連結し、1 本の bracket に見える。線は相手 edit へのリンク。
@@ -7659,7 +7678,7 @@ function symbolsListBody(args: {
         <td><code style="font-size:11px">${esc(r.market)}/${esc(r.currency)}</code></td>
         <td>${lotSizeCell}</td>
         <td>${maxNotionalCell}</td>
-        <td>${budgetCell}</td>
+        ${budgetTd}
         <td>${esc(r.notes ?? '')}</td>
         <td class="muted" style="font-size:11px">${esc(dateOnly)}</td>
         <td>
@@ -7702,26 +7721,20 @@ function symbolsListBody(args: {
   <script>${BUDGET_LADDER_JS}</script>`
 }
 
-// #budget-alloc ladder の client JS: slider 移動でラベル更新 + インバース相手の
-// slider を同値に同期 + 「未確定」バーを表示。保存は確定ボタン押下の form POST のみ
-// (即保存しない = 確定するまで仮)。
+// #budget-alloc ladder の client JS: slider 移動でラベル更新 + 「未確定」バーを表示。
+// 保存は確定ボタン押下の form POST のみ (即保存しない = 確定するまで仮)。
+// インバース対は 1 本の共有 slider なので相手 slider の同期は不要 — POST に載らない
+// 相手側は server が同値同期する (#315 regime hedge)。
 const BUDGET_LADDER_JS = `
   window.__budgetDirty = {};
   window.__fmtBudget = function (v) { return Number(v) <= 0 ? 'risk' : v + '%'; };
-  window.__setBudgetSlider = function (sym, v) {
-    var sl = document.querySelector('input[name="pct_' + sym + '"]');
-    var lb = document.getElementById('budget-label-' + sym);
-    if (sl) sl.value = v;
-    if (lb) lb.textContent = window.__fmtBudget(v);
-  };
   window.onBudgetSlide = function (el) {
     var sym = el.getAttribute('data-symbol');
     var inv = el.getAttribute('data-inverse');
     var v = el.value;
     var lb = document.getElementById('budget-label-' + sym);
     if (lb) lb.textContent = window.__fmtBudget(v);
-    // インバース対は同値に同期 (#315 regime hedge)。相手 slider が一覧に在れば揃える。
-    if (inv) window.__setBudgetSlider(inv, v);
+    // 保存時に server 同期で相手側も変わるので、dirty 数には相手も数える。
     window.__budgetDirty[sym] = true;
     if (inv) window.__budgetDirty[inv] = true;
     var bar = document.getElementById('symbol-budget-bar');
@@ -7744,9 +7757,18 @@ const BUDGET_LADDER_JS = `
     var sliders = document.querySelectorAll('input[name^="pct_"]');
     sliders.forEach(function (s) {
       var sym = s.getAttribute('data-symbol');
+      var inv = s.getAttribute('data-inverse');
       var v = Number(s.value);
-      if (v > 0) bySym[sym] = { pct: v, inv: s.getAttribute('data-inverse') };
-      else delete bySym[sym]; // 0 にした表示中銘柄は除外 (baseline 値で復活させない)
+      // 対の共有 slider は両側を上書きする (相手の baseline が残ると max が
+      // 旧値に張り付き、下げた時にメーターが追従しない)。
+      if (v > 0) {
+        bySym[sym] = { pct: v, inv: inv };
+        if (inv) bySym[inv] = { pct: v, inv: sym };
+      } else {
+        // 0 にした表示中銘柄は除外 (baseline 値で復活させない)
+        delete bySym[sym];
+        if (inv) delete bySym[inv];
+      }
     });
     // 口座(円)単一プールに対する使用率を 1 本で合算。インバース対は max を1回計上。
     var used = 0;

--- a/test/routes/dashboardSymbolsCrud.test.ts
+++ b/test/routes/dashboardSymbolsCrud.test.ts
@@ -49,7 +49,10 @@ interface UpdateCall {
  * `currentRows` を返す。`where` 時に渡される drizzle eq(...) は内部に値を
  * 保持するので JSON 化して symbol を取り出してフィルタする。
  */
-function fakeDb(initial: SymbolConfigRow[]) {
+function fakeDb(
+  initial: SymbolConfigRow[],
+  pairs: Array<{ symbol: string; inverse: string }> = [],
+) {
   const rows: SymbolConfigRow[] = [...initial]
   const inserts: InsertCall[] = []
   const updates: UpdateCall[] = []
@@ -102,7 +105,15 @@ function fakeDb(initial: SymbolConfigRow[]) {
 
   const selectChain = (filtered: () => SymbolConfigRow[]) => {
     const chain = {
-      from: (_tbl: unknown) => chain,
+      // inverse_pairs を select したら pair 行を返す (loadInversePairs 用)。
+      // それ以外 (symbol_config) は従来通り自身を返して rows を流す。
+      from: (tbl: unknown) =>
+        tableName(tbl) === 'inverse_pairs'
+          ? {
+              then: (resolve: (v: unknown[]) => unknown, reject?: (e: unknown) => unknown) =>
+                Promise.resolve(pairs).then(resolve, reject),
+            }
+          : chain,
       where: (cond: unknown) => {
         const sym = extractSymbolFromWhere(cond)
         return selectChain(() => filtered().filter((r) => sym === null || r.symbol === sym))
@@ -1044,6 +1055,53 @@ describe('dashboard symbol_config CRUD UI (#292)', () => {
     // 確定ボタン (即保存しない)
     expect(body).toContain('確定して保存')
     expect(body).toContain('action="/admin/symbol-config/budget-alloc"')
+  })
+
+  it('inverse pair renders one shared budget slider (rowspan=2), not two', async () => {
+    const db = fakeDb(
+      [row({ symbol: 'SOXL', budgetAllocPct: 0.35 }), row({ symbol: 'SOXS', budgetAllocPct: 0.35 })],
+      [{ symbol: 'SOXL', inverse: 'SOXS' }],
+    )
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const app = createApp()
+    const res = await app.request('/dashboard/symbols', { headers: authHeader }, { ...baseEnv, DB: {} as D1Database })
+    const body = await res.text()
+    // 上段 (SOXL) にだけ slider、下段 (SOXS) の予算セルは rowspan で消える
+    expect(body).toContain('name="pct_SOXL"')
+    expect(body).not.toContain('name="pct_SOXS"')
+    expect(body).toContain('rowspan="2"')
+    expect(body).toContain('ペア共通')
+  })
+
+  it('shared pair slider initializes to max of both sides when diverged', async () => {
+    const db = fakeDb(
+      [row({ symbol: 'SOXL', budgetAllocPct: 0.2 }), row({ symbol: 'SOXS', budgetAllocPct: 0.4 })],
+      [{ symbol: 'SOXL', inverse: 'SOXS' }],
+    )
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const app = createApp()
+    const res = await app.request('/dashboard/symbols', { headers: authHeader }, { ...baseEnv, DB: {} as D1Database })
+    const body = await res.text()
+    // meter と同じ max 方式 (同時に建つのは片側のみ) — max(20, 40) = 40
+    expect(body).toMatch(/name="pct_SOXL"[^>]*value="40"/)
+  })
+
+  it('half-present pair (filtered) keeps its own slider without rowspan', async () => {
+    const db = fakeDb(
+      [row({ symbol: 'SOXL', budgetAllocPct: 0.35 }), row({ symbol: 'SOXS', budgetAllocPct: 0.35 })],
+      [{ symbol: 'SOXL', inverse: 'SOXS' }],
+    )
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const app = createApp()
+    const res = await app.request(
+      '/dashboard/symbols?q=SOXS',
+      { headers: authHeader },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    const body = await res.text()
+    expect(body).toContain('name="pct_SOXS"')
+    expect(body).not.toContain('name="pct_SOXL"')
+    expect(body).not.toContain('rowspan="2"')
   })
 
   it('bulk budget-alloc POST converts % → fraction (÷100), 303', async () => {


### PR DESCRIPTION
## Summary

銘柄管理一覧で、インバース対の予算配分スライダーが2行に1本ずつ (強制同値同期) 並んでいたため、ペアで口座予算を倍 (35%+35%=70%) 消費しているように見えていた。実際はランタイムも予算メーターも「同時に建つのは片側のみ = max を1回計上」で設計済みなので、見え方を実態に合わせる。

- 両側表示中のインバース対は予算配分セルを `rowspan=2` の **共有スライダー1本** に統合し、「ペア共通 — 建玉は片側のみ、予算消費は1回分」と注記
- 共有スライダーの初期値は両側の max (保存値がズレていても meter と同じ解釈)。POST に載らない相手側は既存の server 側同値同期 (`/admin/symbol-config/budget-alloc`) がそのまま揃えるので保存系 API は変更なし
- 予算メーターの追従バグ修正: 共有スライダーで値を下げた時、相手側 baseline が残って max が旧値に張り付いていたため、共有スライダーは両側を上書きするように変更
- 相手スライダー同期用の client JS (`__setBudgetSlider`) は不要になったため削除。フィルタで片側のみ表示の場合は従来通り単独スライダー

## Test plan

- 新規テスト3件: ペア統合レンダリング (rowspan / 2本目スライダー無し) / 値ズレ時の max 初期化 / フィルタ片側表示時の単独スライダー
- テスト用 fakeDb に `inverse_pairs` テーブル対応を追加
- `pnpm test` 1328 件通過 / `pnpm typecheck` クリーン
- staging (`trading-staging.chanu.co`) にデプロイして表示・メーター追従を目視確認済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ダッシュボードの予算配分でインバース対が共有スライダーで一括操作可能に

* **バグ修正**
  * インバース対の二重表示を解消

* **テスト**
  * インバース対の表示仕様と動作確認テストを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->