### PR TITLE
POC Phase follow-up: low_volatility / sector_trend / inverse_hedge role の有効化 (issue #457)

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -8398,9 +8398,9 @@ const SYMBOL_ROLE_LABELS_SHORT: Record<SymbolRole, string> = {
   cash_parking: '待機資金ETF',
   core_trend: '非レバ・トレンド',
   leveraged_trend: 'レバETF・トレンド',
-  low_volatility: '低ボラ (entry 無効)',
-  sector_trend: 'セクター (entry 無効)',
-  inverse_hedge: 'インバース (entry 無効)',
+  low_volatility: '低ボラ',
+  sector_trend: 'セクター',
+  inverse_hedge: 'インバースヘッジ (短期)',
 }
 
 /** role select の表示ラベル (#452)。値は DB enum と同一、表示だけ日本語補足。 */
@@ -8408,9 +8408,9 @@ const SYMBOL_ROLE_LABELS: Record<SymbolRole, string> = {
   cash_parking: 'cash_parking — 待機資金 ETF (SGOV / BIL 等)',
   core_trend: 'core_trend — 非レバ・トレンド (QQQ / VOO 等)',
   leveraged_trend: 'leveraged_trend — レバ ETF (TQQQ / SOXL 等)',
-  low_volatility: 'low_volatility — 低ボラ (定義のみ・entry 無効)',
-  sector_trend: 'sector_trend — セクター (定義のみ・entry 無効)',
-  inverse_hedge: 'inverse_hedge — インバース (定義のみ・entry 無効)',
+  low_volatility: 'low_volatility — 低ボラ ETF (USMV / SPLV 等)',
+  sector_trend: 'sector_trend — 1x セクター ETF (SMH / SOXX 等)',
+  inverse_hedge: 'inverse_hedge — 3x インバース・短期 (SQQQ / SOXS。1x は override 必須)',
 }
 
 /** 一覧テーブルの「ロール」セル (#452)。role + 配分の条件連動を 1 セルに要約する。 */
@@ -8651,7 +8651,7 @@ function symbolFormBody(args: SymbolFormArgs): string {
         ).join('')}
       </select>
       ${roleIsKnown ? '' : '<p class="err" style="margin:4px 0 0;font-size:11px">DB に enum 外の role 値が入っています。この銘柄の entry は抑止中 (fail-closed)。正しい role か「未設定」を明示的に選んで保存してください。</p>'}
