### PR TITLE
fix: broker-probe ページの inline JS 構文エラー (全ボタン無反応) (hotfix)

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -749,12 +749,12 @@ export const admin = new Hono<AppBindings>()
       balanceAccountV1,
       balanceAssetsV2,
       balanceAssetsAccountV2,
+      instrumentStockTrade,
+      instrumentStockTradeAlt,
+      instrumentStockQuotes,
+      instrumentStockQuotesAlt,
       instrumentQuotesHost,
       instrumentTradeHost,
-      instrumentQuotesHostAlt,
-      instrumentTradeHostAlt,
-      tradeSecurity,
-      tradableList,
     ] = await Promise.all([
       // path は WebullQuoteClient.DEFAULT_QUOTE_PATH と一致:
       // /openapi/market-data/stock/snapshot (× /openapi/quotes/v2/...)。
@@ -831,13 +831,41 @@ export const admin = new Hono<AppBindings>()
         query: { account_id: accountId },
         version: 'v2',
       }),
-      // #461: instrument 照会 (銘柄が Webull に登録されているか)。公式 SDK
-      // (webull-python-sdk-mdata) の `GET /instrument/list?symbols&category` (v1)
-      // 相当。JP の他 endpoint と同じく `/openapi` prefix を付け、host が
-      // quotes / trade どちら側かは JP docs 未確定のため両方 probe する
-      // (#415 balance path 確定と同じ手順)。**この照会は「Webull が銘柄を認識
-      // しているか」の近似で、発注 allowlist (TICKER_IS_DENY) とは別系統の
-      // 可能性がある** — 確定的な発注可否ガードは #460 が担う。
+      // #461: instrument 照会 (銘柄が Webull に登録されているか)。
+      // **JP の正しい path は `/openapi/instrument/stock/list`** (JP docs
+      // Trading API > Get Stock Instrument)。汎用 SDK の `/instrument/list` とは
+      // drift しており (#251 と同パターン)、HK 専用の `/trade/security` は JP に
+      // 存在しない。host (trade / quotes) は docs に明記が無いので両方 probe。
+      // category は UI のティッカー推定が ETF/STOCK を取り違え得るため
+      // (CodeRabbit #462) 反対側 category も probe する。
+      probeOnce({
+        method: 'GET',
+        path: '/openapi/instrument/stock/list',
+        query: { symbols: symbol, category },
+        version: 'v1',
+      }),
+      probeOnce({
+        method: 'GET',
+        path: '/openapi/instrument/stock/list',
+        query: { symbols: symbol, category: altCategory },
+        version: 'v1',
+      }),
+      probeOnce({
+        method: 'GET',
+        path: '/openapi/instrument/stock/list',
+        query: { symbols: symbol, category },
+        version: 'v1',
+        host: quotesBaseUrl,
+      }),
+      probeOnce({
+        method: 'GET',
+        path: '/openapi/instrument/stock/list',
+        query: { symbols: symbol, category: altCategory },
+        version: 'v1',
+        host: quotesBaseUrl,
+      }),
+      // 汎用 SDK path (`/instrument/list`) も比較用に残す — data-api が将来
+      // 稼働したときに JP がどちらの path を採るかの drift 検証 (#251 方式)。
       probeOnce({
         method: 'GET',
         path: '/openapi/instrument/list',
@@ -849,47 +877,6 @@ export const admin = new Hono<AppBindings>()
         method: 'GET',
         path: '/openapi/instrument/list',
         query: { symbols: symbol, category },
-        version: 'v1',
-      }),
-      // category の ETF/STOCK は UI のティッカー推定で誤り得る (CodeRabbit #462:
-      // 既知 4 銘柄以外の ETF が *_STOCK で照会され「銘柄情報なし」に誤判定)。
-      // 反対側 category も probe して判定を category 非依存にする。
-      probeOnce({
-        method: 'GET',
-        path: '/openapi/instrument/list',
-        query: { symbols: symbol, category: altCategory },
-        version: 'v1',
-        host: quotesBaseUrl,
-      }),
-      probeOnce({
-        method: 'GET',
-        path: '/openapi/instrument/list',
-        query: { symbols: symbol, category: altCategory },
-        version: 'v1',
-      }),
-      // #461 follow-up: **取引可否の本命候補** (trade host = JP で生きている側)。
-      // 公式 SDK trade モジュール準拠:
-      //   - /trade/security?symbol&market&instrument_super_type — symbol 指定の
-      //     取引可能銘柄照会 (TradeSecurityDetailRequest, v1)
-      //   - /trade/instrument/tradable/list — 口座で取引可能な銘柄の一覧
-      //     (TradeableInstrumentRequest, v1, ページング)
-      // market-data 系 instrument/list (上の 4 probe) が JP 未提供でも、こちらが
-      // 200 を返せば事前チェックが成立する。
-      probeOnce({
-        method: 'GET',
-        path: '/openapi/trade/security',
-        query: {
-          account_id: accountId,
-          symbol,
-          market: category.startsWith('JP') ? 'JP' : 'US',
-          instrument_super_type: 'EQUITY',
-        },
-        version: 'v1',
-      }),
-      probeOnce({
-        method: 'GET',
-        path: '/openapi/trade/instrument/tradable/list',
-        query: { account_id: accountId, page_size: '100' },
         version: 'v1',
       }),
     ])
