### PR TITLE
feat: Google Finance-style symbol chart (15m candles, JP colors, tighter layout)

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -6405,7 +6405,7 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
   const content = `<div class="symbol-chart-pin">
   ${renderFocusSymbolHeader(args)}
   ${renderPriceHeader(args.symbolChart, args.universe)}
-  <div id="symbol-chart" style="width:100%;height:460px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;margin-top:8px"></div>
+  <div id="symbol-chart" style="width:100%;height:380px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;margin-top:8px"></div>
   ${renderZoomPresetButtons(args.symbolChart)}
   </div>
   ${renderBuyabilityPanel(args.buyability ?? null)}

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -6219,13 +6219,21 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
         sc.markers.forEach(function (m) {
           if (inRangeMs(new Date(m.timestamp).getTime())) pushIfFinite(m.price);
         });
-        // visible 範囲内の SMA50 値も含める。SMA50 が candle と離れた水準
-        // (例: SOXL は 3x rally で SMA50=65 / 価格=128) の銘柄では candle が
-        // 縦方向に圧縮されるが、SMA50 line が常時可視になる方を優先する
-        // (#181 後の user request)。zoom out すれば candle にとって過剰な
-        // 引き伸ばしも緩和される。
+        // visible 範囲内の SMA50 は「candle range の近傍にある時だけ」含める。
+        // #181 では SMA50 常時可視を優先したが、乖離が大きい銘柄 (3x ETF rally
+        // 等: SMA50=125 / 価格=260) では軸が倍近く引き伸ばされ、candle の
+        // 高値-安値が読めなくなる (operator 指摘で方針転換)。近傍 = candle
+        // range を上下 25% 拡張した帯。帯の外の SMA50 線は clip されるが、値は
+        // 価格ヘッダーのサブ行 (SMA50: X) で常に確認できる。
+        var candleMin = visibleY.length ? Math.min.apply(null, visibleY) : null;
+        var candleMax = visibleY.length ? Math.max.apply(null, visibleY) : null;
         sc.points.forEach(function (p) {
-          if (inRangeMs(new Date(p.timestamp).getTime())) pushIfFinite(p.sma50);
+          if (!inRangeMs(new Date(p.timestamp).getTime())) return;
+          var v = p.sma50;
+          if (v == null || !Number.isFinite(v)) return;
+          if (candleMin == null) { visibleY.push(v); return; }
+          var nearBand = Math.max((candleMax - candleMin) * 0.25, 0.5);
+          if (v >= candleMin - nearBand && v <= candleMax + nearBand) visibleY.push(v);
         });
         // trend line: regression で fit した 1 本。pivots[0]→end の 2 点で
         // 直線が定義される。visible 範囲内に endpoint または時間軸の交点が

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -4369,14 +4369,15 @@ export async function loadSymbolChart(
         lastTimestamp,
       )
     : null
-  // candlestick: 1 時間足 (intraday) を Yahoo から fetch。15m は overnight gap
-  // 後の clustering と barWidth 調整がシビアだったため、daily-trader 向けに
-  // 1h を default 採用 (Pullback Uptrend のような multi-day 戦略では十分な
-  // granularity)。Yahoo intraday range 制限 60d で chart 全期間カバー可能。
+  // candlestick: 15 分足 (intraday) を Yahoo から fetch。旧 1h 足は「1日 ≈ 7本」
+  // でスカスカだった (operator 指摘)。category 軸化で overnight gap は詰まる
+  // ようになり、barWidth も auto にしたため 15m の旧懸念 (gap 後の clustering)
+  // は解消済。Yahoo intraday range 制限 60d は 15m でもカバー可能。
+  // 戦略 cron は従来通り 60m を使う (pullbackScheduler 側、ここは表示専用)。
   // 失敗 (network 等) なら空配列で fallback (candle 自体スキップ)。
   let intradayBars: OhlcBar[] = []
   try {
-    const intraday = await new YahooBarClient().getIntradayBars(symbol, '60m')
+    const intraday = await new YahooBarClient().getIntradayBars(symbol, '15m')
     // lastTimestamp フィルタ: chart x 軸範囲を超える bar (将来に出るはずの bar)
     // を除外。lastTimestamp が無いときは全件採用。
     intradayBars = (cronLastTs == null
@@ -4732,7 +4733,7 @@ export function computeLinearRegressionLine(
  * trend line が描画されないケースが残った。
  *
  * 最も robust な解決策は line の data 自体を「常に zoom 範囲内に複数点が
- * 入る粒度」にすること。ここでは intradayBars (1h candle、60 日で ~720 点)
+ * 入る粒度」にすること。ここでは intradayBars (15m candle、60 日で ~1500 点)
  * の各 timestamp で trend line の y 値を線形補間して、`[[t, y], ...]` の
  * dense path に展開する。これで 5D (~120 点) や 1D zoom でも常に複数点が
  * visible になり filterMode 不問で確実に描画される。
@@ -5284,9 +5285,9 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
 
       // セッション境界 (休場 → 開場) 検出:
       // category axis 化で休場 gap が詰まった結果 (#193)、視覚的に
-      // 「どこから新セッションか」が分かりにくくなった。1h interval なので
-      // 隣接 bar は通常 60 分差。週末 / 夜間 closed 後の最初の bar は数時間〜
-      // 数十時間ぶんの差が空く。閾値 90 分 (= 1.5h) で safe に検出し、後ろ側
+      // 「どこから新セッションか」が分かりにくくなった。15m interval なので
+      // 隣接 bar は通常 15 分差。週末 / 夜間 closed 後の最初の bar は数時間〜
+      // 数十時間ぶんの差が空く。閾値 90 分で safe に検出し、後ろ側
       // category index を「新セッションの開場点」として markLine 描画する。
       // useCategoryAxis === false (intradayBars 空) の場合は描画 skip。
       var sessionOpenIndices = [];
@@ -5464,7 +5465,7 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
       // ユーザ環境で残ケースがあった。本質的に robust にするため、line の
       // data 自体を「常に zoom 範囲内に複数点が入る粒度」に展開する。
       //
-      // 具体的には intradayBars (1h candle、60 日で ~720 点) の各 timestamp
+      // 具体的には intradayBars (15m candle、60 日で ~1500 点) の各 timestamp
       // で trend line の y 値を線形補間し、[[t, y], ...] の dense path にす
       // る。これで 5D (~120 点) や 1D zoom でも複数点が必ず visible になり
       // filterMode 不問で線分が描画される。intradayBars が空 (Yahoo fetch
@@ -5554,7 +5555,7 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
         ? sc.markers[sc.markers.length - 1].timestamp
         : null;
       // category mode では markPoint coord に [categoryIndex, price] を渡す。
-      // fill 時刻を最近接 ohlc bar (= 1h 粒度) の index に snap するため、同 1h
+      // fill 時刻を最近接 ohlc bar (= 15m 粒度) の index に snap するため、同 bar
       // 内の複数 fill は同じ index に重なる。pin label は側 (top/bottom) と色で
       // 区別するため重なっても 1 件は読める。fillTimestamp は秒精度を保持して
       // hover tooltip で full-precision 時刻として表示される (情報損失なし)。
@@ -5982,10 +5983,9 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
           // gap 後の細い candle を視認可能に。borderWidth 強めて
           // body と wick の対比を確保。
           ...(ohlcXY.length > 0 ? [{
-            name: 'price (1h OHLC)', type: 'candlestick', data: ohlcXY,
-            // 1h は 15m より時間軸の間隔が 4 倍広いので、barWidth も少し
-            // 広めに (相対的に gap 比率を一定に保つ)。
-            barWidth: 10,
+            name: 'price (15m OHLC)', type: 'candlestick', data: ohlcXY,
+            // barWidth は auto (slot 幅比例)。15m 化で本数が 4 倍になったため、
+            // 固定 px だと zoom out 時に candle が重なる。
             itemStyle: {
               color: '#d23f31',     // 陽線 (close >= open) — 日本式は赤
               color0: '#1e8e3e',    // 陰線 (close < open) — 日本式は緑
@@ -6436,7 +6436,7 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
  * に配信。
  *
  * mini chart の構成 (PR #239 で個別銘柄タブと表示要素パリティ):
- * - candle (1h OHLC)
+ * - candle (15m OHLC)
  * - 価格トレンド (linear regression)
  * - SMA50
  * - 押し目ゾーン markArea + sloped 上下端線 (未保有時のみ)
@@ -6930,7 +6930,7 @@ export function renderGridTab(args: ChartsBodyGrid): string {
             }] : []),
             ...(ohlcXY.length > 0 ? [{
               name: 'price', type: 'candlestick', data: ohlcXY,
-              barWidth: 6,
+              // barWidth は auto (15m 化で本数 4 倍、固定 px だと mini panel で潰れる)
               // 日本式配色: 赤=陽線 / 緑=陰線 (個別銘柄タブと揃える)
               itemStyle: {
                 color: '#d23f31', color0: '#1e8e3e',

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -5722,14 +5722,17 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
         // 未来スロットの timestamp 間隔 (直近 bar の平均間隔)。
         var span = barsPerDay > 1 ? (lastBarMs - ohlcMs[ohlcMs.length - barsPerDay]) / (barsPerDay - 1) : 3600000;
         if (!Number.isFinite(span) || span <= 0) span = 3600000;
-        // 描く未来日数: 交差あり (= 入場時期の目安が見える) はその近辺まで、
+        // 描く未来 bar 数: 交差あり (= 入場時期の目安が見える) はその近辺まで
         // 1〜5 営業日に clamp。交差なしは向き (傾き) が読めれば十分なので
-        // 1 営業日だけ — 3 日でも未来の空白が axis を占有し、履歴側の candle
-        // が左に圧縮される + 押し目端の endLabel が空白に浮く (operator 指摘)。
-        var drawDays = proj.crossingSteps != null
-          ? Math.min(Math.max(Math.ceil(proj.crossingSteps), 1), 5)
-          : 1;
-        var drawBars = Math.max(barsPerDay, Math.round(drawDays * barsPerDay));
+        // 半営業日分の bar だけ — 未来スロットは axis を占有して履歴側の candle
+        // を左に圧縮するため、最小限に保つ (operator 指摘 ×2)。
+        var drawBars;
+        if (proj.crossingSteps != null) {
+          var drawDays = Math.min(Math.max(Math.ceil(proj.crossingSteps), 1), 5);
+          drawBars = Math.max(barsPerDay, Math.round(drawDays * barsPerDay));
+        } else {
+          drawBars = Math.max(2, Math.ceil(barsPerDay / 2));
+        }
         var startIdx = categories.length - 1;
         for (var k = 1; k <= drawBars; k += 1) {
           categories.push(new Date(lastBarMs + k * span).toISOString());

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1508,6 +1508,10 @@ const STYLE = `
   .rail-sym{font-weight:600;font-size:13px}
   .rail-name{font-size:11px;color:#86868b;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
   .symbol-main{flex:1;min-width:0}
+  /* Google Finance 風 range ピル (チャート直下)。active はクリックで JS が付替 */
+  .zoom-preset{padding:4px 14px;font-size:12.5px;background:#fff;border:1px solid #dadce0;border-radius:16px;cursor:pointer;color:#3c4043;margin-right:6px}
+  .zoom-preset:hover{background:#f8f9fa}
+  .zoom-preset.active{background:#e8f0fe;border-color:#e8f0fe;color:#1967d2;font-weight:600}
   /* チャートを sticky 固定: 下の説明 panel 群 (入場ゲート / 判定 trace) を読む間も
      グラフが見え続ける。下からスクロールしてくる panel は z-index と page 背景色で
      チャートの裏に隠す。STYLE は全 page の <style> に埋まるため、コメントにも
@@ -5773,6 +5777,7 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
       });
       sc.markers.forEach(function (m) { pushIfFinite(m.price); });
       extraYValues.forEach(function (v) { pushIfFinite(v); });
+      pushIfFinite(data.prevClose); // 前日終値 markLine が枠外に出ないように
       var yMin, yMax;
       if (allY.length > 0) {
         var rawMin = Math.min.apply(null, allY);
@@ -5968,8 +5973,8 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
             lineStyle: { width: 1.8, color: '#9333ea', type: 'solid' }, symbol: 'none',
             itemStyle: { color: '#9333ea' }, z: 7,
           }] : []),
-          // candlestick: 15 分足 OHLC を表示。Western 規約 (close >= open = 緑、
-          // candle: 主役。Western 規約 (close >= open = 緑、< = 赤)。
+          // candle: 主役。日本式配色 (Google Finance JA と同じ):
+          // 赤 = 陽線 (close >= open) / 緑 = 陰線 (close < open)。
           // markPoint / markLine もここに anchor。barWidth 明示で overnight
           // gap 後の細い candle を視認可能に。borderWidth 強めて
           // body と wick の対比を確保。
@@ -5979,10 +5984,10 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
             // 広めに (相対的に gap 比率を一定に保つ)。
             barWidth: 10,
             itemStyle: {
-              color: '#057a55',     // bullish (close >= open)
-              color0: '#c22',       // bearish (close < open)
-              borderColor: '#057a55',
-              borderColor0: '#c22',
+              color: '#d23f31',     // 陽線 (close >= open) — 日本式は赤
+              color0: '#1e8e3e',    // 陰線 (close < open) — 日本式は緑
+              borderColor: '#d23f31',
+              borderColor0: '#1e8e3e',
               borderWidth: 1.5,
             },
             z: 5,
@@ -5996,16 +6001,35 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
             // 描画 path が trend line (slanted 2-point markLine) とは別系統。
             // 縦線方向は zoom 範囲外でも描画ロバスト (#193 follow-up)。
             // category 軸モード時のみ data を積む (time axis fallback では空)。
-            markLine: sessionOpenIndices.length > 0 ? {
-              symbol: 'none',
-              silent: true,
-              label: { show: false },
-              lineStyle: { color: '#bbb', width: 1, type: 'dashed' },
-              z: 1,
-              data: sessionOpenIndices.map(function (idx) {
+            markLine: (function () {
+              var mlData = sessionOpenIndices.map(function (idx) {
                 return { xAxis: idx };
-              }),
-            } : undefined,
+              });
+              // 前日終値の水平点線 + 右端ラベル (Google Finance 風)。candle series
+              // の markLine に同居させる (独立 series にすると legend を汚すため)。
+              if (data.prevClose != null && Number.isFinite(data.prevClose)) {
+                mlData.push({
+                  yAxis: data.prevClose,
+                  lineStyle: { color: '#9aa0a6', width: 1, type: 'dotted' },
+                  label: {
+                    show: true,
+                    position: 'insideEndTop',
+                    formatter: data.prevCloseLabel || '前日終値',
+                    color: '#5f6368',
+                    fontSize: 10,
+                  },
+                });
+              }
+              if (mlData.length === 0) return undefined;
+              return {
+                symbol: 'none',
+                silent: true,
+                label: { show: false },
+                lineStyle: { color: '#bbb', width: 1, type: 'dashed' },
+                z: 1,
+                data: mlData,
+              };
+            })(),
             markPoint: entries.length + exits.length > 0 ? {
               symbol: 'pin', symbolSize: 24, data: entries.concat(exits),
               tooltip: {
@@ -6347,6 +6371,9 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
             sv = fromMs;
             eV = toMs;
           }
+          // Google 風ピルの active 付替 (押した range を強調)
+          for (var pj = 0; pj < presetButtons.length; pj += 1) presetButtons[pj].classList.remove('active');
+          ev.currentTarget.classList.add('active');
           // inside / slider 両方を同期更新
           symChart.dispatchAction({ type: 'dataZoom', dataZoomIndex: 0, startValue: sv, endValue: eV });
           symChart.dispatchAction({ type: 'dataZoom', dataZoomIndex: 1, startValue: sv, endValue: eV });
@@ -6367,14 +6394,20 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
   // 参考 価格外挿線 (#entry-distance のグラフ表現)。直近ペースを未来へ延ばした
   // 「予測ではない外挿」。client は category 軸に未来スロットを足して描く。
   const projection = args.buyability?.projection ?? null
+  // 前日終値 (header の前日比とチャート点線の共通基準)。
+  const prevClose = prevDailyClose(args.symbolChart)
+  const prevCloseLabel =
+    prevClose !== null
+      ? `前日終値 ${fmtPriceCcy(prevClose, args.universe?.symbolCurrency[args.symbolChart!.symbol.toUpperCase()] ?? null)}`
+      : null
   const content = `<div class="symbol-chart-pin">
   ${renderFocusSymbolHeader(args)}
-  ${renderCurrentIndicatorsBadge(args.symbolChart)}
-  <div id="symbol-chart" style="width:100%;height:460px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;margin-top:12px"></div>
+  ${renderPriceHeader(args.symbolChart, args.universe)}
+  <div id="symbol-chart" style="width:100%;height:460px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;margin-top:8px"></div>
+  ${renderZoomPresetButtons(args.symbolChart)}
   </div>
   ${renderBuyabilityPanel(args.buyability ?? null)}
   ${renderDecisionPlotCaption(args.symbolChart)}
-  ${renderZoomPresetButtons(args.symbolChart)}
   <div id="decision-trace-panel" class="reason-panel" style="margin-top:10px">
     <p class="muted" style="font-size:12px;margin:0">判定点 (●) をクリックすると、その判定が通った採用ロジックのトレースがここに表示されます。</p>
   </div>
@@ -6383,6 +6416,8 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
   ${safeJsonScript('__chartData', {
     symbolChart: symbolChartPayload,
     projection,
+    prevClose,
+    prevCloseLabel,
     zoomFromMs: args.zoom ? args.zoom.from.getTime() : null,
     zoomToMs: args.zoom ? args.zoom.to.getTime() : null,
   })}
@@ -6894,9 +6929,10 @@ export function renderGridTab(args: ChartsBodyGrid): string {
             ...(ohlcXY.length > 0 ? [{
               name: 'price', type: 'candlestick', data: ohlcXY,
               barWidth: 6,
+              // 日本式配色: 赤=陽線 / 緑=陰線 (個別銘柄タブと揃える)
               itemStyle: {
-                color: '#057a55', color0: '#c22',
-                borderColor: '#057a55', borderColor0: '#c22', borderWidth: 1,
+                color: '#d23f31', color0: '#1e8e3e',
+                borderColor: '#d23f31', borderColor0: '#1e8e3e', borderWidth: 1,
               },
               z: 5,
               markLine: sessionOpenIndices.length > 0 ? {
@@ -7348,16 +7384,17 @@ export function renderZoomPresetButtons(chart: SymbolChartData | null): string {
     return Number.isFinite(ms) ? ms : lastMs
   })()
   const day = 24 * 3600 * 1000
+  // ラベルは Google Finance JA 準拠 (1日 / 5日 / 1か月 / 最大)。
   const presets: Array<{ label: string; fromMs: number; toMs: number }> = [
-    { label: '1D', fromMs: lastMs - 1 * day, toMs: lastMs },
-    { label: '5D', fromMs: lastMs - 5 * day, toMs: lastMs },
-    { label: '1M', fromMs: lastMs - 30 * day, toMs: lastMs },
-    { label: 'All', fromMs: earliestMs, toMs: lastMs },
+    { label: '1日', fromMs: lastMs - 1 * day, toMs: lastMs },
+    { label: '5日', fromMs: lastMs - 5 * day, toMs: lastMs },
+    { label: '1か月', fromMs: lastMs - 30 * day, toMs: lastMs },
+    { label: '最大', fromMs: earliestMs, toMs: lastMs },
   ]
   const buttons = presets
     .map(
       (p) =>
-        `<button class="zoom-preset" data-from-ms="${p.fromMs}" data-to-ms="${p.toMs}" style="margin-right:6px;padding:3px 10px;font-size:12px;background:#fafafa;border:1px solid #d0d0d5;border-radius:4px;cursor:pointer;color:#1d1d1f">${esc(p.label)}</button>`,
+        `<button class="zoom-preset" data-from-ms="${p.fromMs}" data-to-ms="${p.toMs}">${esc(p.label)}</button>`,
     )
     .join('')
   return `<p style="margin:8px 0 0">${buttons}</p>`
@@ -7531,9 +7568,51 @@ export function renderDecisionPlotCaption(chart: SymbolChartData | null): string
   </div>`
 }
 
-export function renderCurrentIndicatorsBadge(chart: SymbolChartData | null): string {
-  if (!chart) return ''
-  // 最新の indicator 付き point を末尾から探す (Yahoo filler は indicators null)
+/** 通貨に応じた価格表示 (JPY は整数 + カンマ、他は小数 2 桁)。 */
+function fmtPriceCcy(v: number, currency: string | null): string {
+  const mark = currency === 'JPY' ? '¥' : '$'
+  const digits = currency === 'JPY' ? 0 : 2
+  return `${mark}${v.toLocaleString('ja-JP', { minimumFractionDigits: digits, maximumFractionDigits: digits })}`
+}
+
+/**
+ * 前日終値 (= 最終 daily point の 1 つ前の price)。比較・markLine 共用。
+ * points が 2 点未満 / 非有限なら null。
+ */
+export function prevDailyClose(chart: SymbolChartData | null): number | null {
+  const pts = chart?.points ?? []
+  if (pts.length < 2) return null
+  const v = pts[pts.length - 2]!.price
+  return Number.isFinite(v) ? v : null
+}
+
+/**
+ * Google Finance 風の価格ヘッダー: 大きい現在値 + 前日比 (%/絶対値)。
+ * 日本式配色 (上昇=赤 / 下落=緑)。下段に SMA50 / high20d / low20d の小バッジ。
+ * 現在値は latestCronPrice (直近 strategy 評価値)、無ければ最終 point の price。
+ */
+export function renderPriceHeader(
+  chart: SymbolChartData | null,
+  universe?: SymbolUniverse | null,
+): string {
+  if (!chart || chart.points.length === 0) return ''
+  const last = chart.points[chart.points.length - 1]!
+  const cur = chart.latestCronPrice ?? last.price
+  if (!Number.isFinite(cur)) return ''
+  const ccy = universe?.symbolCurrency[chart.symbol.toUpperCase()] ?? null
+  const prev = prevDailyClose(chart)
+  let changeHtml = ''
+  if (prev !== null && prev > 0) {
+    const diff = cur - prev
+    const pct = (diff / prev) * 100
+    const up = diff >= 0
+    // 日本式: 上昇=赤 / 下落=緑 (Google Finance JA と同じ)
+    const color = up ? '#d23f31' : '#188038'
+    const arrow = up ? '▲' : '▼'
+    const sign = up ? '+' : ''
+    changeHtml = ` <span style="font-size:14px;font-weight:600;color:${color};margin-left:6px">${arrow} ${sign}${pct.toFixed(2)}% (${sign}${diff.toFixed(2)}) 前日比</span>`
+  }
+  // 最新の indicator 付き point (Yahoo filler は indicators null)
   let latest: SymbolChartPoint | null = null
   for (let i = chart.points.length - 1; i >= 0; i -= 1) {
     const p = chart.points[i]!
@@ -7542,21 +7621,24 @@ export function renderCurrentIndicatorsBadge(chart: SymbolChartData | null): str
       break
     }
   }
-  if (!latest) return ''
   const fmt = (v: number | null): string => (v == null ? '—' : v.toFixed(2))
-  const items: Array<[string, string]> = [
-    ['price', fmt(latest.price)],
-    ['SMA50', fmt(latest.sma50)],
-    ['high20d', fmt(latest.high20d)],
-    ['low20d', fmt(latest.low20d)],
-  ]
-  const badges = items
+  const subItems: Array<[string, string]> = latest
+    ? [
+        ['SMA50', fmt(latest.sma50)],
+        ['high20d', fmt(latest.high20d)],
+        ['low20d', fmt(latest.low20d)],
+      ]
+    : []
+  const sub = subItems
     .map(
       ([k, v]) =>
         `<span style="display:inline-block;margin-right:10px;font-size:12px"><span class="muted">${esc(k)}:</span> <strong>${esc(v)}</strong></span>`,
     )
     .join('')
-  return `<p style="margin:6px 0 0">${badges}</p>`
+  return `<div style="margin:2px 0 0">
+    <span style="font-size:26px;font-weight:700;font-variant-numeric:tabular-nums;letter-spacing:-0.01em">${esc(fmtPriceCcy(cur, ccy))}</span>${changeHtml}
+  </div>
+  ${sub ? `<p style="margin:2px 0 0">${sub}</p>` : ''}`
 }
 
 /**

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -5826,14 +5826,16 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
       // candle / line / scatter / markLine / markPoint / markArea すべてで
       // 「1 点が範囲外でも視覚的に切れて表示される」のが期待動作なので
       // wide chart (1 銘柄 / 数千点) でも問題ない。
-      var dzCommon = {
-        labelFormatter: function (value) { return jstLabelForX(value); },
-        filterMode: 'weakFilter',
-      };
-      var dzInside = { filterMode: 'weakFilter' };
+      // 下部 slider と wheel/pinch zoom は廃止 (Google Finance 風 — range 操作は
+      // 1日/5日/1か月/最大 のピルのみ。operator 要望)。inside dataZoom は
+      // ピルの dispatchAction / URL 同期の受け皿として残すが、マウス・タッチ
+      // 操作は全て無効化する (sticky チャート上で page scroll を奪わない効果も)。
       var dataZoomCfg = [
-        Object.assign({ type: 'inside', xAxisIndex: 0 }, dzInside, dzInitial),
-        Object.assign({ type: 'slider', xAxisIndex: 0, height: 24, bottom: 8 }, dzCommon, dzInitial),
+        Object.assign({
+          type: 'inside', xAxisIndex: 0, filterMode: 'weakFilter',
+          zoomOnMouseWheel: false, moveOnMouseMove: false, moveOnMouseWheel: false,
+          zoomLock: false,
+        }, dzInitial),
       ];
 
       var symChart = echarts.init(document.getElementById('symbol-chart'));
@@ -5886,10 +5888,11 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
         },
         legend: { top: 22, type: 'scroll' },
         // plot 面積最大化: grid 余白を絞り、splitLine 淡く、axisLine 非表示で
-        // candle が映える背景に (trader-strategist 助言)。bottom は slider 用 64px キープ。
+        // candle が映える背景に (trader-strategist 助言)。下部 slider 廃止に伴い
+        // bottom は x軸ラベル分 (28px) のみ。
         // right は stop/TP の endLabel ("stop X (preview)" 等) が見切れないよう
         // 80px 確保 (短い "stop X (-Y%)" でも余白として違和感ない範囲)。
-        grid: { left: 50, right: 120, top: 56, bottom: 64 },
+        grid: { left: 50, right: 120, top: 56, bottom: 28 },
         dataZoom: dataZoomCfg,
         // category mode: categories = intradayBars 各 bar の ISO timestamp。
         // overnight / 週末 / 米国祝日の空白を「詰めて」表示するため (TradingView
@@ -6374,9 +6377,8 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
           // Google 風ピルの active 付替 (押した range を強調)
           for (var pj = 0; pj < presetButtons.length; pj += 1) presetButtons[pj].classList.remove('active');
           ev.currentTarget.classList.add('active');
-          // inside / slider 両方を同期更新
+          // dataZoom は inside 1 つだけ (slider 廃止)
           symChart.dispatchAction({ type: 'dataZoom', dataZoomIndex: 0, startValue: sv, endValue: eV });
-          symChart.dispatchAction({ type: 'dataZoom', dataZoomIndex: 1, startValue: sv, endValue: eV });
         });
       }
     });

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -5722,10 +5722,13 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
         // 未来スロットの timestamp 間隔 (直近 bar の平均間隔)。
         var span = barsPerDay > 1 ? (lastBarMs - ohlcMs[ohlcMs.length - barsPerDay]) / (barsPerDay - 1) : 3600000;
         if (!Number.isFinite(span) || span <= 0) span = 3600000;
-        // 描く未来日数: 交差ありはその近辺まで、交差なし (向きだけ見せる) は短めに
-        // して未来の空白が過大にならないようにする。1〜5 営業日に clamp。
-        var rawDays = proj.crossingSteps != null ? proj.crossingSteps : Math.min(proj.horizonSteps, 3);
-        var drawDays = Math.min(Math.max(Math.ceil(rawDays), 1), 5);
+        // 描く未来日数: 交差あり (= 入場時期の目安が見える) はその近辺まで、
+        // 1〜5 営業日に clamp。交差なしは向き (傾き) が読めれば十分なので
+        // 1 営業日だけ — 3 日でも未来の空白が axis を占有し、履歴側の candle
+        // が左に圧縮される + 押し目端の endLabel が空白に浮く (operator 指摘)。
+        var drawDays = proj.crossingSteps != null
+          ? Math.min(Math.max(Math.ceil(proj.crossingSteps), 1), 5)
+          : 1;
         var drawBars = Math.max(barsPerDay, Math.round(drawDays * barsPerDay));
         var startIdx = categories.length - 1;
         for (var k = 1; k <= drawBars; k += 1) {

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -1788,59 +1788,83 @@ describe('anchorJstMidnight', () => {
   })
 })
 
-import { renderCurrentIndicatorsBadge } from '../../src/routes/dashboard'
+import { renderPriceHeader, prevDailyClose } from '../../src/routes/dashboard'
 
-describe('renderCurrentIndicatorsBadge', () => {
-  function fakeChartWith(points: SymbolChartPoint[]): SymbolChartData {
+describe('renderPriceHeader (Google Finance 風 価格ヘッダー)', () => {
+  function fakeChartWith(
+    points: SymbolChartPoint[],
+    latestCronPrice: number | null = null,
+  ): SymbolChartData {
     return {
       symbol: 'X', points, markers: [], position: null,
       rules: { pullbackMax: 0, pullbackMin: 0, stopPct: 0, takeProfitPct: 0, timeStopDays: 10 },
       trendLine: null, intradayBars: [],
-      latestCronPrice: null, latestCronTimestamp: null,
+      latestCronPrice, latestCronTimestamp: null,
     }
   }
-
-  it('chart が null なら空文字', () => {
-    expect(renderCurrentIndicatorsBadge(null)).toBe('')
+  const pt = (price: number, ind = false): SymbolChartPoint => ({
+    timestamp: '2026-04-25T05:00:00.000Z',
+    price,
+    sma50: ind ? 60 : null,
+    high20d: ind ? 105 : null,
+    low20d: ind ? 90 : null,
   })
 
-  it('points 空なら空文字', () => {
-    expect(renderCurrentIndicatorsBadge(fakeChartWith([]))).toBe('')
+  it('chart null / points 空なら空文字', () => {
+    expect(renderPriceHeader(null)).toBe('')
+    expect(renderPriceHeader(fakeChartWith([]))).toBe('')
   })
 
-  it('全 indicator null の point しか無ければ空文字', () => {
-    const chart = fakeChartWith([
-      { timestamp: '2026-04-25T05:00:00.000Z', price: 120, sma50: null, high20d: null, low20d: null },
-    ])
-    expect(renderCurrentIndicatorsBadge(chart)).toBe('')
+  it('現在値を大きく + 前日比 (上昇=赤 ▲、日本式)', () => {
+    const html = renderPriceHeader(fakeChartWith([pt(100), pt(102)]))
+    expect(html).toContain('$102.00')
+    expect(html).toContain('▲')
+    expect(html).toContain('+2.00%')
+    expect(html).toContain('(+2.00)')
+    expect(html).toContain('#d23f31') // 上昇 = 赤
+    expect(html).toContain('前日比')
   })
 
-  it('最新の indicator 付き point から price/SMA50/high20d/low20d を表示', () => {
-    const chart = fakeChartWith([
-      { timestamp: '2026-04-23T05:00:00.000Z', price: 100, sma50: 60, high20d: 105, low20d: 90 },
-      // Yahoo filler (indicators null) — skip
-      { timestamp: '2026-04-24T16:00:00.000Z', price: 110, sma50: null, high20d: null, low20d: null },
-      // 末尾から探して 04/23 の point を採用
-    ])
-    const html = renderCurrentIndicatorsBadge(chart)
-    expect(html).toContain('price')
-    expect(html).toContain('100.00')
+  it('下落は緑 ▼', () => {
+    const html = renderPriceHeader(fakeChartWith([pt(100), pt(97)]))
+    expect(html).toContain('▼')
+    expect(html).toContain('-3.00%')
+    expect(html).toContain('#188038') // 下落 = 緑
+  })
+
+  it('JPY 銘柄は ¥ + 整数表示', () => {
+    const universe = makeSymbolUniverse({
+      allowedSymbols: ['X'],
+      symbolCurrency: { X: 'JPY' },
+    })
+    const html = renderPriceHeader(fakeChartWith([pt(1535), pt(1549)]), universe)
+    expect(html).toContain('¥1,549')
+    expect(html).not.toContain('¥1,549.00')
+  })
+
+  it('latestCronPrice があれば現在値として優先', () => {
+    const html = renderPriceHeader(fakeChartWith([pt(100), pt(102)], 103.5))
+    expect(html).toContain('$103.50')
+  })
+
+  it('points 1 点 (前日なし) は前日比を出さず価格のみ', () => {
+    const html = renderPriceHeader(fakeChartWith([pt(120)]))
+    expect(html).toContain('$120.00')
+    expect(html).not.toContain('前日比')
+  })
+
+  it('サブ行に SMA50/high20d/low20d (最新の indicator 付き point から)', () => {
+    const html = renderPriceHeader(fakeChartWith([pt(100, true), pt(110)]))
     expect(html).toContain('SMA50')
     expect(html).toContain('60.00')
     expect(html).toContain('high20d')
     expect(html).toContain('105.00')
-    expect(html).toContain('low20d')
-    expect(html).toContain('90.00')
   })
 
-  it('一部 indicator が null でも em-dash で fallback', () => {
-    const chart = fakeChartWith([
-      { timestamp: '2026-04-25T05:00:00.000Z', price: 120, sma50: 60, high20d: null, low20d: null },
-    ])
-    const html = renderCurrentIndicatorsBadge(chart)
-    expect(html).toContain('120.00')
-    expect(html).toContain('60.00')
-    expect(html).toContain('—') // high20d / low20d
+  it('prevDailyClose は最終 point の 1 つ前の price (2 点未満は null)', () => {
+    expect(prevDailyClose(fakeChartWith([pt(100), pt(102)]))).toBe(100)
+    expect(prevDailyClose(fakeChartWith([pt(100)]))).toBeNull()
+    expect(prevDailyClose(null)).toBeNull()
   })
 })
 
@@ -2059,6 +2083,33 @@ describe('renderSymbolTab — 判定点 scatter + click-to-trace の配線', () 
     expect(html).toContain('inactive — paused for review')
   })
 
+  // Google Finance 風: 前日終値を payload に載せ (チャートの点線基準)、
+  // 価格ヘッダー (大きい現在値 + 前日比) を chart 上に出す。
+  it('前日終値を payload に載せ、価格ヘッダーと range ピルを描画する', () => {
+    const base = symbolArgs([])
+    const html = renderSymbolTab({
+      ...base,
+      symbolChart: {
+        ...base.symbolChart!,
+        points: [
+          { timestamp: '2026-06-05T14:00:00.000Z', price: 78, sma50: 70, high20d: 90, low20d: 60 },
+          { timestamp: '2026-06-06T14:00:00.000Z', price: 80, sma50: 70, high20d: 90, low20d: 60 },
+        ],
+      },
+    })
+    expect(html).toContain('"prevClose":78')
+    expect(html).toContain('前日終値 $78.00')
+    // 現在値 (latestCronPrice=80) を大きく + 前日比 (上昇=赤)
+    expect(html).toContain('$80.00')
+    expect(html).toContain('前日比')
+    // range ピルは chart container の直後 (chart-pin 内、チャート直下に出す)
+    const chartIdx = html.indexOf('id="symbol-chart"')
+    const pillIdx = html.indexOf('class="zoom-preset"')
+    const panelIdx = html.indexOf('入場まで')
+    expect(pillIdx).toBeGreaterThan(chartIdx)
+    if (panelIdx >= 0) expect(pillIdx).toBeLessThan(panelIdx)
+  })
+
   // チャートは sticky 固定 (入場ゲート説明 / 判定トレースとグラフを同時に見るため)
   it('チャートと指標バッジを sticky な symbol-chart-pin で包む', () => {
     const html = renderSymbolTab(symbolArgs([]))
@@ -2156,16 +2207,16 @@ describe('renderZoomPresetButtons', () => {
     expect(renderZoomPresetButtons(fakeChart([]))).toBe('')
   })
 
-  it('points あれば 1D / 5D / 1M / All の 4 ボタン', () => {
+  it('points あれば 1日 / 5日 / 1か月 / 最大 の 4 ピル (Google Finance JA 準拠)', () => {
     const chart = fakeChart([
       { timestamp: '2026-04-01T00:00:00.000Z', price: 100, sma50: null, high20d: null, low20d: null },
       { timestamp: '2026-04-25T00:00:00.000Z', price: 120, sma50: null, high20d: null, low20d: null },
     ])
     const html = renderZoomPresetButtons(chart)
-    expect(html).toContain('>1D<')
-    expect(html).toContain('>5D<')
-    expect(html).toContain('>1M<')
-    expect(html).toContain('>All<')
+    expect(html).toContain('>1日<')
+    expect(html).toContain('>5日<')
+    expect(html).toContain('>1か月<')
+    expect(html).toContain('>最大<')
     expect(html.match(/class="zoom-preset"/g)?.length).toBe(4)
   })
 


### PR DESCRIPTION
## Summary

個別銘柄チャートの Google Finance 風 restyle + 表示密度の改善 (operator フィードバック反復、7 commits)。

### 右余白の解消
- 交差なし (向きだけ見せる) の外挿線を 3営業日 → 1日 → **半営業日分の bar** に短縮。未来スロットが axis を占有して履歴 candle が左に圧縮されていた。交差あり (入場時期の目安) は従来通り最大5営業日

### Google Finance 風 (https://www.google.com/finance/beta 参考)
- **ローソクを日本式配色に**: 赤=陽線 / 緑=陰線 (`#d23f31` / `#1e8e3e`)。個別銘柄タブ + 銘柄グリッド
- **価格ヘッダー**: 大きい現在値 (JPY は ¥ + 整数表示) + 前日比 `▲ +X.XX% (+Y.YY) 前日比` (上昇=赤/下落=緑)。旧 price バッジは SMA50/high20d/low20d のサブ行として残置
- **前日終値ライン**: グレー点線 + 右端ラベル。基準値はヘッダーの前日比と共通 (直近 daily point の 1 つ前)
- **range ピル**: `1日/5日/1か月/最大` をチャート直下 (sticky 領域内) に。下部 slider と wheel/pinch zoom は廃止し **ピル操作のみ** (sticky チャート上で page scroll を奪わない副次効果)。URL `?from/?to` 同期は dataZoom 経由で維持

### 表示密度
- **15分足に切替** (旧 1h 足は 1日 ≈ 7本でスカスカ)。barWidth は固定 px → auto (4倍密度で潰れないように)。戦略 cron は従来通り 60m を使用 — 表示専用の変更
- チャート高さ 460px → 380px
- **y軸引き伸ばしの修正**: 乖離した SMA50 (例: 価格 $260 / SMA50 $125) を y range に無条件で含めて candle が潰れていた (#181 の常時可視方針を転換)。candle range ±25% の近傍にある時だけ含め、遠い時は clip (値はヘッダーのサブ行で確認可)

## Test plan

- 価格ヘッダーのテスト一式 (上昇/下落の日本式配色、JPY 整数表示、latestCronPrice 優先、前日終値) + prevClose payload / range ピルのテストを追加・更新
- `pnpm test` 1338 件通過 / `pnpm typecheck` クリーン
- staging に段階デプロイして operator が各ステップ目視確認済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ダッシュボードチャートの時間足を15分間隔に変更し、データの詳細表示が可能に
  * 前日終値をチャートに水平線で表示
  * 価格ヘッダーをリニューアルし、前日比（％/絶対値）と主要指標（SMA50など）を表示

* **改善**
  * 個別銘柄タブ下部のスライダーを廃止
  * チャート描画の安定性を向上
  * ズームプリセットボタンのラベルを日本語に統一（1日/5日/1か月/最大）
  * グリッド表示をチャートと一貫性のある仕様に統一

<!-- end of auto-generated comment: release notes by coderabbit.ai -->