### PR TITLE
fix: 取扱チェックの判定を実証ベースに修正 (preview は allowlist を検証しない)

### DIFF
--- a/src/infrastructure/webull/tradabilityCheck.ts
+++ b/src/infrastructure/webull/tradabilityCheck.ts
@@ -4,23 +4,27 @@ import { resolveAccessToken } from './resolveAccessToken'
 import { toWebullPlaceOrderRequest } from './mapper'
 
 /**
- * 銘柄の Webull JP 取扱チェック (#461)。Preview Order
- * (`POST /openapi/account/orders/preview`) で発注パイプラインの検証だけを通す —
- * **注文は作成されない** (path は preview 固定)。取扱外銘柄は検証段階で
- * `TICKER_IS_DENY` が返るため、発注せずに取引可否を確定できる。
+ * 銘柄の Webull JP 取扱チェック (#461)。
  *
- * body shape は JP 実測で確定途中 (#461: v1 place 形は OPENAPI_PARAM_ERR) の
- * ため、候補 shape を並列で試す (#415 の path 確定と同じ方式)。判定は:
- *   - どれかが 200            → 'tradable'
- *   - どれかが TICKER_IS_DENY → 'denied' (確定)
- *   - 応答はあるが全部エラー   → 'error' (銘柄以外の要因の可能性)
- *   - 設定不足 / 全部不達      → 'unavailable'
+ * **実測で確定した Preview Order (`POST /openapi/account/orders/preview`) の性質
+ * (2026-06-11)**:
+ *   - 実在しない symbol (ZZZZ) は `OAUTH_OPENAPI_PARAM_ERR`
+ *     ("invalid market,symbol,instrument_type") で拒否 → **銘柄マスタの存在検証は
+ *     している**
+ *   - 一方、本番 place が TICKER_IS_DENY で拒否した USMV は preview 200 + 見積を
+ *     返した → **発注 allowlist (deny list) までは検証しない** (または deny list が
+ *     日次で変わる)。**preview 200 から「取引可能」は主張できない**
  *
- * 'denied' 以外で登録をブロックしない想定 (check 不能時に全登録が止まるのは
- * 過剰 fail-closed — 発注側には #460 の事後ガードが別途ある)。
+ * 出せる判定:
+ *   - 'denied'  : (a) 全 variant が銘柄不正 PARAM_ERR (= マスタに不存在 or
+ *                 market/type 不一致)、(b) preview が TICKER_IS_DENY を返した、
+ *                 (c) 呼び出し側 (admin endpoint) が過去の deny 実績
+ *                 (symbol_config.notes の #460 マーカー) を検出した場合
+ *   - 'unknown' : preview は通った/エラーだが確定情報なし。「見積もり可」でも
+ *                 発注可否は保証しない (USMV の前例)。登録はブロックしない
+ *   - 'unavailable': 設定不足 / broker 不達 (判定プロセス自体が走れず)
  */