@@ -937,12 +924,12 @@ export const admin = new Hono<AppBindings>()
       quoteYahoo: quoteYahooResult,
       // #461: instrument 照会 (Webull 取扱の事前チェック近似)。quotes / trade の
       // 両 host 候補。UI は 200 が返った側を採用して判定カードを出す。
+      instrumentStockTrade,
+      instrumentStockTradeAlt,
+      instrumentStockQuotes,
+      instrumentStockQuotesAlt,
       instrumentQuotesHost,
       instrumentTradeHost,
-      instrumentQuotesHostAlt,
-      instrumentTradeHostAlt,
-      tradeSecurity,
-      tradableList,
       readiness: {
         tokenOk: tokenResolved.source === 'do_normal',
         tradeEndpointsOk:

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -753,6 +753,8 @@ export const admin = new Hono<AppBindings>()
       instrumentTradeHost,
       instrumentQuotesHostAlt,
       instrumentTradeHostAlt,
+      tradeSecurity,
+      tradableList,
     ] = await Promise.all([
       // path は WebullQuoteClient.DEFAULT_QUOTE_PATH と一致:
       // /openapi/market-data/stock/snapshot (× /openapi/quotes/v2/...)。
@@ -865,6 +867,31 @@ export const admin = new Hono<AppBindings>()
         query: { symbols: symbol, category: altCategory },
         version: 'v1',
       }),
+      // #461 follow-up: **取引可否の本命候補** (trade host = JP で生きている側)。
+      // 公式 SDK trade モジュール準拠:
+      //   - /trade/security?symbol&market&instrument_super_type — symbol 指定の
+      //     取引可能銘柄照会 (TradeSecurityDetailRequest, v1)
+      //   - /trade/instrument/tradable/list — 口座で取引可能な銘柄の一覧
+      //     (TradeableInstrumentRequest, v1, ページング)
+      // market-data 系 instrument/list (上の 4 probe) が JP 未提供でも、こちらが
+      // 200 を返せば事前チェックが成立する。
+      probeOnce({
+        method: 'GET',
+        path: '/openapi/trade/security',
+        query: {
+          account_id: accountId,
+          symbol,
+          market: category.startsWith('JP') ? 'JP' : 'US',
+          instrument_super_type: 'EQUITY',
+        },
+        version: 'v1',
+      }),
+      probeOnce({
+        method: 'GET',
+        path: '/openapi/trade/instrument/tradable/list',
+        query: { account_id: accountId, page_size: '100' },
+        version: 'v1',
+      }),
     ])
 
     // 診断 payload は raw broker レスポンスを含むので browser / 中間 cache に