-      <p class="muted" style="margin:4px 0 0;font-size:11px">銘柄の戦略ロール (#452)。<strong>core_trend</strong> は非レバ向けの緩い entry プリセット、<strong>leveraged_trend</strong> は従来どおり。<strong>cash_parking / low_volatility / sector_trend / inverse_hedge は現状 BUY を生成しません</strong> (entry 抑止、exit は通常どおり)。空欄 = 従来挙動。</p>
+      <p class="muted" style="margin:4px 0 0;font-size:11px">銘柄の戦略ロール (#452 / #457)。role ごとの entry/exit プリセットが適用されます (個別 override が優先)。<strong>inverse_hedge は短期保有プリセット (time stop 5日)・3x インバース前提</strong>。<strong>cash_parking は BUY を生成しません</strong> (配分は条件連動配分が扱う)。空欄 = 従来挙動。</p>
     </div>
     <label>押し目バンド override <span class="muted" style="font-size:11px">(%)</span></label>
     <div>

--- a/src/trading/strategy/symbolRuleResolution.ts
+++ b/src/trading/strategy/symbolRuleResolution.ts
@@ -12,10 +12,13 @@ import type { SymbolRule } from './strategies/PullbackUptrendStrategy'
  *   そもそもレバ ETF 向けに調整されてきた値のため)
  * - `core_trend`: 非レバ ETF (QQQ / VOO 等) 向けの緩いプリセット。レバ ETF の
  *   1/3 程度の値動きしかないので、押し目深度・トレンド閾値をスケールダウン
- *   しないと事実上 entry 不可能になる (#449 課題2)。**初期値であり backtest
- *   チューニングは #452 非スコープ (後続 issue)** — 個別銘柄で合わない場合は
- *   per-symbol override で吸収する。
- * - その他の role はプリセットなし (entry 自体が抑止される、下記)。
+ *   しないと事実上 entry 不可能になる (#449 課題2)。
+ * - `low_volatility` / `sector_trend` / `inverse_hedge`: #457 で有効化。設計根拠
+ *   (ボラスケーリング・守る失敗モード) は issue #457 参照。
+ *
+ * **全 preset の数値は backtest 未検証の初期推定** — 個別銘柄で合わない場合は
+ * per-symbol override で吸収し、チューニングは後続 issue。迷う値は一貫して
+ * 「トレードが減る側」(fail-closed) を採用している。
  */
 export const ROLE_RULE_PRESETS: Partial<Record<SymbolRole, Partial<SymbolRule>>> = {
   leveraged_trend: {},
@@ -30,21 +33,75 @@ export const ROLE_RULE_PRESETS: Partial<Record<SymbolRole, Partial<SymbolRule>>>
     // +20% に引き下げ (ガードとして機能する値にする)。
     maxSma50DeviationPct: 0.2,
   },
+  // USMV / SPLV (年率ボラ ~12%、日次 ~0.5%)。entry と exit の両方を約 1/3〜1/5
+  // にスケールダウン — レバ向け global では entry gate が永久に開かず (-3% の
+  // 押しが稀)、exit が永久に閉じない (-4% stop は 4-5σ、+7% TP は数ヶ月モノ)。
+  low_volatility: {
+    // 20d +1.5% ≈ 年率 ~20% ペース = 低ボラ ETF の「明確な上昇」下限。
+    minReturn50d: 0.015,
+    // 10d 高値から ~0.6σ の押し。-3% 超 (~2σ) はレジーム破綻疑いで買わない。
+    pullbackMax: -0.01,
+    pullbackMin: -0.03,
+    // +10% 乖離はほぼ起きない値 → ガードとして機能する水準に。
+    maxSma50DeviationPct: 0.1,
+    // ボラ圧縮プロダクトの前提 (ATR が baseline 近傍) が壊れた局面で entry しない。
+    maxAtrRatio: 1.3,
+    // exit 側: stop -1.5% ≈ 3 日分の通常変動、TP +2.5% ≈ 15 営業日の ~1.3σ
+    // (R:R ~1.67)。低ボラの mean-reversion は解決が遅いので time stop は 15 日
+    // (preset 中唯一「保有を増やす」側の変更)。
+    stopPct: -0.015,
+    takeProfitPct: 0.025,
+    timeStopDays: 15,
+  },
+  // SMH / SOXX / XLK (1x セクター、core_trend と global の中間ボラ ~1.5x QQQ)。
+  // entry 側のみ中間値にスケールし、**exit は global 据え置き** (stop -4% ≈ 日次
+  // 2-2.5σ で floor として妥当、変更点を entry 4 つに絞って overfit を避ける)。
+  // 注意: SMH/SOXX は SOXL と原資産がほぼ同一 — leveraged_trend と同時有効化
+  // するとセクター集中が起きる。rule preset では守れず配分側の責務 (#457)。
+  sector_trend: {
+    minReturn50d: 0.04,
+    pullbackMax: -0.02,
+    pullbackMin: -0.05,
+    // 強気相場の SMH は SMA50 +20% 超まで走る — 0.2 は切りすぎ、0.6 は効かない。
+    maxSma50DeviationPct: 0.3,
+  },
+  // SQQQ / SOXS (3x インバース)。市場下落レジームでの inverse 押し目買い。
+  // daily-rebalance のボラ drag が保有日数に複利で効くため **短期保有・早い退出**。
+  // trend filter (inverse 自身の 20d リターン) がレジーム判定を兼ねる。
+  // **PSQ 等 1x インバースにはこの preset は合わない** (minReturn50d 0.15 は
+  // 1x では発火不能) — 使う場合は per-symbol override で吸収する (#457)。
+  inverse_hedge: {
+    // SQQQ +15%/20d ≈ QQQ -5%。チョップ域 (drag で構造的に負ける) を弾く。
+    minReturn50d: 0.15,
+    // panic spike の頂点圏 (+40% 乖離超) で買わない — 次は bear rally の確率大。
+    maxSma50DeviationPct: 0.4,
+    // 1 週間で決着しなければ手仕舞い。レジーム継続なら trend gate が再 entry を
+    // 承認するので長く持つ必要がない。
+    timeStopDays: 5,
+    // bear rally (1 日 +5-10% の逆行が普通) を「通常変動」として耐えない。
+    kAtr: 1.5,
+  },
 }
 
 /**
- * Entry (BUY 生成) が有効な role。`undefined` (= role NULL、従来挙動) と
- * 初期有効化 3 role のうち pullback gate を通す 2 つ。
+ * Entry (BUY 生成) が有効な role。`undefined` (= role NULL、従来挙動) もこの
+ * 集合とは別に常に有効。
  *
  * - `cash_parking` は pullback 判定が無意味 (SMA50 / 押し目が成立しない) なので
  *   strategy 経由の BUY を抑止する。配分は #452 PR 3 の条件連動配分
  *   (`always_active`) が別経路で扱う。
- * - `low_volatility` / `sector_trend` / `inverse_hedge` は定義のみ (後続 issue)。
- *   特に inverse_hedge に long pullback ロジックをそのまま適用するのは誤りなので
- *   fail-closed で抑止する。
- * - repo が enum 外 DB 値を正規化した 'unknown' もここに含まれない (= 抑止)。
+ * - `low_volatility` / `sector_trend` / `inverse_hedge` は #457 で preset 付きで
+ *   有効化。inverse_hedge は inverse_pairs 排他 gate (両建て防止) が引き続き
+ *   下流で効く。
+ * - repo が enum 外 DB 値を正規化した 'unknown' はここに含まれない (= 抑止)。
  */
-const ENTRY_ENABLED_ROLES: ReadonlySet<SymbolRole> = new Set(['core_trend', 'leveraged_trend'])
+const ENTRY_ENABLED_ROLES: ReadonlySet<SymbolRole> = new Set([
+  'core_trend',
+  'leveraged_trend',
+  'low_volatility',
+  'sector_trend',
+  'inverse_hedge',
+])
 
 /**
  * 段階判定 HALF (0.5x entry) を有効にする symbol 集合を作る (#452 PR 2)。

--- a/test/trading/strategy/pullbackScheduler.test.ts
+++ b/test/trading/strategy/pullbackScheduler.test.ts
@@ -2076,3 +2076,40 @@ describe('runPullbackScheduler cash rebalance / entry snapshots (#452 Layer 3)',
     expect(summary.rejected[0]?.reason).toContain('missing-lot-size')
   })
 })
+
+describe('inverse_hedge role enabled but inverse-pair gate still wins (#457)', () => {
+  it('role 有効化後も相手保有中の BUY は inverse-pair gate で reject', async () => {
+    // #457 で inverse_hedge の entry 抑止は外れた (= buildEntrySuppressedSymbols
+    // が空を返す) が、両建て防止 (inverse_pairs) は下流で引き続き効くこと。
+    const { buildEntrySuppressedSymbols } = await import(
+      '../../../src/trading/strategy/symbolRuleResolution'
+    )
+    const suppressed = buildEntrySuppressedSymbols({ SQQQ: 'inverse_hedge' })
+    expect(suppressed).toEqual({})
+
+    const execution = mockExecution()
+    const counterpartHeld: SymbolState = {
+      ...emptySymbolState('TQQQ', () => now),
+      position: { qty: 2, avgPrice: 50, openedAt: now.toISOString() },
+    }
+    const summary = await runPullbackScheduler({
+      symbols: ['SQQQ'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({ TQQQ: counterpartHeld }),
+      execution,
+      entrySuppressedSymbols: suppressed,
+      perSymbolRisk: {
+        inversePairs: { SQQQ: 'TQQQ', TQQQ: 'SQQQ' },
+        spreadLimits: { US: 0.0025, JP: 0.006 },
+        staleQuoteMs: 900_000,
+        gapRejectPct: 0.03,
+      },
+      now: () => now,
+    })
+    expect(summary.buys).toBe(0)
+    expect(execution.calls).toHaveLength(0)
+    const reject = summary.decisions.find((d) => d.decision === 'REJECT')
+    expect(reject?.reason).toContain('inverse')
+  })
+})

--- a/test/trading/strategy/symbolRuleResolution.test.ts
+++ b/test/trading/strategy/symbolRuleResolution.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildEntrySuppressedSymbols,
+  buildHalfEntrySymbols,
   buildSymbolRules,
   ROLE_RULE_PRESETS,
   type SymbolRuleOverrides,
@@ -109,8 +110,8 @@ describe('buildSymbolRules (#452)', () => {
   })
 })
 
-describe('buildEntrySuppressedSymbols (#452)', () => {
-  it('suppresses cash_parking / defined-only roles / unknown, keeps trend roles', () => {
+describe('buildEntrySuppressedSymbols (#452 / #457)', () => {
+  it('suppresses only cash_parking and unknown after #457 enabled the remaining roles', () => {
     const suppressed = buildEntrySuppressedSymbols({
       SGOV: 'cash_parking',
       QQQ: 'core_trend',
@@ -120,12 +121,86 @@ describe('buildEntrySuppressedSymbols (#452)', () => {
       SQQQ: 'inverse_hedge',
       WEIRD: 'unknown',
     })
-    expect(Object.keys(suppressed).sort()).toEqual(['SGOV', 'SMH', 'SQQQ', 'USMV', 'WEIRD'])
+    expect(Object.keys(suppressed).sort()).toEqual(['SGOV', 'WEIRD'])
     expect(suppressed.SGOV).toContain('cash_parking')
     expect(suppressed.WEIRD).toContain('unknown role')
   })
 
   it('returns an empty map when no symbol has a role (従来挙動)', () => {
     expect(buildEntrySuppressedSymbols({})).toEqual({})
+  })
+})
+
+describe('role presets for low_volatility / sector_trend / inverse_hedge (#457)', () => {
+  it('low_volatility rescales both entry and exit sides', () => {
+    const overrides = emptyOverrides()
+    overrides.symbolRole.USMV = 'low_volatility'
+    const rules = buildSymbolRules(TEST_DEFAULT_RULE, overrides)
+    expect(rules.USMV).toEqual({
+      ...TEST_DEFAULT_RULE,
+      minReturn50d: 0.015,
+      pullbackMax: -0.01,
+      pullbackMin: -0.03,
+      maxSma50DeviationPct: 0.1,
+      maxAtrRatio: 1.3,
+      stopPct: -0.015,
+      takeProfitPct: 0.025,
+      timeStopDays: 15,
+    })
+  })
+
+  it('sector_trend adjusts the entry side only — exits stay global (回帰保証)', () => {
+    const overrides = emptyOverrides()
+    overrides.symbolRole.SMH = 'sector_trend'
+    const rules = buildSymbolRules(TEST_DEFAULT_RULE, overrides)
+    expect(rules.SMH!.minReturn50d).toBe(0.04)
+    expect(rules.SMH!.pullbackMax).toBe(-0.02)
+    expect(rules.SMH!.pullbackMin).toBe(-0.05)
+    expect(rules.SMH!.maxSma50DeviationPct).toBe(0.3)
+    // exit 据え置き (issue #457: 変更点を entry 4 つに絞る)
+    expect(rules.SMH!.stopPct).toBe(TEST_DEFAULT_RULE.stopPct)
+    expect(rules.SMH!.takeProfitPct).toBe(TEST_DEFAULT_RULE.takeProfitPct)
+    expect(rules.SMH!.timeStopDays).toBe(TEST_DEFAULT_RULE.timeStopDays)
+    expect(rules.SMH!.kAtr).toBe(TEST_DEFAULT_RULE.kAtr)
+    expect(rules.SMH!.maxAtrRatio).toBe(TEST_DEFAULT_RULE.maxAtrRatio)
+  })
+
+  it('inverse_hedge demands a strong down-regime and holds short', () => {
+    const overrides = emptyOverrides()
+    overrides.symbolRole.SQQQ = 'inverse_hedge'
+    const rules = buildSymbolRules(TEST_DEFAULT_RULE, overrides)
+    expect(rules.SQQQ!.minReturn50d).toBe(0.15)
+    expect(rules.SQQQ!.maxSma50DeviationPct).toBe(0.4)
+    expect(rules.SQQQ!.timeStopDays).toBe(5)
+    expect(rules.SQQQ!.kAtr).toBe(1.5)
+    // 据え置き分 (同ボラクラス / fail-closed で緩めない)
+    expect(rules.SQQQ!.stopPct).toBe(TEST_DEFAULT_RULE.stopPct)
+    expect(rules.SQQQ!.takeProfitPct).toBe(TEST_DEFAULT_RULE.takeProfitPct)
+    expect(rules.SQQQ!.pullbackMax).toBe(TEST_DEFAULT_RULE.pullbackMax)
+    expect(rules.SQQQ!.pullbackMin).toBe(TEST_DEFAULT_RULE.pullbackMin)
+    expect(rules.SQQQ!.requireAboveSma50).toBe(true)
+    expect(rules.SQQQ!.maxAtrRatio).toBe(TEST_DEFAULT_RULE.maxAtrRatio)
+  })
+
+  it('per-symbol override still beats the new presets (PSQ 等 1x inverse の吸収経路)', () => {
+    const overrides = emptyOverrides()
+    overrides.symbolRole.PSQ = 'inverse_hedge'
+    overrides.symbolMinReturn50dOverride.PSQ = 0.05
+    overrides.symbolStopPctOverride.PSQ = -0.015
+    const rules = buildSymbolRules(TEST_DEFAULT_RULE, overrides)
+    expect(rules.PSQ!.minReturn50d).toBe(0.05)
+    expect(rules.PSQ!.stopPct).toBe(-0.015)
+    expect(rules.PSQ!.timeStopDays).toBe(5) // override しない field は preset
+  })
+
+  it('all three roles are half-entry enabled (#457)', () => {
+    const enabled = buildHalfEntrySymbols({
+      USMV: 'low_volatility',
+      SMH: 'sector_trend',
+      SQQQ: 'inverse_hedge',
+      SGOV: 'cash_parking',
+      WEIRD: 'unknown',
+    })
+    expect([...enabled].sort()).toEqual(['SMH', 'SQQQ', 'USMV'])
   })
 })


### PR DESCRIPTION
## Summary

#452 で「定義のみ (entry 抑止)」だった 3 role に preset を与えて有効化 (#457 の設計どおり)。

- **`low_volatility`** (USMV/SPLV): entry/exit 両方を 1/3〜1/5 にスケールダウン (trend +1.5%/20d、押し目 -1%〜-3%、stop -1.5% / TP +2.5% / time stop 15日、maxAtrRatio 1.3)
- **`sector_trend`** (SMH/SOXX): entry 側のみ core_trend と global の中間値 (trend +4%、押し目 -2%〜-5%、過伸長 +30%)。**exit は global 据え置き** (回帰テストで保証)
- **`inverse_hedge`** (SQQQ/SOXS、3x 前提): 強い下落レジームのみ (trend +15%/20d ≈ QQQ -5%)、**time stop 5日** (ボラ drag 対策)、kAtr 1.5、過伸長 +40% (panic 天井で買わない)。**PSQ 等 1x inverse は preset 対象外 — per-symbol override で吸収** (コード註記あり)
- 3 role とも段階判定 HALF (0.5x) の対象に
- dashboard の role ラベルから「(定義のみ・entry 無効)」を除去

## Safety / fail-closed

- 各値は「トレードが減る側」に倒した初期推定 (backtest は後続)
- `cash_parking` / enum 外 `'unknown'` の entry 抑止は従来どおり
- **inverse_pairs 排他 gate は role 有効化後も優先** — 相手保有中の BUY reject を scheduler テストで担保
- role NULL の既存銘柄は無影響

## Test

- `pnpm test`: 99 files / 1413 tests pass (新規: preset 5 / 抑止回帰 1 / inverse gate 1)
- `pnpm typecheck`: pass

## 有効化順の推奨 (staging)

issue #457 のとおり sector_trend → low_volatility → inverse_hedge の順に role を割り当てて観察 (inverse_hedge は「BUY ゼロが続くのが正常」— decision log の WATCH/NG 分布で gate の生存確認)。

Closes #457 / Refs #452

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 銘柄ロール説明をETF種別と運用想定を含めた内容に更新しました。
  * 新たな銘柄ロール（low_volatility、sector_trend、inverse_hedge）に対応するエントリー・エグジット閾値を追加しました。
  * 複数銘柄ロールでのエントリー判定ロジックを拡張しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->