### PR TITLE
POC Phase follow-up: 段階判定 ENTRY/HALF/WATCH/NG + 0.5x sizing (issue #452 PR 2/3)

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -53,6 +53,13 @@ import {
   type EntryGateStatus,
   type EvalIndicatorPoint,
 } from '../trading/strategy/entryDistance'
+import {
+  deriveEntryStatus,
+  deriveEntryStatusFromIndicators,
+  type EntryStatus,
+  type EntryStatusResult,
+} from '../trading/strategy/entryStatus'
+import { buildSymbolRules } from '../trading/strategy/symbolRuleResolution'
 import type {
   PullbackIndicators,
   SymbolRule,
@@ -353,10 +360,37 @@ export const dashboard = new Hono<DashboardBindings>()
         // バッジ + grayed style) は `renderGridTab` 側で symbol 単位に付与する。
         const allGridSymbols = [...universe.allowedSymbols, ...universe.inactiveSymbols]
         const charts = await loadAllSymbolCharts(c.env, allGridSymbols, rules)
+        // 段階判定 (#452 PR 2): 各銘柄の最新 eval indicators を cron と同じ
+        // effective rule (global → role preset → override) で 4 段階判定し、
+        // panel badge + 表示優先度ソート (ENTRY > HALF > WATCH > NG >
+        // cash_parking、inactive / データ無しは末尾) に使う。
+        const gridDefaultRule: SymbolRule = {
+          stopPct: global.pullbackDefaultStopPct,
+          takeProfitPct: global.pullbackDefaultTakeProfitPct,
+          timeStopDays: global.pullbackDefaultTimeStopDays,
+          pullbackMax: global.pullbackDefaultPullbackMax,
+          pullbackMin: global.pullbackDefaultPullbackMin,
+          minReturn50d: global.pullbackDefaultMinReturn50d,
+          requireAboveSma50: global.pullbackDefaultRequireAboveSma50,
+          kAtr: global.pullbackDefaultKAtr,
+          maxSma50DeviationPct: global.pullbackDefaultMaxSma50DeviationPct,
+          maxAtrRatio: global.pullbackDefaultMaxAtrRatio,
+        }
+        const gridRules = buildSymbolRules(gridDefaultRule, universe)
+        const entryStatuses: Record<string, EntryStatus> = {}
+        for (const entry of charts) {
+          const lastEval = entry.chart?.evalIndicators?.[entry.chart.evalIndicators.length - 1]
+          if (!lastEval) continue
+          entryStatuses[entry.symbol] = deriveEntryStatusFromIndicators(
+            lastEval.indicators,
+            gridRules[entry.symbol] ?? gridDefaultRule,
+          ).status
+        }
+        const sortedCharts = sortGridChartsByEntryPriority(charts, entryStatuses, universe)
         // grid の zoom 基準: 全 panel 共通の dataZoom 同期があるため、最初に
         // load 成功した chart の lastTimestamp を基準に直近 7 日 (default) を
         // 採用する。URL ?from / ?to があればそれを優先 (既存と同挙動)。
-        const referenceChart = charts.find((c) => c.chart !== null)?.chart ?? null
+        const referenceChart = sortedCharts.find((c) => c.chart !== null)?.chart ?? null
         const zoom = computeZoomRange(zoomFrom, zoomTo, referenceChart)
         return c.html(
           renderLayout(
@@ -364,9 +398,10 @@ export const dashboard = new Hono<DashboardBindings>()
             'チャート',
             chartsBody({
               tab,
-              charts,
+              charts: sortedCharts,
               zoom,
               universe,
+              entryStatuses,
             }),
             renderChartsSubnav(tab),
           ),
@@ -411,11 +446,11 @@ export const dashboard = new Hono<DashboardBindings>()
         takeProfitPct: strategyParams.takeProfitPct,
         timeStopDays: strategyParams.timeStopDays,
       }
-      // 入場距離 (#entry-distance): entry ゲートの閾値は global default のみ
-      // (pullbackMax/Min・minReturn50d・過熱・ボラに per-symbol override は無い)。
-      // entryDistance は entry 系フィールドだけ使うが、SymbolRule は exit 系も
-      // 要求するので global から full rule を組む。
-      const entryRule: SymbolRule = {
+      // 入場距離 (#entry-distance): cron と同じ effective rule で評価する —
+      // global default → role preset → per-symbol override (#452)。drift すると
+      // ダッシュボードの入場ラインが cron 判定とずれるので必ず buildSymbolRules
+      // を共用する。
+      const defaultEntryRule: SymbolRule = {
         stopPct: strategyParams.stopPct,
         takeProfitPct: strategyParams.takeProfitPct,
         timeStopDays: strategyParams.timeStopDays,
@@ -427,6 +462,9 @@ export const dashboard = new Hono<DashboardBindings>()
         maxSma50DeviationPct: strategyParams.maxSma50DeviationPct,
         maxAtrRatio: strategyParams.maxAtrRatio,
       }
+      const effectiveRules = buildSymbolRules(defaultEntryRule, universe)
+      const entryRule: SymbolRule =
+        (focusSymbol ? effectiveRules[focusSymbol] : undefined) ?? defaultEntryRule
       // SymbolStateDO の position が ground truth (avgPrice / openedAt が
       // partial fill / position add も反映済)。trade_journal からの derive は
       // 直近 BUY 単体しか拾えないので fallback 専用。
@@ -442,6 +480,9 @@ export const dashboard = new Hono<DashboardBindings>()
       const buyability = symbolChart?.evalIndicators?.length
         ? buildBuyabilityView(symbolChart.evalIndicators, entryRule)
         : null
+      // 段階判定 (#452 PR 2): 7 gates から ENTRY/HALF/WATCH/NG を導出して表示。
+      // WATCH/NG 時は alternatives (表示専用) を併記する。
+      const entryStatus = buyability?.current ? deriveEntryStatus(buyability.current) : null
       return c.html(
         renderLayout(
           c,
@@ -455,6 +496,8 @@ export const dashboard = new Hono<DashboardBindings>()
             zoom,
             universe,
             buyability,
+            entryStatus,
+            alternatives: focusSymbol ? universe.symbolAlternatives[focusSymbol] ?? [] : [],
           }),
           renderChartsSubnav(tab, focusSymbol ?? undefined),
         ),
@@ -5091,6 +5134,10 @@ export interface ChartsBodySymbol {
   universe?: SymbolUniverse | null
   /** 入場距離ビュー (#entry-distance)。「入場まであと/いつ頃」の描画用。null = データ無し。 */
   buyability?: BuyabilityView | null
+  /** 段階判定 (#452 PR 2)。null = 評価データ無し。 */
+  entryStatus?: EntryStatusResult | null
+  /** 代替銘柄候補 (#452、表示専用)。WATCH/NG 時に併記する。 */
+  alternatives?: string[]
 }
 
 /**
@@ -5116,6 +5163,8 @@ interface ChartsBodyGrid {
   zoom: { from: Date; to: Date } | null
   /** panel header の銘柄表示を JP 銘柄向け 番号-会社名 形式にするための universe。 */
   universe?: SymbolUniverse | null
+  /** symbol → 段階判定 (#452 PR 2)。評価データ無しの銘柄は不在。panel badge 用。 */
+  entryStatuses?: Record<string, EntryStatus>
 }
 
 type ChartsBodyArgs =
@@ -6416,7 +6465,10 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
   <div id="symbol-chart" style="width:100%;height:380px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;margin-top:8px"></div>
   ${renderZoomPresetButtons(args.symbolChart)}
   </div>
-  ${renderBuyabilityPanel(args.buyability ?? null)}
+  ${renderBuyabilityPanel(args.buyability ?? null, {
+    entryStatus: args.entryStatus ?? null,
+    alternatives: args.alternatives ?? [],
+  })}
   ${renderDecisionPlotCaption(args.symbolChart)}
   <div id="decision-trace-panel" class="reason-panel" style="margin-top:10px">
     <p class="muted" style="font-size:12px;margin:0">判定点 (●) をクリックすると、その判定が通った採用ロジックのトレースがここに表示されます。</p>
@@ -6453,6 +6505,46 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
  * - BUY/SELL pin (markPoint, hover で qty / PnL / fill 時刻 tooltip)
  * - session divider (vertical lines)
  */
+/** 段階判定 badge の配色 (#452 PR 2)。 */
+const ENTRY_STATUS_BADGE: Record<EntryStatus, { label: string; bg: string; fg: string }> = {
+  ENTRY: { label: 'ENTRY', bg: '#e6f6ec', fg: '#057a55' },
+  HALF: { label: 'HALF 0.5x', bg: '#fff4e6', fg: '#b25000' },
+  WATCH: { label: 'WATCH', bg: '#eef2f8', fg: '#46608a' },
+  NG: { label: 'NG', bg: '#fdecec', fg: '#c22' },
+}
+
+function entryStatusBadgeHtml(status: EntryStatus): string {
+  const b = ENTRY_STATUS_BADGE[status]
+  return `<span style="display:inline-block;padding:1px 8px;border-radius:10px;background:${b.bg};color:${b.fg};font-weight:700;font-size:11px" title="段階判定 (#452): 発注対象は ENTRY / HALF のみ">${b.label}</span>`
+}
+
+/**
+ * Grid panel の表示優先度ソート (#452 PR 2)。
+ * ENTRY > HALF > WATCH > NG > cash_parking > 判定不能 (データ無し) > inactive。
+ * 同順位内は元の並び (pair 隣接など) を保つ stable sort。
+ */
+export function sortGridChartsByEntryPriority<T extends { symbol: string }>(
+  charts: T[],
+  entryStatuses: Record<string, EntryStatus>,
+  universe: SymbolUniverse,
+): T[] {
+  const inactive = new Set(universe.inactiveSymbols)
+  const priority = (symbol: string): number => {
+    if (inactive.has(symbol)) return 6
+    if (universe.symbolRole[symbol] === 'cash_parking') return 4
+    const status = entryStatuses[symbol]
+    if (status === 'ENTRY') return 0
+    if (status === 'HALF') return 1
+    if (status === 'WATCH') return 2
+    if (status === 'NG') return 3
+    return 5 // 判定不能 (chart/eval データ無し)
+  }
+  return charts
+    .map((entry, idx) => ({ entry, idx }))
+    .sort((a, b) => priority(a.entry.symbol) - priority(b.entry.symbol) || a.idx - b.idx)
+    .map(({ entry }) => entry)
+}
+
 export function renderGridTab(args: ChartsBodyGrid): string {
   if (args.charts.length === 0) {
     return `<p class="muted">ALLOWED_SYMBOLS が空です。<code>symbol_config</code> に少なくとも 1 銘柄登録してください。</p>`
@@ -6512,7 +6604,10 @@ export function renderGridTab(args: ChartsBodyGrid): string {
         </div>`
       }
       const badge = renderGridPanelBadge(entry.chart)
-      const rightSide = (inactive ? inactiveBadge : '') + positionBadge + badge
+      // 段階判定 badge (#452 PR 2)。inactive 銘柄は cron 評価対象外なので出さない。
+      const status = args.entryStatuses?.[entry.symbol]
+      const statusBadge = status !== undefined && !inactive ? entryStatusBadgeHtml(status) : ''
+      const rightSide = (inactive ? inactiveBadge : '') + statusBadge + positionBadge + badge
       return `<div class="${panelClass}"${dataAttrs} style="${baseStyle}">
         <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:4px;gap:8px">
           ${headerLink}
@@ -7453,9 +7548,20 @@ function fmtGateValue(g: EntryGateStatus): string {
  * - 全ゲートの現在値 vs 閾値チェックリスト
  * buyability / current が無ければ空文字。
  */
-export function renderBuyabilityPanel(buyability: BuyabilityView | null): string {
+export interface BuyabilityPanelContext {
+  /** 段階判定 (#452 PR 2)。null = 出さない。 */
+  entryStatus?: EntryStatusResult | null
+  /** 代替銘柄候補 (#452、表示専用)。WATCH/NG 時のみ表示する。 */
+  alternatives?: string[]
+}
+
+export function renderBuyabilityPanel(
+  buyability: BuyabilityView | null,
+  ctx: BuyabilityPanelContext = {},
+): string {
   if (!buyability || !buyability.current) return ''
   const cur = buyability.current
+  const status = ctx.entryStatus ?? null
 
   // --- 結論 ---
   let headline: string
@@ -7542,13 +7648,32 @@ export function renderBuyabilityPanel(buyability: BuyabilityView | null): string
     })
     .join('')
 
+  // --- 段階判定 badge + HALF 説明 + 代替候補 (#452 PR 2) ---
+  const statusBadge = status ? entryStatusBadgeHtml(status.status) : ''
+  let halfNote = ''
+  if (status?.status === 'HALF' && status.halfGate) {
+    halfNote = `<div style="margin-top:6px;font-size:12px;color:#b25000">HALF: 未通過は「${esc(status.halfGate.labelJa)}」のみで閾値の許容バンド内 → 0.5x サイジングで entry 候補 (role が entry 有効な銘柄のみ発注対象)。</div>`
+  }
+  let altBlock = ''
+  if (status && (status.status === 'WATCH' || status.status === 'NG') && ctx.alternatives?.length) {
+    const links = ctx.alternatives
+      .map(
+        (s) =>
+          `<a href="/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(s)}" style="font-weight:600">${esc(s)}</a>`,
+      )
+      .join(' / ')
+    altBlock = `<div style="margin-top:8px"><strong>代替候補</strong>: ${links}
+      <div class="muted" style="font-size:11px">この銘柄が entry 不可の間の代替 ETF 候補 (表示のみ — 自動で発注先を切り替えることはしない、#452)。</div></div>`
+  }
+
   // 距離の推移 (+ETA) と 入場ゲート は 2 列 (narrow 画面は .panel-row の
   // media query で 1 列に落ちる)。
   return `<div class="reason-panel" style="margin-top:10px;max-width:1000px">
-    <div style="font-size:13px;color:${headColor};margin-bottom:6px">${headline}</div>
+    <div style="font-size:13px;color:${headColor};margin-bottom:6px;display:flex;align-items:center;gap:8px;flex-wrap:wrap">${statusBadge}<span>${headline}</span></div>
+    ${halfNote}
     <div class="panel-row" style="gap:8px 20px">
-      <div>${trendBlock}${etaBlock}</div>
-      <div style="margin-top:8px"><strong>入場ゲート</strong>(全条件。閾値は global 既定)
+      <div>${trendBlock}${etaBlock}${altBlock}</div>
+      <div style="margin-top:8px"><strong>入場ゲート</strong>(全条件。閾値は global 既定 + role preset + 銘柄 override、#452)
         <div style="margin-top:4px;display:flex;flex-direction:column;gap:3px">${gateRows}</div>
       </div>
     </div>

--- a/src/trading/strategy/entryStatus.ts
+++ b/src/trading/strategy/entryStatus.ts
@@ -1,0 +1,86 @@
+import { computeEntryDistance, type EntryDistance, type EntryGateStatus } from './entryDistance'
+import type { PullbackIndicators, SymbolRule } from './strategies/PullbackUptrendStrategy'
+
+/**
+ * 段階判定 (#452 Layer 2b、#449)。7 entry gates の通過状況を BUY/HOLD の二値では
+ * なく 4 段階に分類する:
+ *
+ * | status | 条件                                                        | multiplier |
+ * |--------|-------------------------------------------------------------|-----------|
+ * | ENTRY  | 全 gate 通過                                                | 1.0       |
+ * | HALF   | 未通過が 1 gate のみ、かつ「程度もの」gate (ATR 比 / 押し目深度) で閾値の許容バンド (±20%) 内 | 0.5 |
+ * | WATCH  | 未通過が 1–2 gates (HALF 非該当)                            | 0 (監視のみ) |
+ * | NG     | それ以外 (3 gates 以上未通過)                               | 0         |
+ *
+ * **発注対象は ENTRY / HALF のみ**。WATCH は表示専用で、gate を緩める方向の
+ * 変更ではない (HALF も閾値近傍の取りこぼし救済であって gate 無効化ではない)。
+ * 発注経路への適用は role が entry 有効な銘柄に限る (role NULL = 従来の二値
+ * 挙動、#452 受け入れ条件) — その制御は scheduler 側 (`halfEntrySymbols`)。
+ */
+export type EntryStatus = 'ENTRY' | 'HALF' | 'WATCH' | 'NG'
+
+export interface EntryStatusResult {
+  status: EntryStatus
+  /** ENTRY=1 / HALF=0.5 / WATCH・NG=0。sizing 量に乗算する。 */
+  positionMultiplier: number
+  /** 未通過 gate (評価順)。 */
+  failedGates: EntryGateStatus[]
+  /** HALF 判定の根拠 gate (HALF 以外は null)。 */
+  halfGate: EntryGateStatus | null
+}
+
+/**
+ * 「程度もの」gate (#452)。閾値をわずかに超えているだけなら 0.5x で部分 entry
+ * する余地がある連続量の gate。trend / above_sma50 / overextension / high20d は
+ * レジーム・構造の条件なので、僅差でも HALF にしない。
+ */
+const DEGREE_GATE_KEYS: ReadonlySet<string> = new Set([
+  'volatility',
+  'pullback_shallow',
+  'pullback_deep',
+])
+
+/** HALF の許容バンド: 閾値の大きさに対する超過率 (0.2 = 閾値×1.2 相当まで)。 */
+const HALF_TOLERANCE_RATIO = 0.2
+
+/**
+ * 失敗した「程度もの」gate が許容バンド内か。operator の向きに合わせて
+ * 「閾値からの超過量が |threshold| の 20% 以内」で判定する:
+ *   - '<=' (volatility / pullback_shallow): actual <= threshold + 0.2|threshold|
+ *   - '>=' (pullback_deep):                 actual >= threshold - 0.2|threshold|
+ * threshold = 0 の縮退 (バンド幅 0) は常に false (= HALF にしない、fail-closed)。
+ */
+function withinHalfBand(gate: EntryGateStatus): boolean {
+  const margin = Math.abs(gate.threshold) * HALF_TOLERANCE_RATIO
+  if (!(margin > 0)) return false
+  if (gate.operator === '<=') return gate.actual <= gate.threshold + margin
+  if (gate.operator === '>=') return gate.actual >= gate.threshold - margin
+  return false
+}
+
+/** 入場距離 (全 gate 評価済み) から段階判定を導出する。 */
+export function deriveEntryStatus(distance: EntryDistance): EntryStatusResult {
+  const failedGates = distance.gates.filter((g) => !g.passed)
+  if (failedGates.length === 0) {
+    return { status: 'ENTRY', positionMultiplier: 1, failedGates, halfGate: null }
+  }
+  if (failedGates.length === 1) {
+    const gate = failedGates[0]!
+    if (DEGREE_GATE_KEYS.has(gate.key) && withinHalfBand(gate)) {
+      return { status: 'HALF', positionMultiplier: 0.5, failedGates, halfGate: gate }
+    }
+    return { status: 'WATCH', positionMultiplier: 0, failedGates, halfGate: null }
+  }
+  if (failedGates.length === 2) {
+    return { status: 'WATCH', positionMultiplier: 0, failedGates, halfGate: null }
+  }
+  return { status: 'NG', positionMultiplier: 0, failedGates, halfGate: null }
+}
+
+/** indicators + rule から直接段階判定する便宜関数 (scheduler / dashboard 用)。 */
+export function deriveEntryStatusFromIndicators(
+  indicators: PullbackIndicators,
+  rule: SymbolRule,
+): EntryStatusResult {
+  return deriveEntryStatus(computeEntryDistance(indicators, rule))
+}

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -38,6 +38,7 @@ import type { VixRegimeFilterDecision } from '../risk/vixRegimeFilter'
 import type { EarningsCalendarRepo } from '../../infrastructure/calendar/earningsCalendarRepo'
 import type { MacroEventCalendarRepo } from '../../infrastructure/calendar/macroEventCalendarRepo'
 import { evaluatePerSymbolRisk } from '../risk/perSymbolRiskGate'
+import { deriveEntryStatusFromIndicators } from './entryStatus'
 
 const DEFAULT_BAR_LOOKBACK = 60
 
@@ -181,6 +182,14 @@ export interface PullbackSchedulerOptions {
    * (`runStrategyCron`) は `buildEntrySuppressedSymbols` の結果を渡す。
    */
   entrySuppressedSymbols?: Record<string, string>
+  /**
+   * 段階判定 HALF (0.5x entry) を有効にする symbol 集合 (#452 PR 2)。role が
+   * entry 有効 (core_trend / leveraged_trend) な銘柄のみ。**未注入 / 集合外の
+   * 銘柄は従来の二値挙動 (HALF なし)** — role NULL の既存銘柄の挙動を変えない
+   * (#452 受け入れ条件)。production (`runStrategyCron`) は
+   * `buildHalfEntrySymbols` の結果を渡す。
+   */
+  halfEntrySymbols?: Set<string>
   /**
    * sanity_failed cooldown gate。直近 N 分以内に同 symbol で broker stub
    * fill (`resolveFilledPrice` が ratio guard で reject した) が観測されて
@@ -450,6 +459,45 @@ export async function runPullbackScheduler(
       }
     }
 
+    // 段階判定 HALF (#452 PR 2)。strategy は全 gate 通過でしか BUY を出さない
+    // (二値)。halfEntrySymbols の銘柄に限り、entry 系 HOLD を 4 段階判定に
+    // かけ直し、HALF (未通過 1 gate が「程度もの」で許容バンド内) なら 0.5x の
+    // BUY に昇格させる。position / pendingOrder / cooldown の guard 起因の HOLD
+    // は昇格対象外 (= 新規 entry の文脈のみ)。WATCH / NG は HOLD のまま。
+    let positionMultiplier = 1
+    if (
+      signal.action === 'HOLD' &&
+      options.halfEntrySymbols?.has(upper) &&
+      state.position === null &&
+      state.pendingOrder === null &&
+      !(state.cooldownUntil && new Date(state.cooldownUntil).getTime() > now().getTime())
+    ) {
+      const rule = strategy.resolveRule(upper)
+      const entryStatus = deriveEntryStatusFromIndicators(indicators, rule)
+      if (entryStatus.status === 'HALF' && entryStatus.halfGate !== null) {
+        const gate = entryStatus.halfGate
+        positionMultiplier = entryStatus.positionMultiplier
+        signal = {
+          ...signal,
+          action: 'BUY',
+          reason: `half entry (0.5x): ${gate.key} ${gate.actual.toFixed(4)} near threshold ${gate.threshold} (within tolerance band)`,
+          trace: appendTrace(
+            signal.trace,
+            traceStep(
+              'entry.half_status',
+              true,
+              gate.actual,
+              // EntryGateStatus.operator は人間可読 string だが、ここに来る
+              // degree gate は '<=' / '>=' のみ (DecisionTraceStep の union 内)。
+              gate.operator === '>=' ? '>=' : '<=',
+              gate.threshold,
+              'HALF: single degree-gate miss within tolerance → 0.5x sizing (#452)',
+            ),
+          ),
+        }
+      }
+    }
+
     if (signal.action === 'HOLD') {
       summary.holds += 1
       await emitDecision({
@@ -587,12 +635,36 @@ export async function runPullbackScheduler(
         })
         continue
       }
+      // 段階判定 HALF の 0.5x (#452 PR 2) — sizing 直後・VIX scale より前に適用。
+      // VIX warning と重なった場合は乗算で両方効く (より保守的な側に倒れる)。
+      // lot 丸めで 0 になったら reject (= 部分 entry すらできない小口は見送り)。
+      let scaledQuantity = sizing.quantity
+      if (positionMultiplier < 1) {
+        const lot = resolvedLotSize
+        const rawScaled = sizing.quantity * positionMultiplier
+        scaledQuantity = lot > 1 ? Math.floor(rawScaled / lot) * lot : Math.floor(rawScaled)
+        if (scaledQuantity <= 0) {
+          const reason = `sizing rejected: half-entry qty rounded to 0 (raw ${sizing.quantity} × ${positionMultiplier}, lot=${lot})`
+          summary.rejected.push({ symbol: upper, reason })
+          await emitDecision({
+            symbol: upper,
+            decision: 'REJECT',
+            reason,
+            price: indicators.price,
+            indicatorsJson: JSON.stringify(indicators),
+            trace: appendTrace(
+              signal.trace,
+              traceStep('sizing.half_entry_quantity_positive', false, scaledQuantity, '>', 0, reason),
+            ),
+          })
+          continue
+        }
+      }
       // VIX regime filter (issue #196 3/3) — sizing 直後に適用。
       //   - critical (sizeScale === 0): BUY 全 reject
       //   - warning (0 < sizeScale < 1): qty = floor(qty * sizeScale / lot) * lot
       //   - normal (sizeScale === 1): no-op
       // SELL は VIX 関係なく通すため、ここで scaling しても OK (BUY 経路だけ)。
-      let scaledQuantity = sizing.quantity
       if (options.vixDecision) {
         if (options.vixDecision.sizeScale === 0) {
           // critical: BUY 全 reject。decision.reason をそのまま乗せて操作者に
@@ -617,7 +689,8 @@ export async function runPullbackScheduler(
           // lot=1 の US 株は単純な floor、lot=100 の JP 株は単元未満で 0 になり得る。
           // 結果が 0 になった場合は次の `scaledQuantity <= 0` reject で拾う。
           const lot = resolvedLotSize
-          const rawScaled = sizing.quantity * options.vixDecision.sizeScale
+          // half-entry 適用後の qty を基数にする (#452: 0.5x と VIX scale は乗算)。
+          const rawScaled = scaledQuantity * options.vixDecision.sizeScale
           scaledQuantity = lot > 1
             ? Math.floor(rawScaled / lot) * lot
             : Math.floor(rawScaled)
@@ -1282,6 +1355,9 @@ const TRACE_LABEL_JA: Record<string, string> = {
   'risk.macro_event': 'マクロイベントゲート',
   'risk.per_symbol_gate': '銘柄別リスクゲート',
   'risk.vix_regime': 'VIX レジーム判定',
+  'risk.role_entry_suppressed': 'ロール entry 抑止 (#452)',
+  'entry.half_status': '段階判定 HALF (0.5x、#452)',
+  'sizing.half_entry_quantity_positive': 'HALF 数量が1株/1単元以上ある',
   'risk.buying_power_pool': '口座買付余力プール (発注前)',
   'risk.sanity_failed_cooldown': 'sanity_failed cooldown (broker stub 疑い)',
   'broker.submit': '証券会社への発注送信',

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -46,7 +46,11 @@ import {
 import { detectAndNotifyVixRegimeChange } from '../../infrastructure/notification/vixRegimeChange'
 import { resolveTradingEnabled } from '../runtime/killSwitch'
 import { runPullbackScheduler, type PullbackDecisionTrace, type PullbackRunSummary } from './pullbackScheduler'
-import { buildEntrySuppressedSymbols, buildSymbolRules } from './symbolRuleResolution'
+import {
+  buildEntrySuppressedSymbols,
+  buildHalfEntrySymbols,
+  buildSymbolRules,
+} from './symbolRuleResolution'
 
 const DEFAULT_EQUITY_USD = 10_000
 const DEFAULT_EQUITY_JPY = 1_500_000
@@ -249,6 +253,9 @@ export async function runStrategyCron(
   // Entry 抑止 role (#452): cash_parking / 定義のみの role / enum 外 'unknown' は
   // BUY を生成しない (SELL / HOLD の exit 経路は通す)。
   const entrySuppressedSymbols = buildEntrySuppressedSymbols(universe.symbolRole)
+  // 段階判定 HALF (#452 PR 2): entry 有効 role を明示した銘柄のみ 0.5x entry を
+  // 許可する。role NULL の既存銘柄は従来の二値挙動のまま。
+  const halfEntrySymbols = buildHalfEntrySymbols(universe.symbolRole)
   const byCurrency: Record<SymbolCurrency, string[]> = { USD: [], JPY: [] }
   for (const sym of universe.allowedSymbols) {
     const cur = universe.symbolCurrency[sym] ?? 'USD'
@@ -586,6 +593,7 @@ export async function runStrategyCron(
       defaultRule,
       rulesMap,
       entrySuppressedSymbols,
+      halfEntrySymbols,
       riskPerTradePct: scaledRiskPerTradePct,
       requestId: options.requestId,
       notifier,

--- a/src/trading/strategy/symbolRuleResolution.ts
+++ b/src/trading/strategy/symbolRuleResolution.ts
@@ -47,6 +47,21 @@ export const ROLE_RULE_PRESETS: Partial<Record<SymbolRole, Partial<SymbolRule>>>
 const ENTRY_ENABLED_ROLES: ReadonlySet<SymbolRole> = new Set(['core_trend', 'leveraged_trend'])
 
 /**
+ * 段階判定 HALF (0.5x entry) を有効にする symbol 集合を作る (#452 PR 2)。
+ * entry 有効 role (core_trend / leveraged_trend) を**明示的に**設定した銘柄のみ。
+ * role NULL の既存銘柄は含めない = 従来の二値挙動のまま (受け入れ条件の回帰保証)。
+ */
+export function buildHalfEntrySymbols(
+  symbolRole: Record<string, SymbolRoleValue>,
+): Set<string> {
+  const enabled = new Set<string>()
+  for (const [symbol, role] of Object.entries(symbolRole)) {
+    if (role !== 'unknown' && ENTRY_ENABLED_ROLES.has(role)) enabled.add(symbol)
+  }
+  return enabled
+}
+
+/**
  * strategy cron が BUY を生成してはいけない symbol → 抑止理由、の map を作る
  * (#452)。SELL / HOLD (exit 経路) は対象外 — role を後から変えた銘柄に建玉が
  * 残っていても stop / time-stop / TP は従来どおり動く。

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -2560,3 +2560,71 @@ describe('renderAlertFilterPills', () => {
     )
   })
 })
+
+import { deriveEntryStatus } from '../../src/trading/strategy/entryStatus'
+import { sortGridChartsByEntryPriority } from '../../src/routes/dashboard'
+
+describe('段階判定の表示 (#452 PR 2)', () => {
+  function viewFor(price: number) {
+    return buildBuyabilityView(
+      [{ timestamp: '2026-06-06T14:00:00.000Z', indicators: indFor({ price }) }],
+      TEST_DEFAULT_RULE,
+    )
+  }
+
+  it('buyability panel に EntryStatus badge を出す (ENTRY)', () => {
+    const view = viewFor(95)
+    const status = deriveEntryStatus(view.current!)
+    expect(status.status).toBe('ENTRY')
+    const html = renderBuyabilityPanel(view, { entryStatus: status })
+    expect(html).toContain('>ENTRY<')
+  })
+
+  it('WATCH/NG で alternatives があれば代替候補リンクを出す (表示のみ)', () => {
+    const view = viewFor(99) // 押し目不足 → WATCH
+    const status = deriveEntryStatus(view.current!)
+    expect(status.positionMultiplier).toBe(0)
+    const html = renderBuyabilityPanel(view, {
+      entryStatus: status,
+      alternatives: ['SOXX', 'SMH'],
+    })
+    expect(html).toContain('代替候補')
+    expect(html).toContain('symbol=SOXX')
+    expect(html).toContain('自動で発注先を切り替えることはしない')
+  })
+
+  it('ENTRY では代替候補を出さない', () => {
+    const view = viewFor(95)
+    const status = deriveEntryStatus(view.current!)
+    const html = renderBuyabilityPanel(view, { entryStatus: status, alternatives: ['SOXX'] })
+    expect(html).not.toContain('代替候補')
+  })
+
+  it('grid を ENTRY > HALF > WATCH > NG > cash_parking > データ無し > inactive で並べる', () => {
+    const charts = ['SGOV', 'NODATA', 'NG1', 'WATCH1', 'HALF1', 'ENTRY1', 'OFF'].map((symbol) => ({
+      symbol,
+      chart: null,
+      error: null,
+    }))
+    const universe = makeSymbolUniverse({
+      allowedSymbols: ['SGOV', 'NODATA', 'NG1', 'WATCH1', 'HALF1', 'ENTRY1'],
+      inactiveSymbols: ['OFF'],
+      symbolRole: { SGOV: 'cash_parking' },
+    })
+    const sorted = sortGridChartsByEntryPriority(
+      charts,
+      { ENTRY1: 'ENTRY', HALF1: 'HALF', WATCH1: 'WATCH', NG1: 'NG', SGOV: 'ENTRY' },
+      universe,
+    )
+    // SGOV は status より cash_parking が優先で末尾側、inactive (OFF) が最後。
+    expect(sorted.map((c) => c.symbol)).toEqual([
+      'ENTRY1',
+      'HALF1',
+      'WATCH1',
+      'NG1',
+      'SGOV',
+      'NODATA',
+      'OFF',
+    ])
+  })
+})

--- a/test/trading/strategy/entryStatus.test.ts
+++ b/test/trading/strategy/entryStatus.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+import { deriveEntryStatusFromIndicators } from '../../../src/trading/strategy/entryStatus'
+import {
+  TEST_DEFAULT_RULE,
+  type PullbackIndicators,
+  type SymbolRule,
+} from '../../../src/trading/strategy/strategies/PullbackUptrendStrategy'
+
+// 全 gate 通過するベース指標 (TEST_DEFAULT_RULE 比):
+//   trend: 0.20 > 0.08 / above_sma50: 100 > 90 / overextension: 0.111 <= 0.6
+//   volatility: 1.0 <= 1.5 / high20d_valid: 104 > 0
+//   pullback: (100-104)/104 = -0.0385 ∈ [-0.06, -0.03]
+const baseIndicators = (): PullbackIndicators => ({
+  price: 100,
+  sma50: 90,
+  return50d: 0.2,
+  high20d: 104,
+  atr20: 1.0,
+  baselineAtr20: 1.0,
+})
+
+const rule = (overrides: Partial<SymbolRule> = {}): SymbolRule => ({
+  ...TEST_DEFAULT_RULE,
+  ...overrides,
+})
+
+describe('deriveEntryStatus (#452 段階判定)', () => {
+  it('ENTRY when all gates pass (multiplier 1.0)', () => {
+    const result = deriveEntryStatusFromIndicators(baseIndicators(), rule())
+    expect(result.status).toBe('ENTRY')
+    expect(result.positionMultiplier).toBe(1)
+    expect(result.failedGates).toHaveLength(0)
+  })
+
+  it('HALF when the only failing gate is volatility within the ×1.2 tolerance band', () => {
+    // atrRatio 1.65 > max 1.5、ただし 1.5×1.2=1.8 以内 → HALF。
+    const result = deriveEntryStatusFromIndicators(
+      { ...baseIndicators(), atr20: 1.65 },
+      rule(),
+    )
+    expect(result.status).toBe('HALF')
+    expect(result.positionMultiplier).toBe(0.5)
+    expect(result.halfGate?.key).toBe('volatility')
+  })
+
+  it('HALF when the only failing gate is pullback depth within the tolerance band', () => {
+    // pullback = (100-107)/107 = -0.0654、min -0.06 より深いが -0.072 以内 → HALF。
+    const result = deriveEntryStatusFromIndicators(
+      { ...baseIndicators(), high20d: 107 },
+      rule(),
+    )
+    expect(result.status).toBe('HALF')
+    expect(result.halfGate?.key).toBe('pullback_deep')
+  })
+
+  it('WATCH when a single degree gate fails beyond the tolerance band', () => {
+    // atrRatio 2.0 > 1.8 (バンド外) → HALF にせず WATCH (監視のみ、発注なし)。
+    const result = deriveEntryStatusFromIndicators(
+      { ...baseIndicators(), atr20: 2.0 },
+      rule(),
+    )
+    expect(result.status).toBe('WATCH')
+    expect(result.positionMultiplier).toBe(0)
+  })
+
+  it('WATCH when the single failing gate is a regime gate (trend), even if marginal', () => {
+    // 「程度もの」以外 (トレンド / SMA50 / 過伸長 / high20d) は僅差でも HALF にしない。
+    const result = deriveEntryStatusFromIndicators(
+      { ...baseIndicators(), return50d: 0.079 },
+      rule(),
+    )
+    expect(result.status).toBe('WATCH')
+    expect(result.positionMultiplier).toBe(0)
+  })
+
+  it('WATCH when two gates fail', () => {
+    const result = deriveEntryStatusFromIndicators(
+      { ...baseIndicators(), return50d: 0.05, atr20: 1.65 },
+      rule(),
+    )
+    expect(result.status).toBe('WATCH')
+    expect(result.failedGates).toHaveLength(2)
+  })
+
+  it('NG when three or more gates fail', () => {
+    // trend / above_sma50 / pullback_deep が同時に落ちる局面。
+    const result = deriveEntryStatusFromIndicators(
+      { ...baseIndicators(), price: 80, return50d: 0.05 },
+      rule(),
+    )
+    expect(result.status).toBe('NG')
+    expect(result.positionMultiplier).toBe(0)
+    expect(result.failedGates.length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('does not grant HALF when the degree-gate threshold is 0 (degenerate band, fail-closed)', () => {
+    // pullbackMax=0 だと許容バンド幅も 0。押し目ゼロでの部分 entry は認めない。
+    const result = deriveEntryStatusFromIndicators(
+      { ...baseIndicators(), price: 104.5, high20d: 104, sma50: 95 },
+      rule({ pullbackMax: 0 }),
+    )
+    expect(result.status).not.toBe('HALF')
+  })
+})

--- a/test/trading/strategy/pullbackScheduler.test.ts
+++ b/test/trading/strategy/pullbackScheduler.test.ts
@@ -10,6 +10,7 @@ import type { Execution } from '../../../src/trading/execution/Execution'
 import type { PositionStore } from '../../../src/trading/state/PositionStore'
 import { emptySymbolState, type SymbolState } from '../../../src/trading/state/types'
 import { runPullbackScheduler } from '../../../src/trading/strategy/pullbackScheduler'
+import { TEST_DEFAULT_RULE } from '../../../src/trading/strategy/strategies/PullbackUptrendStrategy'
 import {
   createBuyingPowerLedger,
   createUnavailableBuyingPowerLedger,
@@ -1885,5 +1886,111 @@ describe('runPullbackScheduler role entry suppression (#452)', () => {
       now: () => now,
     })
     expect(summary.buys).toBe(1)
+  })
+})
+
+describe('runPullbackScheduler half entry (#452 段階判定)', () => {
+  // uptrendBars() の pullback は (117.5-122)/122 ≈ -3.69%。pullbackMin を
+  // -0.035 に絞ると pullback_deep だけが僅差で落ち (許容バンド -0.042 以内)、
+  // HALF 候補になる。-0.025 ならバンド外 → WATCH (発注なし)。
+  const HALF_RULE = { ...TEST_DEFAULT_RULE, pullbackMin: -0.035 }
+  const WATCH_RULE = { ...TEST_DEFAULT_RULE, pullbackMin: -0.025, pullbackMax: -0.03 }
+
+  it('upgrades a near-miss HOLD to BUY at 0.5x sizing for half-entry enabled symbols', async () => {
+    // 基準: 同条件で全 gate 通過なら full qty が出る。
+    const fullExecution = mockExecution()
+    await runPullbackScheduler({
+      symbols: ['QQQ'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution: fullExecution,
+      defaultRule: TEST_DEFAULT_RULE,
+      now: () => now,
+    })
+    const fullQty = (fullExecution.calls[0] as { quantity: number }).quantity
+    expect(fullQty).toBeGreaterThan(1)
+
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['QQQ'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution,
+      defaultRule: HALF_RULE,
+      halfEntrySymbols: new Set(['QQQ']),
+      now: () => now,
+    })
+    expect(summary.buys).toBe(1)
+    const intent = execution.calls[0] as { quantity: number; side: string }
+    expect(intent.side).toBe('BUY')
+    expect(intent.quantity).toBe(Math.floor(fullQty * 0.5))
+    const buy = summary.decisions.find((d) => d.decision === 'BUY')
+    expect(buy?.reason).toContain('half entry (0.5x)')
+    expect(buy?.trace?.map((s) => s.label)).toContain('entry.half_status')
+  })
+
+  it('keeps the legacy binary behavior when the symbol is not half-entry enabled (role NULL 回帰)', async () => {
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['SOXL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution,
+      defaultRule: HALF_RULE,
+      now: () => now,
+    })
+    expect(summary.buys).toBe(0)
+    expect(summary.holds).toBe(1)
+    expect(execution.calls).toHaveLength(0)
+  })
+
+  it('does not order on WATCH (single gate miss beyond the tolerance band)', async () => {
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['QQQ'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution,
+      defaultRule: WATCH_RULE,
+      halfEntrySymbols: new Set(['QQQ']),
+      now: () => now,
+    })
+    expect(summary.buys).toBe(0)
+    expect(summary.holds).toBe(1)
+    expect(execution.calls).toHaveLength(0)
+  })
+
+  it('half entry still passes through downstream risk gates (inverse-pair exposure rejects)', async () => {
+    // HALF でも逆ポジ保有中は発注しない (#452 safety)。perSymbolRisk の
+    // inverse-pair gate が BUY intent を reject することを確認する。
+    const execution = mockExecution()
+    const inverseHeld: SymbolState = {
+      ...emptySymbolState('SQQQ', () => now),
+      position: { qty: 3, avgPrice: 20, openedAt: now.toISOString() },
+    }
+    const summary = await runPullbackScheduler({
+      symbols: ['QQQ'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({ SQQQ: inverseHeld }),
+      execution,
+      defaultRule: HALF_RULE,
+      halfEntrySymbols: new Set(['QQQ']),
+      perSymbolRisk: {
+        inversePairs: { QQQ: 'SQQQ', SQQQ: 'QQQ' },
+        spreadLimits: { US: 0.0025, JP: 0.006 },
+        staleQuoteMs: 900_000,
+        gapRejectPct: 0.03,
+      },
+      now: () => now,
+    })
+    expect(summary.buys).toBe(0)
+    expect(execution.calls).toHaveLength(0)
+    const reject = summary.decisions.find((d) => d.decision === 'REJECT')
+    expect(reject?.reason).toContain('inverse')
   })
 })


### PR DESCRIPTION
## Summary

#452 の **PR 2/3 (段階判定 + ダッシュボード)**。**Stacked on #453** (base = `dev/452-role-entry-override`)。

- **`EntryStatus` 導出** (`entryStatus.ts`): 7 entry gates の通過状況から 4 段階判定
  - `ENTRY` = 全 gate 通過 (1.0x) / `HALF` = 未通過 1 gate のみ、かつ「程度もの」(ATR 比 / 押し目深度) で閾値 ×1.2 の許容バンド内 (0.5x) / `WATCH` = 未通過 1–2 gates (発注なし、監視のみ) / `NG` = それ以外
- **HALF 0.5x sizing** (scheduler): 全 gate 通過しない near-miss HOLD を 0.5x BUY に昇格。**role が entry 有効 (core_trend / leveraged_trend) な銘柄のみ opt-in** — role NULL の既存銘柄は従来の二値挙動のまま (回帰テストで保証)。lot 丸めで 0 になれば見送り、VIX warning scale とは乗算で複合
- **ダッシュボード**:
  - buyability panel に EntryStatus badge + HALF 根拠 + WATCH/NG 時の**代替銘柄候補** (表示のみ、自動 routing なし)
  - 銘柄タブ / grid の入場判定を cron と同じ effective rule (global → role preset → per-symbol override) で評価 (従来は global default 固定で PR 1 以降 drift し得た)
  - grid を表示優先度 ENTRY > HALF > WATCH > NG > cash_parking > データ無し > inactive でソート + panel badge

## Safety / fail-closed

- WATCH は表示専用 — gate を緩める方向の変更ではない
- HALF でも下流の risk gate (inverse-pair / spread / 余力 / sanity cooldown 等) は全部通る (逆ポジ保有中は発注しないことをテストで確認)
- 「程度もの」以外の gate (トレンド / SMA50 / 過伸長 / high20d) は僅差でも HALF にしない
- 閾値 0 の縮退バンドは HALF を出さない

## Test

- `pnpm test`: 98 files / 1377 tests pass (新規: entryStatus 8 / scheduler half-entry 4 / dashboard 表示 4)
- `pnpm typecheck`: pass

Refs #452 (PR 1: #453)