-
-export type TradabilityVerdict = 'tradable' | 'denied' | 'error' | 'unavailable'
+export type TradabilityVerdict = 'denied' | 'unknown' | 'unavailable'
 
 /**
  * 銘柄単位の恒久拒否コード判定。Webull は `OAUTH_OPENAPI_` prefix 付き/なしの
@@ -28,6 +32,20 @@ export type TradabilityVerdict = 'tradable' | 'denied' | 'error' | 'unavailable'
  */
 export function isTickerDenyCode(errorCode: string | null): boolean {
   return errorCode !== null && errorCode.endsWith('TICKER_IS_DENY')
+}
+
+/**
+ * 「銘柄が不正」型の PARAM_ERR か (ZZZZ 実測: message が
+ * "Parameter error, invalid market,symbol,instrument_type, value: ..." の形)。
+ * 他フィールド起因の PARAM_ERR と区別するため 'symbol' を含むものに限定する。
+ */
+function isInvalidSymbolParamError(r: TradabilityVariantResult): boolean {
+  return (
+    r.errorCode !== null &&
+    r.errorCode.endsWith('PARAM_ERR') &&
+    typeof r.message === 'string' &&
+    /invalid[^"]*symbol/i.test(r.message)
+  )
 }
 
 export interface TradabilityVariantResult {
@@ -41,6 +59,13 @@ export interface TradabilityVariantResult {
 
 export interface TradabilityResult {
   verdict: TradabilityVerdict
+  /**
+   * UI 表示分岐用の判定根拠。
+   * known_deny: 過去の実発注 deny 実績 / ticker_deny: preview が deny を返却 /
+   * invalid_symbol: 銘柄マスタに不存在 / quote_ok: 見積もり成功 (保証なし) /
+   * preview_error: 判定材料にならないエラー / unreachable: 不達・設定不足
+   */
+  reason: 'known_deny' | 'ticker_deny' | 'invalid_symbol' | 'quote_ok' | 'preview_error' | 'unreachable'
   /** operator 向けの 1 行説明。 */
   detail: string
   variants: TradabilityVariantResult[]
@@ -134,6 +159,7 @@ export async function checkTradability(env: Env, input: CheckInput): Promise<Tra
   if (appKey.length === 0 || appSecret.length === 0 || accountId.length === 0) {
     return {
       verdict: 'unavailable',
+      reason: 'unreachable',
       detail: 'Webull credentials 未設定のため検証不可',
       variants: [],
     }
@@ -212,31 +238,44 @@ export async function checkTradability(env: Env, input: CheckInput): Promise<Tra
     }),
   )
 
-  // deny 判定を 200 判定より先に — 200 body に埋まった deny を「取引可能」と
-  // 誤読しない (status より error_code を信じる)。
+  // 確定 NG (1): preview が deny を返した場合。
   if (results.some((r) => isTickerDenyCode(r.errorCode))) {
     return {
       verdict: 'denied',
+      reason: 'ticker_deny',
       detail: 'Webull JP の OpenAPI では発注できない銘柄 (TICKER_IS_DENY)',
       variants: results,
     }
   }
-  const cleanOk = results.find((r) => r.status === 200 && r.errorCode === null)
-  if (cleanOk) {
-    const cost = cleanOk.bodyExcerpt?.match(/"estimated_cost"\s*:\s*"?([0-9.]+)"?/)?.[1]
+  const responding = results.filter((r) => r.status !== null)
+  // 確定 NG (2): 応答した全 variant が「銘柄不正」PARAM_ERR (= マスタに不存在
+  // or market/instrument_type の組合せ不正。ZZZZ 実測パターン)。
+  if (responding.length > 0 && responding.every((r) => isInvalidSymbolParamError(r))) {
     return {
-      verdict: 'tradable',
-      detail: `発注前検証 (Preview Order) 通過 — 取引可能${cost ? ` (estimated_cost: ${cost})` : ''}`,
+      verdict: 'denied',
+      reason: 'invalid_symbol',
+      detail: 'Webull の銘柄マスタに存在しない (symbol / market の組合せ不正)',
       variants: results,
     }
   }
-  if (results.some((r) => r.status !== null)) {
-    const codes = [...new Set(results.map((r) => r.errorCode).filter(Boolean))].join(', ')
+  // 200 = 見積もり成功。ただし発注 allowlist は検証されない (USMV の前例) ので
+  // 「取引可能」とは言わない。
+  if (results.some((r) => r.status === 200 && r.errorCode === null)) {
     return {
-      verdict: 'error',
-      detail: `検証エラー (${codes || 'unknown'}) — 銘柄以外の要因の可能性`,
+      verdict: 'unknown',
+      reason: 'quote_ok',
+      detail: '銘柄は存在し見積もり可。ただし発注可否 (deny list) は事前検証不可 — 最終確認は Webull アプリで',
       variants: results,
     }
   }
-  return { verdict: 'unavailable', detail: 'broker に到達できず判定不可', variants: results }
+  if (responding.length > 0) {
+    const codes = [...new Set(responding.map((r) => r.errorCode).filter(Boolean))].join(', ')
+    return {
+      verdict: 'unknown',
+      reason: 'preview_error',
+      detail: `判定材料が得られませんでした (${codes || 'unknown'})`,
+      variants: results,
+    }
+  }
+  return { verdict: 'unavailable', reason: 'unreachable', detail: 'broker に到達できず判定不可', variants: results }
 }

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1774,6 +1774,20 @@ export const admin = new Hono<AppBindings>()
       return c.json({ error: 'market must be US or JP' }, 400)
     }
     const market = marketRaw
+    // 確定 NG (registry): #460 ガード/手動対応が symbol_config.notes に残した
+    // deny マーカー。過去に実発注で拒否された銘柄は broker に聞くまでもなく ❌
+    // (preview は allowlist を検証しないため、これが唯一の事前 ❌ 根拠)。
+    if (c.env.DB) {
+      const row = await findSymbolConfig(createDb(c.env.DB), symbolRaw).catch(() => null)
+      if (row?.notes?.includes('TICKER_IS_DENY')) {
+        return c.json({
+          verdict: 'denied',
+          reason: 'known_deny',
+          detail: '過去に Webull が実発注を拒否した実績あり (symbol_config.notes に記録)',
+          variants: [],
+        })
+      }
+    }
     const priceRaw = Number(c.req.query('price'))
     const result = await checkTradability(c.env, {
       symbol: symbolRaw,

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -2081,12 +2081,26 @@ function brokerProbeBody(args: {
         if (v.result && v.result.phase === 'response' && typeof v.result.bodyTruncated === 'string' &&
             v.result.bodyTruncated.indexOf('TICKER_IS_DENY') !== -1) { denyVariant = v; }
       }
+      // 全 variant が「銘柄不正」PARAM_ERR → マスタに不存在 (ZZZZ 実測パターン)。
+      var respondingAll = body.previewVariants.filter(function (v) { return v.result && v.result.status !== null; });
+      var allInvalidSymbol = respondingAll.length > 0 && respondingAll.every(function (v) {
+        var b = parseBody(v.result);
+        return b && typeof b.error_code === 'string' && b.error_code.indexOf('PARAM_ERR') !== -1 &&
+          typeof b.message === 'string' && /invalid[^"]*symbol/i.test(b.message);
+      });
+      if (allInvalidSymbol) {
+        setPill('bp-instrument-pill', 'ng', '銘柄不正');
+        bodyEl.innerHTML = '<strong>' + escHtml(symbol.toUpperCase()) + '</strong> は Webull の銘柄マスタに存在しません (symbol / market の組合せ不正)。';
+        return;
+      }
       if (okVariant) {
-        setPill('bp-instrument-pill', 'ok', '取引可能');
+        // preview 200 = 見積もり成功。発注 allowlist は検証されない (USMV 前例)
+        // ため「取引可能」とは表示しない。
+        setPill('bp-instrument-pill', 'unknown', '見積もり可');
         var okParsed = parseBody(okVariant.result);
         var cost = okParsed && (okParsed.estimated_cost || (okParsed.data && okParsed.data.estimated_cost));
-        bodyEl.innerHTML = '<strong>' + escHtml(symbol.toUpperCase()) + '</strong> は発注前検証 (Preview Order) を通過しました — 取引可能です。' +
-          '<span class="muted" style="font-size:12px"> (body shape: ' + escHtml(okVariant.label) + (cost ? ' / estimated_cost: ' + escHtml(cost) : '') + ')</span>';
+        bodyEl.innerHTML = '<strong>' + escHtml(symbol.toUpperCase()) + '</strong> は銘柄として存在し見積もり可' + (cost ? ' (estimated_cost: ' + escHtml(cost) + ')' : '') + '。' +
+          '<span class="muted">発注可否 (deny list) は事前検証不可 — 最終確認は Webull アプリで。</span>';
         return;
       }
       if (denyVariant) {
@@ -9054,16 +9068,20 @@ function symbolFormBody(args: SymbolFormArgs): string {
         .then(function (r) { return r.json(); })
         .then(function (res) {
           if (mySeq !== window._tradabilitySeq) return; // 古い応答は捨てる
-          if (res.verdict === 'tradable') {
-            statusEl.textContent = '✅ 取引可能';
-            statusEl.style.color = '#057a55';
-          } else if (res.verdict === 'denied') {
-            statusEl.textContent = '❌ Webull JP 取扱なし — 登録できません';
+          if (res.verdict === 'denied') {
+            var why = res.reason === 'known_deny' ? '過去に Webull が発注拒否'
+              : res.reason === 'invalid_symbol' ? 'Webull に存在しない銘柄'
+              : 'Webull JP 取扱なし';
+            statusEl.textContent = '❌ ' + why + ' — 登録できません';
             statusEl.style.color = '#c22';
             window._tradabilityDenied = true;
             if (saveBtn) { saveBtn.disabled = true; saveBtn.style.opacity = '0.4'; }
+          } else if (res.reason === 'quote_ok') {
+            // preview は発注 allowlist を検証しない (USMV 前例) ので ✅ は出さない
+            statusEl.textContent = '△ 見積もり可 — 発注可否は未保証 (Webull アプリで確認)';
+            statusEl.style.color = '#b25000';
           } else {
-            statusEl.textContent = '❓ 取扱を確認できませんでした (登録は可能)';
+            statusEl.textContent = '❓ 確認不可 (登録は可能)';
             statusEl.style.color = '#86868b';
           }
         })

--- a/test/infrastructure/webull/tradabilityCheck.test.ts
+++ b/test/infrastructure/webull/tradabilityCheck.test.ts
@@ -21,7 +21,7 @@ function fetcherReturning(bodies: Array<{ status: number; body: unknown }>): typ
 }
 
 describe('checkTradability (#461 Preview Order)', () => {
-  it('verdict=tradable when any variant returns 200', async () => {
+  it('verdict=unknown(quote_ok) when any variant returns 200 — 取引可能とは主張しない', async () => {
     const result = await checkTradability(env, {
       symbol: 'aapl',
       market: 'US',
@@ -31,7 +31,38 @@ describe('checkTradability (#461 Preview Order)', () => {
         { status: 417, body: { error_code: 'OPENAPI_PARAM_ERR' } },
       ]),
     })
-    expect(result.verdict).toBe('tradable')
+    expect(result.verdict).toBe('unknown')
+    expect(result.reason).toBe('quote_ok')
+  })
+
+  it('verdict=denied(invalid_symbol) when all variants reject the symbol (ZZZZ 実測)', async () => {
+    const result = await checkTradability(env, {
+      symbol: 'ZZZZ',
+      market: 'US',
+      fetcher: fetcherReturning([
+        {
+          status: 417,
+          body: {
+            error_code: 'OAUTH_OPENAPI_PARAM_ERR',
+            message: 'Parameter error, invalid market,symbol,instrument_type, value: US,ZZZZ,EQUITY',
+          },
+        },
+      ]),
+    })
+    expect(result.verdict).toBe('denied')
+    expect(result.reason).toBe('invalid_symbol')
+  })
+
+  it('symbol を含まない PARAM_ERR は invalid_symbol にしない (他フィールド起因)', async () => {
+    const result = await checkTradability(env, {
+      symbol: 'AAPL',
+      market: 'US',
+      fetcher: fetcherReturning([
+        { status: 417, body: { error_code: 'OAUTH_OPENAPI_PARAM_ERR', message: 'Parameter error, invalid quantity' } },
+      ]),
+    })
+    expect(result.verdict).toBe('unknown')
+    expect(result.reason).toBe('preview_error')
   })
 
   it('verdict=denied when any variant returns TICKER_IS_DENY (確定 NG)', async () => {
@@ -46,14 +77,14 @@ describe('checkTradability (#461 Preview Order)', () => {
     expect(result.detail).toContain('TICKER_IS_DENY')
   })
 
-  it('verdict=error when broker responds but all variants fail with other codes', async () => {
+  it('message なしの PARAM_ERR 等は unknown(preview_error)', async () => {
     const result = await checkTradability(env, {
       symbol: 'AAPL',
       market: 'US',
       fetcher: fetcherReturning([{ status: 417, body: { error_code: 'OPENAPI_PARAM_ERR' } }]),
     })
-    expect(result.verdict).toBe('error')
-    expect(result.detail).toContain('OPENAPI_PARAM_ERR')
+    expect(result.verdict).toBe('unknown')
+    expect(result.reason).toBe('preview_error')
   })
 
   it('verdict=unavailable when credentials are missing (登録はブロックしない側)', async () => {
@@ -100,7 +131,7 @@ describe('checkTradability 200 偽陽性ガード (#461 本番 deny との矛盾
     expect(result.verdict).toBe('denied')
   })
 
-  it('HTTP 200 でも body に別の error_code が埋まっていれば tradable にしない', async () => {
+  it('HTTP 200 でも body に別の error_code が埋まっていれば quote_ok にしない', async () => {
     const result = await checkTradability(env, {
       symbol: 'AAPL',
       market: 'US',
@@ -108,10 +139,11 @@ describe('checkTradability 200 偽陽性ガード (#461 本番 deny との矛盾
         { status: 200, body: { new_orders: [{ error_code: 'SOME_EMBEDDED_ERR' }] } },
       ]),
     })
-    expect(result.verdict).toBe('error')
+    expect(result.verdict).toBe('unknown')
+    expect(result.reason).toBe('preview_error')
   })
 
-  it('クリーンな 200 (estimated_cost) は根拠付きで tradable', async () => {
+  it('クリーンな 200 は quote_ok (発注可否は未保証の文言)', async () => {
     const result = await checkTradability(env, {
       symbol: 'AAPL',
       market: 'US',
@@ -120,8 +152,9 @@ describe('checkTradability 200 偽陽性ガード (#461 本番 deny との矛盾
         { status: 200, body: { estimated_cost: '292.55', estimated_transaction_fee: '0' } },
       ]),
     })
-    expect(result.verdict).toBe('tradable')
-    expect(result.detail).toContain('estimated_cost: 292.55')
+    expect(result.verdict).toBe('unknown')
+    expect(result.reason).toBe('quote_ok')
+    expect(result.detail).toContain('事前検証不可')
   })
 })
 

--- a/test/routes/dashboardSymbolsCrud.test.ts
+++ b/test/routes/dashboardSymbolsCrud.test.ts
@@ -1648,8 +1648,9 @@ describe('新規登録フォームの取扱チェック (#461)', () => {
     expect(body).toContain('/admin/symbol-config/tradability-check')
     expect(body).toContain('id="symbol-form-save"')
     expect(body).toContain('_tradabilityDenied')
-    // denied のみブロック (error/unavailable は登録可能の文言)
+    // denied のみブロック。quote_ok は ✅ ではなく △ (発注可否は未保証)
     expect(body).toContain('登録は可能')
+    expect(body).toContain('発注可否は未保証')
     // inline script が構文エラーなく parse できる (#465 の回帰ガードをこのページにも)
     for (const m of body.matchAll(/<script>([\s\S]*?)<\/script>/g)) {
       expect(() => new Function(m[1]!)).not.toThrow()


### PR DESCRIPTION
## 実験で確定した事実 (#461)

| 銘柄 | preview | 実発注 (place) |
|---|---|---|
| ZZZZ (実在しない) | ❌ PARAM_ERR (invalid symbol) | — |
| USMV | ✅ 200 + 見積もり | ❌ TICKER_IS_DENY (本番 6/10 21:00 UTC) |

→ **Preview Order は銘柄マスタの存在は検証するが、発注 allowlist (deny list) は検証しない**。preview 200 から「取引可能」は主張できない (偽陽性の実例 = USMV)。

## 変更

- verdict を実証可能な 3 値に: `denied` / `unknown` / `unavailable` + UI 分岐用の `reason`
- **❌ 確定 NG の根拠は 3 つ**:
  1. preview が TICKER_IS_DENY を返した場合
  2. 全 variant が「銘柄不正」PARAM_ERR (ZZZZ 型 = マスタに不存在)
  3. **過去の実発注 deny 実績** — #460 ガードが `symbol_config.notes` に残すマーカーを broker 照会前に検査 (本番の USMV はこれで即 ❌)
- preview 200 は **「△ 見積もり可 — 発注可否は未保証 (Webull アプリで確認)」** に降格。✅「取引可能」表示は廃止
- フォームのブロックは ❌ (known_deny / invalid_symbol / ticker_deny) のみ。△/❓ は登録可能

## Test

\`pnpm test\`: 103 files / 1443 tests pass (ZZZZ 実測パターン・偽陽性ガード・registry 判定を追加)

Refs #461 #460

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  - 銘柄の取扱可否判定をより詳細化。「拒否」「未検証」「利用不可」の3段階に加え、拒否理由（過去に拒否・銘柄不在・Webull JP未取扱）を表示。
  - ダッシュボードの取扱チェック UI で理由別に異なるメッセージを表示し、発注可否確認の透明性を向上。

* **テスト**
  - 新しい判定ロジックに対応したテスト期待値を更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->