### PR TITLE
POC Phase follow-up: Preview Order による発注前の取扱チェック (issue #461)

### DIFF
--- a/src/infrastructure/webull/tradabilityCheck.ts
+++ b/src/infrastructure/webull/tradabilityCheck.ts
@@ -1,0 +1,208 @@
+import type { Env } from '../../config/env'
+import { buildSignedHeaders } from './WebullAuth'
+import { resolveAccessToken } from './resolveAccessToken'
+import { toWebullPlaceOrderRequest } from './mapper'
+
+/**
+ * 銘柄の Webull JP 取扱チェック (#461)。Preview Order
+ * (`POST /openapi/account/orders/preview`) で発注パイプラインの検証だけを通す —
+ * **注文は作成されない** (path は preview 固定)。取扱外銘柄は検証段階で
+ * `TICKER_IS_DENY` が返るため、発注せずに取引可否を確定できる。
+ *
+ * body shape は JP 実測で確定途中 (#461: v1 place 形は OPENAPI_PARAM_ERR) の
+ * ため、候補 shape を並列で試す (#415 の path 確定と同じ方式)。判定は:
+ *   - どれかが 200            → 'tradable'
+ *   - どれかが TICKER_IS_DENY → 'denied' (確定)
+ *   - 応答はあるが全部エラー   → 'error' (銘柄以外の要因の可能性)
+ *   - 設定不足 / 全部不達      → 'unavailable'
+ *
+ * 'denied' 以外で登録をブロックしない想定 (check 不能時に全登録が止まるのは
+ * 過剰 fail-closed — 発注側には #460 の事後ガードが別途ある)。
+ */
+
+export type TradabilityVerdict = 'tradable' | 'denied' | 'error' | 'unavailable'
+
+export interface TradabilityVariantResult {
+  label: string
+  status: number | null
+  errorCode: string | null
+  message: string | null
+}
+
+export interface TradabilityResult {
+  verdict: TradabilityVerdict
+  /** operator 向けの 1 行説明。 */
+  detail: string
+  variants: TradabilityVariantResult[]
+}
+
+/**
+ * Preview Order に試す body shape 候補 (#461)。確定したら 1 つに絞る。
+ * broker/probe (診断ページ) と form チェックの両方がこれを共有する。
+ */
+export function buildPreviewOrderVariants(
+  symbol: string,
+  market: 'US' | 'JP',
+  price: number,
+  accountId: string,
+): Array<{ label: string; body: unknown }> {
+  const baseEntry = {
+    symbol,
+    instrument_type: 'EQUITY',
+    market,
+    side: 'BUY',
+    quantity: '1',
+    time_in_force: 'DAY',
+    entrust_type: 'QTY',
+    account_tax_type: 'GENERAL',
+  }
+  return [
+    {
+      // production place (v1 mapper) と同形: client_order_id + MARKET + limit cap
+      label: 'v1-place-shape',
+      body: toWebullPlaceOrderRequest(
+        {
+          symbol,
+          side: 'BUY',
+          quantity: 1,
+          price,
+          notional: price,
+          clientOrderId: `probe-preview-${crypto.randomUUID()}`,
+        },
+        'v1',
+        accountId,
+      ),
+    },
+    {
+      // JP preview docs (preview-order-v2) の field 集合: client_order_id なし、
+      // v2 session enum
+      label: 'v2-fields-market',
+      body: {
+        new_orders: [
+          {
+            ...baseEntry,
+            order_type: 'MARKET',
+            support_trading_session: 'CORE',
+            limit_price: price.toFixed(3),
+          },
+        ],
+      },
+    },
+    {
+      label: 'v2-fields-limit',
+      body: {
+        new_orders: [
+          {
+            ...baseEntry,
+            order_type: 'LIMIT',
+            support_trading_session: 'CORE',
+            limit_price: price.toFixed(3),
+          },
+        ],
+      },
+    },
+  ]
+}
+
+const PREVIEW_PATH = '/openapi/account/orders/preview'
+const DEFAULT_TRADE_API_BASE = 'https://api.webull.co.jp'
+const PREVIEW_TIMEOUT_MS = 10_000
+
+interface CheckInput {
+  symbol: string
+  market: 'US' | 'JP'
+  /** preview の limit cap。未指定は 100 (shape 確定までの placeholder)。 */
+  price?: number
+  /** test seam。default は globalThis.fetch。 */
+  fetcher?: typeof fetch
+}
+
+export async function checkTradability(env: Env, input: CheckInput): Promise<TradabilityResult> {
+  const appKey = (env.WEBULL_APP_KEY ?? '').trim()
+  const appSecret = (env.WEBULL_APP_SECRET ?? '').trim()
+  const accountId = (env.WEBULL_ACCOUNT_ID_JP_CASH ?? '').trim()
+  if (appKey.length === 0 || appSecret.length === 0 || accountId.length === 0) {
+    return {
+      verdict: 'unavailable',
+      detail: 'Webull credentials 未設定のため検証不可',
+      variants: [],
+    }
+  }
+  const symbol = input.symbol.trim().toUpperCase()
+  const price = Number.isFinite(input.price) && (input.price as number) > 0 ? (input.price as number) : 100
+  const baseUrl = (env.WEBULL_TRADE_API_BASE ?? '').trim() || DEFAULT_TRADE_API_BASE
+  const accessToken = await resolveAccessToken(env).catch(() => undefined)
+  const doFetch = input.fetcher ?? fetch
+  const variants = buildPreviewOrderVariants(symbol, input.market, price, accountId)
+
+  const results: TradabilityVariantResult[] = await Promise.all(
+    variants.map(async (variant): Promise<TradabilityVariantResult> => {
+      const url = new URL(PREVIEW_PATH, `${baseUrl}/`)
+      url.searchParams.set('account_id', accountId)
+      const payload = JSON.stringify(variant.body)
+      try {
+        const headers = await buildSignedHeaders({
+          method: 'POST',
+          path: url.pathname,
+          query: { account_id: accountId },
+          body: payload,
+          host: url.host,
+          appKey,
+          appSecret,
+          version: 'v1',
+          ...(accessToken !== undefined ? { accessToken } : {}),
+        })
+        const controller = new AbortController()
+        const timeoutId = setTimeout(() => controller.abort(), PREVIEW_TIMEOUT_MS)
+        try {
+          const response = await doFetch(url.href, {
+            method: 'POST',
+            headers: { Accept: 'application/json', 'Content-Type': 'application/json', ...headers },
+            body: payload,
+            signal: controller.signal,
+          })
+          const text = await response.text()
+          let errorCode: string | null = null
+          let message: string | null = null
+          try {
+            const parsed = JSON.parse(text) as { error_code?: unknown; message?: unknown }
+            errorCode = typeof parsed.error_code === 'string' ? parsed.error_code : null
+            message = typeof parsed.message === 'string' ? parsed.message : null
+          } catch {
+            // 非 JSON 応答は status だけで判定
+          }
+          return { label: variant.label, status: response.status, errorCode, message }
+        } finally {
+          clearTimeout(timeoutId)
+        }
+      } catch (err) {
+        return {
+          label: variant.label,
+          status: null,
+          errorCode: null,
+          message: err instanceof Error ? err.message : String(err),
+        }
+      }
+    }),
+  )
+
+  if (results.some((r) => r.status === 200)) {
+    return { verdict: 'tradable', detail: '発注前検証 (Preview Order) 通過 — 取引可能', variants: results }
+  }
+  if (results.some((r) => r.errorCode === 'OAUTH_OPENAPI_TICKER_IS_DENY')) {
+    return {
+      verdict: 'denied',
+      detail: 'Webull JP の OpenAPI では発注できない銘柄 (TICKER_IS_DENY)',
+      variants: results,
+    }
+  }
+  if (results.some((r) => r.status !== null)) {
+    const codes = [...new Set(results.map((r) => r.errorCode).filter(Boolean))].join(', ')
+    return {
+      verdict: 'error',
+      detail: `検証エラー (${codes || 'unknown'}) — 銘柄以外の要因の可能性`,
+      variants: results,
+    }
+  }
+  return { verdict: 'unavailable', detail: 'broker に到達できず判定不可', variants: results }
+}

--- a/src/infrastructure/webull/tradabilityCheck.ts
+++ b/src/infrastructure/webull/tradabilityCheck.ts
@@ -22,6 +22,14 @@ import { toWebullPlaceOrderRequest } from './mapper'
 
 export type TradabilityVerdict = 'tradable' | 'denied' | 'error' | 'unavailable'
 
+/**
+ * 銘柄単位の恒久拒否コード判定。Webull は `OAUTH_OPENAPI_` prefix 付き/なしの
+ * 両方の表記が観測されているため suffix で判定する (CodeRabbit #466)。
+ */
+export function isTickerDenyCode(errorCode: string | null): boolean {
+  return errorCode !== null && errorCode.endsWith('TICKER_IS_DENY')
+}
+
 export interface TradabilityVariantResult {
   label: string
   status: number | null
@@ -206,7 +214,7 @@ export async function checkTradability(env: Env, input: CheckInput): Promise<Tra
 
   // deny 判定を 200 判定より先に — 200 body に埋まった deny を「取引可能」と
   // 誤読しない (status より error_code を信じる)。
-  if (results.some((r) => r.errorCode === 'OAUTH_OPENAPI_TICKER_IS_DENY')) {
+  if (results.some((r) => isTickerDenyCode(r.errorCode))) {
     return {
       verdict: 'denied',
       detail: 'Webull JP の OpenAPI では発注できない銘柄 (TICKER_IS_DENY)',
@@ -219,13 +227,6 @@ export async function checkTradability(env: Env, input: CheckInput): Promise<Tra
     return {
       verdict: 'tradable',
       detail: `発注前検証 (Preview Order) 通過 — 取引可能${cost ? ` (estimated_cost: ${cost})` : ''}`,
-      variants: results,
-    }
-  }
-  if (results.some((r) => r.errorCode === 'OAUTH_OPENAPI_TICKER_IS_DENY')) {
-    return {
-      verdict: 'denied',
-      detail: 'Webull JP の OpenAPI では発注できない銘柄 (TICKER_IS_DENY)',
       variants: results,
     }
   }

--- a/src/infrastructure/webull/tradabilityCheck.ts
+++ b/src/infrastructure/webull/tradabilityCheck.ts
@@ -27,6 +27,8 @@ export interface TradabilityVariantResult {
   status: number | null
   errorCode: string | null
   message: string | null
+  /** 判定根拠の確認用 (200 偽陽性の調査 #461)。先頭 300 chars。 */
+  bodyExcerpt?: string
 }
 
 export interface TradabilityResult {
@@ -171,7 +173,23 @@ export async function checkTradability(env: Env, input: CheckInput): Promise<Tra
           } catch {
             // 非 JSON 応答は status だけで判定
           }
-          return { label: variant.label, status: response.status, errorCode, message }
+          // HTTP 200 でも batch 系 API は per-order エラーを body に埋めることが
+          // ある (本番 place の deny と staging preview 200 の矛盾調査 #461)。
+          // top-level の error_code に加え body 全文も走査する。
+          if (errorCode === null && /TICKER_IS_DENY/.test(text)) {
+            errorCode = 'OAUTH_OPENAPI_TICKER_IS_DENY'
+          }
+          if (errorCode === null && response.status === 200 && /"error_code"/.test(text)) {
+            const m = text.match(/"error_code"\s*:\s*"([A-Z0-9_]+)"/)
+            if (m) errorCode = m[1]!
+          }
+          return {
+            label: variant.label,
+            status: response.status,
+            errorCode,
+            message,
+            bodyExcerpt: text.slice(0, 300),
+          }
         } finally {
           clearTimeout(timeoutId)
         }
@@ -186,8 +204,23 @@ export async function checkTradability(env: Env, input: CheckInput): Promise<Tra
     }),
   )
 