@@ -914,6 +941,8 @@ export const admin = new Hono<AppBindings>()
       instrumentTradeHost,
       instrumentQuotesHostAlt,
       instrumentTradeHostAlt,
+      tradeSecurity,
+      tradableList,
       readiness: {
         tokenOk: tokenResolved.source === 'do_normal',
         tradeEndpointsOk:

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -2047,8 +2047,8 @@ function brokerProbeBody(args: {
     ];
     if (rawTarget) {
       rawTarget.textContent = candidates.map(function (cnd) {
-        return '--- ' + cnd.label + ' ---\n' + prettify(cnd.section);
-      }).join('\n\n');
+        return '--- ' + cnd.label + ' ---\\n' + prettify(cnd.section);
+      }).join('\\n\\n');
     }
     if (!bodyEl) return;
     var responded = [];

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -2037,59 +2037,24 @@ function brokerProbeBody(args: {
   function renderInstrumentCard(body, symbol) {
     var bodyEl = document.getElementById('bp-instrument-body');
     var rawTarget = document.getElementById('bp-instrument-raw');
-    // category は UI のティッカー推定なので ETF/STOCK を取り違え得る — server が
-    // 反対側 category も probe しており (CodeRabbit #462)、4 候補すべてを見る。
+    // JP の正しい path は /openapi/instrument/stock/list (JP docs Trading API >
+    // Get Stock Instrument、#461)。host 未確定のため trade / quotes 両方、かつ
+    // category 推定の取り違え対策 (CodeRabbit #462) で ETF/STOCK 両 category を
+    // 並べる。末尾 2 つは汎用 SDK path の drift 検証用 (#251 方式)。
     var candidates = [
-      { label: 'quotes host', section: body.instrumentQuotesHost },
-      { label: 'trade host', section: body.instrumentTradeHost },
-      { label: 'quotes host (alt category)', section: body.instrumentQuotesHostAlt },
-      { label: 'trade host (alt category)', section: body.instrumentTradeHostAlt },
-    ];
-    var tradeCandidates = [
-      { label: 'trade/security', section: body.tradeSecurity },
-      { label: 'trade/instrument/tradable/list', section: body.tradableList },
+      { label: 'stock/list (trade host)', section: body.instrumentStockTrade },
+      { label: 'stock/list (trade host, alt category)', section: body.instrumentStockTradeAlt },
+      { label: 'stock/list (quotes host)', section: body.instrumentStockQuotes },
+      { label: 'stock/list (quotes host, alt category)', section: body.instrumentStockQuotesAlt },
+      { label: 'instrument/list (quotes host, 汎用 path)', section: body.instrumentQuotesHost },
+      { label: 'instrument/list (trade host, 汎用 path)', section: body.instrumentTradeHost },
     ];
     if (rawTarget) {
-      rawTarget.textContent = tradeCandidates.concat(candidates).map(function (cnd) {
+      rawTarget.textContent = candidates.map(function (cnd) {
         return '--- ' + cnd.label + ' ---\\n' + prettify(cnd.section);
       }).join('\\n\\n');
     }
     if (!bodyEl) return;
-
-    // 本命: trade/security (#461 follow-up)。symbol 指定の取引可能銘柄照会で、
-    // 200 + 中身があれば「発注対象として取引可能」の直接の根拠になる。
-    var sec = body.tradeSecurity;
-    if (sec && sec.phase === 'response') {
-      var secBody = parseBody(sec);
-      if (sec.status === 200 && secBody != null) {
-        var secItems = Array.isArray(secBody) ? secBody : (Array.isArray(secBody.data) ? secBody.data : [secBody]);
-        var nonEmpty = secItems.length > 0 && secItems[0] && Object.keys(secItems[0]).length > 0;
-        if (nonEmpty) {
-          setPill('bp-instrument-pill', 'ok', '取引可能');
-          var first = secItems[0];
-          var secFields = [];
-          if (first.instrument_id) secFields.push('instrument_id: <code>' + escHtml(first.instrument_id) + '</code>');
-          if (first.instrument_type) secFields.push('type: <code>' + escHtml(first.instrument_type) + '</code>');
-          if (first.symbol) secFields.push('symbol: <code>' + escHtml(first.symbol) + '</code>');
-          bodyEl.innerHTML = '<strong>' + escHtml(symbol.toUpperCase()) + '</strong> は取引可能銘柄として照会できました (via trade/security)。<br>' +
-            '<span class="muted" style="font-size:12px">' + (secFields.join(' ・ ') || '(詳細は raw 参照)') + '</span>';
-          return;
-        }
-        setPill('bp-instrument-pill', 'ng', '取扱なし');
-        bodyEl.innerHTML = '<strong>' + escHtml(symbol.toUpperCase()) + '</strong> は trade/security 照会で空応答 — ' +
-          '<span style="color:#c22">取引対象外の可能性が高い (発注すると TICKER_IS_DENY 見込み)。</span>';
-        return;
-      }
-      var secErrBody = secBody;
-      if (secErrBody && typeof secErrBody === 'object' && secErrBody.error_code) {
-        setPill('bp-instrument-pill', 'ng', '取扱なし');
-        bodyEl.innerHTML = '<strong>' + escHtml(symbol.toUpperCase()) + '</strong> — trade/security が <code>' + escHtml(secErrBody.error_code) + '</code> を返しました。' +
-          '<span style="color:#c22">取引対象外の可能性が高い。</span> <span class="muted">(raw 参照)</span>';
-        return;
-      }
-      // 404 等 = endpoint 自体が未提供 → market-data 系候補へ fall through
-    }
-
     var responded = [];
     for (var i = 0; i < candidates.length; i++) {
       var sct = candidates[i].section;
@@ -2099,13 +2064,12 @@ function brokerProbeBody(args: {
       }
     }
     if (responded.length === 0) {
-      var statuses = candidates.slice(0, 2).map(function (cnd) {
+      var statuses = [candidates[0], candidates[2]].map(function (cnd) {
         return escHtml(cnd.label) + ': ' + escHtml(humanizeError(cnd.section));
       }).join(' ／ ');
       setPill('bp-instrument-pill', 'unknown', '判定不可');
-      bodyEl.innerHTML = 'instrument endpoint が 200 を返しませんでした (' + statuses + ')。' +
-        '<span class="muted">quotes host (data-api) の無応答は既知 (#21、quote は Yahoo 移行済み)。trade host の 404 は endpoint 未提供。' +
-        '判定不可のときの発注可否は実発注の結果 (#460 の自動停止ガード) で確定します。</span>';
+      bodyEl.innerHTML = 'instrument/stock/list が 200 を返しませんでした (' + statuses + ')。' +
+        '<span class="muted">quotes host (data-api) の無応答は既知 (#21)。判定不可のときの発注可否は実発注の結果 (#460 の自動停止ガード) で確定します。</span>';
       return;
     }
     // どれか 1 候補にでも symbol が出てくれば「銘柄情報あり」(category 非依存)。

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -2115,6 +2115,10 @@ function brokerProbeBody(args: {
     }
     var parsed = parseBody(section);
     var item = Array.isArray(parsed) ? parsed[0] : parsed;
+    // Yahoo chart API は価格が chart.result[0].meta に入る (#461 follow-up)。
+    if (item && item.chart && Array.isArray(item.chart.result) && item.chart.result[0] && item.chart.result[0].meta) {
+      item = item.chart.result[0].meta;
+    }
     var price = null;
     for (var i = 0; item && i < priceKeys.length; i++) {
       var v = item[priceKeys[i]];

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -2127,6 +2127,14 @@ function brokerProbeBody(args: {
       var v = item[priceKeys[i]];
       if (v != null && Number.isFinite(Number(v))) { price = Number(v); break; }
     }
+    // 大きい body は probe 側で truncate され JSON.parse が失敗する (Yahoo chart
+    // は 30KB 超)。価格 key を regex で直接拾う fallback。
+    if (price == null && typeof section.bodyTruncated === 'string') {
+      for (var r = 0; r < priceKeys.length; r++) {
+        var m = section.bodyTruncated.match(new RegExp('"' + priceKeys[r] + '"\\s*:\\s*(-?[0-9.]+)'));
+        if (m && Number.isFinite(Number(m[1]))) { price = Number(m[1]); break; }
+      }
+    }
     var ms = Number(section.msTaken) || 0;
     bodyEl.innerHTML = price != null
       ? '<span style="font-size:18px;font-weight:700" class="bp-num">' + escHtml(formatNumber(price)) + '</span> <span class="muted" style="font-size:11px">(' + ms + 'ms)</span>'

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -2045,12 +2045,51 @@ function brokerProbeBody(args: {
       { label: 'quotes host (alt category)', section: body.instrumentQuotesHostAlt },
       { label: 'trade host (alt category)', section: body.instrumentTradeHostAlt },
     ];
+    var tradeCandidates = [
+      { label: 'trade/security', section: body.tradeSecurity },
+      { label: 'trade/instrument/tradable/list', section: body.tradableList },
+    ];
     if (rawTarget) {
-      rawTarget.textContent = candidates.map(function (cnd) {
+      rawTarget.textContent = tradeCandidates.concat(candidates).map(function (cnd) {
         return '--- ' + cnd.label + ' ---\\n' + prettify(cnd.section);
       }).join('\\n\\n');
     }
     if (!bodyEl) return;
+
+    // 本命: trade/security (#461 follow-up)。symbol 指定の取引可能銘柄照会で、
+    // 200 + 中身があれば「発注対象として取引可能」の直接の根拠になる。
+    var sec = body.tradeSecurity;
+    if (sec && sec.phase === 'response') {
+      var secBody = parseBody(sec);
+      if (sec.status === 200 && secBody != null) {
+        var secItems = Array.isArray(secBody) ? secBody : (Array.isArray(secBody.data) ? secBody.data : [secBody]);
+        var nonEmpty = secItems.length > 0 && secItems[0] && Object.keys(secItems[0]).length > 0;
+        if (nonEmpty) {
+          setPill('bp-instrument-pill', 'ok', '取引可能');
+          var first = secItems[0];
+          var secFields = [];
+          if (first.instrument_id) secFields.push('instrument_id: <code>' + escHtml(first.instrument_id) + '</code>');
+          if (first.instrument_type) secFields.push('type: <code>' + escHtml(first.instrument_type) + '</code>');
+          if (first.symbol) secFields.push('symbol: <code>' + escHtml(first.symbol) + '</code>');
+          bodyEl.innerHTML = '<strong>' + escHtml(symbol.toUpperCase()) + '</strong> は取引可能銘柄として照会できました (via trade/security)。<br>' +
+            '<span class="muted" style="font-size:12px">' + (secFields.join(' ・ ') || '(詳細は raw 参照)') + '</span>';
+          return;
+        }
+        setPill('bp-instrument-pill', 'ng', '取扱なし');
+        bodyEl.innerHTML = '<strong>' + escHtml(symbol.toUpperCase()) + '</strong> は trade/security 照会で空応答 — ' +
+          '<span style="color:#c22">取引対象外の可能性が高い (発注すると TICKER_IS_DENY 見込み)。</span>';
+        return;
+      }
+      var secErrBody = secBody;
+      if (secErrBody && typeof secErrBody === 'object' && secErrBody.error_code) {
+        setPill('bp-instrument-pill', 'ng', '取扱なし');
+        bodyEl.innerHTML = '<strong>' + escHtml(symbol.toUpperCase()) + '</strong> — trade/security が <code>' + escHtml(secErrBody.error_code) + '</code> を返しました。' +
+          '<span style="color:#c22">取引対象外の可能性が高い。</span> <span class="muted">(raw 参照)</span>';
+        return;
+      }
+      // 404 等 = endpoint 自体が未提供 → market-data 系候補へ fall through
+    }
+
     var responded = [];
     for (var i = 0; i < candidates.length; i++) {
       var sct = candidates[i].section;

--- a/test/routes/dashboardBrokerProbe.test.ts
+++ b/test/routes/dashboardBrokerProbe.test.ts
@@ -29,7 +29,7 @@ describe('/dashboard/broker-probe カード UI (#461)', () => {
     // CodeRabbit #462: XSS escape helper / 失敗時リセット / alt-category 候補
     expect(body).toContain('function escHtml(')
     expect(body).toContain('function resetProbeView(')
-    expect(body).toContain('instrumentQuotesHostAlt')
+    expect(body).toContain('instrumentStockTrade')
   })
 
   it('control の AAPL chip と再 probe ボタンがある', async () => {

--- a/test/routes/dashboardInlineScripts.test.ts
+++ b/test/routes/dashboardInlineScripts.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { createApp } from '../../src/app'
+
+/**
+ * Inline <script> の構文回帰テスト。dashboard の JS は TS テンプレートリテラル
+ * 内に手書きされており、`\n` (TS で実改行に展開) と `\\n` (rendered JS の
+ * escape) の取り違えで **ページ全体の click handler が無音で死ぬ** 事故が
+ * 実際に起きた (#462 後の staging で broker-probe が全ボタン無反応)。
+ * 抽出した script を `new Function` で parse して構文エラーを CI で検出する。
+ */
+const baseEnv = { ACCESS_DEV_BYPASS_USER: 'admin' }
+
+async function inlineScriptsOf(path: string): Promise<string[]> {
+  const app = createApp()
+  const res = await app.request(path, {}, baseEnv as never)
+  expect(res.status).toBe(200)
+  const body = await res.text()
+  const blocks = [...body.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]!)
+  expect(blocks.length).toBeGreaterThan(0)
+  return blocks
+}
+
+describe('dashboard inline scripts parse (#462 regression)', () => {
+  it('/dashboard/broker-probe の全 inline script が構文エラーなく parse できる', async () => {
+    for (const code of await inlineScriptsOf('/dashboard/broker-probe')) {
+      // 構文エラーなら new Function が SyntaxError を throw する (実行はしない)。
+      expect(() => new Function(code)).not.toThrow()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

#462 の編集で TS テンプレートリテラル内の `\\n` (rendered JS 用 escape) を `\n` (TS が実改行に展開) にしてしまい、broker-probe ページの inline script 全体が SyntaxError → **ページ上の全ボタンが無反応** (staging で実発生)。

- escape を修正 (2 箇所)
- **回帰テスト追加**: ページの inline script を抽出して `new Function` で parse — 構文破壊は CI で落ちる

## Test

`pnpm test`: 102 files / 1430 tests pass / `pnpm typecheck` pass

Refs #461 #462

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 管理向けプローブ診断で追加の銘柄照会チェックを並列実行し、複数候補の結果を応答に含めるようにしました。

* **Bug Fixes**
  * broker-probe の生データ表示をセクション区切りで整形し、エラーメッセージと失敗時の状況要約を改善しました。
  * 外部チャート応答の構造差異に対応し、価格抽出の安定性を向上しました。

* **Tests**
  * ダッシュボード内インラインスクリプトを構文解析する回帰テストを追加し、描画テストの期待値を調整しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->