### PR TITLE
POC Phase follow-up: TICKER_IS_DENY 自動停止ガード (issue #460)

### DIFF
--- a/src/infrastructure/db/symbolConfigRepo.ts
+++ b/src/infrastructure/db/symbolConfigRepo.ts
@@ -596,6 +596,36 @@ export async function updateSymbolConfig(
  * 観測する可能性があるが、DB 上の state 自体は SQL NOT で atomic に
  * flip するので冪等性は壊れない。POC scope では許容。
  */
+/**
+ * Broker が銘柄単位で発注拒否 (TICKER_IS_DENY 等の恒久エラー) を返したとき、
+ * cron が該当銘柄を fail-closed で自動 entry 停止する (#460)。
+ *
+ * - `active = 0` + notes に理由を**追記** (既存メモは保持、256 chars に切詰め)
+ * - 既に inactive なら no-op (`null` 返却) — 同 tick 内の並走や再検知で
+ *   notes が重複追記されない冪等ガード
+ * - 解除 (再有効化) は operator の明示操作のみ。自動では戻さない
+ */
+export async function deactivateSymbolForBrokerDeny(
+  db: DrizzleD1Database,
+  symbol: string,
+  reasonNote: string,
+  nowIso: string,
+): Promise<{ before: SymbolConfigRow; after: SymbolConfigRow } | null> {
+  const upper = symbol.trim().toUpperCase()
+  const before = await findSymbolConfig(db, upper)
+  if (before === null || !before.active) return null
+  const beforeSnapshot: SymbolConfigRow = { ...before }
+  const existingNotes = before.notes?.trim() ?? ''
+  const mergedNotes = (existingNotes.length > 0 ? `${existingNotes} / ${reasonNote}` : reasonNote).slice(0, 256)
+  await db
+    .update(symbolConfig)
+    .set({ active: false, notes: mergedNotes, updatedAt: nowIso })
+    .where(eq(symbolConfig.symbol, upper))
+  const after = await findSymbolConfig(db, upper)
+  if (after === null) return null
+  return { before: beforeSnapshot, after }
+}
+
 export async function toggleSymbolActive(
   db: DrizzleD1Database,
   symbol: string,

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -152,6 +152,21 @@ export function isSellQtyExceedError(error: unknown): error is BrokerClientError
   return error.message.includes(WEBULL_SELL_QTY_EXCEED_CODE)
 }
 
+/**
+ * Webull JP OpenAPI の銘柄単位の取扱拒否 (#460)。USMV で本番実証: 銘柄が
+ * OpenAPI の取引対象外だと place order が 417 + この error_code を返す。
+ * **恒久エラー** (リトライ・signing・token の問題ではない) なので、検知したら
+ * 該当銘柄を自動 entry 停止する (tickerDenyGuard)。
+ */
+export const WEBULL_TICKER_DENY_CODE = 'OAUTH_OPENAPI_TICKER_IS_DENY'
+
+/** True when Webull rejected the order because the ticker is not tradable via OpenAPI (#460). */
+export function isTickerDenyError(error: unknown): error is BrokerClientError {
+  if (!(error instanceof BrokerClientError)) return false
+  if (error.brokerStatus !== 417) return false
+  return error.message.includes(WEBULL_TICKER_DENY_CODE)
+}
+
 // Planned but deferred per issue #1 §13:
 // RiskRejectedError, BrokerResponseError, ConfigurationError,
 // TradeEventIngestError, BridgeConnectionError.

--- a/src/trading/risk/tickerDenyGuard.ts
+++ b/src/trading/risk/tickerDenyGuard.ts
@@ -1,0 +1,91 @@
+import type { DrizzleD1Database } from 'drizzle-orm/d1'
+import { recordChange } from '../../infrastructure/db/configAuditLog'
+import { deactivateSymbolForBrokerDeny } from '../../infrastructure/db/symbolConfigRepo'
+import type { Notifier } from '../../infrastructure/notification/Notifier'
+
+/**
+ * TICKER_IS_DENY 自動停止ガード (#460)。
+ *
+ * Webull が銘柄単位の恒久的な発注拒否 (`OAUTH_OPENAPI_TICKER_IS_DENY`、USMV で
+ * 本番実証) を返した場合、cooldown は約定後にしか付かないため、entry 条件が
+ * 成立し続ける限り 5 分 cron ごとに実 submit → 417 を繰り返してしまう。
+ * このガードは検知した銘柄を fail-closed で自動 entry 停止する:
+ *
+ *   1. `symbol_config.active = 0` + notes に理由・日時を追記 (既存メモ保持)
+ *   2. config_audit_log に actor='cron:ticker-deny-guard' で before/after を記録
+ *      (cron による self-mutation を operator が後追いできるように)
+ *   3. STATE_CHANGE を **1 回だけ** 通知 (inactive 化により次 tick から評価
+ *      対象外になるので、毎 tick の ERROR 通知スパムが構造的に止まる)
+ *
+ * 解除は operator の明示操作 (dashboard の有効化ボタン) のみ。自動再試行しない。
+ * ガード自身の失敗は握りつぶしてログだけ残す — 停止に失敗しても次 tick で
+ * 同じ 417 → 再検知されるので、cron 本体を巻き込まない方が安全。
+ */
+export interface TickerDenyGuardDeps {
+  db: DrizzleD1Database
+  /** audit log 用の raw D1 binding (recordChange が直接受ける)。 */
+  rawDb: D1Database
+  notifier: Notifier
+  requestId?: string
+  now?: () => Date
+}
+
+export function createTickerDenyGuard(deps: TickerDenyGuardDeps): (symbol: string) => Promise<void> {
+  return async (symbol: string): Promise<void> => {
+    const upper = symbol.trim().toUpperCase()
+    const nowIso = (deps.now ?? (() => new Date()))().toISOString()
+    try {
+      const reasonNote = `Webull TICKER_IS_DENY により自動停止 (${nowIso.slice(0, 10)}, #460)`
+      const result = await deactivateSymbolForBrokerDeny(deps.db, upper, reasonNote, nowIso)
+      if (result === null) {
+        // 既に inactive (並走 / 再検知) — 冪等 no-op。通知も出さない。
+        return
+      }
+      await recordChange(deps.rawDb, {
+        actor: 'cron:ticker-deny-guard',
+        endpoint: 'cron:strategy',
+        targetKey: `symbol_config:${upper}`,
+        before: { active: result.before.active, notes: result.before.notes },
+        after: { active: result.after.active, notes: result.after.notes },
+        requestId: deps.requestId ?? null,
+      }).catch((err) => {
+        console.error(
+          JSON.stringify({
+            event: 'ticker_deny_guard_audit_failed',
+            symbol: upper,
+            requestId: deps.requestId ?? null,
+            message: err instanceof Error ? err.message : String(err),
+          }),
+        )
+      })
+      // 「実発注を止める向き」の遷移なので severity は warning (critical だと
+      // ops 即対応扱いになるが、ここは既に安全側に倒した後の事後報告)。
+      await deps.notifier
+        .notify({
+          type: 'STATE_CHANGE',
+          field: `symbol_config.${upper}.active`,
+          from: true,
+          to: false,
+          severity: 'warning',
+          note: `Webull が銘柄単位で発注拒否 (TICKER_IS_DENY) — ${upper} を自動 entry 停止しました。再有効化は operator 操作のみ (#460)`,
+        })
+        .catch(() => undefined)
+      console.warn(
+        JSON.stringify({
+          event: 'ticker_deny_guard_deactivated',
+          symbol: upper,
+          requestId: deps.requestId ?? null,
+        }),
+      )
+    } catch (err) {
+      console.error(
+        JSON.stringify({
+          event: 'ticker_deny_guard_failed',
+          symbol: upper,
+          requestId: deps.requestId ?? null,
+          message: err instanceof Error ? err.message : String(err),
+        }),
+      )
+    }
+  }
+}

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -2,7 +2,7 @@ import type { BarClient } from '../../infrastructure/quotes/BarClient'
 import { logPostSubmit, logPreSubmit } from '../../infrastructure/logger/tradeJournal'
 import { classifyBrokerErrorCause } from '../../infrastructure/notification/brokerErrorSurge'
 import type { Notifier } from '../../infrastructure/notification/Notifier'
-import { isSellQtyExceedError } from '../../shared/errors'
+import { isSellQtyExceedError, isTickerDenyError } from '../../shared/errors'
 import type { DecisionTraceStep } from '../domain/Signal'
 import { inferTradingMarket, isWithinUsCloseWindow } from '../domain/tradingCalendar'
 import type { Execution } from '../execution/Execution'
@@ -202,6 +202,16 @@ export interface PullbackSchedulerOptions {
    * off の間は runStrategyCron がこの map を渡さない。
    */
   cashRebalanceQuantityMap?: Record<string, number>
+  /**
+   * TICKER_IS_DENY 自動停止 hook (#460)。BUY submit が Webull の銘柄単位の
+   * 恒久拒否 (`OAUTH_OPENAPI_TICKER_IS_DENY`) で失敗したとき、該当 symbol を
+   * 引数に 1 回呼ばれる。production (`runStrategyCron`) は
+   * `createTickerDenyGuard` (symbol_config の自動 inactive 化 + audit + 通知)
+   * を注入する。未注入なら従来挙動 (毎 tick 再送)。hook 内の失敗は hook 側で
+   * 握りつぶす契約 (scheduler は await するだけ)。SELL では呼ばない — 万一
+   * exit 側で deny が出ても銘柄を評価対象から外すと建玉が orphan になるため。
+   */
+  onTickerDeny?: (symbol: string) => Promise<void>
   /**
    * sanity_failed cooldown gate。直近 N 分以内に同 symbol で broker stub
    * fill (`resolveFilledPrice` が ratio guard で reject した) が観測されて
@@ -1110,6 +1120,12 @@ export async function runPullbackScheduler(
           // error ではない) なら legacy の `'broker submit'` に戻す。
           cause: classifyBrokerErrorCause(error) ?? 'broker submit',
         })
+        // TICKER_IS_DENY 自動停止 (#460): 銘柄単位の恒久拒否は再送しても解消
+        // しないので、BUY のみ hook で fail-closed に停止する (SELL は対象外 —
+        // exit 経路と建玉の orphan 化を避ける)。
+        if (intent.side === 'BUY' && options.onTickerDeny && isTickerDenyError(error)) {
+          await options.onTickerDeny(upper)
+        }
         try {
           logPostSubmit({
             clientOrderId: intent.clientOrderId,

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -51,6 +51,8 @@ import {
   buildHalfEntrySymbols,
   buildSymbolRules,
 } from './symbolRuleResolution'
+import { createTickerDenyGuard } from '../risk/tickerDenyGuard'
+import { createDb as createSymbolConfigDb } from '../../infrastructure/db/tradeJournalRepo'
 import {
   buildCashRebalancePlan,
   computeConditionalAllocation,
@@ -586,6 +588,17 @@ export async function runStrategyCron(
     ? await resolveBuyingPowerLedger(liveReadClient, usdJpyRate, options.requestId)
     : undefined
 
+  // TICKER_IS_DENY 自動停止ガード (#460)。env.DB がある時だけ有効化 — D1 が
+  // 無いと symbol_config を停止できないので skip (= 従来挙動)。
+  const onTickerDeny = env.DB
+    ? createTickerDenyGuard({
+        db: createSymbolConfigDb(env.DB),
+        rawDb: env.DB,
+        notifier,
+        requestId: options.requestId,
+      })
+    : undefined
+
   for (const run of runs) {
     analysis.runs.push({
       currency: run.currency,
@@ -612,6 +625,7 @@ export async function runStrategyCron(
       rulesMap,
       entrySuppressedSymbols,
       halfEntrySymbols,
+      ...(onTickerDeny ? { onTickerDeny } : {}),
       riskPerTradePct: scaledRiskPerTradePct,
       requestId: options.requestId,
       notifier,
@@ -757,6 +771,7 @@ export async function runStrategyCron(
           execution,
           symbolCapMap: universe.symbolMaxNotional,
           cashRebalanceQuantityMap: Object.fromEntries(orders.map((o) => [o.symbol, o.quantity])),
+          ...(onTickerDeny ? { onTickerDeny } : {}),
           fxJpyPerSymbolCcy: run.currency === 'JPY' ? 1 : (usdJpyRate ?? undefined),
           buyingPower,
           defaultRule,

--- a/test/infrastructure/db/symbolConfigRepo.test.ts
+++ b/test/infrastructure/db/symbolConfigRepo.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
+  deactivateSymbolForBrokerDeny,
   loadInversePairs,
   loadSymbolConfig,
 } from '../../../src/infrastructure/db/symbolConfigRepo'
@@ -385,5 +386,64 @@ describe('loadSymbolConfig role / entry overrides / alternatives (#452)', () => 
     const result = await loadSymbolConfig(fakeDb(rows))
     // self (SOXL) と重複は除去。不正 JSON / 不正 ticker / 空配列 / NULL は map 不在。
     expect(result.symbolAlternatives).toEqual({ SOXL: ['SOXX', 'SMH'] })
+  })
+})
+
+describe('deactivateSymbolForBrokerDeny (#460)', () => {
+  // select (findSymbolConfig) と update を備えた最小 fake。update の set 内容を
+  // in-memory rows に反映し、呼び出し回数も記録する。
+  function fakeRwDb(rows: Array<Record<string, unknown>>) {
+    const updates: Array<Record<string, unknown>> = []
+    const db = {
+      select() {
+        return {
+          from() {
+            return {
+              where: () => ({
+                limit: async () => rows,
+              }),
+            }
+          },
+        }
+      },
+      update() {
+        return {
+          set(values: Record<string, unknown>) {
+            return {
+              where: async () => {
+                updates.push(values)
+                Object.assign(rows[0]!, values)
+              },
+            }
+          },
+        }
+      },
+    }
+    return { db: db as unknown as Parameters<typeof deactivateSymbolForBrokerDeny>[0], updates }
+  }
+
+  it('deactivates and appends the reason to existing notes (既存メモ保持)', async () => {
+    const { db, updates } = fakeRwDb([
+      { symbol: 'USMV', active: true, notes: '手動メモ' },
+    ])
+    const result = await deactivateSymbolForBrokerDeny(db, 'usmv', 'TICKER_IS_DENY により自動停止', 't1')
+    expect(result?.before.active).toBe(true)
+    expect(updates[0]).toMatchObject({ active: false, updatedAt: 't1' })
+    expect(updates[0]!.notes).toBe('手動メモ / TICKER_IS_DENY により自動停止')
+  })
+
+  it('no-ops when the symbol is already inactive (冪等、notes 重複追記なし)', async () => {
+    const { db, updates } = fakeRwDb([
+      { symbol: 'USMV', active: false, notes: 'x' },
+    ])
+    const result = await deactivateSymbolForBrokerDeny(db, 'USMV', 'reason', 't1')
+    expect(result).toBeNull()
+    expect(updates).toHaveLength(0)
+  })
+
+  it('no-ops when the symbol does not exist', async () => {
+    const { db, updates } = fakeRwDb([])
+    expect(await deactivateSymbolForBrokerDeny(db, 'NOPE', 'reason', 't1')).toBeNull()
+    expect(updates).toHaveLength(0)
   })
 })

--- a/test/shared/errors.test.ts
+++ b/test/shared/errors.test.ts
@@ -92,3 +92,35 @@ describe('isSellQtyExceedError', () => {
     expect(isSellQtyExceedError(undefined)).toBe(false)
   })
 })
+
+import { BrokerServerError as _BSE2 } from '../../src/shared/errors'
+import {
+  BrokerClientError as TickerDenyBCE,
+  isTickerDenyError,
+  WEBULL_TICKER_DENY_CODE,
+} from '../../src/shared/errors'
+
+describe('isTickerDenyError (#460)', () => {
+  const denyMessage = `Webull request failed permanently with status 417: {"message":"The current security is not available.","error_code":"${WEBULL_TICKER_DENY_CODE}"}`
+
+  it('matches a 417 BrokerClientError containing the deny code', () => {
+    const err = new TickerDenyBCE(denyMessage, 'placeOrder', { brokerStatus: 417 })
+    expect(isTickerDenyError(err)).toBe(true)
+  })
+
+  it('rejects other 417 business errors (e.g. SELL_QTY_EXCEED)', () => {
+    const err = new TickerDenyBCE(
+      'status 417: {"error_code":"OAUTH_OPENAPI_SELL_QTY_EXCEED_AVAILABLE_QTY"}',
+      'placeOrder',
+      { brokerStatus: 417 },
+    )
+    expect(isTickerDenyError(err)).toBe(false)
+  })
+
+  it('rejects non-417 / non-BrokerClientError', () => {
+    expect(isTickerDenyError(new TickerDenyBCE(denyMessage, 'placeOrder', { brokerStatus: 400 }))).toBe(false)
+    expect(isTickerDenyError(new _BSE2(denyMessage, 'placeOrder', { brokerStatus: 500 }))).toBe(false)
+    expect(isTickerDenyError(new Error(denyMessage))).toBe(false)
+    expect(isTickerDenyError(null)).toBe(false)
+  })
+})

--- a/test/trading/risk/tickerDenyGuard.test.ts
+++ b/test/trading/risk/tickerDenyGuard.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../src/infrastructure/db/symbolConfigRepo', async () => {
+  const actual = await vi.importActual<typeof import('../../../src/infrastructure/db/symbolConfigRepo')>(
+    '../../../src/infrastructure/db/symbolConfigRepo',
+  )
+  return { ...actual, deactivateSymbolForBrokerDeny: vi.fn() }
+})
+vi.mock('../../../src/infrastructure/db/configAuditLog', () => ({
+  recordChange: vi.fn(async () => ({ recorded: true })),
+}))
+
+import { createTickerDenyGuard } from '../../../src/trading/risk/tickerDenyGuard'
+import { deactivateSymbolForBrokerDeny } from '../../../src/infrastructure/db/symbolConfigRepo'
+import { recordChange } from '../../../src/infrastructure/db/configAuditLog'
+
+const fakeRow = (over: Record<string, unknown> = {}) => ({
+  symbol: 'USMV',
+  active: true,
+  notes: null,
+  ...over,
+})
+
+function makeDeps() {
+  const notify = vi.fn(async () => undefined)
+  return {
+    deps: {
+      db: {} as never,
+      rawDb: {} as never,
+      notifier: { notify },
+      requestId: 'req-1',
+      now: () => new Date('2026-06-11T00:00:00.000Z'),
+    },
+    notify,
+  }
+}
+
+describe('createTickerDenyGuard (#460)', () => {
+  beforeEach(() => {
+    vi.mocked(deactivateSymbolForBrokerDeny).mockReset()
+    vi.mocked(recordChange).mockClear()
+  })
+
+  it('deactivates the symbol, records audit (actor=cron) and notifies once', async () => {
+    vi.mocked(deactivateSymbolForBrokerDeny).mockResolvedValue({
+      before: fakeRow() as never,
+      after: fakeRow({ active: false, notes: 'auto' }) as never,
+    })
+    const { deps, notify } = makeDeps()
+    await createTickerDenyGuard(deps as never)('usmv')
+
+    expect(deactivateSymbolForBrokerDeny).toHaveBeenCalledWith(
+      deps.db,
+      'USMV',
+      expect.stringContaining('TICKER_IS_DENY'),
+      '2026-06-11T00:00:00.000Z',
+    )
+    expect(recordChange).toHaveBeenCalledWith(
+      deps.rawDb,
+      expect.objectContaining({
+        actor: 'cron:ticker-deny-guard',
+        targetKey: 'symbol_config:USMV',
+        requestId: 'req-1',
+      }),
+    )
+    expect(notify).toHaveBeenCalledTimes(1)
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'STATE_CHANGE', severity: 'warning', from: true, to: false }),
+    )
+  })
+
+  it('is idempotent: already-inactive symbol → no audit, no notification', async () => {
+    vi.mocked(deactivateSymbolForBrokerDeny).mockResolvedValue(null)
+    const { deps, notify } = makeDeps()
+    await createTickerDenyGuard(deps as never)('USMV')
+    expect(recordChange).not.toHaveBeenCalled()
+    expect(notify).not.toHaveBeenCalled()
+  })
+
+  it('swallows its own failures (cron 本体を巻き込まない)', async () => {
+    vi.mocked(deactivateSymbolForBrokerDeny).mockRejectedValue(new Error('D1 down'))
+    const { deps } = makeDeps()
+    await expect(createTickerDenyGuard(deps as never)('USMV')).resolves.toBeUndefined()
+  })
+
+  it('audit failure does not block the notification (best-effort 並走)', async () => {
+    vi.mocked(deactivateSymbolForBrokerDeny).mockResolvedValue({
+      before: fakeRow() as never,
+      after: fakeRow({ active: false }) as never,
+    })
+    vi.mocked(recordChange).mockRejectedValue(new Error('audit table missing'))
+    const { deps, notify } = makeDeps()
+    await createTickerDenyGuard(deps as never)('USMV')
+    expect(notify).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/trading/strategy/pullbackScheduler.test.ts
+++ b/test/trading/strategy/pullbackScheduler.test.ts
@@ -2113,3 +2113,91 @@ describe('inverse_hedge role enabled but inverse-pair gate still wins (#457)', (
     expect(reject?.reason).toContain('inverse')
   })
 })
+
+describe('runPullbackScheduler TICKER_IS_DENY hook (#460)', () => {
+  const denyError = () =>
+    new BrokerClientError(
+      'Webull request failed permanently with status 417: {"message":"The current security is not available.","error_code":"OAUTH_OPENAPI_TICKER_IS_DENY"}',
+      'placeOrder',
+      { brokerStatus: 417 },
+    )
+
+  function throwingExecution(err: Error): Execution & { calls: unknown[] } {
+    const calls: unknown[] = []
+    return {
+      calls,
+      async execute(intent) {
+        calls.push(intent)
+        throw err
+      },
+    }
+  }
+
+  it('calls onTickerDeny when a BUY submit is denied per-ticker', async () => {
+    const hook = vi.fn(async () => undefined)
+    const summary = await runPullbackScheduler({
+      symbols: ['USMV'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution: throwingExecution(denyError()),
+      onTickerDeny: hook,
+      now: () => now,
+    })
+    expect(hook).toHaveBeenCalledWith('USMV')
+    expect(summary.errors).toHaveLength(1)
+    // 通常の ERROR decision / journal は従来どおり残る (hook は追加動作)
+    expect(summary.decisions.find((d) => d.decision === 'ERROR')?.reason).toContain('TICKER_IS_DENY')
+  })
+
+  it('does not call the hook for other broker errors', async () => {
+    const hook = vi.fn(async () => undefined)
+    await runPullbackScheduler({
+      symbols: ['USMV'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution: throwingExecution(new BrokerServerError('boom', 'placeOrder', { brokerStatus: 500 })),
+      onTickerDeny: hook,
+      now: () => now,
+    })
+    expect(hook).not.toHaveBeenCalled()
+  })
+
+  it('does not call the hook on the SELL path (建玉 orphan 化を避ける)', async () => {
+    // time stop で SELL が出る建玉を持たせ、SELL submit が deny で落ちても
+    // hook は呼ばれない (= 銘柄は評価対象に残り、exit は次 tick で再試行)。
+    const hook = vi.fn(async () => undefined)
+    const heldState: SymbolState = {
+      ...emptySymbolState('USMV', () => now),
+      position: {
+        qty: 5,
+        avgPrice: 80,
+        openedAt: new Date('2026-01-01T00:00:00.000Z').toISOString(),
+      },
+    }
+    const summary = await runPullbackScheduler({
+      symbols: ['USMV'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({ USMV: heldState }),
+      execution: throwingExecution(denyError()),
+      onTickerDeny: hook,
+      now: () => now,
+    })
+    expect(summary.errors).toHaveLength(1)
+    expect(hook).not.toHaveBeenCalled()
+  })
+
+  it('skips the hook when option is omitted (back-compat)', async () => {
+    const summary = await runPullbackScheduler({
+      symbols: ['USMV'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution: throwingExecution(denyError()),
+      now: () => now,
+    })
+    expect(summary.errors).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Summary

USMV 本番事故 (#460) の恒久対策。Webull の銘柄単位恒久拒否 (`OAUTH_OPENAPI_TICKER_IS_DENY`) を受けた銘柄を **fail-closed で自動 entry 停止**する。

- `isTickerDenyError` classifier (`isSellQtyExceedError` と同パターン: BrokerClientError + 417 + error_code)
- scheduler に `onTickerDeny` hook — **BUY submit の deny のみ**で発火 (SELL は対象外: 銘柄を評価から外すと建玉が orphan 化するため)
- `createTickerDenyGuard` (production 注入):
  1. `symbol_config.active = 0` + notes に理由・日時を**追記** (既存メモ保持、`deactivateSymbolForBrokerDeny`)
  2. config_audit_log に `actor='cron:ticker-deny-guard'` で before/after 記録 (cron self-mutation の追跡可能性)
  3. STATE_CHANGE 通知を **1 回だけ** (inactive 化で次 tick から評価対象外 = エラースパムが構造的に止まる)
- 既に inactive なら no-op (冪等)。ガード自身の失敗は握りつぶしてログのみ (次 tick の再検知に任せ、cron 本体を巻き込まない)
- 解除は operator の明示操作のみ。自動で再有効化しない
- pass 2 (cash rebalance #452) の発注経路にも同 hook を注入

## Safety

- 動作方向は常に「発注を止める」側のみ。発注を増やす変更はゼロ
- hook 未注入 (env.DB なし / legacy caller) は従来挙動
- audit 失敗時も通知は出す (best-effort 並走)

## Test

- `pnpm test`: 100 files / 1427 tests pass (新規: classifier 3 / guard 4 / scheduler hook 4 / repo 3)
- `pnpm typecheck`: pass

Closes #460 / Refs #452 #461

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * ブローカーからの銘柄拒否に対応し、当該銘柄の自動停止機能を実装
  * 銘柄の状態変更を監査ログに記録して可視化
  * エラーメッセージからの拒否理由を自動検知し、理由を記録

* **Tests**
  * 自動停止機能および関連する拒否検知ロジックのテストケースを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->