### PR TITLE
POC Phase follow-up: 条件連動配分 + cash fallback (issue #452 PR 3/3)

### DIFF
--- a/drizzle/0030_add_conditional_allocation.sql
+++ b/drizzle/0030_add_conditional_allocation.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `global_config` ADD `cash_fallback_orders_enabled` integer DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE `symbol_config` ADD `entry_required` integer DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE `symbol_config` ADD `always_active` integer DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE `symbol_config` ADD `cash_fallback_symbol` text;

--- a/drizzle/meta/0030_snapshot.json
+++ b/drizzle/meta/0030_snapshot.json
@@ -1,0 +1,1444 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "90dd37e7-072d-4c97-ad2e-25ee454f3048",
+  "prevId": "1a373bc9-e1ae-4bbb-ab92-befc5f63c61c",
+  "tables": {
+    "config_audit_log": {
+      "name": "config_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before_json": {
+          "name": "before_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "after_json": {
+          "name": "after_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "config_audit_log_timestamp_id_idx": {
+          "name": "config_audit_log_timestamp_id_idx",
+          "columns": [
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "config_audit_log_actor_timestamp_id_idx": {
+          "name": "config_audit_log_actor_timestamp_id_idx",
+          "columns": [
+            "actor",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "config_audit_log_endpoint_timestamp_id_idx": {
+          "name": "config_audit_log_endpoint_timestamp_id_idx",
+          "columns": [
+            "endpoint",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "config_state_snapshot": {
+      "name": "config_state_snapshot",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "earnings_calendar": {
+      "name": "earnings_calendar",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "earnings_date": {
+          "name": "earnings_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "earnings_calendar_symbol_date_unique": {
+          "name": "earnings_calendar_symbol_date_unique",
+          "columns": [
+            "symbol",
+            "earnings_date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "global_config": {
+      "name": "global_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "trading_enabled": {
+          "name": "trading_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "market_hours_check": {
+          "name": "market_hours_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "max_order_notional": {
+          "name": "max_order_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "max_order_notional_usd": {
+          "name": "max_order_notional_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2000
+        },
+        "max_order_notional_jpy": {
+          "name": "max_order_notional_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100000
+        },
+        "total_capital_usd": {
+          "name": "total_capital_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_capital_jpy": {
+          "name": "total_capital_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_portfolio_exposure_pct": {
+          "name": "max_portfolio_exposure_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.6
+        },
+        "drawdown_kill_threshold": {
+          "name": "drawdown_kill_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.02
+        },
+        "stale_quote_ms": {
+          "name": "stale_quote_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 900000
+        },
+        "gap_reject_pct": {
+          "name": "gap_reject_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.03
+        },
+        "spread_limit_pct_us": {
+          "name": "spread_limit_pct_us",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.0025
+        },
+        "spread_limit_pct_jp": {
+          "name": "spread_limit_pct_jp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.006
+        },
+        "pullback_default_stop_pct": {
+          "name": "pullback_default_stop_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.04
+        },
+        "pullback_default_take_profit_pct": {
+          "name": "pullback_default_take_profit_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.07
+        },
+        "pullback_default_time_stop_days": {
+          "name": "pullback_default_time_stop_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "pullback_default_pullback_max": {
+          "name": "pullback_default_pullback_max",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.03
+        },
+        "pullback_default_pullback_min": {
+          "name": "pullback_default_pullback_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.06
+        },
+        "pullback_default_min_return_50d": {
+          "name": "pullback_default_min_return_50d",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.08
+        },
+        "pullback_default_require_above_sma50": {
+          "name": "pullback_default_require_above_sma50",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "pullback_default_k_atr": {
+          "name": "pullback_default_k_atr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "pullback_default_max_sma50_deviation_pct": {
+          "name": "pullback_default_max_sma50_deviation_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.6
+        },
+        "pullback_default_max_atr_ratio": {
+          "name": "pullback_default_max_atr_ratio",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1.5
+        },
+        "risk_base_per_trade_pct": {
+          "name": "risk_base_per_trade_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.004
+        },
+        "risk_dd_half_threshold": {
+          "name": "risk_dd_half_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.05
+        },
+        "risk_dd_halt_threshold": {
+          "name": "risk_dd_halt_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.1
+        },
+        "vix_warning_threshold": {
+          "name": "vix_warning_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 25
+        },
+        "vix_critical_threshold": {
+          "name": "vix_critical_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "vix_warning_size_scale": {
+          "name": "vix_warning_size_scale",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.5
+        },
+        "overview_panels": {
+          "name": "overview_panels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'kpi,equity,composition,recent'"
+        },
+        "cash_fallback_orders_enabled": {
+          "name": "cash_fallback_orders_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "global_config_max_order_notional_range": {
+          "name": "global_config_max_order_notional_range",
+          "value": "\"global_config\".\"max_order_notional\" > 0 AND \"global_config\".\"max_order_notional\" <= 10000000"
+        },
+        "global_config_max_order_notional_usd_range": {
+          "name": "global_config_max_order_notional_usd_range",
+          "value": "\"global_config\".\"max_order_notional_usd\" > 0 AND \"global_config\".\"max_order_notional_usd\" <= 1000000"
+        },
+        "global_config_max_order_notional_jpy_range": {
+          "name": "global_config_max_order_notional_jpy_range",
+          "value": "\"global_config\".\"max_order_notional_jpy\" > 0 AND \"global_config\".\"max_order_notional_jpy\" <= 100000000"
+        },
+        "global_config_total_capital_usd_range": {
+          "name": "global_config_total_capital_usd_range",
+          "value": "\"global_config\".\"total_capital_usd\" IS NULL OR \"global_config\".\"total_capital_usd\" > 0"
+        },
+        "global_config_total_capital_jpy_range": {
+          "name": "global_config_total_capital_jpy_range",
+          "value": "\"global_config\".\"total_capital_jpy\" IS NULL OR \"global_config\".\"total_capital_jpy\" > 0"
+        },
+        "global_config_max_portfolio_exposure_pct_range": {
+          "name": "global_config_max_portfolio_exposure_pct_range",
+          "value": "\"global_config\".\"max_portfolio_exposure_pct\" > 0 AND \"global_config\".\"max_portfolio_exposure_pct\" <= 1"
+        },
+        "global_config_drawdown_kill_threshold_range": {
+          "name": "global_config_drawdown_kill_threshold_range",
+          "value": "\"global_config\".\"drawdown_kill_threshold\" >= -1 AND \"global_config\".\"drawdown_kill_threshold\" <= 0"
+        },
+        "global_config_stale_quote_ms_range": {
+          "name": "global_config_stale_quote_ms_range",
+          "value": "\"global_config\".\"stale_quote_ms\" >= 0"
+        },
+        "global_config_gap_reject_pct_range": {
+          "name": "global_config_gap_reject_pct_range",
+          "value": "\"global_config\".\"gap_reject_pct\" >= 0 AND \"global_config\".\"gap_reject_pct\" <= 1"
+        },
+        "global_config_spread_limit_pct_us_range": {
+          "name": "global_config_spread_limit_pct_us_range",
+          "value": "\"global_config\".\"spread_limit_pct_us\" >= 0 AND \"global_config\".\"spread_limit_pct_us\" <= 1"
+        },
+        "global_config_spread_limit_pct_jp_range": {
+          "name": "global_config_spread_limit_pct_jp_range",
+          "value": "\"global_config\".\"spread_limit_pct_jp\" >= 0 AND \"global_config\".\"spread_limit_pct_jp\" <= 1"
+        },
+        "global_config_pullback_default_stop_pct_range": {
+          "name": "global_config_pullback_default_stop_pct_range",
+          "value": "\"global_config\".\"pullback_default_stop_pct\" < 0 AND \"global_config\".\"pullback_default_stop_pct\" >= -1"
+        },
+        "global_config_pullback_default_take_profit_pct_range": {
+          "name": "global_config_pullback_default_take_profit_pct_range",
+          "value": "\"global_config\".\"pullback_default_take_profit_pct\" > 0 AND \"global_config\".\"pullback_default_take_profit_pct\" <= 1"
+        },
+        "global_config_pullback_default_time_stop_days_range": {
+          "name": "global_config_pullback_default_time_stop_days_range",
+          "value": "\"global_config\".\"pullback_default_time_stop_days\" > 0 AND \"global_config\".\"pullback_default_time_stop_days\" <= ?"
+        },
+        "global_config_pullback_default_pullback_max_range": {
+          "name": "global_config_pullback_default_pullback_max_range",
+          "value": "\"global_config\".\"pullback_default_pullback_max\" <= 0 AND \"global_config\".\"pullback_default_pullback_max\" >= -1"
+        },
+        "global_config_pullback_default_pullback_min_range": {
+          "name": "global_config_pullback_default_pullback_min_range",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= 0 AND \"global_config\".\"pullback_default_pullback_min\" >= -1"
+        },
+        "global_config_pullback_default_min_return_50d_range": {
+          "name": "global_config_pullback_default_min_return_50d_range",
+          "value": "\"global_config\".\"pullback_default_min_return_50d\" >= -1 AND \"global_config\".\"pullback_default_min_return_50d\" <= 10"
+        },
+        "global_config_pullback_default_k_atr_range": {
+          "name": "global_config_pullback_default_k_atr_range",
+          "value": "\"global_config\".\"pullback_default_k_atr\" > 0 AND \"global_config\".\"pullback_default_k_atr\" <= 10"
+        },
+        "global_config_pullback_default_pullback_window_order": {
+          "name": "global_config_pullback_default_pullback_window_order",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= \"global_config\".\"pullback_default_pullback_max\""
+        },
+        "global_config_risk_base_per_trade_pct_range": {
+          "name": "global_config_risk_base_per_trade_pct_range",
+          "value": "\"global_config\".\"risk_base_per_trade_pct\" > 0 AND \"global_config\".\"risk_base_per_trade_pct\" <= 1"
+        },
+        "global_config_risk_dd_half_threshold_range": {
+          "name": "global_config_risk_dd_half_threshold_range",
+          "value": "\"global_config\".\"risk_dd_half_threshold\" < 0 AND \"global_config\".\"risk_dd_half_threshold\" >= -1"
+        },
+        "global_config_risk_dd_halt_threshold_range": {
+          "name": "global_config_risk_dd_halt_threshold_range",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" < 0 AND \"global_config\".\"risk_dd_halt_threshold\" >= -1"
+        },
+        "global_config_risk_dd_threshold_order": {
+          "name": "global_config_risk_dd_threshold_order",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" <= \"global_config\".\"risk_dd_half_threshold\""
+        },
+        "global_config_vix_warning_threshold_range": {
+          "name": "global_config_vix_warning_threshold_range",
+          "value": "\"global_config\".\"vix_warning_threshold\" > 0 AND \"global_config\".\"vix_warning_threshold\" <= 200"
+        },
+        "global_config_vix_critical_threshold_range": {
+          "name": "global_config_vix_critical_threshold_range",
+          "value": "\"global_config\".\"vix_critical_threshold\" > 0 AND \"global_config\".\"vix_critical_threshold\" <= 200"
+        },
+        "global_config_vix_threshold_order": {
+          "name": "global_config_vix_threshold_order",
+          "value": "\"global_config\".\"vix_warning_threshold\" <= \"global_config\".\"vix_critical_threshold\""
+        },
+        "global_config_vix_warning_size_scale_range": {
+          "name": "global_config_vix_warning_size_scale_range",
+          "value": "\"global_config\".\"vix_warning_size_scale\" >= 0 AND \"global_config\".\"vix_warning_size_scale\" <= 1"
+        }
+      }
+    },
+    "inverse_pairs": {
+      "name": "inverse_pairs",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inverse": {
+          "name": "inverse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "macro_event_calendar": {
+      "name": "macro_event_calendar",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_time": {
+          "name": "event_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "macro_event_calendar_type_date_unique": {
+          "name": "macro_event_calendar_type_date_unique",
+          "columns": [
+            "event_type",
+            "event_date"
+          ],
+          "isUnique": true
+        },
+        "macro_event_calendar_date_idx": {
+          "name": "macro_event_calendar_date_idx",
+          "columns": [
+            "event_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_emit_log": {
+      "name": "notification_emit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cause": {
+          "name": "cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notification_emit_log_timestamp_id_idx": {
+          "name": "notification_emit_log_timestamp_id_idx",
+          "columns": [
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "notification_emit_log_severity_timestamp_id_idx": {
+          "name": "notification_emit_log_severity_timestamp_id_idx",
+          "columns": [
+            "severity",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "notification_emit_log_event_type_timestamp_id_idx": {
+          "name": "notification_emit_log_event_type_timestamp_id_idx",
+          "columns": [
+            "event_type",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "portfolio_equity_snapshot": {
+      "name": "portfolio_equity_snapshot",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "daily_start_equity_usd": {
+          "name": "daily_start_equity_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_start_equity_jpy": {
+          "name": "daily_start_equity_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_realized_pnl_usd": {
+          "name": "daily_realized_pnl_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_realized_pnl_jpy": {
+          "name": "daily_realized_pnl_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "drawdown_pct": {
+          "name": "drawdown_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "portfolio_equity_snapshot_at_idx": {
+          "name": "portfolio_equity_snapshot_at_idx",
+          "columns": [
+            "snapshot_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "strategy_decision_log": {
+      "name": "strategy_decision_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indicators_json": {
+          "name": "indicators_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trace_json": {
+          "name": "trace_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "strategy_decision_log_symbol_id_idx": {
+          "name": "strategy_decision_log_symbol_id_idx",
+          "columns": [
+            "symbol",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "strategy_decision_log_coid_idx": {
+          "name": "strategy_decision_log_coid_idx",
+          "columns": [
+            "client_order_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "symbol_config": {
+      "name": "symbol_config",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "market": {
+          "name": "market",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_notional": {
+          "name": "max_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_stop_days_override": {
+          "name": "time_stop_days_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "k_atr_override": {
+          "name": "k_atr_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "budget_alloc_pct": {
+          "name": "budget_alloc_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lot_size": {
+          "name": "lot_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stop_pct_override": {
+          "name": "stop_pct_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "take_profit_pct_override": {
+          "name": "take_profit_pct_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "intraday_only": {
+          "name": "intraday_only",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pullback_max_override": {
+          "name": "pullback_max_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pullback_min_override": {
+          "name": "pullback_min_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "min_return_50d_override": {
+          "name": "min_return_50d_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_atr_ratio_override": {
+          "name": "max_atr_ratio_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_sma50_deviation_pct_override": {
+          "name": "max_sma50_deviation_pct_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "require_above_sma50_override": {
+          "name": "require_above_sma50_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alternatives": {
+          "name": "alternatives",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_required": {
+          "name": "entry_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "always_active": {
+          "name": "always_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cash_fallback_symbol": {
+          "name": "cash_fallback_symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "symbol_config_currency_enum": {
+          "name": "symbol_config_currency_enum",
+          "value": "\"symbol_config\".\"currency\" IN ('USD', 'JPY')"
+        },
+        "symbol_config_time_stop_days_override_range": {
+          "name": "symbol_config_time_stop_days_override_range",
+          "value": "\"symbol_config\".\"time_stop_days_override\" IS NULL OR (\"symbol_config\".\"time_stop_days_override\" >= 1 AND \"symbol_config\".\"time_stop_days_override\" <= ?)"
+        },
+        "symbol_config_k_atr_override_range": {
+          "name": "symbol_config_k_atr_override_range",
+          "value": "\"symbol_config\".\"k_atr_override\" IS NULL OR (\"symbol_config\".\"k_atr_override\" >= 0.5 AND \"symbol_config\".\"k_atr_override\" <= 5.0)"
+        }
+      }
+    },
+    "trade_journal": {
+      "name": "trade_journal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trade_event_type": {
+          "name": "trade_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "strategy_name": {
+          "name": "strategy_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_action": {
+          "name": "signal_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_reason": {
+          "name": "signal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_allowed": {
+          "name": "risk_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_reasons": {
+          "name": "risk_reasons",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "limit_price": {
+          "name": "limit_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notional": {
+          "name": "notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "broker_status": {
+          "name": "broker_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "submitted": {
+          "name": "submitted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_qty": {
+          "name": "filled_qty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_price": {
+          "name": "filled_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "realized_pnl": {
+          "name": "realized_pnl",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hold_days": {
+          "name": "hold_days",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_reason": {
+          "name": "exit_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_applied_at": {
+          "name": "state_applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_error": {
+          "name": "state_apply_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_attempts": {
+          "name": "state_apply_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trading_toggle_history": {
+      "name": "trading_toggle_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before": {
+          "name": "before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "after": {
+          "name": "after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1781107185057,
       "tag": "0029_add_symbol_role_entry_overrides",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "6",
+      "when": 1781109056713,
+      "tag": "0030_add_conditional_allocation",
+      "breakpoints": true
     }
   ]
 }

--- a/src/infrastructure/db/globalConfigRepo.ts
+++ b/src/infrastructure/db/globalConfigRepo.ts
@@ -51,6 +51,11 @@ export interface GlobalConfigSnapshot {
   vixCriticalThreshold: number
   /** warning 領域の size 倍率。default 0.5。 */
   vixWarningSizeScale: number
+  /**
+   * 条件連動配分の cash fallback 自動発注 (#452 Layer 3)。default false
+   * (fail-closed): off の間は判定・表示のみで退避先への自動 BUY は出さない。
+   */
+  cashFallbackOrdersEnabled: boolean
 }
 
 /**
@@ -89,6 +94,7 @@ export const GLOBAL_CONFIG_DEFAULTS: GlobalConfigSnapshot = Object.freeze({
   vixWarningThreshold: 25.0,
   vixCriticalThreshold: 30.0,
   vixWarningSizeScale: 0.5,
+  cashFallbackOrdersEnabled: false,
 })
 
 /**
@@ -319,6 +325,8 @@ export async function loadGlobalConfig(
             vixWarningThreshold: GLOBAL_CONFIG_DEFAULTS.vixWarningThreshold,
             vixCriticalThreshold: GLOBAL_CONFIG_DEFAULTS.vixCriticalThreshold,
             vixWarningSizeScale: GLOBAL_CONFIG_DEFAULTS.vixWarningSizeScale,
+            // 0030 追加列 (#452)。legacy path は default (false = 自動発注しない)。
+            cashFallbackOrdersEnabled: GLOBAL_CONFIG_DEFAULTS.cashFallbackOrdersEnabled,
           }, requestId)
         }
       } catch (legacyError) {
@@ -376,5 +384,9 @@ export async function loadGlobalConfig(
       row.vixCriticalThreshold ?? GLOBAL_CONFIG_DEFAULTS.vixCriticalThreshold,
     vixWarningSizeScale:
       row.vixWarningSizeScale ?? GLOBAL_CONFIG_DEFAULTS.vixWarningSizeScale,
+    // 0030 で追加 (#452)。古い D1 では undefined になり得るため default (false =
+    // 自動発注しない) へ畳む — fail-closed 側なので安全。
+    cashFallbackOrdersEnabled:
+      row.cashFallbackOrdersEnabled ?? GLOBAL_CONFIG_DEFAULTS.cashFallbackOrdersEnabled,
   }, requestId)
 }

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -180,6 +180,26 @@ export const symbolConfig = sqliteTable(
      * 使わない。NULL / 不正 JSON は「候補なし」扱い。
      */
     alternatives: text('alternatives'),
+    /**
+     * 条件連動配分 (#452 Layer 3 / #450)。true = entry gate (ENTRY/HALF) 通過を
+     * 実配分 (active weight) の必須条件にする。未通過の間は active=0 になり、
+     * 浮いた配分は `cash_fallback_symbol` へ退避される。false (default) =
+     * 従来どおり `budget_alloc_pct` の枠が常時有効。
+     */
+    entryRequired: integer('entry_required', { mode: 'boolean' }).notNull().default(false),
+    /**
+     * cash_parking 用 (#452)。true = entry 判定に関わらず常時 target = active。
+     * pullback gate を通らない待機資金 ETF (SGOV 等) の配分先として使う。
+     */
+    alwaysActive: integer('always_active', { mode: 'boolean' }).notNull().default(false),
+    /**
+     * entry_required 銘柄が条件未通過のときの退避先 symbol (例 'SGOV')。
+     * NULL = 退避しない (浮いた分は現金のまま)。同一通貨の銘柄のみ有効 —
+     * 通貨が異なる場合は配分計算時に退避を skip する (fail-closed、現金待機)。
+     * 退避先への**自動発注は global_config.cash_fallback_orders_enabled (default
+     * false) を on にするまで行わない** (判定・表示のみ)。
+     */
+    cashFallbackSymbol: text('cash_fallback_symbol'),
     updatedAt: text('updated_at').notNull(),
   },
   (t) => ({
@@ -320,6 +340,16 @@ export const globalConfig = sqliteTable(
      * key: kpi / equity / composition / recent。default は全表示。
      */
     overviewPanels: text('overview_panels').notNull().default('kpi,equity,composition,recent'),
+    /**
+     * 条件連動配分の cash fallback 自動発注 (#452 Layer 3 / #450)。**default false
+     * (fail-closed)**: off の間は target/active の判定・表示のみ行い、退避先
+     * (SGOV 等) への自動 BUY は出さない。DRY_RUN + staging で検証してから
+     * `wrangler d1 execute "UPDATE global_config SET cash_fallback_orders_enabled=1"`
+     * で有効化する。on でも DRY_RUN / TRADING_ENABLED / risk gate は全部効く。
+     */
+    cashFallbackOrdersEnabled: integer('cash_fallback_orders_enabled', { mode: 'boolean' })
+      .notNull()
+      .default(false),
     updatedAt: text('updated_at').notNull(),
   },
   (t) => ({

--- a/src/infrastructure/db/symbolConfigRepo.ts
+++ b/src/infrastructure/db/symbolConfigRepo.ts
@@ -134,6 +134,18 @@ export interface SymbolConfigSnapshot {
    * 含めない。要素は大文字 ticker、self 参照と重複は除去、上限 MAX_ALTERNATIVES。
    */
   symbolAlternatives: Record<string, string[]>
+  /**
+   * entry_required=true の symbol 集合 (#452 Layer 3)。gate 未通過の間
+   * active weight = 0 になり cash fallback へ退避される。false は不在。
+   */
+  symbolEntryRequired: Record<string, boolean>
+  /** always_active=true の symbol 集合 (#452、cash_parking 用)。false は不在。 */
+  symbolAlwaysActive: Record<string, boolean>
+  /**
+   * symbol → cash_fallback_symbol (#452)。NULL / 不正 ticker / self 参照は不在
+   * (= 退避しない、現金のまま)。
+   */
+  symbolCashFallback: Record<string, string>
 }
 
 /**
@@ -198,6 +210,9 @@ export async function loadSymbolConfig(
   const symbolMaxSma50DeviationPctOverride: Record<string, number> = {}
   const symbolRequireAboveSma50Override: Record<string, boolean> = {}
   const symbolAlternatives: Record<string, string[]> = {}
+  const symbolEntryRequired: Record<string, boolean> = {}
+  const symbolAlwaysActive: Record<string, boolean> = {}
+  const symbolCashFallback: Record<string, string> = {}
   for (const row of rows) {
     const symbol = row.symbol.toUpperCase()
     if (row.active) {
@@ -348,6 +363,21 @@ export async function loadSymbolConfig(
     if (alternatives !== null) {
       symbolAlternatives[symbol] = alternatives
     }
+    // 条件連動配分 (#452 Layer 3)。false は map に出さない (従来挙動 = 常時枠)。
+    if (row.entryRequired === true) {
+      symbolEntryRequired[symbol] = true
+    }
+    if (row.alwaysActive === true) {
+      symbolAlwaysActive[symbol] = true
+    }
+    // 退避先は ticker 文法 + self 参照禁止まで検証。無効値は不在 (= 退避なし、
+    // 現金のまま) — 誤った退避先に積み増すより安全側。
+    if (row.cashFallbackSymbol !== null && row.cashFallbackSymbol !== undefined) {
+      const fallback = row.cashFallbackSymbol.trim().toUpperCase()
+      if (/^[A-Z0-9]{1,10}$/.test(fallback) && fallback !== symbol) {
+        symbolCashFallback[symbol] = fallback
+      }
+    }
   }
   return {
     allowedSymbols,
@@ -372,6 +402,9 @@ export async function loadSymbolConfig(
     symbolMaxSma50DeviationPctOverride,
     symbolRequireAboveSma50Override,
     symbolAlternatives,
+    symbolEntryRequired,
+    symbolAlwaysActive,
+    symbolCashFallback,
   }
 }
 
@@ -433,6 +466,12 @@ export interface SymbolConfigWriteInput {
   requireAboveSma50Override: boolean | null
   /** 代替銘柄候補 (表示専用、NULL = なし、#452)。DB には JSON text で保存。 */
   alternatives: string[] | null
+  /** 条件連動配分 (#452 Layer 3): gate 通過を実配分の必須条件にする。default false。 */
+  entryRequired: boolean
+  /** 常時 target = active (cash_parking 用、#452)。default false。 */
+  alwaysActive: boolean
+  /** 条件未通過時の退避先 symbol (NULL = 退避しない、#452)。 */
+  cashFallbackSymbol: string | null
 }
 
 /** alternatives 配列 → DB 保存形式 (JSON text / NULL)。空配列は NULL に正規化。 */
@@ -478,6 +517,9 @@ export async function insertSymbolConfig(
       maxSma50DeviationPctOverride: input.maxSma50DeviationPctOverride,
       requireAboveSma50Override: input.requireAboveSma50Override,
       alternatives: alternativesToJson(input.alternatives),
+      entryRequired: input.entryRequired,
+      alwaysActive: input.alwaysActive,
+      cashFallbackSymbol: input.cashFallbackSymbol,
       updatedAt: nowIso,
     })
   } catch (err) {
@@ -534,6 +576,9 @@ export async function updateSymbolConfig(
       maxSma50DeviationPctOverride: input.maxSma50DeviationPctOverride,
       requireAboveSma50Override: input.requireAboveSma50Override,
       alternatives: alternativesToJson(input.alternatives),
+      entryRequired: input.entryRequired,
+      alwaysActive: input.alwaysActive,
+      cashFallbackSymbol: input.cashFallbackSymbol,
       updatedAt: nowIso,
     })
     .where(eq(symbolConfig.symbol, input.symbol))
@@ -793,6 +838,11 @@ export async function createSymbolPair(
       maxSma50DeviationPctOverride: null,
       requireAboveSma50Override: null,
       alternatives: null,
+      // 条件連動配分も継承しない (#452): 方向が逆の相手に同じ配分条件は適用
+      // できない。default (false / NULL) = 従来挙動で開始。
+      entryRequired: false,
+      alwaysActive: false,
+      cashFallbackSymbol: null,
       updatedAt: nowIso,
     })
     await db.batch([delLink, insCounterpart, insLink])

--- a/src/infrastructure/db/symbolUniverse.ts
+++ b/src/infrastructure/db/symbolUniverse.ts
@@ -67,6 +67,12 @@ export interface SymbolUniverse {
   symbolRequireAboveSma50Override: Record<string, boolean>
   /** symbol → 代替銘柄候補 (#452、表示専用)。不在 = 候補なし。 */
   symbolAlternatives: Record<string, string[]>
+  /** entry_required=true の集合 (#452 Layer 3)。false は不在。 */
+  symbolEntryRequired: Record<string, boolean>
+  /** always_active=true の集合 (#452、cash_parking 用)。false は不在。 */
+  symbolAlwaysActive: Record<string, boolean>
+  /** symbol → 退避先 symbol (#452)。不在 = 退避しない。 */
+  symbolCashFallback: Record<string, string>
   inversePairs: Record<string, string>
   source: 'd1'
 }
@@ -110,6 +116,9 @@ export async function loadSymbolUniverse(env: UniverseEnv): Promise<SymbolUniver
     symbolMaxSma50DeviationPctOverride: config.symbolMaxSma50DeviationPctOverride,
     symbolRequireAboveSma50Override: config.symbolRequireAboveSma50Override,
     symbolAlternatives: config.symbolAlternatives,
+    symbolEntryRequired: config.symbolEntryRequired,
+    symbolAlwaysActive: config.symbolAlwaysActive,
+    symbolCashFallback: config.symbolCashFallback,
     inversePairs: pairs,
     source: 'd1',
   }

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -2201,6 +2201,12 @@ function parseSymbolConfigBody(body: unknown): SymbolConfigWriteInput {
     require_above_sma50_override?: unknown
     requireAboveSma50Override?: unknown
     alternatives?: unknown
+    entry_required?: unknown
+    entryRequired?: unknown
+    always_active?: unknown
+    alwaysActive?: unknown
+    cash_fallback_symbol?: unknown
+    cashFallbackSymbol?: unknown
   }
   const symbol = normalizeSymbol(raw.symbol)
   const market = parseMarket(raw.market)
@@ -2318,6 +2324,14 @@ function parseSymbolConfigBody(body: unknown): SymbolConfigWriteInput {
     'requireAboveSma50Override',
   )
   const alternatives = parseAlternativesInput(raw.alternatives, symbol)
+  // 条件連動配分 (#452 Layer 3): checkbox 未送信は false (= 従来挙動)。退避先は
+  // ticker 文法 + self 参照禁止。空 → NULL (= 退避しない)。
+  const entryRequired = parseFormBool(raw.entry_required ?? raw.entryRequired, false)
+  const alwaysActive = parseFormBool(raw.always_active ?? raw.alwaysActive, false)
+  const cashFallbackSymbol = parseCashFallbackSymbol(
+    raw.cash_fallback_symbol ?? raw.cashFallbackSymbol,
+    symbol,
+  )
   return {
     symbol,
     name,
@@ -2341,7 +2355,36 @@ function parseSymbolConfigBody(body: unknown): SymbolConfigWriteInput {
     maxSma50DeviationPctOverride,
     requireAboveSma50Override,
     alternatives,
+    entryRequired,
+    alwaysActive,
+    cashFallbackSymbol,
   }
+}
+
+/**
+ * cash_fallback_symbol (#452): 空 / undefined → NULL。ticker 文法外・self 参照は
+ * 400 (誤った退避先へ積み増す事故の入口防御)。
+ */
+function parseCashFallbackSymbol(value: unknown, selfSymbol: string): string | null {
+  if (value === undefined || value === null) return null
+  if (typeof value !== 'string') {
+    throw new ValidationError('cashFallbackSymbol must be a symbol string', {
+      field: 'cashFallbackSymbol',
+    })
+  }
+  const sym = value.trim().toUpperCase()
+  if (sym === '') return null
+  if (!/^[A-Z0-9]{1,10}$/.test(sym)) {
+    throw new ValidationError(`cashFallbackSymbol is not a valid symbol: ${sym}`, {
+      field: 'cashFallbackSymbol',
+    })
+  }
+  if (sym === selfSymbol.toUpperCase()) {
+    throw new ValidationError('cashFallbackSymbol cannot reference itself', {
+      field: 'cashFallbackSymbol',
+    })
+  }
+  return sym
 }
 
 /**

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -7994,6 +7994,9 @@ function symbolsListBody(args: {
       // 売買単位 (lot_size)。未設定・不正値 (NULL/0/負/非整数) は cron sizing が
       // fail-closed (発注見送り) するので、一覧でも同じ判定で赤字警告を出す
       // (loadSymbolConfig の採用条件 = integer>=1 と揃える、CodeRabbit #409)。
+      // 戦略ロール + 条件連動配分の要約 (#452)。NULL は従来挙動なので「—」。
+      // entry 抑止 role (cash_parking / 定義のみ) は title で発注されない旨を明示。
+      const roleCell = renderSymbolRoleCell(r)
       const lotSizeValid = Number.isInteger(r.lotSize) && (r.lotSize as number) >= 1
       const lotSizeCell = !lotSizeValid
         ? '<span class="err" title="売買単位が未設定または不正です。設定するまで BUY は発注されません (fail-closed)。編集から入力してください。">⚠ 未設定</span>'
@@ -8042,6 +8045,7 @@ function symbolsListBody(args: {
         <td><strong><span${symStyle}>${esc(r.symbol)}</span></strong></td>
         <td>${esc(r.name ?? '')}</td>
         <td><code style="font-size:11px">${esc(r.market)}/${esc(r.currency)}</code></td>
+        <td>${roleCell}</td>
         <td>${lotSizeCell}</td>
         <td>${maxNotionalCell}</td>
         ${budgetTd}
@@ -8064,6 +8068,7 @@ function symbolsListBody(args: {
       <th>銘柄</th>
       <th>銘柄名</th>
       <th>市場/通貨</th>
+      <th>ロール</th>
       <th>売買単位</th>
       <th>1注文上限</th>
       <th>予算配分</th>
@@ -8334,6 +8339,30 @@ const SYMBOL_ROLE_LABELS: Record<SymbolRole, string> = {
   low_volatility: 'low_volatility — 低ボラ (定義のみ・entry 無効)',
   sector_trend: 'sector_trend — セクター (定義のみ・entry 無効)',
   inverse_hedge: 'inverse_hedge — インバース (定義のみ・entry 無効)',
+}
+
+/** 一覧テーブルの「ロール」セル (#452)。role + 配分の条件連動を 1 セルに要約する。 */
+export function renderSymbolRoleCell(row: SymbolConfigRow): string {
+  const role = row.role?.trim() || null
+  const known = role !== null && (SYMBOL_ROLES as readonly string[]).includes(role)
+  const roleBadge =
+    role === null
+      ? '<span class="muted" title="role 未設定 = 従来挙動">—</span>'
+      : known
+        ? `<code style="font-size:11px" title="${esc(SYMBOL_ROLE_LABELS[role as SymbolRole])}">${esc(role)}</code>`
+        : `<span class="err" title="不正な role 値です。entry は抑止されます (fail-closed)。編集から正しい値を選んでください。">⚠ ${esc(role)}</span>`
+  const notes: string[] = []
+  if (row.alwaysActive) notes.push('<span title="判定に関わらず常時 target = active">常時配分</span>')
+  if (row.entryRequired) notes.push('<span title="entry 判定 (ENTRY/HALF) 通過時のみ実配分有効">条件連動</span>')
+  if (row.cashFallbackSymbol) {
+    notes.push(
+      `<a href="/dashboard/symbols/${encodeURIComponent(row.cashFallbackSymbol)}/edit" title="条件未通過時の退避先">→${esc(row.cashFallbackSymbol)}</a>`,
+    )
+  }
+  const noteHtml = notes.length
+    ? `<div class="muted" style="font-size:11px;margin-top:2px">${notes.join(' / ')}</div>`
+    : ''
+  return `${roleBadge}${noteHtml}`
 }
 
 function symbolFormBody(args: SymbolFormArgs): string {

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -6625,7 +6625,7 @@ export function renderSymbolPolicyLine(
     const known = (SYMBOL_ROLES as readonly string[]).includes(policy.role)
     parts.push(
       known
-        ? `ロール: <code style="font-size:11px" title="${esc(SYMBOL_ROLE_LABELS[policy.role as SymbolRole])}">${esc(policy.role)}</code>`
+        ? `ロール: <code style="font-size:12px" title="${esc(SYMBOL_ROLE_LABELS[policy.role as SymbolRole])}">${esc(policy.role)}</code>: <strong>${esc(SYMBOL_ROLE_LABELS_SHORT[policy.role as SymbolRole])}</strong>`
         : `ロール: <span class="err" title="不正な role 値 — entry は抑止されます (fail-closed)">⚠ ${esc(policy.role)}</span>`,
     )
   }
@@ -6639,9 +6639,9 @@ export function renderSymbolPolicyLine(
       `退避先 <a href="/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(policy.cashFallbackSymbol)}">${esc(policy.cashFallbackSymbol)}</a>`,
     )
   }
-  return `<div class="muted" style="margin-top:8px;font-size:12px;display:flex;gap:12px;flex-wrap:wrap;align-items:center">
+  return `<div style="margin-top:8px;font-size:13px;color:#3a3a3c;display:flex;gap:12px;flex-wrap:wrap;align-items:center">
     ${parts.join('<span style="color:#d0d0d5">｜</span>')}
-    <a href="/dashboard/symbols/${encodeURIComponent(symbol)}/edit" style="font-size:11px">設定変更</a>
+    <a href="/dashboard/symbols/${encodeURIComponent(symbol)}/edit" style="font-size:12px">設定変更</a>
   </div>`
 }
 
@@ -8393,6 +8393,16 @@ interface SymbolFormArgs {
   currentInverse?: string | null
 }
 
+/** role の短い日本語名 (#452)。一覧 / チャートタブのインライン表示用。 */
+const SYMBOL_ROLE_LABELS_SHORT: Record<SymbolRole, string> = {
+  cash_parking: '待機資金ETF',
+  core_trend: '非レバ・トレンド',
+  leveraged_trend: 'レバETF・トレンド',
+  low_volatility: '低ボラ (entry 無効)',
+  sector_trend: 'セクター (entry 無効)',
+  inverse_hedge: 'インバース (entry 無効)',
+}
+
 /** role select の表示ラベル (#452)。値は DB enum と同一、表示だけ日本語補足。 */
 const SYMBOL_ROLE_LABELS: Record<SymbolRole, string> = {
   cash_parking: 'cash_parking — 待機資金 ETF (SGOV / BIL 等)',
@@ -8411,7 +8421,7 @@ export function renderSymbolRoleCell(row: SymbolConfigRow): string {
     role === null
       ? '<span class="muted" title="role 未設定 = 従来挙動">—</span>'
       : known
-        ? `<code style="font-size:11px" title="${esc(SYMBOL_ROLE_LABELS[role as SymbolRole])}">${esc(role)}</code>`
+        ? `<code style="font-size:11px" title="${esc(SYMBOL_ROLE_LABELS[role as SymbolRole])}">${esc(role)}</code><div class="muted" style="font-size:11px">${esc(SYMBOL_ROLE_LABELS_SHORT[role as SymbolRole])}</div>`
         : `<span class="err" title="不正な role 値です。entry は抑止されます (fail-closed)。編集から正しい値を選んでください。">⚠ ${esc(role)}</span>`
   const notes: string[] = []
   if (row.alwaysActive) notes.push('<span title="判定に関わらず常時 target = active">常時配分</span>')

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -60,6 +60,10 @@ import {
   type EntryStatusResult,
 } from '../trading/strategy/entryStatus'
 import { buildSymbolRules } from '../trading/strategy/symbolRuleResolution'
+import {
+  computeConditionalAllocation,
+  type SymbolAllocation,
+} from '../trading/strategy/conditionalAllocation'
 import type {
   PullbackIndicators,
   SymbolRule,
@@ -386,6 +390,22 @@ export const dashboard = new Hono<DashboardBindings>()
             gridRules[entry.symbol] ?? gridDefaultRule,
           ).status
         }
+        // 条件連動配分 (#452 Layer 3): target/active を並記する (「設定上 5% だが
+        // 現在は SGOV に退避中」の可視化)。cron と同じ pure 関数で計算する。
+        const heldSymbols = new Set(
+          charts.filter((entry) => entry.chart?.position != null).map((entry) => entry.symbol),
+        )
+        const allocationView = computeConditionalAllocation({
+          targetWeights: universe.symbolBudgetAllocPct,
+          policy: {
+            entryRequired: new Set(Object.keys(universe.symbolEntryRequired)),
+            alwaysActive: new Set(Object.keys(universe.symbolAlwaysActive)),
+            cashFallback: universe.symbolCashFallback,
+          },
+          entryStatuses,
+          heldSymbols,
+          symbolCurrency: universe.symbolCurrency,
+        })
         const sortedCharts = sortGridChartsByEntryPriority(charts, entryStatuses, universe)
         // grid の zoom 基準: 全 panel 共通の dataZoom 同期があるため、最初に
         // load 成功した chart の lastTimestamp を基準に直近 7 日 (default) を
@@ -402,6 +422,7 @@ export const dashboard = new Hono<DashboardBindings>()
               zoom,
               universe,
               entryStatuses,
+              allocations: allocationView.bySymbol,
             }),
             renderChartsSubnav(tab),
           ),
@@ -5165,6 +5186,8 @@ interface ChartsBodyGrid {
   universe?: SymbolUniverse | null
   /** symbol → 段階判定 (#452 PR 2)。評価データ無しの銘柄は不在。panel badge 用。 */
   entryStatuses?: Record<string, EntryStatus>
+  /** symbol → 条件連動配分 (#452 Layer 3)。target weight 関連銘柄のみ。 */
+  allocations?: Record<string, SymbolAllocation>
 }
 
 type ChartsBodyArgs =
@@ -6545,6 +6568,21 @@ export function sortGridChartsByEntryPriority<T extends { symbol: string }>(
     .map(({ entry }) => entry)
 }
 
+/**
+ * target / active weight の並記 (#452 Layer 3)。target を持つ (or 退避を受けた)
+ * 銘柄のみ 1 行出す。「設定上 5% だが現在は SGOV に退避中」を panel 上で見せる。
+ */
+export function renderAllocationLine(alloc: SymbolAllocation | undefined): string {
+  if (!alloc) return ''
+  const pct = (w: number) => `${Math.round(w * 1000) / 10}%`
+  const changed = Math.abs(alloc.activeWeight - alloc.targetWeight) > 1e-9
+  const color = alloc.activeWeight === 0 ? '#b25000' : changed ? '#057a55' : '#86868b'
+  const arrow = changed ? ` → <strong>${pct(alloc.activeWeight)}</strong>` : ''
+  const reroute = alloc.rerouteTo ? `（${esc(alloc.rerouteTo)} へ退避中）` : ''
+  const rerouted = alloc.reroutedInWeight > 0 ? `（+${pct(alloc.reroutedInWeight)} 退避受入）` : ''
+  return `<div style="font-size:11px;color:${color};margin-bottom:4px" title="${esc(alloc.reason)}">配分 target ${pct(alloc.targetWeight)}${arrow}${reroute}${rerouted}</div>`
+}
+
 export function renderGridTab(args: ChartsBodyGrid): string {
   if (args.charts.length === 0) {
     return `<p class="muted">ALLOWED_SYMBOLS が空です。<code>symbol_config</code> に少なくとも 1 銘柄登録してください。</p>`
@@ -6607,12 +6645,16 @@ export function renderGridTab(args: ChartsBodyGrid): string {
       // 段階判定 badge (#452 PR 2)。inactive 銘柄は cron 評価対象外なので出さない。
       const status = args.entryStatuses?.[entry.symbol]
       const statusBadge = status !== undefined && !inactive ? entryStatusBadgeHtml(status) : ''
+      const allocationLine = inactive
+        ? ''
+        : renderAllocationLine(args.allocations?.[entry.symbol])
       const rightSide = (inactive ? inactiveBadge : '') + statusBadge + positionBadge + badge
       return `<div class="${panelClass}"${dataAttrs} style="${baseStyle}">
         <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:4px;gap:8px">
           ${headerLink}
           <div style="display:flex;gap:6px;align-items:center">${rightSide}</div>
         </div>
+        ${allocationLine}
         <div id="grid-chart-${idx}" style="width:100%;height:280px"></div>
       </div>`
     })
@@ -8351,6 +8393,10 @@ function symbolFormBody(args: SymbolFormArgs): string {
       ? ''
       : String(row.requireAboveSma50Override)
   const alternativesValue = (parseAlternativesJson(row?.alternatives ?? null, symbolValue) ?? []).join(', ')
+  // 条件連動配分 (#452 Layer 3)。
+  const entryRequiredChecked = row?.entryRequired ? ' checked' : ''
+  const alwaysActiveChecked = row?.alwaysActive ? ' checked' : ''
+  const cashFallbackValue = row?.cashFallbackSymbol ?? ''
   const timeStopPlaceholder = globalDefaults
     ? `空欄で global default (${globalDefaults.timeStopDays}日) を使用`
     : '空欄で global default を使用'
@@ -8535,6 +8581,21 @@ function symbolFormBody(args: SymbolFormArgs): string {
     <div>
       <input type="text" name="alternatives" value="${esc(alternativesValue)}" maxlength="120" placeholder="例: SOXX, SMH" style="padding:6px;width:240px">
       <p class="muted" style="margin:4px 0 0;font-size:11px">カンマ区切り (最大 8)。この銘柄が entry 不可のときダッシュボードに出す代替候補 (<strong>表示のみ</strong>、自動発注はしない、#452)。</p>
+    </div>
+    <label>配分の条件連動 <span class="muted" style="font-size:11px">(entry_required)</span></label>
+    <label style="display:flex;align-items:center;gap:6px">
+      <input type="hidden" name="entry_required" value="false">
+      <input type="checkbox" name="entry_required" value="true"${entryRequiredChecked}> entry 判定 (ENTRY/HALF) 通過時のみ実配分を有効にする
+    </label>
+    <label>常時配分 <span class="muted" style="font-size:11px">(always_active)</span></label>
+    <label style="display:flex;align-items:center;gap:6px">
+      <input type="hidden" name="always_active" value="false">
+      <input type="checkbox" name="always_active" value="true"${alwaysActiveChecked}> 判定に関わらず常時 target = active (待機資金 ETF 用)
+    </label>
+    <label>退避先 <span class="muted" style="font-size:11px">(cash_fallback_symbol)</span></label>
+    <div>
+      <input type="text" name="cash_fallback_symbol" value="${esc(cashFallbackValue)}" maxlength="10" pattern="[A-Za-z0-9]{0,10}" placeholder="例: SGOV" style="padding:6px;width:160px;text-transform:uppercase">
+      <p class="muted" style="margin:4px 0 0;font-size:11px">entry_required 銘柄が条件未通過の間、浮いた配分の退避先 (#452)。同一通貨のみ有効。<strong>退避先への自動発注は <code>cash_fallback_orders_enabled</code> (default off) を on にするまで行いません</strong> (判定・表示のみ)。</p>
     </div>
     <label>メモ <span class="muted" style="font-size:11px">(notes)</span></label>
     <textarea name="notes" maxlength="256" rows="3" placeholder="自由記述 (例: 一時停止理由 / 上限を絞ってる事情)" style="padding:6px;font-family:inherit">${esc(notesValue)}</textarea>

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -519,6 +519,15 @@ export const dashboard = new Hono<DashboardBindings>()
             buyability,
             entryStatus,
             alternatives: focusSymbol ? universe.symbolAlternatives[focusSymbol] ?? [] : [],
+            symbolPolicy: focusSymbol
+              ? {
+                  role: universe.symbolRole[focusSymbol] ?? null,
+                  targetWeight: universe.symbolBudgetAllocPct[focusSymbol] ?? null,
+                  entryRequired: universe.symbolEntryRequired[focusSymbol] === true,
+                  alwaysActive: universe.symbolAlwaysActive[focusSymbol] === true,
+                  cashFallbackSymbol: universe.symbolCashFallback[focusSymbol] ?? null,
+                }
+              : null,
           }),
           renderChartsSubnav(tab, focusSymbol ?? undefined),
         ),
@@ -5159,6 +5168,17 @@ export interface ChartsBodySymbol {
   entryStatus?: EntryStatusResult | null
   /** 代替銘柄候補 (#452、表示専用)。WATCH/NG 時に併記する。 */
   alternatives?: string[]
+  /** focus symbol のロール / 配分ポリシー要約 (#452)。 */
+  symbolPolicy?: SymbolPolicySummary | null
+}
+
+export interface SymbolPolicySummary {
+  role: string | null
+  /** budget_alloc_pct (fraction)。未設定 (risk-% sizing) は null。 */
+  targetWeight: number | null
+  entryRequired: boolean
+  alwaysActive: boolean
+  cashFallbackSymbol: string | null
 }
 
 /**
@@ -6488,6 +6508,7 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
   <div id="symbol-chart" style="width:100%;height:380px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;margin-top:8px"></div>
   ${renderZoomPresetButtons(args.symbolChart)}
   </div>
+  ${renderSymbolPolicyLine(args.focusSymbol, args.symbolPolicy ?? null)}
   ${renderBuyabilityPanel(args.buyability ?? null, {
     entryStatus: args.entryStatus ?? null,
     alternatives: args.alternatives ?? [],
@@ -6581,6 +6602,47 @@ export function renderAllocationLine(alloc: SymbolAllocation | undefined): strin
   const reroute = alloc.rerouteTo ? `（${esc(alloc.rerouteTo)} へ退避中）` : ''
   const rerouted = alloc.reroutedInWeight > 0 ? `（+${pct(alloc.reroutedInWeight)} 退避受入）` : ''
   return `<div style="font-size:11px;color:${color};margin-bottom:4px" title="${esc(alloc.reason)}">配分 target ${pct(alloc.targetWeight)}${arrow}${reroute}${rerouted}</div>`
+}
+
+/**
+ * 個別銘柄タブのロール / 配分ポリシー行 (#452)。role も配分も未設定なら出さない
+ * (従来挙動の銘柄でノイズにしない)。設定変更は編集フォームへのリンクで誘導。
+ */
+export function renderSymbolPolicyLine(
+  symbol: string | null,
+  policy: SymbolPolicySummary | null,
+): string {
+  if (!symbol || !policy) return ''
+  const hasAny =
+    policy.role !== null ||
+    policy.targetWeight !== null ||
+    policy.entryRequired ||
+    policy.alwaysActive ||
+    policy.cashFallbackSymbol !== null
+  if (!hasAny) return ''
+  const parts: string[] = []
+  if (policy.role !== null) {
+    const known = (SYMBOL_ROLES as readonly string[]).includes(policy.role)
+    parts.push(
+      known
+        ? `ロール: <code style="font-size:11px" title="${esc(SYMBOL_ROLE_LABELS[policy.role as SymbolRole])}">${esc(policy.role)}</code>`
+        : `ロール: <span class="err" title="不正な role 値 — entry は抑止されます (fail-closed)">⚠ ${esc(policy.role)}</span>`,
+    )
+  }
+  if (policy.targetWeight !== null) {
+    parts.push(`配分 target ${Math.round(policy.targetWeight * 1000) / 10}%`)
+  }
+  if (policy.alwaysActive) parts.push('<span title="判定に関わらず常時 target = active">常時配分</span>')
+  if (policy.entryRequired) parts.push('<span title="entry 判定 (ENTRY/HALF) 通過時のみ実配分有効">条件連動</span>')
+  if (policy.cashFallbackSymbol !== null) {
+    parts.push(
+      `退避先 <a href="/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(policy.cashFallbackSymbol)}">${esc(policy.cashFallbackSymbol)}</a>`,
+    )
+  }
+  return `<div class="muted" style="margin-top:8px;font-size:12px;display:flex;gap:12px;flex-wrap:wrap;align-items:center">
+    ${parts.join('<span style="color:#d0d0d5">｜</span>')}
+    <a href="/dashboard/symbols/${encodeURIComponent(symbol)}/edit" style="font-size:11px">設定変更</a>
+  </div>`
 }
 
 export function renderGridTab(args: ChartsBodyGrid): string {

--- a/src/trading/strategy/conditionalAllocation.ts
+++ b/src/trading/strategy/conditionalAllocation.ts
@@ -1,0 +1,223 @@
+import type { SymbolCurrency } from '../../infrastructure/db/symbolConfigRepo'
+import type { EntryStatus } from './entryStatus'
+
+/**
+ * 条件連動配分 (#452 Layer 3 / #450)。`budget_alloc_pct` を **target weight
+ * (目標配分)** として扱い、実配分 (active weight) を entry 判定に連動させる:
+ *
+ *   - `always_active` (cash_parking 用): 常時 active = target
+ *   - `entry_required`: ENTRY / HALF (発注対象) か建玉保有中のみ active = target。
+ *     未通過 (WATCH / NG / 評価データ無し) は active = 0 で、浮いた分は
+ *     `cash_fallback_symbol` の active に積み増す (退避)
+ *   - どちらでもない: 従来どおり常時 active = target (挙動変更なし)
+ *
+ * 退避は**同一通貨間のみ** — 通貨が異なる退避先は skip して現金のまま
+ * (fail-closed: 為替を跨ぐ自動退避はしない)。建玉保有中の銘柄は entry gate が
+ * 新規 entry 用の条件なので退避しない (exit は stop / time-stop / TP が管理)。
+ *
+ * このモジュールは**計算のみ** (pure)。退避先への自動発注は
+ * `global_config.cash_fallback_orders_enabled` (default false) が on の時だけ
+ * runStrategyCron が別途行う。off の間は判定・表示のみ。
+ */
+
+export interface ConditionalAllocationPolicy {
+  /** entry_required=true の集合。 */
+  entryRequired: ReadonlySet<string>
+  /** always_active=true の集合。 */
+  alwaysActive: ReadonlySet<string>
+  /** symbol → 退避先 symbol。 */
+  cashFallback: Record<string, string>
+}
+
+export interface AllocationComputeInput {
+  /** symbol → target weight (fraction 0<w<=1、budget_alloc_pct)。 */
+  targetWeights: Record<string, number>
+  policy: ConditionalAllocationPolicy
+  /** symbol → 最新の段階判定。評価できなかった銘柄は不在 (= 未通過扱い、fail-closed)。 */
+  entryStatuses: Record<string, EntryStatus>
+  /** 建玉保有中 (qty > 0) の symbol 集合。 */
+  heldSymbols: ReadonlySet<string>
+  /** symbol → 通貨。退避の同一通貨チェックに使う (不在は 'USD' 扱い)。 */
+  symbolCurrency: Record<string, SymbolCurrency>
+}
+
+export interface SymbolAllocation {
+  symbol: string
+  /** 設定上の目標配分 (budget_alloc_pct)。 */
+  targetWeight: number
+  /** 判定連動後の実配分。退避受入分を含む。 */
+  activeWeight: number
+  /** 自銘柄の枠が退避された先 (退避なしは undefined)。 */
+  rerouteTo?: string
+  /** 退避 / 据え置きの理由 (操作者向け)。 */
+  reason: string
+  /** 他銘柄から退避で受け入れた weight 合計 (退避先のみ > 0)。 */
+  reroutedInWeight: number
+}
+
+export interface AllocationView {
+  /** target weight を持つ銘柄 + 退避を受けた銘柄。 */
+  bySymbol: Record<string, SymbolAllocation>
+}
+
+/** 発注対象になる段階判定 (#452 PR 2 と同義: ENTRY / HALF のみ)。 */
+function isEntryEligible(status: EntryStatus | undefined): boolean {
+  return status === 'ENTRY' || status === 'HALF'
+}
+
+export function computeConditionalAllocation(input: AllocationComputeInput): AllocationView {
+  const bySymbol: Record<string, SymbolAllocation> = {}
+  const ensure = (symbol: string, targetWeight: number): SymbolAllocation => {
+    bySymbol[symbol] ??= {
+      symbol,
+      targetWeight,
+      activeWeight: targetWeight,
+      reason: '',
+      reroutedInWeight: 0,
+    }
+    return bySymbol[symbol]!
+  }
+
+  for (const [symbol, target] of Object.entries(input.targetWeights)) {
+    if (!Number.isFinite(target) || target <= 0) continue
+    const alloc = ensure(symbol, target)
+    if (input.policy.alwaysActive.has(symbol)) {
+      alloc.reason = 'always_active: 常時配分対象'
+      continue
+    }
+    if (!input.policy.entryRequired.has(symbol)) {
+      alloc.reason = '従来挙動 (entry_required off): 常時枠有効'
+      continue
+    }
+    if (input.heldSymbols.has(symbol)) {
+      alloc.reason = '建玉保有中: 配分は使用中 (exit は stop / time-stop / TP が管理)'
+      continue
+    }
+    const status = input.entryStatuses[symbol]
+    if (isEntryEligible(status)) {
+      alloc.reason = `entry 判定 ${status}: 配分有効`
+      continue
+    }
+    // 未通過 (WATCH / NG / 評価不能) → 実配分 0。退避先があり同一通貨なら積み増す。
+    alloc.activeWeight = 0
+    const statusLabel = status ?? '評価データ無し'
+    const fallback = input.policy.cashFallback[symbol]
+    if (fallback === undefined) {
+      alloc.reason = `entry 判定 ${statusLabel}: 実配分 0 (退避先未設定 → 現金のまま)`
+      continue
+    }
+    const ownCurrency = input.symbolCurrency[symbol] ?? 'USD'
+    const fallbackCurrency = input.symbolCurrency[fallback] ?? 'USD'
+    if (ownCurrency !== fallbackCurrency) {
+      alloc.reason = `entry 判定 ${statusLabel}: 実配分 0 (退避先 ${fallback} と通貨不一致 → 現金のまま)`
+      continue
+    }
+    alloc.rerouteTo = fallback
+    alloc.reason = `entry 判定 ${statusLabel}: 実配分 0 → ${fallback} へ退避`
+    const fallbackAlloc = ensure(fallback, input.targetWeights[fallback] ?? 0)
+    fallbackAlloc.activeWeight += target
+    fallbackAlloc.reroutedInWeight += target
+    if (fallbackAlloc.reason === '') {
+      fallbackAlloc.reason = '退避受入のみ (自身の target なし)'
+    }
+  }
+  return { bySymbol }
+}
+
+/** runStrategyCron が pass 1 の scheduler summary から集める per-symbol 観測値。 */
+export interface EntrySnapshot {
+  status: EntryStatus
+  /** 評価時の価格 (intraday or daily close)。 */
+  price: number
+  /** 建玉数量 (未保有は 0)。 */
+  heldQty: number
+}
+
+export interface CashRebalancePlanInput {
+  allocation: AllocationView
+  snapshots: Record<string, EntrySnapshot>
+  /** 口座総額 (JPY、total_capital_jpy)。 */
+  budgetBasisJpy: number
+  /** symbol 通貨 → JPY レート resolver (JPY=1、USD=USD/JPY)。取得失敗は undefined。 */
+  fxJpyPerCcy: (currency: SymbolCurrency) => number | undefined
+  symbolCurrency: Record<string, SymbolCurrency>
+  /** symbol → lot size。不在は fail-closed (発注計画から除外)。 */
+  symbolLotSize: Record<string, number>
+  /** symbol → 1 注文 notional 上限 (symbol_config.max_notional)。 */
+  symbolMaxNotional: Record<string, number>
+  /** 通貨別 global 1 注文上限。 */
+  maxOrderNotional: Record<SymbolCurrency, number>
+}
+
+export interface CashRebalanceOrder {
+  symbol: string
+  quantity: number
+  /** 概算 notional (symbol 通貨)。実際の execution では再計算される。 */
+  estimatedNotional: number
+}
+
+export interface CashRebalanceSkip {
+  symbol: string
+  reason: string
+}
+
+export interface CashRebalancePlan {
+  orders: CashRebalanceOrder[]
+  skipped: CashRebalanceSkip[]
+}
+
+/**
+ * cash fallback / always_active 銘柄の「目標配分に対する不足分」を BUY 数量に
+ * 落とす (#452 Layer 3)。**BUY-only**: 退避元が再 entry して active が縮んでも
+ * 退避先を自動 SELL はしない (待機資金の取り崩しは operator 判断 — 後続 issue)。
+ *
+ * fail-closed 系: price / lot / fx が無い銘柄は発注計画に入れない。上限は
+ * min(差分, symbol max_notional, 通貨別 global max_order_notional) を lot に
+ * floor する。
+ */
+export function buildCashRebalancePlan(input: CashRebalancePlanInput): CashRebalancePlan {
+  const orders: CashRebalanceOrder[] = []
+  const skipped: CashRebalanceSkip[] = []
+  for (const alloc of Object.values(input.allocation.bySymbol)) {
+    // 発注対象は「退避を受けた or always_active で target を持つ」cash 側のみ。
+    // 通常の entry_required / 従来挙動銘柄の枠は pullback 戦略経路が使う。
+    if (alloc.activeWeight <= 0) continue
+    if (alloc.reroutedInWeight <= 0 && !alloc.reason.startsWith('always_active')) continue
+    const symbol = alloc.symbol
+    const snapshot = input.snapshots[symbol]
+    if (!snapshot || !Number.isFinite(snapshot.price) || snapshot.price <= 0) {
+      skipped.push({ symbol, reason: 'no fresh price snapshot (fail-closed)' })
+      continue
+    }
+    const currency = input.symbolCurrency[symbol] ?? 'USD'
+    const fx = input.fxJpyPerCcy(currency)
+    if (fx === undefined || !Number.isFinite(fx) || fx <= 0) {
+      skipped.push({ symbol, reason: `fx unavailable for ${currency} (fail-closed)` })
+      continue
+    }
+    const lot = input.symbolLotSize[symbol]
+    if (lot === undefined || !Number.isInteger(lot) || lot < 1) {
+      skipped.push({ symbol, reason: 'lot_size not configured (fail-closed)' })
+      continue
+    }
+    const desiredJpy = alloc.activeWeight * input.budgetBasisJpy
+    const currentJpy = snapshot.heldQty * snapshot.price * fx
+    const deltaJpy = desiredJpy - currentJpy
+    if (deltaJpy <= 0) {
+      skipped.push({ symbol, reason: 'already at/above active weight (BUY-only, no auto-sell)' })
+      continue
+    }
+    const capCcy = Math.min(
+      input.symbolMaxNotional[symbol] ?? Number.POSITIVE_INFINITY,
+      input.maxOrderNotional[currency],
+    )
+    const deltaCcy = Math.min(deltaJpy / fx, capCcy)
+    const quantity = Math.floor(deltaCcy / snapshot.price / lot) * lot
+    if (quantity < lot) {
+      skipped.push({ symbol, reason: `delta below 1 lot (delta ${Math.round(deltaCcy)} ${currency})` })
+      continue
+    }
+    orders.push({ symbol, quantity, estimatedNotional: quantity * snapshot.price })
+  }
+  return { orders, skipped }
+}

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -38,7 +38,8 @@ import type { VixRegimeFilterDecision } from '../risk/vixRegimeFilter'
 import type { EarningsCalendarRepo } from '../../infrastructure/calendar/earningsCalendarRepo'
 import type { MacroEventCalendarRepo } from '../../infrastructure/calendar/macroEventCalendarRepo'
 import { evaluatePerSymbolRisk } from '../risk/perSymbolRiskGate'
-import { deriveEntryStatusFromIndicators } from './entryStatus'
+import { deriveEntryStatusFromIndicators, type EntryStatus } from './entryStatus'
+import type { EntrySnapshot } from './conditionalAllocation'
 
 const DEFAULT_BAR_LOOKBACK = 60
 
@@ -191,6 +192,17 @@ export interface PullbackSchedulerOptions {
    */
   halfEntrySymbols?: Set<string>
   /**
+   * 条件連動配分の cash rebalance 数量 (#452 Layer 3)。runStrategyCron が
+   * pass 1 (通常評価) の entrySnapshots から allocation を計算し、退避先 /
+   * always_active 銘柄の不足分 BUY 数量を pass 2 でこの map に入れて呼ぶ。
+   * 指定 symbol は **pullback 戦略判定と sizing を bypass** して固定数量の
+   * BUY intent を作る — ただし下流の gate (lot fail-closed / per-symbol risk /
+   * buying-power / pending lock / execution の DRY_RUN) は全部通る。
+   * 未注入なら従来挙動。`cash_fallback_orders_enabled` (default false) が
+   * off の間は runStrategyCron がこの map を渡さない。
+   */
+  cashRebalanceQuantityMap?: Record<string, number>
+  /**
    * sanity_failed cooldown gate。直近 N 分以内に同 symbol で broker stub
    * fill (`resolveFilledPrice` が ratio guard で reject した) が観測されて
    * いた場合、新規 BUY を block する。9697 04/28 incident (30 min/6 fills 累積、
@@ -270,6 +282,12 @@ export interface PullbackRunSummary {
    */
   decisions: PullbackDecisionTrace[]
   /**
+   * 条件連動配分 (#452 Layer 3) 用の per-symbol 観測値。評価が成立した
+   * symbol のみ (bars 不足 / ERROR は不在 = 下流が fail-closed に扱う)。
+   * 段階判定 / 評価価格 / 建玉数量を runStrategyCron の allocation 計算に渡す。
+   */
+  entrySnapshots: Record<string, EntrySnapshot>
+  /**
    * VIX regime filter decision applied to this run (issue #196 3/3)。
    * `vixDecision` option を渡された時のみ set される (POC 後方互換)。
    * cron summary log / dashboard で「この run でどの regime で動いていたか」
@@ -321,6 +339,7 @@ export async function runPullbackScheduler(
     rejected: [],
     errors: [],
     decisions: [],
+    entrySnapshots: {},
     ...(options.vixDecision !== undefined ? { vix: options.vixDecision } : {}),
   }
 
@@ -425,6 +444,17 @@ export async function runPullbackScheduler(
         ? computeHoldBusinessDays(state.position.openedAt, now(), market)
         : 0
 
+    // 条件連動配分 (#452 Layer 3) 用の観測値。判定そのものには使わず、
+    // runStrategyCron が run 後に target/active weight を計算する材料。
+    summary.entrySnapshots[upper] = {
+      status: deriveEntryStatusFromIndicators(indicators, strategy.resolveRule(upper)).status,
+      price: indicators.price,
+      heldQty:
+        state.position !== null && Number.isFinite(state.position.qty) && state.position.qty > 0
+          ? state.position.qty
+          : 0,
+    }
+
     let signal = strategy.decide({
       symbol: upper,
       indicators,
@@ -434,6 +464,26 @@ export async function runPullbackScheduler(
       holdBusinessDays,
       now: now(),
     })
+
+    // cash rebalance (#452 Layer 3 pass 2): 指定数量の BUY に置き換える。
+    // pending order 中は strategy の HOLD (pending guard) をそのまま残す。
+    // 下流 gate (lot / per-symbol risk / buying-power / pending lock /
+    // execution の DRY_RUN) は通常 BUY と同様に全部通る。
+    const cashRebalanceQty = options.cashRebalanceQuantityMap?.[upper]
+    if (cashRebalanceQty !== undefined && state.pendingOrder === null) {
+      if (Number.isInteger(cashRebalanceQty) && cashRebalanceQty > 0) {
+        signal = {
+          ...signal,
+          action: 'BUY',
+          quantity: cashRebalanceQty,
+          reason: `cash allocation rebalance: buy ${cashRebalanceQty} toward active weight (#452)`,
+          trace: appendTrace(
+            signal.trace,
+            traceStep('entry.cash_rebalance', true, cashRebalanceQty, '>', 0, 'conditional allocation cash rebalance (#452)'),
+          ),
+        }
+      }
+    }
 
     // #intraday-only: レバ ETF 等は US 引け前 window で建玉があれば strategy 判定を
     // 上書きして強制 SELL (オーバーナイト持ち越し禁止 = 寄りギャップ stop-out 回避)。
@@ -605,20 +655,31 @@ export async function runPullbackScheduler(
         })
         continue
       }
-      const sizing = computePullbackSizing({
-        equity: options.equity,
-        entryPrice: indicators.price,
-        stopPct: rule.stopPct,
-        atr20: indicators.atr20,
-        baselineAtr20: indicators.baselineAtr20,
-        symbolCap: options.symbolCapMap?.[upper],
-        riskPerTradePct: options.riskPerTradePct,
-        lotSize: resolvedLotSize,
-        kAtr: rule.kAtr,
-        budgetAllocPct: options.symbolBudgetAllocPctMap?.[upper],
-        budgetBasisJpy: options.budgetBasisJpy,
-        fxJpyPerSymbolCcy: options.fxJpyPerSymbolCcy,
-      })
+      // cash rebalance (#452): 数量は runStrategyCron が allocation 差分から
+      // 計算済み (cap / lot 適用済み)。pullback sizing は通さず、lot 整合だけ
+      // 再確認する (lot 倍数でなければ floor、0 になれば下の reject で見送り)。
+      const sizing =
+        cashRebalanceQty !== undefined
+          ? {
+              quantity: Math.floor(cashRebalanceQty / resolvedLotSize) * resolvedLotSize,
+              notional:
+                Math.floor(cashRebalanceQty / resolvedLotSize) * resolvedLotSize * indicators.price,
+              capped: false,
+            }
+          : computePullbackSizing({
+              equity: options.equity,
+              entryPrice: indicators.price,
+              stopPct: rule.stopPct,
+              atr20: indicators.atr20,
+              baselineAtr20: indicators.baselineAtr20,
+              symbolCap: options.symbolCapMap?.[upper],
+              riskPerTradePct: options.riskPerTradePct,
+              lotSize: resolvedLotSize,
+              kAtr: rule.kAtr,
+              budgetAllocPct: options.symbolBudgetAllocPctMap?.[upper],
+              budgetBasisJpy: options.budgetBasisJpy,
+              fxJpyPerSymbolCcy: options.fxJpyPerSymbolCcy,
+            })
       if (sizing.quantity <= 0) {
         const reason = buildSizingRejectReason(sizing, {
           lotSize: resolvedLotSize,
@@ -1357,6 +1418,7 @@ const TRACE_LABEL_JA: Record<string, string> = {
   'risk.vix_regime': 'VIX レジーム判定',
   'risk.role_entry_suppressed': 'ロール entry 抑止 (#452)',
   'entry.half_status': '段階判定 HALF (0.5x、#452)',
+  'entry.cash_rebalance': '条件連動配分 cash rebalance (#452)',
   'sizing.half_entry_quantity_positive': 'HALF 数量が1株/1単元以上ある',
   'risk.buying_power_pool': '口座買付余力プール (発注前)',
   'risk.sanity_failed_cooldown': 'sanity_failed cooldown (broker stub 疑い)',

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -51,6 +51,13 @@ import {
   buildHalfEntrySymbols,
   buildSymbolRules,
 } from './symbolRuleResolution'
+import {
+  buildCashRebalancePlan,
+  computeConditionalAllocation,
+  type AllocationView,
+  type CashRebalanceSkip,
+  type EntrySnapshot,
+} from './conditionalAllocation'
 
 const DEFAULT_EQUITY_USD = 10_000
 const DEFAULT_EQUITY_JPY = 1_500_000
@@ -138,6 +145,16 @@ export interface StrategyCronAnalysis {
     symbols: string[]
   }>
   decisions: PullbackDecisionTrace[]
+  /**
+   * 条件連動配分 (#452 Layer 3)。target/active weight と退避の判定結果。
+   * `cash_fallback_orders_enabled` が off でも**計算は常に行い**ここに残す
+   * (判定・表示のみモード)。発注 plan は on の時のみ。
+   */
+  allocation?: {
+    view: AllocationView
+    ordersEnabled: boolean
+    rebalanceSkipped?: CashRebalanceSkip[]
+  }
 }
 
 /**
@@ -173,6 +190,7 @@ export async function runStrategyCron(
     rejected: [],
     errors: [],
     decisions: [],
+    entrySnapshots: {},
   })
 
   const [global, universe] = await Promise.all([
@@ -678,7 +696,99 @@ export async function runStrategyCron(
     summary.rejected.push(...sub.rejected)
     summary.errors.push(...sub.errors)
     summary.decisions.push(...sub.decisions)
+    Object.assign(summary.entrySnapshots, sub.entrySnapshots)
     analysis.decisions.push(...sub.decisions)
+  }
+
+  // ---- 条件連動配分 (#452 Layer 3) ----
+  // target/active weight の計算は flag に関わらず常に行い analysis に残す
+  // (判定・表示)。退避先への自動発注 (pass 2) は cash_fallback_orders_enabled
+  // (default false) が on で、かつ budget 基準額がある時だけ。
+  const allocationView = computeConditionalAllocation({
+    targetWeights: universe.symbolBudgetAllocPct,
+    policy: {
+      entryRequired: new Set(Object.keys(universe.symbolEntryRequired)),
+      alwaysActive: new Set(Object.keys(universe.symbolAlwaysActive)),
+      cashFallback: universe.symbolCashFallback,
+    },
+    entryStatuses: Object.fromEntries(
+      Object.entries(summary.entrySnapshots).map(([sym, snap]) => [sym, snap.status]),
+    ),
+    heldSymbols: new Set(
+      Object.entries(summary.entrySnapshots)
+        .filter(([, snap]) => snap.heldQty > 0)
+        .map(([sym]) => sym),
+    ),
+    symbolCurrency: universe.symbolCurrency,
+  })
+  analysis.allocation = { view: allocationView, ordersEnabled: global.cashFallbackOrdersEnabled }
+
+  if (global.cashFallbackOrdersEnabled && budgetBasisJpy !== undefined) {
+    const plan = buildCashRebalancePlan({
+      allocation: allocationView,
+      snapshots: summary.entrySnapshots,
+      budgetBasisJpy,
+      fxJpyPerCcy: (currency) => (currency === 'JPY' ? 1 : (usdJpyRate ?? undefined)),
+      symbolCurrency: universe.symbolCurrency,
+      symbolLotSize: universe.symbolLotSize,
+      symbolMaxNotional: universe.symbolMaxNotional,
+      maxOrderNotional: { USD: global.maxOrderNotionalUsd, JPY: global.maxOrderNotionalJpy },
+    })
+    analysis.allocation.rebalanceSkipped = plan.skipped
+    if (plan.orders.length > 0) {
+      // pass 2: cash 銘柄だけを cashRebalanceQuantityMap 付きで再実行する。
+      // entrySuppressedSymbols は渡さない (cash_parking の BUY を許可する唯一の
+      // 経路)。lot / per-symbol risk / buying-power / pending lock / DRY_RUN は
+      // 通常 BUY と同じ gate を通る。
+      const byCcy: Record<SymbolCurrency, typeof plan.orders> = { USD: [], JPY: [] }
+      for (const order of plan.orders) {
+        byCcy[universe.symbolCurrency[order.symbol] ?? 'USD'].push(order)
+      }
+      for (const run of runs) {
+        const orders = byCcy[run.currency]
+        if (orders.length === 0) continue
+        const decisionDb = strategyDecisionDbOrUndefined(env)
+        const sub = await runPullbackScheduler({
+          symbols: orders.map((o) => o.symbol),
+          equity: run.equity,
+          symbolLotSizeMap: universe.symbolLotSize,
+          barClient,
+          positionStore,
+          execution,
+          symbolCapMap: universe.symbolMaxNotional,
+          cashRebalanceQuantityMap: Object.fromEntries(orders.map((o) => [o.symbol, o.quantity])),
+          fxJpyPerSymbolCcy: run.currency === 'JPY' ? 1 : (usdJpyRate ?? undefined),
+          buyingPower,
+          defaultRule,
+          rulesMap,
+          requestId: options.requestId,
+          notifier,
+          perSymbolRisk: {
+            inversePairs: universe.inversePairs,
+            spreadLimits: {
+              US: global.spreadLimitPctUs,
+              JP: global.spreadLimitPctJp,
+            },
+            staleQuoteMs: global.staleQuoteMs,
+            gapRejectPct: global.gapRejectPct,
+          },
+          vixDecision,
+          onDecision: ({ trace, ...record }) =>
+            logStrategyDecision(decisionDb, {
+              timestamp: new Date().toISOString(),
+              requestId: options.requestId,
+              ...record,
+              traceJson: trace && trace.length > 0 ? JSON.stringify(trace) : null,
+            }),
+        })
+        summary.evaluated += sub.evaluated
+        summary.buys += sub.buys
+        summary.rejected.push(...sub.rejected)
+        summary.errors.push(...sub.errors)
+        summary.decisions.push(...sub.decisions)
+        analysis.decisions.push(...sub.decisions)
+      }
+    }
   }
 
   return { summary, symbols: universe.allowedSymbols, analysis }

--- a/test/helpers/configFixtures.ts
+++ b/test/helpers/configFixtures.ts
@@ -40,6 +40,7 @@ export function makeGlobalConfigSnapshot(
     vixWarningThreshold: 25.0,
     vixCriticalThreshold: 30.0,
     vixWarningSizeScale: 0.5,
+    cashFallbackOrdersEnabled: false,
     source: 'd1',
     ...overrides,
   }
@@ -69,6 +70,9 @@ export function makeSymbolUniverse(overrides: Partial<SymbolUniverse> = {}): Sym
     symbolMaxSma50DeviationPctOverride: {},
     symbolRequireAboveSma50Override: {},
     symbolAlternatives: {},
+    symbolEntryRequired: {},
+    symbolAlwaysActive: {},
+    symbolCashFallback: {},
     inversePairs: {},
     source: 'd1',
     ...overrides,

--- a/test/infrastructure/db/symbolConfigRepo.test.ts
+++ b/test/infrastructure/db/symbolConfigRepo.test.ts
@@ -259,6 +259,9 @@ const writeInput = (symbol: string): SymbolConfigWriteInput => ({
   maxSma50DeviationPctOverride: null,
   requireAboveSma50Override: null,
   alternatives: null,
+  entryRequired: false,
+  alwaysActive: false,
+  cashFallbackSymbol: null,
 })
 
 describe('setInversePair', () => {

--- a/test/routes/admin.test.ts
+++ b/test/routes/admin.test.ts
@@ -1152,6 +1152,9 @@ describe('POST /admin/orders/sync-holdings', () => {
       symbolMaxSma50DeviationPctOverride: {},
       symbolRequireAboveSma50Override: {},
       symbolAlternatives: {},
+      symbolEntryRequired: {},
+      symbolAlwaysActive: {},
+      symbolCashFallback: {},
       inversePairs: {},
       source: 'd1',
     })

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -2663,3 +2663,45 @@ describe('renderAllocationLine (#452 Layer 3 target/active 並記)', () => {
     expect(renderAllocationLine(undefined)).toBe('')
   })
 })
+
+import { renderSymbolPolicyLine } from '../../src/routes/dashboard'
+
+describe('renderSymbolPolicyLine (#452 個別銘柄タブのロール表示)', () => {
+  it('role / target / 条件連動 / 退避先を 1 行に要約する', () => {
+    const html = renderSymbolPolicyLine('TQQQ', {
+      role: 'leveraged_trend',
+      targetWeight: 0.05,
+      entryRequired: true,
+      alwaysActive: false,
+      cashFallbackSymbol: 'SGOV',
+    })
+    expect(html).toContain('leveraged_trend')
+    expect(html).toContain('配分 target 5%')
+    expect(html).toContain('条件連動')
+    expect(html).toContain('symbol=SGOV')
+    expect(html).toContain('/dashboard/symbols/TQQQ/edit')
+  })
+
+  it('role も配分も未設定なら何も出さない (従来挙動の銘柄)', () => {
+    expect(
+      renderSymbolPolicyLine('SOXL', {
+        role: null,
+        targetWeight: null,
+        entryRequired: false,
+        alwaysActive: false,
+        cashFallbackSymbol: null,
+      }),
+    ).toBe('')
+  })
+
+  it('不正 role は警告表示', () => {
+    const html = renderSymbolPolicyLine('OOPS', {
+      role: 'unknown',
+      targetWeight: null,
+      entryRequired: false,
+      alwaysActive: false,
+      cashFallbackSymbol: null,
+    })
+    expect(html).toContain('⚠ unknown')
+  })
+})

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -2628,3 +2628,38 @@ describe('段階判定の表示 (#452 PR 2)', () => {
     ])
   })
 })
+
+import { renderAllocationLine } from '../../src/routes/dashboard'
+import { computeConditionalAllocation } from '../../src/trading/strategy/conditionalAllocation'
+
+describe('renderAllocationLine (#452 Layer 3 target/active 並記)', () => {
+  const view = computeConditionalAllocation({
+    targetWeights: { SGOV: 0.7, TQQQ: 0.05 },
+    policy: {
+      entryRequired: new Set(['TQQQ']),
+      alwaysActive: new Set(['SGOV']),
+      cashFallback: { TQQQ: 'SGOV' },
+    },
+    entryStatuses: { TQQQ: 'NG' },
+    heldSymbols: new Set(),
+    symbolCurrency: { SGOV: 'USD', TQQQ: 'USD' },
+  })
+
+  it('退避された銘柄は target → 0% と退避先を表示', () => {
+    const html = renderAllocationLine(view.bySymbol.TQQQ)
+    expect(html).toContain('target 5%')
+    expect(html).toContain('<strong>0%</strong>')
+    expect(html).toContain('SGOV へ退避中')
+  })
+
+  it('退避先は受入分を表示 (70% + 5% = 75%)', () => {
+    const html = renderAllocationLine(view.bySymbol.SGOV)
+    expect(html).toContain('target 70%')
+    expect(html).toContain('<strong>75%</strong>')
+    expect(html).toContain('+5% 退避受入')
+  })
+
+  it('配分の無い銘柄は空文字', () => {
+    expect(renderAllocationLine(undefined)).toBe('')
+  })
+})

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -2676,6 +2676,7 @@ describe('renderSymbolPolicyLine (#452 個別銘柄タブのロール表示)', (
       cashFallbackSymbol: 'SGOV',
     })
     expect(html).toContain('leveraged_trend')
+    expect(html).toContain('レバETF・トレンド')
     expect(html).toContain('配分 target 5%')
     expect(html).toContain('条件連動')
     expect(html).toContain('symbol=SGOV')

--- a/test/routes/dashboardSymbolsCrud.test.ts
+++ b/test/routes/dashboardSymbolsCrud.test.ts
@@ -1557,3 +1557,50 @@ describe('dashboard symbol_config 条件連動配分 (#452 Layer 3)', () => {
     expect(body).toMatch(/name="cash_fallback_symbol"[^>]*value="SGOV"/)
   })
 })
+
+describe('symbols list ロール列 (#452)', () => {
+  beforeEach(() => {
+    vi.mocked(loadGlobalConfigFrom).mockResolvedValue(makeGlobalConfigSnapshot())
+  })
+  afterEach(() => vi.resetAllMocks())
+
+  it('一覧に role と条件連動配分の要約を表示する', async () => {
+    const db = fakeDb([
+      row({ symbol: 'SGOV', role: 'cash_parking', alwaysActive: true }),
+      row({
+        symbol: 'QQQ',
+        role: 'core_trend',
+        entryRequired: true,
+        cashFallbackSymbol: 'SGOV',
+      }),
+      row({ symbol: 'SOXL' }), // role NULL = 従来挙動
+    ])
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const app = createApp()
+    const res = await app.request(
+      '/dashboard/symbols',
+      { headers: authHeader },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    const body = await res.text()
+    expect(body).toContain('<th>ロール</th>')
+    expect(body).toContain('cash_parking')
+    expect(body).toContain('常時配分')
+    expect(body).toContain('core_trend')
+    expect(body).toContain('条件連動')
+    expect(body).toContain('→SGOV')
+  })
+
+  it('不正な role 値は警告表示 (entry 抑止の旨)', async () => {
+    const db = fakeDb([row({ symbol: 'OOPS', role: 'cash_praking' })])
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const app = createApp()
+    const res = await app.request(
+      '/dashboard/symbols',
+      { headers: authHeader },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    const body = await res.text()
+    expect(body).toContain('⚠ cash_praking')
+  })
+})

--- a/test/routes/dashboardSymbolsCrud.test.ts
+++ b/test/routes/dashboardSymbolsCrud.test.ts
@@ -177,6 +177,9 @@ function fakeDb(
               maxSma50DeviationPctOverride: (v.maxSma50DeviationPctOverride as number | null) ?? null,
               requireAboveSma50Override: (v.requireAboveSma50Override as boolean | null) ?? null,
               alternatives: (v.alternatives as string | null) ?? null,
+              entryRequired: v.entryRequired === true || v.entryRequired === 1,
+              alwaysActive: v.alwaysActive === true || v.alwaysActive === 1,
+              cashFallbackSymbol: (v.cashFallbackSymbol as string | null) ?? null,
               updatedAt: String(v.updatedAt ?? ''),
             })
           }
@@ -244,6 +247,9 @@ function row(overrides: Partial<SymbolConfigRow> = {}): SymbolConfigRow {
     maxSma50DeviationPctOverride: null,
     requireAboveSma50Override: null,
     alternatives: null,
+    entryRequired: false,
+    alwaysActive: false,
+    cashFallbackSymbol: null,
     updatedAt: '2026-04-23T00:00:00.000Z',
     ...overrides,
   }
@@ -1473,5 +1479,81 @@ describe('dashboard symbol_config role / entry override / alternatives (#452)', 
     expect(body).toMatch(/name="min_return_50d_override"[^>]*value="3"/)
     expect(body).toMatch(/name="require_above_sma50_override"/)
     expect(body).toMatch(/name="alternatives"[^>]*value="VOO, SPLG"/)
+  })
+})
+
+describe('dashboard symbol_config 条件連動配分 (#452 Layer 3)', () => {
+  beforeEach(() => {
+    vi.mocked(loadGlobalConfigFrom).mockResolvedValue(makeGlobalConfigSnapshot())
+  })
+  afterEach(() => vi.resetAllMocks())
+
+  it('POST persists entry_required / always_active / cash_fallback_symbol', async () => {
+    const db = fakeDb([])
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const app = createApp()
+    const form = new URLSearchParams({
+      symbol: 'QQQ',
+      market: 'US',
+      currency: 'USD',
+      active: 'true',
+      lot_size: '1',
+      entry_required: 'true',
+      always_active: 'false',
+      cash_fallback_symbol: 'sgov', // 小文字も大文字正規化
+    })
+    const res = await app.request(
+      '/admin/symbol-config',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...authHeader },
+        body: form.toString(),
+      },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    expect(res.status).toBe(303)
+    const inserted = db.inserts.find((i) => i.table === 'symbol_config')!
+    expect(inserted.values.entryRequired).toBe(true)
+    expect(inserted.values.alwaysActive).toBe(false)
+    expect(inserted.values.cashFallbackSymbol).toBe('SGOV')
+  })
+
+  it('rejects a self-referential cash_fallback_symbol with 400', async () => {
+    const db = fakeDb([])
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const app = createApp()
+    const res = await app.request(
+      '/admin/symbol-config',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...authHeader },
+        body: new URLSearchParams({
+          symbol: 'SGOV',
+          market: 'US',
+          currency: 'USD',
+          active: 'true',
+          lot_size: '1',
+          cash_fallback_symbol: 'SGOV',
+        }).toString(),
+      },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('edit form shows 条件連動配分 fields with current values', async () => {
+    const db = fakeDb([
+      row({ symbol: 'QQQ', entryRequired: true, cashFallbackSymbol: 'SGOV' }),
+    ])
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const app = createApp()
+    const res = await app.request(
+      '/dashboard/symbols/QQQ/edit',
+      { headers: authHeader },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    const body = await res.text()
+    expect(body).toMatch(/name="entry_required" value="true" checked/)
+    expect(body).toMatch(/name="cash_fallback_symbol"[^>]*value="SGOV"/)
   })
 })

--- a/test/trading/strategy/conditionalAllocation.test.ts
+++ b/test/trading/strategy/conditionalAllocation.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildCashRebalancePlan,
+  computeConditionalAllocation,
+  type AllocationComputeInput,
+} from '../../../src/trading/strategy/conditionalAllocation'
+
+const baseInput = (): AllocationComputeInput => ({
+  targetWeights: { SGOV: 0.7, QQQ: 0.2, TQQQ: 0.05, SOXL: 0.05 },
+  policy: {
+    entryRequired: new Set(['QQQ', 'TQQQ', 'SOXL']),
+    alwaysActive: new Set(['SGOV']),
+    cashFallback: { QQQ: 'SGOV', TQQQ: 'SGOV', SOXL: 'SGOV' },
+  },
+  entryStatuses: { SGOV: 'NG', QQQ: 'ENTRY', TQQQ: 'WATCH', SOXL: 'NG' },
+  heldSymbols: new Set(),
+  symbolCurrency: { SGOV: 'USD', QQQ: 'USD', TQQQ: 'USD', SOXL: 'USD' },
+})
+
+describe('computeConditionalAllocation (#452 Layer 3)', () => {
+  it('issue #450 の設定例: 未通過のレバ枠が SGOV へ退避される', () => {
+    const view = computeConditionalAllocation(baseInput())
+    // QQQ は ENTRY → target 維持。TQQQ/SOXL は未通過 → 0、SGOV へ +10%。
+    expect(view.bySymbol.QQQ!.activeWeight).toBeCloseTo(0.2, 9)
+    expect(view.bySymbol.TQQQ!.activeWeight).toBe(0)
+    expect(view.bySymbol.TQQQ!.rerouteTo).toBe('SGOV')
+    expect(view.bySymbol.SOXL!.activeWeight).toBe(0)
+    expect(view.bySymbol.SGOV!.activeWeight).toBeCloseTo(0.8, 9)
+    expect(view.bySymbol.SGOV!.reroutedInWeight).toBeCloseTo(0.1, 9)
+  })
+
+  it('always_active は判定 NG でも常時 target = active (cash_parking)', () => {
+    const view = computeConditionalAllocation(baseInput())
+    // SGOV 自身の判定は NG だが always_active なので退避前で 0.7 を維持。
+    expect(view.bySymbol.SGOV!.activeWeight).toBeGreaterThanOrEqual(0.7)
+    expect(view.bySymbol.SGOV!.reason).toContain('always_active')
+  })
+
+  it('HALF も発注対象なので配分有効', () => {
+    const input = baseInput()
+    input.entryStatuses.TQQQ = 'HALF'
+    const view = computeConditionalAllocation(input)
+    expect(view.bySymbol.TQQQ!.activeWeight).toBeCloseTo(0.05, 9)
+  })
+
+  it('entry_required でない銘柄は従来挙動 (常時枠有効、挙動変更なし)', () => {
+    const input = baseInput()
+    input.policy.entryRequired = new Set()
+    const view = computeConditionalAllocation(input)
+    expect(view.bySymbol.TQQQ!.activeWeight).toBeCloseTo(0.05, 9)
+    expect(view.bySymbol.SGOV!.activeWeight).toBeCloseTo(0.7, 9)
+  })
+
+  it('建玉保有中は未通過でも退避しない (exit 経路が管理)', () => {
+    const input = baseInput()
+    input.heldSymbols = new Set(['SOXL'])
+    const view = computeConditionalAllocation(input)
+    expect(view.bySymbol.SOXL!.activeWeight).toBeCloseTo(0.05, 9)
+    expect(view.bySymbol.SGOV!.reroutedInWeight).toBeCloseTo(0.05, 9) // TQQQ 分のみ
+  })
+
+  it('評価データの無い entry_required 銘柄は未通過扱い (fail-closed) で退避', () => {
+    const input = baseInput()
+    delete input.entryStatuses.SOXL
+    const view = computeConditionalAllocation(input)
+    expect(view.bySymbol.SOXL!.activeWeight).toBe(0)
+    expect(view.bySymbol.SOXL!.reason).toContain('評価データ無し')
+  })
+
+  it('退避先が通貨不一致なら退避しない (現金のまま、fail-closed)', () => {
+    const input = baseInput()
+    input.symbolCurrency.TQQQ = 'JPY'
+    const view = computeConditionalAllocation(input)
+    expect(view.bySymbol.TQQQ!.activeWeight).toBe(0)
+    expect(view.bySymbol.TQQQ!.rerouteTo).toBeUndefined()
+    expect(view.bySymbol.SGOV!.reroutedInWeight).toBeCloseTo(0.05, 9) // SOXL 分のみ
+  })
+
+  it('退避先未設定は実配分 0 のまま (現金待機)', () => {
+    const input = baseInput()
+    delete input.policy.cashFallback.SOXL
+    const view = computeConditionalAllocation(input)
+    expect(view.bySymbol.SOXL!.activeWeight).toBe(0)
+    expect(view.bySymbol.SOXL!.rerouteTo).toBeUndefined()
+  })
+
+  it('target を持たない退避先も bySymbol に現れる (退避受入のみ)', () => {
+    const input = baseInput()
+    delete input.targetWeights.SGOV
+    input.policy.alwaysActive = new Set()
+    const view = computeConditionalAllocation(input)
+    expect(view.bySymbol.SGOV!.targetWeight).toBe(0)
+    expect(view.bySymbol.SGOV!.activeWeight).toBeCloseTo(0.1, 9)
+  })
+})
+
+describe('buildCashRebalancePlan (#452 Layer 3)', () => {
+  const view = computeConditionalAllocation(baseInput()) // SGOV active 0.8
+
+  const planInput = () => ({
+    allocation: view,
+    snapshots: {
+      SGOV: { status: 'NG' as const, price: 100, heldQty: 0 },
+      QQQ: { status: 'ENTRY' as const, price: 400, heldQty: 0 },
+      TQQQ: { status: 'WATCH' as const, price: 60, heldQty: 0 },
+      SOXL: { status: 'NG' as const, price: 30, heldQty: 0 },
+    },
+    budgetBasisJpy: 1_500_000,
+    fxJpyPerCcy: ((ccy) => (ccy === 'JPY' ? 1 : 150)) as (
+      ccy: 'USD' | 'JPY',
+    ) => number | undefined,
+    symbolCurrency: { SGOV: 'USD' as const },
+    symbolLotSize: { SGOV: 1 } as Record<string, number>,
+    symbolMaxNotional: {},
+    maxOrderNotional: { USD: 1_000_000, JPY: 100_000_000 },
+  })
+
+  it('cash 側 (退避受入 / always_active) だけ BUY 計画になる', () => {
+    const plan = buildCashRebalancePlan(planInput())
+    // desired = 0.8 * 1.5M = 1.2M JPY = $8,000 → 80 株 @ $100。
+    expect(plan.orders).toEqual([{ symbol: 'SGOV', quantity: 80, estimatedNotional: 8000 }])
+  })
+
+  it('保有が目標以上なら BUY しない (BUY-only、自動 SELL なし)', () => {
+    const input = planInput()
+    input.snapshots.SGOV = { status: 'NG', price: 100, heldQty: 90 } // $9,000 > $8,000
+    const plan = buildCashRebalancePlan(input)
+    expect(plan.orders).toEqual([])
+    expect(plan.skipped.find((s) => s.symbol === 'SGOV')?.reason).toContain('BUY-only')
+  })
+
+  it('不足分だけ買う (差分 BUY)', () => {
+    const input = planInput()
+    input.snapshots.SGOV = { status: 'NG', price: 100, heldQty: 30 } // $3,000 → 残 $5,000
+    const plan = buildCashRebalancePlan(input)
+    expect(plan.orders[0]?.quantity).toBe(50)
+  })
+
+  it('lot 未設定 / price 無し / fx 無しは fail-closed で skip', () => {
+    const noLot = planInput()
+    noLot.symbolLotSize = {}
+    expect(buildCashRebalancePlan(noLot).orders).toEqual([])
+
+    const noSnap = planInput()
+    delete (noSnap.snapshots as Record<string, unknown>).SGOV
+    expect(buildCashRebalancePlan(noSnap).orders).toEqual([])
+
+    const noFx = planInput()
+    noFx.fxJpyPerCcy = () => undefined
+    expect(buildCashRebalancePlan(noFx).orders).toEqual([])
+  })
+
+  it('1 注文上限 (symbol / global) で clamp する', () => {
+    const input = planInput()
+    input.symbolMaxNotional = { SGOV: 2000 } // $2,000 cap
+    const plan = buildCashRebalancePlan(input)
+    expect(plan.orders[0]?.quantity).toBe(20)
+  })
+})

--- a/test/trading/strategy/pullbackScheduler.test.ts
+++ b/test/trading/strategy/pullbackScheduler.test.ts
@@ -1994,3 +1994,85 @@ describe('runPullbackScheduler half entry (#452 段階判定)', () => {
     expect(reject?.reason).toContain('inverse')
   })
 })
+
+describe('runPullbackScheduler cash rebalance / entry snapshots (#452 Layer 3)', () => {
+  it('collects per-symbol entry snapshots (status / price / heldQty)', async () => {
+    const heldState: SymbolState = {
+      ...emptySymbolState('SOXS', () => now),
+      position: { qty: 7, avgPrice: 100, openedAt: now.toISOString() },
+    }
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL', 'SOXS'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({ SOXS: heldState }),
+      execution: mockExecution(),
+      now: () => now,
+    })
+    expect(summary.entrySnapshots.AAPL).toEqual({ status: 'ENTRY', price: 117.5, heldQty: 0 })
+    expect(summary.entrySnapshots.SOXS?.heldQty).toBe(7)
+  })
+
+  it('cashRebalanceQuantityMap forces a fixed-quantity BUY bypassing pullback gates', async () => {
+    const execution = mockExecution()
+    // downtrend 相当でも (= 通常なら HOLD でも) cash 銘柄は指定数量で BUY する。
+    const summary = await runPullbackScheduler({
+      symbols: ['SGOV'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution,
+      cashRebalanceQuantityMap: { SGOV: 80 },
+      // 通常評価なら WATCH/NG になる厳しい rule でも rebalance は通る
+      defaultRule: { ...TEST_DEFAULT_RULE, minReturn50d: 5 },
+      now: () => now,
+    })
+    expect(summary.buys).toBe(1)
+    const intent = execution.calls[0] as { symbol: string; side: string; quantity: number }
+    expect(intent).toMatchObject({ symbol: 'SGOV', side: 'BUY', quantity: 80 })
+    const buy = summary.decisions.find((d) => d.decision === 'BUY')
+    expect(buy?.reason).toContain('cash allocation rebalance')
+    expect(buy?.trace?.map((s) => s.label)).toContain('entry.cash_rebalance')
+  })
+
+  it('cash rebalance respects pending-order lock (no double submit)', async () => {
+    const execution = mockExecution()
+    const pendingState: SymbolState = {
+      ...emptySymbolState('SGOV', () => now),
+      pendingOrder: {
+        clientOrderId: 'coid-1',
+        side: 'BUY',
+        submittedAt: now.toISOString(),
+        expiresAt: new Date(now.getTime() + 60_000).toISOString(),
+      },
+    }
+    const summary = await runPullbackScheduler({
+      symbols: ['SGOV'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({ SGOV: pendingState }),
+      execution,
+      cashRebalanceQuantityMap: { SGOV: 80 },
+      now: () => now,
+    })
+    expect(summary.buys).toBe(0)
+    expect(execution.calls).toHaveLength(0)
+  })
+
+  it('cash rebalance still fails closed without lot_size when map mode is on', async () => {
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['SGOV'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution,
+      cashRebalanceQuantityMap: { SGOV: 80 },
+      symbolLotSizeMap: {}, // lot 必須モード + SGOV 未設定
+      now: () => now,
+    })
+    expect(summary.buys).toBe(0)
+    expect(execution.calls).toHaveLength(0)
+    expect(summary.rejected[0]?.reason).toContain('missing-lot-size')
+  })
+})


### PR DESCRIPTION
## Summary

#452 の **PR 3/3 (条件連動配分 + cash fallback)**。**Stacked on #454** (base = `dev/452-entry-status`)。

- **D1 migration 0030**: `symbol_config.entry_required` / `always_active` / `cash_fallback_symbol`、`global_config.cash_fallback_orders_enabled` (**default false**)
- **`budget_alloc_pct` を target weight として扱い、active weight を段階判定に連動** (`conditionalAllocation.ts`、pure):
  - `always_active` (cash_parking 用): 常時 target = active
  - `entry_required`: ENTRY/HALF か建玉保有中のみ有効。未通過 (WATCH/NG/評価不能) は active=0 で `cash_fallback_symbol` へ退避積み増し
  - どちらでもない銘柄は従来挙動 (常時枠) — 挙動変更ゼロ
  - 退避は**同一通貨のみ** (為替を跨ぐ自動退避はしない)
- **cash rebalance 発注 (flag on 時のみ)**: cron pass 1 で全銘柄の段階判定 snapshot を収集 → allocation 計算 → 退避先/always_active 銘柄の不足分を **BUY-only 差分**で pass 2 発注。`cashRebalanceQuantityMap` 指定銘柄は pullback 判定を bypass するが、**lot fail-closed / per-symbol risk gate / buying-power pool / pending lock / DRY_RUN (MockExecution) は通常 BUY と同一経路**
- **ダッシュボード**: grid panel に target / active 並記 (「設定上 5% だが現在は SGOV に退避中」「+5% 退避受入」)、銘柄フォームに 3 field 追加

## Safety / fail-closed

- `cash_fallback_orders_enabled` は **default off** — on にするまで判定・表示のみ。allocation 計算自体は常に行い `analysis.allocation` に残す
- 自動 SELL はしない (BUY-only)。退避元の再 entry 時の取り崩しは operator 判断 (後続 issue)
- price / lot / fx 欠落の cash 銘柄は発注計画から除外 (skip 理由を analysis に記録)
- 上限は min(差分, symbol max_notional, 通貨別 global max_order_notional)
- DRY_RUN / TRADING_ENABLED / drawdown kill / inverse_pairs は全経路維持

## 有効化手順 (staging 検証後)

```
wrangler d1 execute <env> --command "UPDATE global_config SET cash_fallback_orders_enabled = 1 WHERE id = 'default'"
```

## Test

- `pnpm test`: 99 files / 1401 tests pass (新規: conditionalAllocation 14 / scheduler 4 / CRUD 3 / 表示 3)
- `pnpm typecheck`: pass

Refs #452 (PR 1: #453 / PR 2: #454)。merge 後 #449 / #450 / #451 は #452 に supersede。