-  if (results.some((r) => r.status === 200)) {
-    return { verdict: 'tradable', detail: '発注前検証 (Preview Order) 通過 — 取引可能', variants: results }
+  // deny 判定を 200 判定より先に — 200 body に埋まった deny を「取引可能」と
+  // 誤読しない (status より error_code を信じる)。
+  if (results.some((r) => r.errorCode === 'OAUTH_OPENAPI_TICKER_IS_DENY')) {
+    return {
+      verdict: 'denied',
+      detail: 'Webull JP の OpenAPI では発注できない銘柄 (TICKER_IS_DENY)',
+      variants: results,
+    }
+  }
+  const cleanOk = results.find((r) => r.status === 200 && r.errorCode === null)
+  if (cleanOk) {
+    const cost = cleanOk.bodyExcerpt?.match(/"estimated_cost"\s*:\s*"?([0-9.]+)"?/)?.[1]
+    return {
+      verdict: 'tradable',
+      detail: `発注前検証 (Preview Order) 通過 — 取引可能${cost ? ` (estimated_cost: ${cost})` : ''}`,
+      variants: results,
+    }
   }
   if (results.some((r) => r.errorCode === 'OAUTH_OPENAPI_TICKER_IS_DENY')) {
     return {

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -11,7 +11,10 @@ import {
   resolveAccessTokenWithSource,
 } from '../infrastructure/webull/resolveAccessToken'
 import { WebullAuth } from '../infrastructure/webull/WebullAuth'
-import { toWebullPlaceOrderRequest } from '../infrastructure/webull/mapper'
+import {
+  buildPreviewOrderVariants,
+  checkTradability,
+} from '../infrastructure/webull/tradabilityCheck'
 import { WebullTokenClient } from '../infrastructure/webull/WebullTokenClient'
 import { WebullTokenStateClient } from '../trading/state/WebullTokenStateClient'
 import { buildSignedHeaders } from '../infrastructure/webull/WebullAuth'
@@ -901,67 +904,9 @@ export const admin = new Hono<AppBindings>()
     if (c.req.query('preview') === '1') {
       const priceRaw = Number(c.req.query('price'))
       const previewPrice = Number.isFinite(priceRaw) && priceRaw > 0 ? priceRaw : 100
-      const market = category.startsWith('JP') ? 'JP' : 'US'
-      // 初回実測 (#461) で v1 mapper body は OPENAPI_PARAM_ERR — JP preview の
-      // docs は v2 系 (preview-order-v2) で field 集合が place v1 と違う可能性が
-      // 高い。どの shape が通るか確定するため variant を並列で試す (#415 方式)。
-      // どれも注文は作成しない (path は preview 固定)。
-      const baseEntry = {
-        symbol,
-        instrument_type: 'EQUITY',
-        market,
-        side: 'BUY',
-        quantity: '1',
-        time_in_force: 'DAY',
-        entrust_type: 'QTY',
-        account_tax_type: 'GENERAL',
-      }
-      const variants: Array<{ label: string; body: unknown }> = [
-        {
-          // production place (v1 mapper) と同形: client_order_id + MARKET +
-          // limit cap + session 'N'
-          label: 'v1-place-shape',
-          body: toWebullPlaceOrderRequest(
-            {
-              symbol,
-              side: 'BUY',
-              quantity: 1,
-              price: previewPrice,
-              notional: previewPrice,
-              clientOrderId: `probe-preview-${crypto.randomUUID()}`,
-            },
-            'v1',
-            accountId,
-          ),
-        },
-        {
-          // JP preview docs の field 集合 (client_order_id なし、v2 session enum)
-          label: 'v2-fields-market',
-          body: {
-            new_orders: [
-              {
-                ...baseEntry,
-                order_type: 'MARKET',
-                support_trading_session: 'CORE',
-                limit_price: previewPrice.toFixed(3),
-              },
-            ],
-          },
-        },
-        {
-          label: 'v2-fields-limit',
-          body: {
-            new_orders: [
-              {
-                ...baseEntry,
-                order_type: 'LIMIT',
-                support_trading_session: 'CORE',
-                limit_price: previewPrice.toFixed(3),
-              },
-            ],
-          },
-        },
-      ]
+      const market = (category.startsWith('JP') ? 'JP' : 'US') as 'US' | 'JP'
+      // body shape 候補は form チェック (#461 tradabilityCheck) と共有。
+      const variants = buildPreviewOrderVariants(symbol, market, previewPrice, accountId)
       const results = await Promise.all(
         variants.map((v) =>
           probeOnce({
@@ -1805,6 +1750,27 @@ export const admin = new Hono<AppBindings>()
    * Yahoo 障害時は `matches: []` を返して client は手動入力に fallback。
    * Access auth + ADMIN_WRITE rate-limit を通る。
    */
+  /**
+   * 銘柄の Webull JP 取扱チェック (#461)。登録フォームが symbol 選択時に呼ぶ。
+   * Preview Order (発注しない注文検証) で TICKER_IS_DENY を発注前に引く。
+   * 'denied' のみ登録ブロック対象 — 'error' / 'unavailable' は通す (check 不能で
+   * 全登録が止まるのは過剰 fail-closed。発注側には #460 の事後ガードがある)。
+   */
+  .get('/symbol-config/tradability-check', rateLimit('ADMIN_WRITE'), async (c) => {
+    c.header('Cache-Control', 'no-store')
+    const symbolRaw = (c.req.query('symbol') ?? '').trim().toUpperCase()
+    if (!/^[A-Z0-9]{1,10}$/.test(symbolRaw)) {
+      return c.json({ error: 'invalid symbol' }, 400)
+    }
+    const market = (c.req.query('market') ?? 'US').trim().toUpperCase() === 'JP' ? 'JP' : 'US'
+    const priceRaw = Number(c.req.query('price'))
+    const result = await checkTradability(c.env, {
+      symbol: symbolRaw,
+      market,
+      ...(Number.isFinite(priceRaw) && priceRaw > 0 ? { price: priceRaw } : {}),
+    })
+    return c.json(result)
+  })
   .get('/symbol-config/lookup', rateLimit('ADMIN_WRITE'), async (c) => {
     const queryRaw = c.req.query('q') ?? c.req.query('symbol') ?? ''
     const query = queryRaw.trim().toUpperCase()

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -897,30 +897,83 @@ export const admin = new Hono<AppBindings>()
     // でのみ実行する。body は production の place order と同じ mapper を使い
     // (qty=1 の BUY、limit cap は Yahoo 価格 or 100)、**path は place ではなく
     // preview に固定** — 注文は作成されない。
-    let previewOrder: ProbeResult | null = null
+    let previewVariants: Array<{ label: string; result: ProbeResult }> | null = null
     if (c.req.query('preview') === '1') {
       const priceRaw = Number(c.req.query('price'))
       const previewPrice = Number.isFinite(priceRaw) && priceRaw > 0 ? priceRaw : 100
-      const schema = c.env.WEBULL_PLACE_ORDER_SCHEMA === 'v2' ? ('v2' as const) : ('v1' as const)
-      const previewBody = toWebullPlaceOrderRequest(
+      const market = category.startsWith('JP') ? 'JP' : 'US'
+      // 初回実測 (#461) で v1 mapper body は OPENAPI_PARAM_ERR — JP preview の
+      // docs は v2 系 (preview-order-v2) で field 集合が place v1 と違う可能性が
+      // 高い。どの shape が通るか確定するため variant を並列で試す (#415 方式)。
+      // どれも注文は作成しない (path は preview 固定)。
+      const baseEntry = {
+        symbol,
+        instrument_type: 'EQUITY',
+        market,
+        side: 'BUY',
+        quantity: '1',
+        time_in_force: 'DAY',
+        entrust_type: 'QTY',
+        account_tax_type: 'GENERAL',
+      }
+      const variants: Array<{ label: string; body: unknown }> = [
         {
-          symbol,
-          side: 'BUY',
-          quantity: 1,
-          price: previewPrice,
-          notional: previewPrice,
-          clientOrderId: `probe-preview-${crypto.randomUUID()}`,
+          // production place (v1 mapper) と同形: client_order_id + MARKET +
+          // limit cap + session 'N'
+          label: 'v1-place-shape',
+          body: toWebullPlaceOrderRequest(
+            {
+              symbol,
+              side: 'BUY',
+              quantity: 1,
+              price: previewPrice,
+              notional: previewPrice,
+              clientOrderId: `probe-preview-${crypto.randomUUID()}`,
+            },
+            'v1',
+            accountId,
+          ),
         },
-        schema,
-        accountId,
+        {
+          // JP preview docs の field 集合 (client_order_id なし、v2 session enum)
+          label: 'v2-fields-market',
+          body: {
+            new_orders: [
+              {
+                ...baseEntry,
+                order_type: 'MARKET',
+                support_trading_session: 'CORE',
+                limit_price: previewPrice.toFixed(3),
+              },
+            ],
+          },
+        },
+        {
+          label: 'v2-fields-limit',
+          body: {
+            new_orders: [
+              {
+                ...baseEntry,
+                order_type: 'LIMIT',
+                support_trading_session: 'CORE',
+                limit_price: previewPrice.toFixed(3),
+              },
+            ],
+          },
+        },
+      ]
+      const results = await Promise.all(
+        variants.map((v) =>
+          probeOnce({
+            method: 'POST',
+            path: '/openapi/account/orders/preview',
+            query: { account_id: accountId },
+            version: 'v1',
+            body: JSON.stringify(v.body),
+          }),
+        ),
       )
-      previewOrder = await probeOnce({
-        method: 'POST',
-        path: schema === 'v2' ? '/openapi/trade/order/preview' : '/openapi/account/orders/preview',
-        query: schema === 'v2' ? {} : { account_id: accountId },
-        version: schema,
-        body: JSON.stringify(previewBody),
-      })
+      previewVariants = variants.map((v, i) => ({ label: v.label, result: results[i]! }))
     }
 
     // 診断 payload は raw broker レスポンスを含むので browser / 中間 cache に
@@ -972,7 +1025,7 @@ export const admin = new Hono<AppBindings>()
       instrumentStockQuotesAlt,
       instrumentQuotesHost,
       instrumentTradeHost,
-      previewOrder,
+      previewVariants,
       readiness: {
         tokenOk: tokenResolved.source === 'do_normal',
         tradeEndpointsOk:

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -904,7 +904,14 @@ export const admin = new Hono<AppBindings>()
     if (c.req.query('preview') === '1') {
       const priceRaw = Number(c.req.query('price'))
       const previewPrice = Number.isFinite(priceRaw) && priceRaw > 0 ? priceRaw : 100
-      const market = (category.startsWith('JP') ? 'JP' : 'US') as 'US' | 'JP'
+      // category の typo を US に黙って丸めない (CodeRabbit #466) — preview は
+      // 表示と保存可否に直結するので許容値以外は 400。
+      if (!/^(US|JP)_(STOCK|ETF)$/.test(category)) {
+        throw new ValidationError(`unsupported category for preview: ${category}`, {
+          field: 'category',
+        })
+      }
+      const market = (category.startsWith('JP_') ? 'JP' : 'US') as 'US' | 'JP'
       // body shape 候補は form チェック (#461 tradabilityCheck) と共有。
       const variants = buildPreviewOrderVariants(symbol, market, previewPrice, accountId)
       const results = await Promise.all(
@@ -1762,7 +1769,11 @@ export const admin = new Hono<AppBindings>()
     if (!/^[A-Z0-9]{1,10}$/.test(symbolRaw)) {
       return c.json({ error: 'invalid symbol' }, 400)
     }
-    const market = (c.req.query('market') ?? 'US').trim().toUpperCase() === 'JP' ? 'JP' : 'US'
+    const marketRaw = (c.req.query('market') ?? '').trim().toUpperCase()
+    if (marketRaw !== 'US' && marketRaw !== 'JP') {
+      return c.json({ error: 'market must be US or JP' }, 400)
+    }
+    const market = marketRaw
     const priceRaw = Number(c.req.query('price'))
     const result = await checkTradability(c.env, {
       symbol: symbolRaw,

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -11,6 +11,7 @@ import {
   resolveAccessTokenWithSource,
 } from '../infrastructure/webull/resolveAccessToken'
 import { WebullAuth } from '../infrastructure/webull/WebullAuth'
+import { toWebullPlaceOrderRequest } from '../infrastructure/webull/mapper'
 import { WebullTokenClient } from '../infrastructure/webull/WebullTokenClient'
 import { WebullTokenStateClient } from '../trading/state/WebullTokenStateClient'
 import { buildSignedHeaders } from '../infrastructure/webull/WebullAuth'
@@ -609,6 +610,8 @@ export const admin = new Hono<AppBindings>()
       path: string
       query: Record<string, string>
       version?: string
+      /** POST body (JSON 文字列)。署名対象に含める (place/preview 系)。 */
+      body?: string
       /**
        * 既定は trade host (`WEBULL_TRADE_API_BASE`)。snapshot probe は quotes host
        * (`WEBULL_QUOTES_API_BASE`) を明示的に渡す — JP 本番では data-api 系に
@@ -625,6 +628,7 @@ export const admin = new Hono<AppBindings>()
           method: args.method,
           path: url.pathname,
           query: args.query,
+          body: args.body,
           host: url.host,
           appKey,
           appSecret,
@@ -650,7 +654,12 @@ export const admin = new Hono<AppBindings>()
       try {
         const response = await fetch(url.href, {
           method: args.method,
-          headers: { Accept: 'application/json', ...headers },
+          headers: {
+            Accept: 'application/json',
+            ...(args.body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+            ...headers,
+          },
+          ...(args.body !== undefined ? { body: args.body } : {}),
           signal: controller.signal,
         })
         const body = await response.text()
@@ -881,6 +890,39 @@ export const admin = new Hono<AppBindings>()
       }),
     ])
 
+    // #461 follow-up: **Preview Order = 発注しない注文検証** (JP docs 正式記載:
+    // POST /openapi/account/orders/preview)。発注パイプラインの検証 (取扱外
+    // 銘柄の TICKER_IS_DENY を含む) を、注文を作らずに引ける唯一の documented
+    // API。POST なので通常 probe では叩かず、UI の明示ボタン (query preview=1)
+    // でのみ実行する。body は production の place order と同じ mapper を使い
+    // (qty=1 の BUY、limit cap は Yahoo 価格 or 100)、**path は place ではなく
+    // preview に固定** — 注文は作成されない。
+    let previewOrder: ProbeResult | null = null
+    if (c.req.query('preview') === '1') {
+      const priceRaw = Number(c.req.query('price'))
+      const previewPrice = Number.isFinite(priceRaw) && priceRaw > 0 ? priceRaw : 100
+      const schema = c.env.WEBULL_PLACE_ORDER_SCHEMA === 'v2' ? ('v2' as const) : ('v1' as const)
+      const previewBody = toWebullPlaceOrderRequest(
+        {
+          symbol,
+          side: 'BUY',
+          quantity: 1,
+          price: previewPrice,
+          notional: previewPrice,
+          clientOrderId: `probe-preview-${crypto.randomUUID()}`,
+        },
+        schema,
+        accountId,
+      )
+      previewOrder = await probeOnce({
+        method: 'POST',
+        path: schema === 'v2' ? '/openapi/trade/order/preview' : '/openapi/account/orders/preview',
+        query: schema === 'v2' ? {} : { account_id: accountId },
+        version: schema,
+        body: JSON.stringify(previewBody),
+      })
+    }
+
     // 診断 payload は raw broker レスポンスを含むので browser / 中間 cache に
     // 残させない (CodeRabbit #243)。ヘッダは json() 前に c.header() で付ける。
     c.header('Cache-Control', 'no-store')
@@ -930,6 +972,7 @@ export const admin = new Hono<AppBindings>()
       instrumentStockQuotesAlt,
       instrumentQuotesHost,
       instrumentTradeHost,
+      previewOrder,
       readiness: {
         tokenOk: tokenResolved.source === 'do_normal',
         tradeEndpointsOk:

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1874,20 +1874,27 @@ function brokerProbeBody(args: {
   .bp-pill-wait{background:#f3f3f5;color:#86868b}
   .bp-chip{padding:4px 12px;font-size:12px;border:1px solid #d8d8de;border-radius:14px;cursor:pointer;background:#fff;margin:0 4px 6px 0}
   .bp-chip:hover{background:#eef4ff;border-color:#06c}
+  .bp-chip-selected{background:#06c !important;border-color:#06c !important;color:#fff !important}
+  .bp-chip-selected .muted{color:#cfe0ff !important}
   .bp-raw{background:#f6f6f8;border:1px solid #e3e3e8;border-radius:6px;padding:8px;font-size:11px;overflow:auto;max-height:300px;white-space:pre-wrap;word-break:break-all;margin-top:8px}
   .bp-num{font-variant-numeric:tabular-nums}
   </style>
 
   <div class="bp-card" style="margin-top:8px">
-    <h3>銘柄を選んで probe <span class="muted" id="probe-status" style="font-weight:normal;font-size:12px">待機中</span></h3>
+    <h3>1. 銘柄を選択 → 2. 診断を実行 <span class="muted" id="probe-status" style="font-weight:normal;font-size:12px">待機中</span></h3>
     <div class="bp-body">
       <div style="margin-bottom:6px">${universeLinks}</div>
-      <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
+      <div style="margin-bottom:10px">
         <button type="button" class="bp-chip probe-pickbtn" data-symbol="AAPL" data-category="US_STOCK">AAPL <span class="muted" style="font-size:10px">control</span></button>
-        <button type="button" id="probe-refresh" class="bp-chip" style="border-color:#06c;color:#06c">↻ 再 probe</button>
-        <span class="muted" id="probe-current" style="font-size:12px"></span>
       </div>
-      <p class="muted" style="margin:8px 0 0;font-size:11px">Webull broker (host: <code>WEBULL_TRADE_API_BASE</code> / <code>WEBULL_QUOTES_API_BASE</code>) へ直接照会して結果を表示します。任意 symbol は <code>curl /admin/broker/probe?symbol=X&amp;category=Y</code>。</p>
+      <div style="display:flex;gap:12px;align-items:center;flex-wrap:wrap;padding:10px;background:#f6f8fc;border-radius:8px">
+        <span style="font-size:13px">選択中: <strong id="probe-current">未選択</strong></span>
+        <label style="display:flex;align-items:center;gap:5px;font-size:12px;cursor:pointer">
+          <input type="checkbox" id="probe-preview-check" checked> 発注前検証 (Preview Order) も実行 <span class="muted" style="font-size:11px">— 注文は作成されません</span>
+        </label>
+        <button type="button" id="probe-submit" style="padding:7px 22px;background:#06c;color:#fff;border:none;border-radius:6px;cursor:pointer;font-size:13px;font-weight:600">診断を実行</button>
+      </div>
+      <p class="muted" style="margin:8px 0 0;font-size:11px">銘柄 chip をクリックして選択し、「診断を実行」で Webull broker へ照会します (選択だけでは通信しません)。任意 symbol は <code>curl /admin/broker/probe?symbol=X&amp;category=Y</code>。</p>
     </div>
   </div>
 
@@ -1896,8 +1903,7 @@ function brokerProbeBody(args: {
       <h3>Webull 取扱 <span class="muted" style="font-size:11px;font-weight:normal">(instrument 照会 #461)</span><span id="bp-instrument-pill" class="bp-pill bp-pill-wait">未実行</span></h3>
       <div class="bp-body" id="bp-instrument-body" class="muted">銘柄をクリックすると Webull の instrument 照会で「銘柄として認識されているか」を確認します。</div>
       <p class="muted" style="font-size:11px;margin:8px 0 0">⚠ 照会は<strong>取扱有無の近似</strong>。発注 allowlist (TICKER_IS_DENY) は別系統の可能性があり、確定的なガードは事後の自動停止 (#460) が担う。</p>
-      <button type="button" id="bp-preview-btn" class="bp-chip" style="margin-top:8px;border-color:#057a55;color:#057a55">✓ 発注前検証を実行 (Preview Order — 注文は作成されません)</button>
-      <p class="muted" style="font-size:11px;margin:4px 0 0">Webull の Preview Order API で発注パイプラインの検証だけを通します。取扱外銘柄はここで TICKER_IS_DENY が返り、<strong>発注せずに</strong>取引可否を確定できます (#461)。</p>
+      <p class="muted" style="font-size:11px;margin:4px 0 0">「発注前検証」は Webull の Preview Order API で発注パイプラインの検証だけを通すもの。取扱外銘柄は TICKER_IS_DENY が返り、<strong>発注せずに</strong>取引可否を確定できます (#461)。</p>
     </div>
     <div class="bp-card">
       <h3>Yahoo quote <span class="muted" style="font-size:11px;font-weight:normal">(cron の default source)</span><span id="bp-yahoo-pill" class="bp-pill bp-pill-wait">未実行</span></h3>
@@ -1948,7 +1954,6 @@ function brokerProbeBody(args: {
 <script>
 (function () {
   var statusEl = document.getElementById('probe-status');
-  var refreshBtn = document.getElementById('probe-refresh');
   var positionsListEl = document.getElementById('probe-positions-list');
   var quoteEl = document.getElementById('probe-quote');
   var metaEl = document.getElementById('probe-meta');
@@ -2284,8 +2289,7 @@ function brokerProbeBody(args: {
 
   function probe(symbol, category, opts) {
     opts = opts || {};
-    refreshBtn.disabled = true;
-    statusEl.textContent = (opts.preview ? '発注前検証 実行中: ' : '実行中: ') + symbol + ' (' + category + ')';
+    statusEl.textContent = (opts.preview ? '診断 + 発注前検証 実行中: ' : '診断 実行中: ') + symbol + ' (' + category + ')';
     currentEl.textContent = '— ' + symbol + ' / ' + category;
     resetProbeView('実行中');
     var url = '/admin/broker/probe?symbol=' + encodeURIComponent(symbol) +
@@ -2336,47 +2340,61 @@ function brokerProbeBody(args: {
         // 失敗時も前回 probe の結果を残さない (stale 防止 #462)。
         resetProbeView('失敗');
       })
-      .finally(function () {
-        refreshBtn.disabled = false;
-      });
+  }
+
+  // 選択 → 実行の 2 段階フロー (操作要望): chip クリックは**選択のみ** (通信
+  // しない)。「診断を実行」で初めて probe + (checkbox ON なら) 発注前検証を走らせる。
+  var selected = { symbol: null, category: null };
+
+  function setSelection(sym, cat) {
+    selected.symbol = sym;
+    selected.category = cat;
+    if (currentEl) currentEl.textContent = sym + ' (' + cat + ')';
+    document.querySelectorAll('.probe-pickbtn').forEach(function (b) {
+      b.classList.toggle('bp-chip-selected', b.getAttribute('data-symbol') === sym);
+    });
+    try {
+      var u = new URL(window.location.href);
+      u.searchParams.set('symbol', sym);
+      u.searchParams.set('category', cat);
+      window.history.replaceState({}, '', u.toString());
+    } catch (_) {}
   }
 
   function onPickClick(ev) {
     var btn = ev.currentTarget;
     var sym = btn.getAttribute('data-symbol');
     var cat = btn.getAttribute('data-category');
-    if (sym && cat) probe(sym, cat);
+    if (sym && cat) setSelection(sym, cat);
   }
 
   document.querySelectorAll('.probe-pickbtn').forEach(function (btn) {
     btn.addEventListener('click', onPickClick);
   });
 
-  refreshBtn.addEventListener('click', function () {
-    var qs = new URLSearchParams(window.location.search);
-    var sym = qs.get('symbol') || 'AAPL';
-    var cat = qs.get('category') || 'US_STOCK';
-    probe(sym, cat);
-  });
-
-  // 発注前検証 (Preview Order) ボタン: 現在の symbol で preview=1 を付けて再
-  // probe。POST だが注文は作成されない (path は orders/preview 固定、#461)。
-  var previewBtn = document.getElementById('bp-preview-btn');
-  if (previewBtn) {
-    previewBtn.addEventListener('click', function () {
-      var qs = new URLSearchParams(window.location.search);
-      var sym = qs.get('symbol') || 'AAPL';
-      var cat = qs.get('category') || 'US_STOCK';
-      probe(sym, cat, { preview: true, price: lastYahooPrice });
+  var submitBtn = document.getElementById('probe-submit');
+  var previewCheck = document.getElementById('probe-preview-check');
+  if (submitBtn) {
+    submitBtn.addEventListener('click', function () {
+      if (!selected.symbol) {
+        statusEl.textContent = '銘柄を選択してください';
+        return;
+      }
+      submitBtn.disabled = true;
+      var withPreview = !!(previewCheck && previewCheck.checked);
+      probe(selected.symbol, selected.category, withPreview ? { preview: true, price: lastYahooPrice } : {}).finally(function () {
+        submitBtn.disabled = false;
+      });
     });
   }
 
-  // 自動 probe は URL に symbol+category 両方ある時だけ (PR #250 の方針維持)。
+  // URL params は**プリ選択のみ** (自動実行しない — 選択 → 実行の流れを徹底)。
   var qs = new URLSearchParams(window.location.search);
   if (qs.has('symbol') && qs.has('category')) {
-    probe(qs.get('symbol'), qs.get('category'));
+    setSelection(qs.get('symbol'), qs.get('category'));
+    statusEl.textContent = '「診断を実行」で開始';
   } else {
-    statusEl.textContent = '銘柄ボタンをクリックして probe 開始';
+    statusEl.textContent = '銘柄を選択してください';
   }
 })();
 </script>`

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1862,6 +1862,14 @@ function brokerProbeBody(args: {
   // (Cloudflare Access cookie 流用、payload は no-store)。
   // 自動 probe は URL に symbol+category がある時だけ (PR #250 の方針を維持)。
   const universeLinks = renderUniverseLinks(args.universe)
+  // AAPL control chip は universe に AAPL が居る環境では重複するので出さない。
+  const hasAapl = [
+    ...(args.universe?.allowedSymbols ?? []),
+    ...(args.universe?.inactiveSymbols ?? []),
+  ].some((sym) => sym.toUpperCase() === 'AAPL')
+  const controlChip = hasAapl
+    ? ''
+    : `<div style="margin-bottom:10px"><button type="button" class="bp-chip probe-pickbtn" data-symbol="AAPL" data-category="US_STOCK">AAPL <span class="muted" style="font-size:10px">control</span></button></div>`
   return `<style>
   .bp-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:12px;margin:12px 0}
   .bp-card{background:#fff;border:1px solid #e3e3e8;border-radius:10px;padding:14px 16px}
@@ -1881,39 +1889,33 @@ function brokerProbeBody(args: {
   </style>
 
   <div class="bp-card" style="margin-top:8px">
-    <h3>1. 銘柄を選択 → 2. 診断を実行 <span class="muted" id="probe-status" style="font-weight:normal;font-size:12px">待機中</span></h3>
+    <h3>銘柄を選んで診断 <span class="muted" id="probe-status" style="font-weight:normal;font-size:12px">待機中</span></h3>
     <div class="bp-body">
       <div style="margin-bottom:6px">${universeLinks}</div>
-      <div style="margin-bottom:10px">
-        <button type="button" class="bp-chip probe-pickbtn" data-symbol="AAPL" data-category="US_STOCK">AAPL <span class="muted" style="font-size:10px">control</span></button>
-      </div>
+      ${controlChip}
       <div style="display:flex;gap:12px;align-items:center;flex-wrap:wrap;padding:10px;background:#f6f8fc;border-radius:8px">
         <span style="font-size:13px">選択中: <strong id="probe-current">未選択</strong></span>
         <label style="display:flex;align-items:center;gap:5px;font-size:12px;cursor:pointer">
-          <input type="checkbox" id="probe-preview-check" checked> 発注前検証 (Preview Order) も実行 <span class="muted" style="font-size:11px">— 注文は作成されません</span>
+          <input type="checkbox" id="probe-preview-check" checked> 発注前検証も実行 <span class="muted" style="font-size:11px">(発注なし)</span>
         </label>
         <button type="button" id="probe-submit" style="padding:7px 22px;background:#06c;color:#fff;border:none;border-radius:6px;cursor:pointer;font-size:13px;font-weight:600">診断を実行</button>
       </div>
-      <p class="muted" style="margin:8px 0 0;font-size:11px">銘柄 chip をクリックして選択し、「診断を実行」で Webull broker へ照会します (選択だけでは通信しません)。任意 symbol は <code>curl /admin/broker/probe?symbol=X&amp;category=Y</code>。</p>
     </div>
   </div>
 
   <div class="bp-grid">
     <div class="bp-card">
-      <h3>Webull 取扱 <span class="muted" style="font-size:11px;font-weight:normal">(instrument 照会 #461)</span><span id="bp-instrument-pill" class="bp-pill bp-pill-wait">未実行</span></h3>
-      <div class="bp-body" id="bp-instrument-body" class="muted">銘柄をクリックすると Webull の instrument 照会で「銘柄として認識されているか」を確認します。</div>
-      <p class="muted" style="font-size:11px;margin:8px 0 0">⚠ 照会は<strong>取扱有無の近似</strong>。発注 allowlist (TICKER_IS_DENY) は別系統の可能性があり、確定的なガードは事後の自動停止 (#460) が担う。</p>
-      <p class="muted" style="font-size:11px;margin:4px 0 0">「発注前検証」は Webull の Preview Order API で発注パイプラインの検証だけを通すもの。取扱外銘柄は TICKER_IS_DENY が返り、<strong>発注せずに</strong>取引可否を確定できます (#461)。</p>
+      <h3>Webull 取扱 <span id="bp-instrument-pill" class="bp-pill bp-pill-wait">未実行</span></h3>
+      <div class="bp-body" id="bp-instrument-body" class="muted">—</div>
     </div>
     <div class="bp-card">
-      <h3>Yahoo quote <span class="muted" style="font-size:11px;font-weight:normal">(cron の default source)</span><span id="bp-yahoo-pill" class="bp-pill bp-pill-wait">未実行</span></h3>
+      <h3>Yahoo quote <span id="bp-yahoo-pill" class="bp-pill bp-pill-wait">未実行</span></h3>
       <div class="bp-body" id="bp-yahoo-body" class="muted">—</div>
       <details><summary class="muted" style="font-size:11px;cursor:pointer">raw</summary><pre id="probe-quote-yahoo" class="bp-raw">(未実行)</pre></details>
     </div>
     <div class="bp-card">
-      <h3>買付余力 <span class="muted" style="font-size:11px;font-weight:normal">#415</span><span id="bp-bp-pill" class="bp-pill bp-pill-wait">未実行</span></h3>
+      <h3>買付余力 <span id="bp-bp-pill" class="bp-pill bp-pill-wait">未実行</span></h3>
       <div class="bp-body" id="probe-buying-power" class="muted">—</div>
-      <p class="muted" style="font-size:11px;margin:8px 0 0">取得失敗時は cron が当 tick の BUY を全見送り (fail-closed)。</p>
     </div>
   </div>
 

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1900,11 +1900,6 @@ function brokerProbeBody(args: {
       <p class="muted" style="font-size:11px;margin:4px 0 0">Webull の Preview Order API で発注パイプラインの検証だけを通します。取扱外銘柄はここで TICKER_IS_DENY が返り、<strong>発注せずに</strong>取引可否を確定できます (#461)。</p>
     </div>
     <div class="bp-card">
-      <h3>Webull quote <span id="bp-quote-pill" class="bp-pill bp-pill-wait">未実行</span></h3>
-      <div class="bp-body" id="bp-quote-body" class="muted">—</div>
-      <details><summary class="muted" style="font-size:11px;cursor:pointer">raw</summary><pre id="probe-quote" class="bp-raw">(未実行)</pre></details>
-    </div>
-    <div class="bp-card">
       <h3>Yahoo quote <span class="muted" style="font-size:11px;font-weight:normal">(cron の default source)</span><span id="bp-yahoo-pill" class="bp-pill bp-pill-wait">未実行</span></h3>
       <div class="bp-body" id="bp-yahoo-body" class="muted">—</div>
       <details><summary class="muted" style="font-size:11px;cursor:pointer">raw</summary><pre id="probe-quote-yahoo" class="bp-raw">(未実行)</pre></details>
@@ -1935,6 +1930,9 @@ function brokerProbeBody(args: {
           <tr><td colspan="3" class="muted" style="padding:8px;text-align:center">(未実行)</td></tr>
         </tbody>
       </table>
+      <h3 style="margin-top:14px">Webull quote <span class="muted" style="font-size:11px;font-weight:normal">(data-api — 無応答が既知のため詳細に格下げ #461。稼働開始は疎通監視 #21 が通知)</span> <span id="bp-quote-pill" class="bp-pill bp-pill-wait">未実行</span></h3>
+      <div id="bp-quote-body" style="font-size:12px;margin:4px 0">—</div>
+      <pre id="probe-quote" class="bp-raw">(未実行)</pre>
       <h3 style="margin-top:14px">instrument 照会 raw (quotes host / trade host)</h3>
       <pre id="bp-instrument-raw" class="bp-raw">(未実行)</pre>
       <h3 style="margin-top:14px">positions / orderHistory raw (旧/新)</h3>
@@ -2052,8 +2050,10 @@ function brokerProbeBody(args: {
       { label: 'instrument/list (trade host, 汎用 path)', section: body.instrumentTradeHost },
     ];
     var rawList = candidates;
-    if (body.previewOrder) {
-      rawList = [{ label: 'preview order (発注前検証)', section: body.previewOrder }].concat(candidates);
+    if (Array.isArray(body.previewVariants)) {
+      rawList = body.previewVariants.map(function (v) {
+        return { label: 'preview (' + v.label + ')', section: v.result };
+      }).concat(candidates);
     }
     if (rawTarget) {
       rawTarget.textContent = rawList.map(function (cnd) {
@@ -2063,32 +2063,40 @@ function brokerProbeBody(args: {
     if (!bodyEl) return;
 
     // 発注前検証 (Preview Order) の結果が最優先 — 発注パイプラインそのものの
-    // 検証なので instrument 照会より確度が高い (#461)。
-    if (body.previewOrder) {
-      var pv = body.previewOrder;
-      var pvBody = parseBody(pv);
-      if (pv.phase === 'response' && pv.status === 200) {
+    // 検証なので instrument 照会より確度が高い (#461)。body shape を複数試して
+    // どれか 1 つでも通れば取引可能、どれかが TICKER_IS_DENY なら取扱なし確定。
+    if (Array.isArray(body.previewVariants) && body.previewVariants.length > 0) {
+      var okVariant = null;
+      var denyVariant = null;
+      for (var pvi = 0; pvi < body.previewVariants.length; pvi++) {
+        var v = body.previewVariants[pvi];
+        if (v.result && v.result.phase === 'response' && v.result.status === 200) { okVariant = v; break; }
+        if (v.result && v.result.phase === 'response' && typeof v.result.bodyTruncated === 'string' &&
+            v.result.bodyTruncated.indexOf('TICKER_IS_DENY') !== -1) { denyVariant = v; }
+      }
+      if (okVariant) {
         setPill('bp-instrument-pill', 'ok', '取引可能');
-        var cost = pvBody && (pvBody.estimated_cost || (pvBody.data && pvBody.data.estimated_cost));
+        var okParsed = parseBody(okVariant.result);
+        var cost = okParsed && (okParsed.estimated_cost || (okParsed.data && okParsed.data.estimated_cost));
         bodyEl.innerHTML = '<strong>' + escHtml(symbol.toUpperCase()) + '</strong> は発注前検証 (Preview Order) を通過しました — 取引可能です。' +
-          (cost ? '<br><span class="muted" style="font-size:12px">estimated_cost: ' + escHtml(cost) + '</span>' : '');
+          '<span class="muted" style="font-size:12px"> (body shape: ' + escHtml(okVariant.label) + (cost ? ' / estimated_cost: ' + escHtml(cost) : '') + ')</span>';
         return;
       }
-      if (pv.phase === 'response' && typeof pv.bodyTruncated === 'string' && pv.bodyTruncated.indexOf('TICKER_IS_DENY') !== -1) {
+      if (denyVariant) {
         setPill('bp-instrument-pill', 'ng', '取扱なし (確定)');
         bodyEl.innerHTML = '<strong>' + escHtml(symbol.toUpperCase()) + '</strong> — 発注前検証が <code>TICKER_IS_DENY</code> を返しました。' +
           '<span style="color:#c22">Webull JP の OpenAPI では発注できない銘柄です (確定)。</span>';
         return;
       }
-      if (pv.phase === 'response') {
-        var pvErr = pvBody && pvBody.error_code ? pvBody.error_code : 'status=' + pv.status;
-        setPill('bp-instrument-pill', 'unknown', '検証エラー');
-        bodyEl.innerHTML = '発注前検証がエラーを返しました: <code>' + escHtml(pvErr) + '</code>。' +
-          '<span class="muted">銘柄以外の要因 (価格・数量・口座) の可能性あり — raw を確認してください。</span>';
-        return;
-      }
-      setPill('bp-instrument-pill', 'unknown', '判定不可');
-      bodyEl.innerHTML = '発注前検証に到達できませんでした (' + escHtml(humanizeError(pv)) + ')。';
+      setPill('bp-instrument-pill', 'unknown', '検証エラー');
+      var lines = body.previewVariants.map(function (v) {
+        var b = parseBody(v.result);
+        var detail = b && b.error_code ? b.error_code + (b.message ? ' — ' + b.message : '') : humanizeError(v.result);
+        return '<li><code>' + escHtml(v.label) + '</code>: ' + escHtml(detail) + '</li>';
+      }).join('');
+      bodyEl.innerHTML = '発注前検証がどの body shape でも通りませんでした:' +
+        '<ul style="margin:4px 0 0 16px;padding:0;font-size:12px">' + lines + '</ul>' +
+        '<span class="muted" style="font-size:11px">エラー内容から shape を調整します — raw を共有してください。</span>';
       return;
     }
     var responded = [];

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1896,6 +1896,8 @@ function brokerProbeBody(args: {
       <h3>Webull 取扱 <span class="muted" style="font-size:11px;font-weight:normal">(instrument 照会 #461)</span><span id="bp-instrument-pill" class="bp-pill bp-pill-wait">未実行</span></h3>
       <div class="bp-body" id="bp-instrument-body" class="muted">銘柄をクリックすると Webull の instrument 照会で「銘柄として認識されているか」を確認します。</div>
       <p class="muted" style="font-size:11px;margin:8px 0 0">⚠ 照会は<strong>取扱有無の近似</strong>。発注 allowlist (TICKER_IS_DENY) は別系統の可能性があり、確定的なガードは事後の自動停止 (#460) が担う。</p>
+      <button type="button" id="bp-preview-btn" class="bp-chip" style="margin-top:8px;border-color:#057a55;color:#057a55">✓ 発注前検証を実行 (Preview Order — 注文は作成されません)</button>
+      <p class="muted" style="font-size:11px;margin:4px 0 0">Webull の Preview Order API で発注パイプラインの検証だけを通します。取扱外銘柄はここで TICKER_IS_DENY が返り、<strong>発注せずに</strong>取引可否を確定できます (#461)。</p>
     </div>
     <div class="bp-card">
       <h3>Webull quote <span id="bp-quote-pill" class="bp-pill bp-pill-wait">未実行</span></h3>
@@ -2049,12 +2051,46 @@ function brokerProbeBody(args: {
       { label: 'instrument/list (quotes host, 汎用 path)', section: body.instrumentQuotesHost },
       { label: 'instrument/list (trade host, 汎用 path)', section: body.instrumentTradeHost },
     ];
+    var rawList = candidates;
+    if (body.previewOrder) {
+      rawList = [{ label: 'preview order (発注前検証)', section: body.previewOrder }].concat(candidates);
+    }
     if (rawTarget) {
-      rawTarget.textContent = candidates.map(function (cnd) {
+      rawTarget.textContent = rawList.map(function (cnd) {
         return '--- ' + cnd.label + ' ---\\n' + prettify(cnd.section);
       }).join('\\n\\n');
     }
     if (!bodyEl) return;
+
+    // 発注前検証 (Preview Order) の結果が最優先 — 発注パイプラインそのものの
+    // 検証なので instrument 照会より確度が高い (#461)。
+    if (body.previewOrder) {
+      var pv = body.previewOrder;
+      var pvBody = parseBody(pv);
+      if (pv.phase === 'response' && pv.status === 200) {
+        setPill('bp-instrument-pill', 'ok', '取引可能');
+        var cost = pvBody && (pvBody.estimated_cost || (pvBody.data && pvBody.data.estimated_cost));
+        bodyEl.innerHTML = '<strong>' + escHtml(symbol.toUpperCase()) + '</strong> は発注前検証 (Preview Order) を通過しました — 取引可能です。' +
+          (cost ? '<br><span class="muted" style="font-size:12px">estimated_cost: ' + escHtml(cost) + '</span>' : '');
+        return;
+      }
+      if (pv.phase === 'response' && typeof pv.bodyTruncated === 'string' && pv.bodyTruncated.indexOf('TICKER_IS_DENY') !== -1) {
+        setPill('bp-instrument-pill', 'ng', '取扱なし (確定)');
+        bodyEl.innerHTML = '<strong>' + escHtml(symbol.toUpperCase()) + '</strong> — 発注前検証が <code>TICKER_IS_DENY</code> を返しました。' +
+          '<span style="color:#c22">Webull JP の OpenAPI では発注できない銘柄です (確定)。</span>';
+        return;
+      }
+      if (pv.phase === 'response') {
+        var pvErr = pvBody && pvBody.error_code ? pvBody.error_code : 'status=' + pv.status;
+        setPill('bp-instrument-pill', 'unknown', '検証エラー');
+        bodyEl.innerHTML = '発注前検証がエラーを返しました: <code>' + escHtml(pvErr) + '</code>。' +
+          '<span class="muted">銘柄以外の要因 (価格・数量・口座) の可能性あり — raw を確認してください。</span>';
+        return;
+      }
+      setPill('bp-instrument-pill', 'unknown', '判定不可');
+      bodyEl.innerHTML = '発注前検証に到達できませんでした (' + escHtml(humanizeError(pv)) + ')。';
+      return;
+    }
     var responded = [];
     for (var i = 0; i < candidates.length; i++) {
       var sct = candidates[i].section;
@@ -2105,6 +2141,31 @@ function brokerProbeBody(args: {
     }
   }
 
+  // 価格抽出: parse → (Yahoo chart は meta へ) → 失敗時は truncate 済み body から
+  // regex fallback。quote カードと preview の limit cap の両方で使う。
+  function extractPrice(section, priceKeys) {
+    if (!section) return null;
+    var parsed = parseBody(section);
+    var item = Array.isArray(parsed) ? parsed[0] : parsed;
+    if (item && item.chart && Array.isArray(item.chart.result) && item.chart.result[0] && item.chart.result[0].meta) {
+      item = item.chart.result[0].meta;
+    }
+    for (var i = 0; item && i < priceKeys.length; i++) {
+      var v = item[priceKeys[i]];
+      if (v != null && Number.isFinite(Number(v))) return Number(v);
+    }
+    if (typeof section.bodyTruncated === 'string') {
+      for (var r = 0; r < priceKeys.length; r++) {
+        var m = section.bodyTruncated.match(new RegExp('"' + priceKeys[r] + '"\\s*:\\s*(-?[0-9.]+)'));
+        if (m && Number.isFinite(Number(m[1]))) return Number(m[1]);
+      }
+    }
+    return null;
+  }
+
+  // 直近 probe の Yahoo 価格 (preview の limit cap 用)。
+  var lastYahooPrice = null;
+
   // quote カード: status pill + 価格らしきフィールドの要約。shape が読めなくても
   // pill と raw は必ず更新する (stale 表示を残さない、CodeRabbit #262 の方針)。
   function renderQuoteCard(pillId, bodyId, section, priceKeys) {
@@ -2116,25 +2177,7 @@ function brokerProbeBody(args: {
       bodyEl.innerHTML = '<span class="muted">' + escHtml(humanizeError(section)) + '</span>';
       return;
     }
-    var parsed = parseBody(section);
-    var item = Array.isArray(parsed) ? parsed[0] : parsed;
-    // Yahoo chart API は価格が chart.result[0].meta に入る (#461 follow-up)。
-    if (item && item.chart && Array.isArray(item.chart.result) && item.chart.result[0] && item.chart.result[0].meta) {
-      item = item.chart.result[0].meta;
-    }
-    var price = null;
-    for (var i = 0; item && i < priceKeys.length; i++) {
-      var v = item[priceKeys[i]];
-      if (v != null && Number.isFinite(Number(v))) { price = Number(v); break; }
-    }
-    // 大きい body は probe 側で truncate され JSON.parse が失敗する (Yahoo chart
-    // は 30KB 超)。価格 key を regex で直接拾う fallback。
-    if (price == null && typeof section.bodyTruncated === 'string') {
-      for (var r = 0; r < priceKeys.length; r++) {
-        var m = section.bodyTruncated.match(new RegExp('"' + priceKeys[r] + '"\\s*:\\s*(-?[0-9.]+)'));
-        if (m && Number.isFinite(Number(m[1]))) { price = Number(m[1]); break; }
-      }
-    }
+    var price = extractPrice(section, priceKeys);
     var ms = Number(section.msTaken) || 0;
     bodyEl.innerHTML = price != null
       ? '<span style="font-size:18px;font-weight:700" class="bp-num">' + escHtml(formatNumber(price)) + '</span> <span class="muted" style="font-size:11px">(' + ms + 'ms)</span>'
@@ -2231,13 +2274,18 @@ function brokerProbeBody(args: {
       row('instrument (quotes/trade host)', body.instrumentQuotesHost, body.instrumentTradeHost);
   }
 
-  function probe(symbol, category) {
+  function probe(symbol, category, opts) {
+    opts = opts || {};
     refreshBtn.disabled = true;
-    statusEl.textContent = '実行中: ' + symbol + ' (' + category + ')';
+    statusEl.textContent = (opts.preview ? '発注前検証 実行中: ' : '実行中: ') + symbol + ' (' + category + ')';
     currentEl.textContent = '— ' + symbol + ' / ' + category;
     resetProbeView('実行中');
     var url = '/admin/broker/probe?symbol=' + encodeURIComponent(symbol) +
       '&category=' + encodeURIComponent(category);
+    if (opts.preview) {
+      url += '&preview=1';
+      if (Number.isFinite(opts.price) && opts.price > 0) url += '&price=' + encodeURIComponent(opts.price);
+    }
     try {
       var u = new URL(window.location.href);
       u.searchParams.set('symbol', symbol);
@@ -2254,6 +2302,7 @@ function brokerProbeBody(args: {
         var quoteYahooEl = document.getElementById('probe-quote-yahoo');
         if (quoteYahooEl) quoteYahooEl.textContent = body.quoteYahoo ? prettify(body.quoteYahoo) : '(no data)';
         renderQuoteCard('bp-yahoo-pill', 'bp-yahoo-body', body.quoteYahoo || null, ['regularMarketPrice', 'price', 'close']);
+        lastYahooPrice = extractPrice(body.quoteYahoo || null, ['regularMarketPrice', 'price', 'close']);
         renderInstrumentCard(body, symbol);
         renderPositionsList(body.positions || null);
         var positionsNewRaw = document.getElementById('probe-positions-new-raw');
@@ -2301,6 +2350,18 @@ function brokerProbeBody(args: {
     var cat = qs.get('category') || 'US_STOCK';
     probe(sym, cat);
   });
+
+  // 発注前検証 (Preview Order) ボタン: 現在の symbol で preview=1 を付けて再
+  // probe。POST だが注文は作成されない (path は orders/preview 固定、#461)。
+  var previewBtn = document.getElementById('bp-preview-btn');
+  if (previewBtn) {
+    previewBtn.addEventListener('click', function () {
+      var qs = new URLSearchParams(window.location.search);
+      var sym = qs.get('symbol') || 'AAPL';
+      var cat = qs.get('category') || 'US_STOCK';
+      probe(sym, cat, { preview: true, price: lastYahooPrice });
+    });
+  }
 
   // 自動 probe は URL に symbol+category 両方ある時だけ (PR #250 の方針維持)。
   var qs = new URLSearchParams(window.location.search);

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -2178,8 +2178,9 @@ function brokerProbeBody(args: {
     return null;
   }
 
-  // 直近 probe の Yahoo 価格 (preview の limit cap 用)。
-  var lastYahooPrice = null;
+  // 直近 probe の Yahoo 価格 (preview の limit cap 用)。銘柄が変わったら使わない
+  // — 前銘柄の価格で preview すると価格系エラーが deny 判定を潰す (CodeRabbit #466)。
+  var lastYahoo = { symbol: null, price: null };
 
   // quote カード: status pill + 価格らしきフィールドの要約。shape が読めなくても
   // pill と raw は必ず更新する (stale 表示を残さない、CodeRabbit #262 の方針)。
@@ -2316,7 +2317,7 @@ function brokerProbeBody(args: {
         var quoteYahooEl = document.getElementById('probe-quote-yahoo');
         if (quoteYahooEl) quoteYahooEl.textContent = body.quoteYahoo ? prettify(body.quoteYahoo) : '(no data)';
         renderQuoteCard('bp-yahoo-pill', 'bp-yahoo-body', body.quoteYahoo || null, ['regularMarketPrice', 'price', 'close']);
-        lastYahooPrice = extractPrice(body.quoteYahoo || null, ['regularMarketPrice', 'price', 'close']);
+        lastYahoo = { symbol: symbol, price: extractPrice(body.quoteYahoo || null, ['regularMarketPrice', 'price', 'close']) };
         renderInstrumentCard(body, symbol);
         renderPositionsList(body.positions || null);
         var positionsNewRaw = document.getElementById('probe-positions-new-raw');
@@ -2384,7 +2385,8 @@ function brokerProbeBody(args: {
       }
       submitBtn.disabled = true;
       var withPreview = !!(previewCheck && previewCheck.checked);
-      probe(selected.symbol, selected.category, withPreview ? { preview: true, price: lastYahooPrice } : {}).finally(function () {
+      var previewPrice = lastYahoo.symbol === selected.symbol ? lastYahoo.price : null;
+      probe(selected.symbol, selected.category, withPreview ? { preview: true, price: previewPrice } : {}).finally(function () {
         submitBtn.disabled = false;
       });
     });

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -8757,6 +8757,7 @@ function symbolFormBody(args: SymbolFormArgs): string {
              <input type="text" name="symbol" id="symbol-form-symbol" value="${esc(symbolValue)}" required maxlength="10" pattern="[A-Za-z0-9]{1,10}" placeholder="SOXL / 7974 / 1570" autocomplete="off" data-1p-ignore="true" data-lpignore="true" data-form-type="other" oninput="window.searchSymbolSuggest(this.value)" onfocus="window.searchSymbolSuggest(this.value)" onblur="setTimeout(window.hideSymbolSuggest, 200)" style="padding:6px;width:200px;text-transform:uppercase">
              <ul id="symbol-form-symbol-suggest" style="display:none;position:absolute;top:100%;left:0;margin:2px 0 0;padding:0;list-style:none;background:#fff;border:1px solid #d0d0d5;border-radius:4px;width:380px;max-height:280px;overflow-y:auto;z-index:10;box-shadow:0 2px 6px rgba(0,0,0,0.1)"></ul>
            </div>
+           <span id="symbol-tradability" style="margin-left:10px;font-size:13px"></span>
          </div>`
   // #315: 登録モード選択 (単体 / インバース対)。new のみ。
   const modeSelector =
@@ -8942,7 +8943,7 @@ function symbolFormBody(args: SymbolFormArgs): string {
     <textarea name="notes" maxlength="256" rows="3" placeholder="自由記述 (例: 一時停止理由 / 上限を絞ってる事情)" style="padding:6px;font-family:inherit">${esc(notesValue)}</textarea>
     <span></span>
     <div style="display:flex;gap:8px">
-      <button type="submit" style="padding:6px 16px;background:#06c;color:#fff;border:none;border-radius:4px;cursor:pointer">保存</button>
+      <button type="submit" id="symbol-form-save" style="padding:6px 16px;background:#06c;color:#fff;border:none;border-radius:4px;cursor:pointer">保存</button>
       <a href="/dashboard/symbols" style="padding:6px 16px;text-decoration:none;border:1px solid #d0d0d5;border-radius:4px">キャンセル</a>
     </div>
   </form>
@@ -9025,7 +9026,68 @@ function symbolFormBody(args: SymbolFormArgs): string {
       window.suggestLotSizeFromMatch(m);
       window.hideSymbolSuggest();
       if (symInput) symInput.focus();
+      window.checkSymbolTradability();
     };
+    // 取扱チェック (#461): 銘柄確定時に Preview Order (発注なし) で Webull JP の
+    // 取引可否を照会。'denied' (TICKER_IS_DENY 確定) のみ保存をブロックする。
+    // 'error' / 'unavailable' はブロックしない — check 不能で登録が全部止まるのは
+    // 過剰 fail-closed (発注側には #460 の事後ガードがある)。
+    window._tradabilityDenied = false;
+    window._tradabilitySeq = 0;
+    window.checkSymbolTradability = function () {
+      var statusEl = document.getElementById('symbol-tradability');
+      var saveBtn = document.getElementById('symbol-form-save');
+      var symInput = document.getElementById('symbol-form-symbol');
+      var marketSel = document.getElementById('symbol-form-market');
+      if (!statusEl || !symInput) return;
+      var sym = (symInput.value || '').trim().toUpperCase();
+      window._tradabilityDenied = false;
+      if (saveBtn) { saveBtn.disabled = false; saveBtn.style.opacity = ''; }
+      if (!/^[A-Z0-9]{1,10}$/.test(sym)) { statusEl.textContent = ''; return; }
+      var mySeq = ++window._tradabilitySeq;
+      statusEl.textContent = '⏳ 取扱確認中...';
+      statusEl.style.color = '#86868b';
+      var market = marketSel && marketSel.value === 'JP' ? 'JP' : 'US';
+      fetch('/admin/symbol-config/tradability-check?symbol=' + encodeURIComponent(sym) + '&market=' + market, { credentials: 'same-origin' })
+        .then(function (r) { return r.json(); })
+        .then(function (res) {
+          if (mySeq !== window._tradabilitySeq) return; // 古い応答は捨てる
+          if (res.verdict === 'tradable') {
+            statusEl.textContent = '✅ 取引可能';
+            statusEl.style.color = '#057a55';
+          } else if (res.verdict === 'denied') {
+            statusEl.textContent = '❌ Webull JP 取扱なし — 登録できません';
+            statusEl.style.color = '#c22';
+            window._tradabilityDenied = true;
+            if (saveBtn) { saveBtn.disabled = true; saveBtn.style.opacity = '0.4'; }
+          } else {
+            statusEl.textContent = '❓ 取扱を確認できませんでした (登録は可能)';
+            statusEl.style.color = '#86868b';
+          }
+        })
+        .catch(function () {
+          if (mySeq !== window._tradabilitySeq) return;
+          statusEl.textContent = '❓ 取扱を確認できませんでした (登録は可能)';
+          statusEl.style.color = '#86868b';
+        });
+    };
+    // 手入力で symbol を変えた場合も blur で再チェック。submit は denied 時に阻止。
+    (function () {
+      var symInput = document.getElementById('symbol-form-symbol');
+      if (symInput && !symInput.readOnly) {
+        symInput.addEventListener('change', function () { window.checkSymbolTradability(); });
+        var form = symInput.closest('form');
+        if (form) {
+          form.addEventListener('submit', function (ev) {
+            if (window._tradabilityDenied) {
+              ev.preventDefault();
+              var statusEl = document.getElementById('symbol-tradability');
+              if (statusEl) statusEl.textContent = '❌ Webull JP 取扱なし — 登録できません';
+            }
+          });
+        }
+      }
+    })();
     // Yahoo quoteType + market から売買単位の推奨値を自動入力する。
     // ETF → 1 口、JP 個別株 (EQUITY) → 100 株、US 個別株 → 1 株。あくまで推奨で、
     // operator が手入力で上書き可能 (確定は手入力必須・fail-closed なので #symbol-lot-size)。

--- a/test/infrastructure/webull/tradabilityCheck.test.ts
+++ b/test/infrastructure/webull/tradabilityCheck.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildPreviewOrderVariants,
+  checkTradability,
+} from '../../../src/infrastructure/webull/tradabilityCheck'
+import type { Env } from '../../../src/config/env'
+
+const env = {
+  WEBULL_APP_KEY: 'k'.repeat(32),
+  WEBULL_APP_SECRET: 's'.repeat(32),
+  WEBULL_ACCOUNT_ID_JP_CASH: 'acct-1',
+} as unknown as Env
+
+function fetcherReturning(bodies: Array<{ status: number; body: unknown }>): typeof fetch {
+  let i = 0
+  return (async () => {
+    const next = bodies[Math.min(i, bodies.length - 1)]!
+    i += 1
+    return new Response(JSON.stringify(next.body), { status: next.status })
+  }) as typeof fetch
+}
+
+describe('checkTradability (#461 Preview Order)', () => {
+  it('verdict=tradable when any variant returns 200', async () => {
+    const result = await checkTradability(env, {
+      symbol: 'aapl',
+      market: 'US',
+      fetcher: fetcherReturning([
+        { status: 417, body: { error_code: 'OPENAPI_PARAM_ERR' } },
+        { status: 200, body: { estimated_cost: '292.55' } },
+        { status: 417, body: { error_code: 'OPENAPI_PARAM_ERR' } },
+      ]),
+    })
+    expect(result.verdict).toBe('tradable')
+  })
+
+  it('verdict=denied when any variant returns TICKER_IS_DENY (確定 NG)', async () => {
+    const result = await checkTradability(env, {
+      symbol: 'USMV',
+      market: 'US',
+      fetcher: fetcherReturning([
+        { status: 417, body: { error_code: 'OAUTH_OPENAPI_TICKER_IS_DENY', message: 'The current security is not available.' } },
+      ]),
+    })
+    expect(result.verdict).toBe('denied')
+    expect(result.detail).toContain('TICKER_IS_DENY')
+  })
+
+  it('verdict=error when broker responds but all variants fail with other codes', async () => {
+    const result = await checkTradability(env, {
+      symbol: 'AAPL',
+      market: 'US',
+      fetcher: fetcherReturning([{ status: 417, body: { error_code: 'OPENAPI_PARAM_ERR' } }]),
+    })
+    expect(result.verdict).toBe('error')
+    expect(result.detail).toContain('OPENAPI_PARAM_ERR')
+  })
+
+  it('verdict=unavailable when credentials are missing (登録はブロックしない側)', async () => {
+    const result = await checkTradability({} as Env, { symbol: 'AAPL', market: 'US' })
+    expect(result.verdict).toBe('unavailable')
+  })
+
+  it('verdict=unavailable when the broker is unreachable', async () => {
+    const result = await checkTradability(env, {
+      symbol: 'AAPL',
+      market: 'US',
+      fetcher: (async () => {
+        throw new Error('connect timeout')
+      }) as typeof fetch,
+    })
+    expect(result.verdict).toBe('unavailable')
+  })
+
+  it('variants は preview 専用 path 前提の body (発注 path に流さない契約の確認)', () => {
+    const variants = buildPreviewOrderVariants('AAPL', 'US', 100, 'acct-1')
+    expect(variants).toHaveLength(3)
+    for (const v of variants) {
+      const body = v.body as { new_orders: Array<Record<string, unknown>> }
+      expect(body.new_orders).toHaveLength(1)
+      expect(body.new_orders[0]!.symbol).toBe('AAPL')
+      expect(body.new_orders[0]!.quantity).toBe('1')
+      expect(body.new_orders[0]!.side).toBe('BUY')
+    }
+  })
+})

--- a/test/infrastructure/webull/tradabilityCheck.test.ts
+++ b/test/infrastructure/webull/tradabilityCheck.test.ts
@@ -84,3 +84,43 @@ describe('checkTradability (#461 Preview Order)', () => {
     }
   })
 })
+
+describe('checkTradability 200 偽陽性ガード (#461 本番 deny との矛盾調査)', () => {
+  it('HTTP 200 でも body に TICKER_IS_DENY が埋まっていれば denied', async () => {
+    const result = await checkTradability(env, {
+      symbol: 'USMV',
+      market: 'US',
+      fetcher: fetcherReturning([
+        {
+          status: 200,
+          body: { new_orders: [{ symbol: 'USMV', error_code: 'OAUTH_OPENAPI_TICKER_IS_DENY' }] },
+        },
+      ]),
+    })
+    expect(result.verdict).toBe('denied')
+  })
+
+  it('HTTP 200 でも body に別の error_code が埋まっていれば tradable にしない', async () => {
+    const result = await checkTradability(env, {
+      symbol: 'AAPL',
+      market: 'US',
+      fetcher: fetcherReturning([
+        { status: 200, body: { new_orders: [{ error_code: 'SOME_EMBEDDED_ERR' }] } },
+      ]),
+    })
+    expect(result.verdict).toBe('error')
+  })
+
+  it('クリーンな 200 (estimated_cost) は根拠付きで tradable', async () => {
+    const result = await checkTradability(env, {
+      symbol: 'AAPL',
+      market: 'US',
+      fetcher: fetcherReturning([
+        { status: 417, body: { error_code: 'OPENAPI_PARAM_ERR' } },
+        { status: 200, body: { estimated_cost: '292.55', estimated_transaction_fee: '0' } },
+      ]),
+    })
+    expect(result.verdict).toBe('tradable')
+    expect(result.detail).toContain('estimated_cost: 292.55')
+  })
+})

--- a/test/infrastructure/webull/tradabilityCheck.test.ts
+++ b/test/infrastructure/webull/tradabilityCheck.test.ts
@@ -124,3 +124,16 @@ describe('checkTradability 200 偽陽性ガード (#461 本番 deny との矛盾
     expect(result.detail).toContain('estimated_cost: 292.55')
   })
 })
+
+describe('isTickerDenyCode (#466: prefix なし表記も deny 扱い)', () => {
+  it('bare TICKER_IS_DENY も denied になる', async () => {
+    const result = await checkTradability(env, {
+      symbol: 'USMV',
+      market: 'US',
+      fetcher: fetcherReturning([
+        { status: 417, body: { error_code: 'TICKER_IS_DENY' } },
+      ]),
+    })
+    expect(result.verdict).toBe('denied')
+  })
+})

--- a/test/routes/dashboardBrokerProbe.test.ts
+++ b/test/routes/dashboardBrokerProbe.test.ts
@@ -32,6 +32,15 @@ describe('/dashboard/broker-probe カード UI (#461)', () => {
     expect(body).toContain('instrumentStockTrade')
   })
 
+  it('発注前検証 (Preview Order) ボタンと注記がある (#461)', async () => {
+    const app = createApp()
+    const res = await app.request('/dashboard/broker-probe', {}, baseEnv as never)
+    const body = await res.text()
+    expect(body).toContain('id="bp-preview-btn"')
+    expect(body).toContain('注文は作成されません')
+    expect(body).toContain('previewOrder')
+  })
+
   it('control の AAPL chip と再 probe ボタンがある', async () => {
     const app = createApp()
     const res = await app.request('/dashboard/broker-probe', {}, baseEnv)

--- a/test/routes/dashboardBrokerProbe.test.ts
+++ b/test/routes/dashboardBrokerProbe.test.ts
@@ -11,11 +11,8 @@ describe('/dashboard/broker-probe カード UI (#461)', () => {
     const res = await app.request('/dashboard/broker-probe', {}, baseEnv)
     expect(res.status).toBe(200)
     const body = await res.text()
-    // instrument 照会の判定カード + 近似である旨の注記 (#460 への参照)
     expect(body).toContain('Webull 取扱')
     expect(body).toContain('id="bp-instrument-pill"')
-    expect(body).toContain('取扱有無の近似')
-    expect(body).toContain('#460')
     // quote / 買付余力カード
     expect(body).toContain('id="bp-quote-pill"')
     expect(body).toContain('id="bp-yahoo-pill"')
@@ -38,7 +35,7 @@ describe('/dashboard/broker-probe カード UI (#461)', () => {
     const body = await res.text()
     expect(body).toContain('id="probe-submit"')
     expect(body).toContain('id="probe-preview-check"')
-    expect(body).toContain('注文は作成されません')
+    expect(body).toContain('発注なし')
     expect(body).toContain('previewVariants')
     // chip クリックは選択のみ (setSelection)、通信は submit ボタンから
     expect(body).toContain('function setSelection(')

--- a/test/routes/dashboardBrokerProbe.test.ts
+++ b/test/routes/dashboardBrokerProbe.test.ts
@@ -31,7 +31,7 @@ describe('/dashboard/broker-probe カード UI (#461)', () => {
 
   it('選択 → 実行フロー: 実行ボタン / 発注前検証 checkbox / chip は選択のみ (#461)', async () => {
     const app = createApp()
-    const res = await app.request('/dashboard/broker-probe', {}, baseEnv as never)
+    const res = await app.request('/dashboard/broker-probe', {}, baseEnv)
     const body = await res.text()
     expect(body).toContain('id="probe-submit"')
     expect(body).toContain('id="probe-preview-check"')

--- a/test/routes/dashboardBrokerProbe.test.ts
+++ b/test/routes/dashboardBrokerProbe.test.ts
@@ -32,20 +32,16 @@ describe('/dashboard/broker-probe カード UI (#461)', () => {
     expect(body).toContain('instrumentStockTrade')
   })
 
-  it('発注前検証 (Preview Order) ボタンと注記がある (#461)', async () => {
+  it('選択 → 実行フロー: 実行ボタン / 発注前検証 checkbox / chip は選択のみ (#461)', async () => {
     const app = createApp()
     const res = await app.request('/dashboard/broker-probe', {}, baseEnv as never)
     const body = await res.text()
-    expect(body).toContain('id="bp-preview-btn"')
+    expect(body).toContain('id="probe-submit"')
+    expect(body).toContain('id="probe-preview-check"')
     expect(body).toContain('注文は作成されません')
     expect(body).toContain('previewVariants')
-  })
-
-  it('control の AAPL chip と再 probe ボタンがある', async () => {
-    const app = createApp()
-    const res = await app.request('/dashboard/broker-probe', {}, baseEnv)
-    const body = await res.text()
+    // chip クリックは選択のみ (setSelection)、通信は submit ボタンから
+    expect(body).toContain('function setSelection(')
     expect(body).toMatch(/data-symbol="AAPL" data-category="US_STOCK"/)
-    expect(body).toContain('id="probe-refresh"')
   })
 })

--- a/test/routes/dashboardBrokerProbe.test.ts
+++ b/test/routes/dashboardBrokerProbe.test.ts
@@ -38,7 +38,7 @@ describe('/dashboard/broker-probe カード UI (#461)', () => {
     const body = await res.text()
     expect(body).toContain('id="bp-preview-btn"')
     expect(body).toContain('注文は作成されません')
-    expect(body).toContain('previewOrder')
+    expect(body).toContain('previewVariants')
   })
 
   it('control の AAPL chip と再 probe ボタンがある', async () => {

--- a/test/routes/dashboardSymbolsCrud.test.ts
+++ b/test/routes/dashboardSymbolsCrud.test.ts
@@ -1627,3 +1627,32 @@ describe('CodeRabbit #453 対応 (不正 role のフォーム防御)', () => {
     expect(body).not.toMatch(/<option value="" selected>未設定/)
   })
 })
+
+describe('新規登録フォームの取扱チェック (#461)', () => {
+  beforeEach(() => {
+    vi.mocked(loadGlobalConfigFrom).mockResolvedValue(makeGlobalConfigSnapshot())
+  })
+  afterEach(() => vi.resetAllMocks())
+
+  it('new フォームに取扱チェック表示と denied 時の保存ブロックがある', async () => {
+    const db = fakeDb([])
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const app = createApp()
+    const res = await app.request(
+      '/dashboard/symbols/new',
+      { headers: authHeader },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    const body = await res.text()
+    expect(body).toContain('id="symbol-tradability"')
+    expect(body).toContain('/admin/symbol-config/tradability-check')
+    expect(body).toContain('id="symbol-form-save"')
+    expect(body).toContain('_tradabilityDenied')
+    // denied のみブロック (error/unavailable は登録可能の文言)
+    expect(body).toContain('登録は可能')
+    // inline script が構文エラーなく parse できる (#465 の回帰ガードをこのページにも)
+    for (const m of body.matchAll(/<script>([\s\S]*?)<\/script>/g)) {
+      expect(() => new Function(m[1]!)).not.toThrow()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

「その銘柄が Webull JP でサポートされているか」の実際に機能する事前チェック (#461) + 診断ページ UX 刷新。

### 取扱チェック (Preview Order)

- **`POST /openapi/account/orders/preview`** (JP docs 正式記載) = 発注パイプラインの検証のみで**注文は作成されない**。生きている trade host 側
- body shape は JP 実測で確定途中のため 3 候補を並列で試す (#415 方式)。共有モジュール `tradabilityCheck.ts`
- **判定の堅牢化**: HTTP 200 でも body 内の埋め込み error_code を走査 (本番 place の USMV deny と staging preview pass の矛盾調査より)。deny 判定 > 200 判定の優先順。判定根拠 (body 抜粋・estimated_cost) をレスポンスに含める

### 登録フォーム (`/dashboard/symbols/new`)

- 銘柄選択時に横で自動チェック: ✅ 取引可能 / **❌ 取扱なし → 保存ブロック** / ❓ 確認不可 (登録は可能)
- ブロックは TICKER_IS_DENY 確定時のみ — check 不能で全登録を止めない (発注側は #460 の事後ガードが防衛)
- 新 endpoint `GET /admin/symbol-config/tradability-check?symbol&market`

### 診断ページ刷新

- **選択 → ☑発注前検証 → [診断を実行] → 結果**の明示フロー (chip クリックは選択のみ)
- AAPL control chip は未登録環境のみ表示 (重複解消)、説明文を削減
- 死んでいる Webull quote カードは「詳細」へ格下げ (稼働開始は疎通監視 #21 が通知)
- instrument 照会は JP 正式 path (`/openapi/instrument/stock/list`) を probe (JP は全 path 404/無応答が現状 — 判定不可は正常)

## Test

- \`pnpm test\`: 103 files / 1440 tests pass (新規: tradabilityCheck 9 / form gate 1 / UI)
- staging で動作確認済み (operator LGTM)

Refs #461 #460 #415