### PR TITLE
POC Phase follow-up: Pair regime layer — インバース対の採択ロジック (issue #472)

### DIFF
--- a/drizzle/0031_add_pair_regime.sql
+++ b/drizzle/0031_add_pair_regime.sql
@@ -1,0 +1,8 @@
+ALTER TABLE `global_config` ADD `pair_regime_mode` text DEFAULT 'off' NOT NULL;--> statement-breakpoint
+ALTER TABLE `global_config` ADD `pair_regime_theta_bull_enter` real DEFAULT 0.03 NOT NULL;--> statement-breakpoint
+ALTER TABLE `global_config` ADD `pair_regime_theta_bull_exit` real DEFAULT 0.01 NOT NULL;--> statement-breakpoint
+ALTER TABLE `global_config` ADD `pair_regime_theta_bear_enter` real DEFAULT -0.04 NOT NULL;--> statement-breakpoint
+ALTER TABLE `global_config` ADD `pair_regime_theta_bear_exit` real DEFAULT -0.015 NOT NULL;--> statement-breakpoint
+ALTER TABLE `inverse_pairs` ADD `regime_enabled` integer DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE `inverse_pairs` ADD `regime_proxy_symbol` text;--> statement-breakpoint
+ALTER TABLE `inverse_pairs` ADD `regime_bull_symbol` text;

--- a/drizzle/meta/0031_snapshot.json
+++ b/drizzle/meta/0031_snapshot.json
@@ -1,0 +1,1506 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "5b489c56-5f18-4992-92f5-fc6ada6c7210",
+  "prevId": "90dd37e7-072d-4c97-ad2e-25ee454f3048",
+  "tables": {
+    "config_audit_log": {
+      "name": "config_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before_json": {
+          "name": "before_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "after_json": {
+          "name": "after_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "config_audit_log_timestamp_id_idx": {
+          "name": "config_audit_log_timestamp_id_idx",
+          "columns": [
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "config_audit_log_actor_timestamp_id_idx": {
+          "name": "config_audit_log_actor_timestamp_id_idx",
+          "columns": [
+            "actor",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "config_audit_log_endpoint_timestamp_id_idx": {
+          "name": "config_audit_log_endpoint_timestamp_id_idx",
+          "columns": [
+            "endpoint",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "config_state_snapshot": {
+      "name": "config_state_snapshot",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "earnings_calendar": {
+      "name": "earnings_calendar",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "earnings_date": {
+          "name": "earnings_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "earnings_calendar_symbol_date_unique": {
+          "name": "earnings_calendar_symbol_date_unique",
+          "columns": [
+            "symbol",
+            "earnings_date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "global_config": {
+      "name": "global_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "trading_enabled": {
+          "name": "trading_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "market_hours_check": {
+          "name": "market_hours_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "max_order_notional": {
+          "name": "max_order_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "max_order_notional_usd": {
+          "name": "max_order_notional_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2000
+        },
+        "max_order_notional_jpy": {
+          "name": "max_order_notional_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100000
+        },
+        "total_capital_usd": {
+          "name": "total_capital_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_capital_jpy": {
+          "name": "total_capital_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_portfolio_exposure_pct": {
+          "name": "max_portfolio_exposure_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.6
+        },
+        "drawdown_kill_threshold": {
+          "name": "drawdown_kill_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.02
+        },
+        "stale_quote_ms": {
+          "name": "stale_quote_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 900000
+        },
+        "gap_reject_pct": {
+          "name": "gap_reject_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.03
+        },
+        "spread_limit_pct_us": {
+          "name": "spread_limit_pct_us",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.0025
+        },
+        "spread_limit_pct_jp": {
+          "name": "spread_limit_pct_jp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.006
+        },
+        "pullback_default_stop_pct": {
+          "name": "pullback_default_stop_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.04
+        },
+        "pullback_default_take_profit_pct": {
+          "name": "pullback_default_take_profit_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.07
+        },
+        "pullback_default_time_stop_days": {
+          "name": "pullback_default_time_stop_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "pullback_default_pullback_max": {
+          "name": "pullback_default_pullback_max",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.03
+        },
+        "pullback_default_pullback_min": {
+          "name": "pullback_default_pullback_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.06
+        },
+        "pullback_default_min_return_50d": {
+          "name": "pullback_default_min_return_50d",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.08
+        },
+        "pullback_default_require_above_sma50": {
+          "name": "pullback_default_require_above_sma50",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "pullback_default_k_atr": {
+          "name": "pullback_default_k_atr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "pullback_default_max_sma50_deviation_pct": {
+          "name": "pullback_default_max_sma50_deviation_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.6
+        },
+        "pullback_default_max_atr_ratio": {
+          "name": "pullback_default_max_atr_ratio",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1.5
+        },
+        "risk_base_per_trade_pct": {
+          "name": "risk_base_per_trade_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.004
+        },
+        "risk_dd_half_threshold": {
+          "name": "risk_dd_half_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.05
+        },
+        "risk_dd_halt_threshold": {
+          "name": "risk_dd_halt_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.1
+        },
+        "vix_warning_threshold": {
+          "name": "vix_warning_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 25
+        },
+        "vix_critical_threshold": {
+          "name": "vix_critical_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "vix_warning_size_scale": {
+          "name": "vix_warning_size_scale",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.5
+        },
+        "pair_regime_mode": {
+          "name": "pair_regime_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'off'"
+        },
+        "pair_regime_theta_bull_enter": {
+          "name": "pair_regime_theta_bull_enter",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.03
+        },
+        "pair_regime_theta_bull_exit": {
+          "name": "pair_regime_theta_bull_exit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.01
+        },
+        "pair_regime_theta_bear_enter": {
+          "name": "pair_regime_theta_bear_enter",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.04
+        },
+        "pair_regime_theta_bear_exit": {
+          "name": "pair_regime_theta_bear_exit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.015
+        },
+        "overview_panels": {
+          "name": "overview_panels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'kpi,equity,composition,recent'"
+        },
+        "cash_fallback_orders_enabled": {
+          "name": "cash_fallback_orders_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "global_config_max_order_notional_range": {
+          "name": "global_config_max_order_notional_range",
+          "value": "\"global_config\".\"max_order_notional\" > 0 AND \"global_config\".\"max_order_notional\" <= 10000000"
+        },
+        "global_config_max_order_notional_usd_range": {
+          "name": "global_config_max_order_notional_usd_range",
+          "value": "\"global_config\".\"max_order_notional_usd\" > 0 AND \"global_config\".\"max_order_notional_usd\" <= 1000000"
+        },
+        "global_config_max_order_notional_jpy_range": {
+          "name": "global_config_max_order_notional_jpy_range",
+          "value": "\"global_config\".\"max_order_notional_jpy\" > 0 AND \"global_config\".\"max_order_notional_jpy\" <= 100000000"
+        },
+        "global_config_total_capital_usd_range": {
+          "name": "global_config_total_capital_usd_range",
+          "value": "\"global_config\".\"total_capital_usd\" IS NULL OR \"global_config\".\"total_capital_usd\" > 0"
+        },
+        "global_config_total_capital_jpy_range": {
+          "name": "global_config_total_capital_jpy_range",
+          "value": "\"global_config\".\"total_capital_jpy\" IS NULL OR \"global_config\".\"total_capital_jpy\" > 0"
+        },
+        "global_config_max_portfolio_exposure_pct_range": {
+          "name": "global_config_max_portfolio_exposure_pct_range",
+          "value": "\"global_config\".\"max_portfolio_exposure_pct\" > 0 AND \"global_config\".\"max_portfolio_exposure_pct\" <= 1"
+        },
+        "global_config_drawdown_kill_threshold_range": {
+          "name": "global_config_drawdown_kill_threshold_range",
+          "value": "\"global_config\".\"drawdown_kill_threshold\" >= -1 AND \"global_config\".\"drawdown_kill_threshold\" <= 0"
+        },
+        "global_config_stale_quote_ms_range": {
+          "name": "global_config_stale_quote_ms_range",
+          "value": "\"global_config\".\"stale_quote_ms\" >= 0"
+        },
+        "global_config_gap_reject_pct_range": {
+          "name": "global_config_gap_reject_pct_range",
+          "value": "\"global_config\".\"gap_reject_pct\" >= 0 AND \"global_config\".\"gap_reject_pct\" <= 1"
+        },
+        "global_config_spread_limit_pct_us_range": {
+          "name": "global_config_spread_limit_pct_us_range",
+          "value": "\"global_config\".\"spread_limit_pct_us\" >= 0 AND \"global_config\".\"spread_limit_pct_us\" <= 1"
+        },
+        "global_config_spread_limit_pct_jp_range": {
+          "name": "global_config_spread_limit_pct_jp_range",
+          "value": "\"global_config\".\"spread_limit_pct_jp\" >= 0 AND \"global_config\".\"spread_limit_pct_jp\" <= 1"
+        },
+        "global_config_pullback_default_stop_pct_range": {
+          "name": "global_config_pullback_default_stop_pct_range",
+          "value": "\"global_config\".\"pullback_default_stop_pct\" < 0 AND \"global_config\".\"pullback_default_stop_pct\" >= -1"
+        },
+        "global_config_pullback_default_take_profit_pct_range": {
+          "name": "global_config_pullback_default_take_profit_pct_range",
+          "value": "\"global_config\".\"pullback_default_take_profit_pct\" > 0 AND \"global_config\".\"pullback_default_take_profit_pct\" <= 1"
+        },
+        "global_config_pullback_default_time_stop_days_range": {
+          "name": "global_config_pullback_default_time_stop_days_range",
+          "value": "\"global_config\".\"pullback_default_time_stop_days\" > 0 AND \"global_config\".\"pullback_default_time_stop_days\" <= ?"
+        },
+        "global_config_pullback_default_pullback_max_range": {
+          "name": "global_config_pullback_default_pullback_max_range",
+          "value": "\"global_config\".\"pullback_default_pullback_max\" <= 0 AND \"global_config\".\"pullback_default_pullback_max\" >= -1"
+        },
+        "global_config_pullback_default_pullback_min_range": {
+          "name": "global_config_pullback_default_pullback_min_range",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= 0 AND \"global_config\".\"pullback_default_pullback_min\" >= -1"
+        },
+        "global_config_pullback_default_min_return_50d_range": {
+          "name": "global_config_pullback_default_min_return_50d_range",
+          "value": "\"global_config\".\"pullback_default_min_return_50d\" >= -1 AND \"global_config\".\"pullback_default_min_return_50d\" <= 10"
+        },
+        "global_config_pullback_default_k_atr_range": {
+          "name": "global_config_pullback_default_k_atr_range",
+          "value": "\"global_config\".\"pullback_default_k_atr\" > 0 AND \"global_config\".\"pullback_default_k_atr\" <= 10"
+        },
+        "global_config_pullback_default_pullback_window_order": {
+          "name": "global_config_pullback_default_pullback_window_order",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= \"global_config\".\"pullback_default_pullback_max\""
+        },
+        "global_config_risk_base_per_trade_pct_range": {
+          "name": "global_config_risk_base_per_trade_pct_range",
+          "value": "\"global_config\".\"risk_base_per_trade_pct\" > 0 AND \"global_config\".\"risk_base_per_trade_pct\" <= 1"
+        },
+        "global_config_risk_dd_half_threshold_range": {
+          "name": "global_config_risk_dd_half_threshold_range",
+          "value": "\"global_config\".\"risk_dd_half_threshold\" < 0 AND \"global_config\".\"risk_dd_half_threshold\" >= -1"
+        },
+        "global_config_risk_dd_halt_threshold_range": {
+          "name": "global_config_risk_dd_halt_threshold_range",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" < 0 AND \"global_config\".\"risk_dd_halt_threshold\" >= -1"
+        },
+        "global_config_risk_dd_threshold_order": {
+          "name": "global_config_risk_dd_threshold_order",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" <= \"global_config\".\"risk_dd_half_threshold\""
+        },
+        "global_config_vix_warning_threshold_range": {
+          "name": "global_config_vix_warning_threshold_range",
+          "value": "\"global_config\".\"vix_warning_threshold\" > 0 AND \"global_config\".\"vix_warning_threshold\" <= 200"
+        },
+        "global_config_vix_critical_threshold_range": {
+          "name": "global_config_vix_critical_threshold_range",
+          "value": "\"global_config\".\"vix_critical_threshold\" > 0 AND \"global_config\".\"vix_critical_threshold\" <= 200"
+        },
+        "global_config_vix_threshold_order": {
+          "name": "global_config_vix_threshold_order",
+          "value": "\"global_config\".\"vix_warning_threshold\" <= \"global_config\".\"vix_critical_threshold\""
+        },
+        "global_config_vix_warning_size_scale_range": {
+          "name": "global_config_vix_warning_size_scale_range",
+          "value": "\"global_config\".\"vix_warning_size_scale\" >= 0 AND \"global_config\".\"vix_warning_size_scale\" <= 1"
+        }
+      }
+    },
+    "inverse_pairs": {
+      "name": "inverse_pairs",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inverse": {
+          "name": "inverse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "regime_enabled": {
+          "name": "regime_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "regime_proxy_symbol": {
+          "name": "regime_proxy_symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "regime_bull_symbol": {
+          "name": "regime_bull_symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "macro_event_calendar": {
+      "name": "macro_event_calendar",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_time": {
+          "name": "event_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "macro_event_calendar_type_date_unique": {
+          "name": "macro_event_calendar_type_date_unique",
+          "columns": [
+            "event_type",
+            "event_date"
+          ],
+          "isUnique": true
+        },
+        "macro_event_calendar_date_idx": {
+          "name": "macro_event_calendar_date_idx",
+          "columns": [
+            "event_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_emit_log": {
+      "name": "notification_emit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cause": {
+          "name": "cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notification_emit_log_timestamp_id_idx": {
+          "name": "notification_emit_log_timestamp_id_idx",
+          "columns": [
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "notification_emit_log_severity_timestamp_id_idx": {
+          "name": "notification_emit_log_severity_timestamp_id_idx",
+          "columns": [
+            "severity",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "notification_emit_log_event_type_timestamp_id_idx": {
+          "name": "notification_emit_log_event_type_timestamp_id_idx",
+          "columns": [
+            "event_type",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "portfolio_equity_snapshot": {
+      "name": "portfolio_equity_snapshot",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "daily_start_equity_usd": {
+          "name": "daily_start_equity_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_start_equity_jpy": {
+          "name": "daily_start_equity_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_realized_pnl_usd": {
+          "name": "daily_realized_pnl_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_realized_pnl_jpy": {
+          "name": "daily_realized_pnl_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "drawdown_pct": {
+          "name": "drawdown_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "portfolio_equity_snapshot_at_idx": {
+          "name": "portfolio_equity_snapshot_at_idx",
+          "columns": [
+            "snapshot_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "strategy_decision_log": {
+      "name": "strategy_decision_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indicators_json": {
+          "name": "indicators_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trace_json": {
+          "name": "trace_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "strategy_decision_log_symbol_id_idx": {
+          "name": "strategy_decision_log_symbol_id_idx",
+          "columns": [
+            "symbol",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "strategy_decision_log_coid_idx": {
+          "name": "strategy_decision_log_coid_idx",
+          "columns": [
+            "client_order_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "symbol_config": {
+      "name": "symbol_config",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "market": {
+          "name": "market",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_notional": {
+          "name": "max_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_stop_days_override": {
+          "name": "time_stop_days_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "k_atr_override": {
+          "name": "k_atr_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "budget_alloc_pct": {
+          "name": "budget_alloc_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lot_size": {
+          "name": "lot_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stop_pct_override": {
+          "name": "stop_pct_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "take_profit_pct_override": {
+          "name": "take_profit_pct_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "intraday_only": {
+          "name": "intraday_only",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pullback_max_override": {
+          "name": "pullback_max_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pullback_min_override": {
+          "name": "pullback_min_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "min_return_50d_override": {
+          "name": "min_return_50d_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_atr_ratio_override": {
+          "name": "max_atr_ratio_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_sma50_deviation_pct_override": {
+          "name": "max_sma50_deviation_pct_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "require_above_sma50_override": {
+          "name": "require_above_sma50_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alternatives": {
+          "name": "alternatives",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_required": {
+          "name": "entry_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "always_active": {
+          "name": "always_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cash_fallback_symbol": {
+          "name": "cash_fallback_symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "symbol_config_currency_enum": {
+          "name": "symbol_config_currency_enum",
+          "value": "\"symbol_config\".\"currency\" IN ('USD', 'JPY')"
+        },
+        "symbol_config_time_stop_days_override_range": {
+          "name": "symbol_config_time_stop_days_override_range",
+          "value": "\"symbol_config\".\"time_stop_days_override\" IS NULL OR (\"symbol_config\".\"time_stop_days_override\" >= 1 AND \"symbol_config\".\"time_stop_days_override\" <= ?)"
+        },
+        "symbol_config_k_atr_override_range": {
+          "name": "symbol_config_k_atr_override_range",
+          "value": "\"symbol_config\".\"k_atr_override\" IS NULL OR (\"symbol_config\".\"k_atr_override\" >= 0.5 AND \"symbol_config\".\"k_atr_override\" <= 5.0)"
+        }
+      }
+    },
+    "trade_journal": {
+      "name": "trade_journal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trade_event_type": {
+          "name": "trade_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "strategy_name": {
+          "name": "strategy_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_action": {
+          "name": "signal_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_reason": {
+          "name": "signal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_allowed": {
+          "name": "risk_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_reasons": {
+          "name": "risk_reasons",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "limit_price": {
+          "name": "limit_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notional": {
+          "name": "notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "broker_status": {
+          "name": "broker_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "submitted": {
+          "name": "submitted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_qty": {
+          "name": "filled_qty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_price": {
+          "name": "filled_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "realized_pnl": {
+          "name": "realized_pnl",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hold_days": {
+          "name": "hold_days",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_reason": {
+          "name": "exit_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_applied_at": {
+          "name": "state_applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_error": {
+          "name": "state_apply_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_attempts": {
+          "name": "state_apply_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trading_toggle_history": {
+      "name": "trading_toggle_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before": {
+          "name": "before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "after": {
+          "name": "after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -218,6 +218,13 @@
       "when": 1781109056713,
       "tag": "0030_add_conditional_allocation",
       "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "6",
+      "when": 1781174769487,
+      "tag": "0031_add_pair_regime",
+      "breakpoints": true
     }
   ]
 }

--- a/src/infrastructure/db/globalConfigRepo.ts
+++ b/src/infrastructure/db/globalConfigRepo.ts
@@ -56,6 +56,16 @@ export interface GlobalConfigSnapshot {
    * (fail-closed): off の間は判定・表示のみで退避先への自動 BUY は出さない。
    */
   cashFallbackOrdersEnabled: boolean
+  /**
+   * ペアレジーム layer (#472)。'off' (default) / 'observe' (log のみ) /
+   * 'enforce'。enum 外の DB 値は 'off' に倒す (gate 無効 = 従来挙動が安全側)。
+   */
+  pairRegimeMode: 'off' | 'observe' | 'enforce'
+  /** Schmitt 閾値 (1x proxy 基準、#472)。順序検証は pairRegime 側 (破壊→unknown)。 */
+  pairRegimeThetaBullEnter: number
+  pairRegimeThetaBullExit: number
+  pairRegimeThetaBearEnter: number
+  pairRegimeThetaBearExit: number
 }
 
 /**
@@ -95,6 +105,11 @@ export const GLOBAL_CONFIG_DEFAULTS: GlobalConfigSnapshot = Object.freeze({
   vixCriticalThreshold: 30.0,
   vixWarningSizeScale: 0.5,
   cashFallbackOrdersEnabled: false,
+  pairRegimeMode: 'off',
+  pairRegimeThetaBullEnter: 0.03,
+  pairRegimeThetaBullExit: 0.01,
+  pairRegimeThetaBearEnter: -0.04,
+  pairRegimeThetaBearExit: -0.015,
 })
 
 /**
@@ -327,6 +342,12 @@ export async function loadGlobalConfig(
             vixWarningSizeScale: GLOBAL_CONFIG_DEFAULTS.vixWarningSizeScale,
             // 0030 追加列 (#452)。legacy path は default (false = 自動発注しない)。
             cashFallbackOrdersEnabled: GLOBAL_CONFIG_DEFAULTS.cashFallbackOrdersEnabled,
+            // 0031 追加列 (#472)。legacy path は default ('off' = gate 無効)。
+            pairRegimeMode: GLOBAL_CONFIG_DEFAULTS.pairRegimeMode,
+            pairRegimeThetaBullEnter: GLOBAL_CONFIG_DEFAULTS.pairRegimeThetaBullEnter,
+            pairRegimeThetaBullExit: GLOBAL_CONFIG_DEFAULTS.pairRegimeThetaBullExit,
+            pairRegimeThetaBearEnter: GLOBAL_CONFIG_DEFAULTS.pairRegimeThetaBearEnter,
+            pairRegimeThetaBearExit: GLOBAL_CONFIG_DEFAULTS.pairRegimeThetaBearExit,
           }, requestId)
         }
       } catch (legacyError) {
@@ -388,5 +409,18 @@ export async function loadGlobalConfig(
     // 自動発注しない) へ畳む — fail-closed 側なので安全。
     cashFallbackOrdersEnabled:
       row.cashFallbackOrdersEnabled ?? GLOBAL_CONFIG_DEFAULTS.cashFallbackOrdersEnabled,
+    // 0031 で追加 (#472)。mode は enum 検証して不正値は 'off' (gate 無効が安全側)。
+    pairRegimeMode:
+      row.pairRegimeMode === 'observe' || row.pairRegimeMode === 'enforce'
+        ? row.pairRegimeMode
+        : 'off',
+    pairRegimeThetaBullEnter:
+      row.pairRegimeThetaBullEnter ?? GLOBAL_CONFIG_DEFAULTS.pairRegimeThetaBullEnter,
+    pairRegimeThetaBullExit:
+      row.pairRegimeThetaBullExit ?? GLOBAL_CONFIG_DEFAULTS.pairRegimeThetaBullExit,
+    pairRegimeThetaBearEnter:
+      row.pairRegimeThetaBearEnter ?? GLOBAL_CONFIG_DEFAULTS.pairRegimeThetaBearEnter,
+    pairRegimeThetaBearExit:
+      row.pairRegimeThetaBearExit ?? GLOBAL_CONFIG_DEFAULTS.pairRegimeThetaBearExit,
   }, requestId)
 }

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -238,6 +238,23 @@ export type SymbolConfigInsert = typeof symbolConfig.$inferInsert
 export const inversePairs = sqliteTable('inverse_pairs', {
   symbol: text('symbol').primaryKey(),
   inverse: text('inverse').notNull(),
+  /**
+   * ペアレジーム layer (#472) の per-pair opt-in。0 のペアは挙動完全不変。
+   * 1 にする場合は regime_proxy_symbol / regime_bull_symbol が必須 — repo 検証で
+   * 不備があれば該当ペアは zone=unknown (両側 BUY block) に倒す (fail-closed)。
+   */
+  regimeEnabled: integer('regime_enabled', { mode: 'boolean' }).notNull().default(false),
+  /**
+   * レジームスコアの計算対象 (#472 review: **非レバ原資産 ETF** を推奨。例:
+   * SOXL/SOXS → SOXX、TQQQ/SQQQ → QQQ)。universe 登録不要 — regime 評価は
+   * ペア単位で daily bars を独立 fetch する。
+   */
+  regimeProxySymbol: text('regime_proxy_symbol'),
+  /**
+   * ペアのどちらがブル側かの明示 (#472)。convention (symbol 列 = ブル) に
+   * 頼らない。symbol か inverse のどちらかと一致しなければ misconfig。
+   */
+  regimeBullSymbol: text('regime_bull_symbol'),
   updatedAt: text('updated_at').notNull(),
 })
 
@@ -333,6 +350,22 @@ export const globalConfig = sqliteTable(
      * default 0.5 (= 半分に縮小)。0..1 で運用想定。
      */
     vixWarningSizeScale: real('vix_warning_size_scale').notNull().default(0.5),
+    /**
+     * ペアレジーム layer (#472)。'off' (default) | 'observe' (log のみ、gate
+     * しない) | 'enforce'。enum 検証は loader 側 — 不正値は 'off' に倒す
+     * (= gate 無効が安全側)。
+     */
+    pairRegimeMode: text('pair_regime_mode').notNull().default('off'),
+    /**
+     * Schmitt trigger 閾値 (#472、1x 非レバ proxy 基準)。順序制約
+     * bear_enter < bear_exit < bull_exit < bull_enter は SQLite ALTER で
+     * table-level CHECK を足せないため admin parse + runtime 検証で担保
+     * (順序破壊を検出したら該当ペアは zone=unknown)。
+     */
+    pairRegimeThetaBullEnter: real('pair_regime_theta_bull_enter').notNull().default(0.03),
+    pairRegimeThetaBullExit: real('pair_regime_theta_bull_exit').notNull().default(0.01),
+    pairRegimeThetaBearEnter: real('pair_regime_theta_bear_enter').notNull().default(-0.04),
+    pairRegimeThetaBearExit: real('pair_regime_theta_bear_exit').notNull().default(-0.015),
     /**
      * Dashboard overview パネルの表示 ON/OFF (#dashboard-mf-layout)。有効パネル
      * key の CSV。表示専用設定なので trading config (`GlobalConfigSnapshot`) には

--- a/src/infrastructure/db/symbolConfigRepo.ts
+++ b/src/infrastructure/db/symbolConfigRepo.ts
@@ -735,7 +735,11 @@ export async function loadPairRegimeConfigs(
     const proxy = row.regimeProxySymbol?.trim().toUpperCase() ?? ''
     const bull = row.regimeBullSymbol?.trim().toUpperCase() ?? ''
     let invalidConfig: string | null = null
-    if (proxy.length === 0 || !/^[A-Z0-9]{1,10}$/.test(proxy)) {
+    if (a === b) {
+      // 書き込み経路 (buildInversePairWrite) は self-pair を throw で弾くが、
+      // DB 直書きで入り得る。黙って有効扱いにせず unknown へ (CodeRabbit #473)。
+      invalidConfig = `inverse pair must contain two distinct symbols (got ${a}/${b})`
+    } else if (proxy.length === 0 || !/^[A-Z0-9]{1,10}$/.test(proxy)) {
       invalidConfig = `regime_proxy_symbol is missing/invalid for pair ${a}/${b}`
     } else if (bull !== a && bull !== b) {
       invalidConfig = `regime_bull_symbol must be ${a} or ${b} (got '${bull}')`

--- a/src/infrastructure/db/symbolConfigRepo.ts
+++ b/src/infrastructure/db/symbolConfigRepo.ts
@@ -718,6 +718,36 @@ export async function loadInversePairs(
 }
 
 /**
+ * regime 有効化済みペアの設定を返す (#472)。`regime_enabled=1` の行のみ。
+ * proxy / bull の不備・bull がペア членでない等の misconfig は **skip せず**
+ * `invalidConfig` 付きで返す — 下流 (scheduler) が zone=unknown (両側 BUY
+ * block) に倒すため。「不正設定を黙って無効扱い」にしない (fail-closed)。
+ */
+export async function loadPairRegimeConfigs(
+  db: DrizzleD1Database,
+): Promise<import('../../trading/strategy/pairRegime').PairRegimeEntry[]> {
+  const rows = await db.select().from(inversePairs)
+  const entries: import('../../trading/strategy/pairRegime').PairRegimeEntry[] = []
+  for (const row of rows) {
+    if (!row.regimeEnabled) continue
+    const a = row.symbol.toUpperCase()
+    const b = row.inverse.toUpperCase()
+    const proxy = row.regimeProxySymbol?.trim().toUpperCase() ?? ''
+    const bull = row.regimeBullSymbol?.trim().toUpperCase() ?? ''
+    let invalidConfig: string | null = null
+    if (proxy.length === 0 || !/^[A-Z0-9]{1,10}$/.test(proxy)) {
+      invalidConfig = `regime_proxy_symbol is missing/invalid for pair ${a}/${b}`
+    } else if (bull !== a && bull !== b) {
+      invalidConfig = `regime_bull_symbol must be ${a} or ${b} (got '${bull}')`
+    }
+    const bullSymbol = bull === b ? b : a
+    const bearSymbol = bullSymbol === a ? b : a
+    entries.push({ bullSymbol, bearSymbol, proxySymbol: proxy || a, invalidConfig })
+  }
+  return entries
+}
+
+/**
  * inverse_pairs を 1:1 で張る (#315 regime hedge の対登録)。canonical 1 行のみ
  * 保存し、`loadInversePairs` が双方向展開する。
  *

--- a/src/infrastructure/db/symbolUniverse.ts
+++ b/src/infrastructure/db/symbolUniverse.ts
@@ -1,11 +1,13 @@
 import { createDb } from './tradeJournalRepo'
 import {
   loadInversePairs,
+  loadPairRegimeConfigs,
   loadSymbolConfig,
   type SymbolCurrency,
   type SymbolMarket,
   type SymbolRoleValue,
 } from './symbolConfigRepo'
+import type { PairRegimeEntry } from '../../trading/strategy/pairRegime'
 
 export interface SymbolUniverse {
   /** active=1 のみ。cron / risk gate の評価対象。 */
@@ -74,6 +76,8 @@ export interface SymbolUniverse {
   /** symbol → 退避先 symbol (#452)。不在 = 退避しない。 */
   symbolCashFallback: Record<string, string>
   inversePairs: Record<string, string>
+  /** regime 有効化済みペア (#472)。misconfig は invalidConfig 付き (= unknown 扱い)。 */
+  pairRegimes: PairRegimeEntry[]
   source: 'd1'
 }
 
@@ -92,7 +96,11 @@ export async function loadSymbolUniverse(env: UniverseEnv): Promise<SymbolUniver
     throw new Error('loadSymbolUniverse: env.DB is not bound (D1 setup required)')
   }
   const db = createDb(env.DB)
-  const [config, pairs] = await Promise.all([loadSymbolConfig(db), loadInversePairs(db)])
+  const [config, pairs, pairRegimes] = await Promise.all([
+    loadSymbolConfig(db),
+    loadInversePairs(db),
+    loadPairRegimeConfigs(db),
+  ])
   return {
     allowedSymbols: config.allowedSymbols,
     inactiveSymbols: config.inactiveSymbols,
@@ -120,6 +128,7 @@ export async function loadSymbolUniverse(env: UniverseEnv): Promise<SymbolUniver
     symbolAlwaysActive: config.symbolAlwaysActive,
     symbolCashFallback: config.symbolCashFallback,
     inversePairs: pairs,
+    pairRegimes,
     source: 'd1',
   }
 }

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -5952,6 +5952,7 @@ export function renderPairRegimeLine(
     ペアレジーム: <strong style="color:${color}">${esc(PAIR_REGIME_ZONE_LABELS[d.zone])}</strong>
     <span class="muted" style="font-size:12px">この銘柄は${sideJa} → ${verdict}${view.mode === 'observe' ? ' (observe: gate は未適用)' : ''}</span>
     <span class="muted" style="font-size:12px">${d.score !== null ? `score ${(d.score * 100).toFixed(2)}%` : ''} proxy ${esc(d.proxySymbol)}${d.asOfDate ? ` / ${esc(d.asOfDate)} 時点` : ''}</span>
+    ${d.zone === 'unknown' ? `<span class="err" style="font-size:12px">${esc(d.reason)}</span>` : ''}
   </div>`
 }
 

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -61,6 +61,11 @@ import {
 } from '../trading/strategy/entryStatus'
 import { buildSymbolRules } from '../trading/strategy/symbolRuleResolution'
 import {
+  evaluatePairRegime,
+  PAIR_REGIME_ZONE_LABELS,
+  type PairRegimeDecision,
+} from '../trading/strategy/pairRegime'
+import {
   computeConditionalAllocation,
   type SymbolAllocation,
 } from '../trading/strategy/conditionalAllocation'
@@ -516,6 +521,44 @@ export const dashboard = new Hono<DashboardBindings>()
       // 段階判定 (#452 PR 2): 7 gates から ENTRY/HALF/WATCH/NG を導出して表示。
       // WATCH/NG 時は alternatives (表示専用) を併記する。
       const entryStatus = buyability?.current ? deriveEntryStatus(buyability.current) : null
+      // ペアレジーム (#472): focus symbol が regime 有効ペアの一員なら、cron と
+      // 同じ pure 関数で zone を評価して表示する (mode=off では出さない)。
+      let pairRegimeView: { decision: PairRegimeDecision; side: 'bull' | 'bear'; mode: string } | null = null
+      if (focusSymbol && global.pairRegimeMode !== 'off') {
+        const pair = universe.pairRegimes.find(
+          (pr) => pr.bullSymbol === focusSymbol || pr.bearSymbol === focusSymbol,
+        )
+        if (pair) {
+          const side = pair.bullSymbol === focusSymbol ? ('bull' as const) : ('bear' as const)
+          let decision: PairRegimeDecision
+          if (pair.invalidConfig !== null) {
+            decision = { zone: 'unknown', score: null, proxySymbol: pair.proxySymbol, asOfDate: null, reason: `misconfig: ${pair.invalidConfig}` }
+          } else {
+            decision = await new YahooBarClient()
+              .getDailyBars(pair.proxySymbol, 80)
+              .then((bars) =>
+                evaluatePairRegime(bars, {
+                  proxySymbol: pair.proxySymbol,
+                  thresholds: {
+                    bullEnter: global.pairRegimeThetaBullEnter,
+                    bullExit: global.pairRegimeThetaBullExit,
+                    bearEnter: global.pairRegimeThetaBearEnter,
+                    bearExit: global.pairRegimeThetaBearExit,
+                  },
+                  now: new Date(),
+                }),
+              )
+              .catch((err) => ({
+                zone: 'unknown' as const,
+                score: null,
+                proxySymbol: pair.proxySymbol,
+                asOfDate: null,
+                reason: `proxy bars fetch failed: ${messageOf(err)}`,
+              }))
+          }
+          pairRegimeView = { decision, side, mode: global.pairRegimeMode }
+        }
+      }
       // 判定履歴 (#decisions-chart-unify): 戦略判定ページと同じ loader を共用。
       // 失敗 (migration 未適用等) はチャート本体を巻き込まず空表示に落とす。
       const decisionRows =
@@ -539,6 +582,7 @@ export const dashboard = new Hono<DashboardBindings>()
             buyability,
             entryStatus,
             decisionRows,
+            pairRegime: pairRegimeView,
             alternatives: focusSymbol ? universe.symbolAlternatives[focusSymbol] ?? [] : [],
             symbolPolicy: focusSymbol
               ? {
@@ -5694,6 +5738,8 @@ export interface ChartsBodySymbol {
    * loader/renderer を共用 — チャートの判定 pin と同じデータを表でも読める。
    */
   decisionRows?: DecisionRow[]
+  /** ペアレジーム表示 (#472)。regime 有効ペアの一員 + mode != off のときのみ。 */
+  pairRegime?: { decision: PairRegimeDecision; side: 'bull' | 'bear'; mode: string } | null
 }
 
 export interface SymbolPolicySummary {
@@ -5885,6 +5931,27 @@ function renderSymbolDecisionHistory(args: ChartsBodySymbol): string {
       showSymbol: false,
       filterLabel: `symbol=${args.focusSymbol}, limit=30`,
     })}
+  </div>`
+}
+
+/**
+ * ペアレジーム行 (#472)。zone を日本語で表示し、score / proxy / 判定日を併記。
+ * observe mode はその旨を明示 (gate していないことが分かるように)。
+ */
+export function renderPairRegimeLine(
+  view: { decision: PairRegimeDecision; side: 'bull' | 'bear'; mode: string } | null,
+): string {
+  if (!view) return ''
+  const d = view.decision
+  const color =
+    d.zone === 'bull' ? '#057a55' : d.zone === 'bear' ? '#b25000' : d.zone === 'neutral' ? '#46608a' : '#c22'
+  const sideJa = view.side === 'bull' ? 'ブル側' : 'ベア側'
+  const allowed = (view.side === 'bull' && d.zone === 'bull') || (view.side === 'bear' && d.zone === 'bear')
+  const verdict = allowed ? 'entry 可' : 'entry 不可'
+  return `<div style="margin-top:8px;font-size:13px;color:#3a3a3c;display:flex;gap:12px;flex-wrap:wrap;align-items:center">
+    ペアレジーム: <strong style="color:${color}">${esc(PAIR_REGIME_ZONE_LABELS[d.zone])}</strong>
+    <span class="muted" style="font-size:12px">この銘柄は${sideJa} → ${verdict}${view.mode === 'observe' ? ' (observe: gate は未適用)' : ''}</span>
+    <span class="muted" style="font-size:12px">${d.score !== null ? `score ${(d.score * 100).toFixed(2)}%` : ''} proxy ${esc(d.proxySymbol)}${d.asOfDate ? ` / ${esc(d.asOfDate)} 時点` : ''}</span>
   </div>`
 }
 
@@ -7055,6 +7122,7 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
   ${renderZoomPresetButtons(args.symbolChart)}
   </div>
   ${renderSymbolPolicyLine(args.focusSymbol, args.symbolPolicy ?? null)}
+  ${renderPairRegimeLine(args.pairRegime ?? null)}
   ${renderBuyabilityPanel(args.buyability ?? null, {
     entryStatus: args.entryStatus ?? null,
     alternatives: args.alternatives ?? [],

--- a/src/trading/reconciliation/reconcileFills.ts
+++ b/src/trading/reconciliation/reconcileFills.ts
@@ -2,6 +2,7 @@ import { and, asc, eq, gte, isNotNull, isNull, or, sql } from 'drizzle-orm'
 import { alias } from 'drizzle-orm/sqlite-core'
 import type { Env } from '../../config/env'
 import { createDb } from '../../infrastructure/db/tradeJournalRepo'
+import type { PairRegimeEntry } from '../strategy/pairRegime'
 import { tradeJournal } from '../../infrastructure/db/schema'
 import { resolveAccessToken } from '../../infrastructure/webull/resolveAccessToken'
 import { createWebullReadClient } from '../../infrastructure/webull/WebullReadClient'
@@ -265,10 +266,14 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
   // Loaded BEFORE the main `db` handle so `createDb` mock ordering in tests
   // remains stable (main SELECT uses the second mock return).
   let symbolCurrency: Record<string, SymbolCurrency> | undefined
+  // ペア switch cooldown (#472) 用。universe load に相乗りし、追加の DB 呼び出し
+  // はしない (load 失敗時は cooldown も best-effort で skip)。
+  let pairRegimes: PairRegimeEntry[] | undefined
   if (options.env.PORTFOLIO_STATE) {
     try {
       const universe = await loadSymbolUniverse(options.env)
       symbolCurrency = universe.symbolCurrency
+      pairRegimes = universe.pairRegimes
     } catch (error) {
       console.warn(
         JSON.stringify({
@@ -517,6 +522,7 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
         runNow,
         nowIso: runNow.toISOString(),
         symbolCurrency,
+        pairRegimes,
       })
       if (ok) {
         summary.stateApplied += 1
@@ -822,6 +828,8 @@ async function tryApplyAndStamp(args: {
    * when the universe load failed — `applyFillToState` falls back to the
    * JP-numeric heuristic. */
   symbolCurrency?: Record<string, SymbolCurrency>
+  /** Pre-loaded regime 有効ペア (#472 pair switch cooldown 用、best-effort)。 */
+  pairRegimes?: PairRegimeEntry[]
 }): Promise<boolean> {
   const {
     env,
@@ -837,6 +845,7 @@ async function tryApplyAndStamp(args: {
     runNow,
     nowIso,
     symbolCurrency,
+    pairRegimes,
   } = args
 
   try {
@@ -851,6 +860,7 @@ async function tryApplyAndStamp(args: {
       realizedPnl,
       runNow,
       symbolCurrency,
+      pairRegimes,
     })
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
@@ -1043,6 +1053,8 @@ async function applyFillToState(args: {
   runNow: Date
   /** Pre-loaded symbol → currency map (#77 portfolio exposure tracking). */
   symbolCurrency?: Record<string, SymbolCurrency>
+  /** Pre-loaded regime 有効ペア (#472 pair switch cooldown 用、best-effort)。 */
+  pairRegimes?: PairRegimeEntry[]
 }): Promise<void> {
   const {
     env,
@@ -1055,6 +1067,7 @@ async function applyFillToState(args: {
     realizedPnl,
     runNow,
     symbolCurrency,
+    pairRegimes,
   } = args
   let symbolApplied = false
   let portfolioApplied = false
@@ -1136,6 +1149,51 @@ async function applyFillToState(args: {
       console.error(
         JSON.stringify({
           event: 'reconcile_cooldown_apply_error',
+          requestId,
+          clientOrderId,
+          symbol,
+          message: error instanceof Error ? error.message : String(error),
+        }),
+      )
+    }
+  }
+
+  // ペア switch cooldown (#472 §3c): regime 有効ペアの片側が exit したら、
+  // **理由問わず** (stop / TP / time-stop / regime_flip、損益符号も問わず)
+  // 反対 symbol にも翌営業日まで cooldown を張る — same-day ドテン (whipsaw の
+  // 最悪形) の禁止。regime_enabled=0 のペアには適用しない (既存挙動の回帰保証)。
+  // 失敗は non-fatal (上の自 symbol cooldown と同じ理由)。
+  if (
+    side === 'SELL' &&
+    env.SYMBOL_STATE &&
+    pairRegimes !== undefined &&
+    (symbolApplied || portfolioApplied)
+  ) {
+    try {
+      const upper = symbol.toUpperCase()
+      const pair = pairRegimes.find((p) => p.bullSymbol === upper || p.bearSymbol === upper)
+      if (pair) {
+        const partner = pair.bullSymbol === upper ? pair.bearSymbol : pair.bullSymbol
+        const market = inferTradingMarket(partner)
+        const until = nextTradingDay(runNow, market).toISOString()
+        await new SymbolStateClient(env.SYMBOL_STATE).setCooldown(partner, until)
+        console.warn(
+          JSON.stringify({
+            event: 'pair_exit_cooldown_applied',
+            requestId,
+            cooldown: {
+              sourceSymbol: upper,
+              targetSymbol: partner,
+              reason: 'pair_exit_cooldown',
+              until,
+            },
+          }),
+        )
+      }
+    } catch (error) {
+      console.error(
+        JSON.stringify({
+          event: 'pair_exit_cooldown_apply_error',
           requestId,
           clientOrderId,
           symbol,

--- a/src/trading/strategy/pairRegime.ts
+++ b/src/trading/strategy/pairRegime.ts
@@ -1,0 +1,158 @@
+import type { DailyBar } from './indicators'
+
+/**
+ * ペアレジーム layer (#472)。インバース対 (SOXL/SOXS 等) を両側独立に評価する
+ * のではなく、**非レバ原資産 proxy** (SOXX / QQQ 等) の 20 営業日リターンから
+ * ペア単位の zone を先に決める:
+ *
+ *   - bull    : ブル側のみ entry 可
+ *   - bear    : ベア側のみ entry 可
+ *   - neutral : 両側 entry 不可 (= chop 帯。交互 stop-out の帯を明示的に回避)
+ *   - unknown : 判定不能 (データ不足 / stale / misconfig / fetch 失敗) —
+ *               fail-closed で両側 entry 不可。**exit は一切妨げない**
+ *
+ * 設計の要 (issue #472 + operator review):
+ *   - score は**完結済み daily bar のみ**から計算 (当日進行中 bar は落とす) →
+ *     score は 1 日 1 回しか変化せず、5 分 cron でのフラップを入口で殺す
+ *   - 二重閾値の Schmitt trigger + 前 zone 依存 (hysteresis)。順序制約
+ *     bearEnter < bearExit < bullExit < bullEnter により bull↔bear の直接遷移
+ *     は構造的に不可能 (必ず neutral を経由)
+ *   - zone は stateless 決定: 毎評価で score 列の先頭を neutral に seed して
+ *     walk → 状態ストア不要・決定論的・decision log から完全再現可能
+ *   - 単一スコアは起点 (20 営業日前の価格) 依存がある。初版は overfit 防止の
+ *     ため意図的に単純化 — 傾き / MA クロス / ADX 等の追加は out of scope
+ */
+
+export type PairRegimeZone = 'bull' | 'bear' | 'neutral' | 'unknown'
+
+export interface PairRegimeThresholds {
+  /** neutral → bull (1x proxy の 20d リターン)。default +0.03。 */
+  bullEnter: number
+  /** bull → neutral。default +0.01。 */
+  bullExit: number
+  /** neutral → bear。default -0.04。 */
+  bearEnter: number
+  /** bear → neutral。default -0.015。 */
+  bearExit: number
+}
+
+export interface PairRegimeDecision {
+  zone: PairRegimeZone
+  /** 最新 score (= proxy の 20 営業日リターン)。unknown 時は null。 */
+  score: number | null
+  proxySymbol: string
+  /** score 計算に使った最終完結 bar の日付 (YYYY-MM-DD)。unknown 時は null。 */
+  asOfDate: string | null
+  /** 判定根拠 / unknown の理由 (operator 向け)。 */
+  reason: string
+}
+
+/** score 1 点の lookback (営業日)。既存 trend filter (#318) と同じ実体 20d。 */
+const SCORE_LOOKBACK = 20
+
+/** Schmitt walk に使う score 数の上限 (= bar 約 80 本ぶん)。 */
+const WALK_WINDOW = 60
+
+/** 最終完結 bar がこれより古ければ stale → unknown (暦日)。 */
+const STALE_CALENDAR_DAYS = 5
+
+const NY_DATE_FMT = new Intl.DateTimeFormat('en-CA', { timeZone: 'America/New_York' })
+
+/** thresholds の順序制約。破壊は misconfig → unknown (静かに続行しない)。 */
+export function validatePairRegimeThresholds(t: PairRegimeThresholds): boolean {
+  return (
+    Number.isFinite(t.bearEnter) &&
+    Number.isFinite(t.bearExit) &&
+    Number.isFinite(t.bullExit) &&
+    Number.isFinite(t.bullEnter) &&
+    t.bearEnter < t.bearExit &&
+    t.bearExit < t.bullExit &&
+    t.bullExit < t.bullEnter
+  )
+}
+
+/**
+ * Schmitt trigger 1 step。1 評価につき遷移は最大 1 段 — bull 状態で
+ * score が bearEnter を割っても、その評価では neutral 止まり (直接 bull→bear
+ * しない)。次の score で bear に入る。
+ */
+function stepZone(prev: PairRegimeZone, score: number, t: PairRegimeThresholds): PairRegimeZone {
+  if (prev === 'bull') {
+    return score < t.bullExit ? 'neutral' : 'bull'
+  }
+  if (prev === 'bear') {
+    return score > t.bearExit ? 'neutral' : 'bear'
+  }
+  // neutral (unknown からは呼ばれない)
+  if (score >= t.bullEnter) return 'bull'
+  if (score <= t.bearEnter) return 'bear'
+  return 'neutral'
+}
+
+const unknown = (proxySymbol: string, reason: string): PairRegimeDecision => ({
+  zone: 'unknown',
+  score: null,
+  proxySymbol,
+  asOfDate: null,
+  reason,
+})
+
+export function evaluatePairRegime(
+  bars: DailyBar[],
+  opts: { proxySymbol: string; thresholds: PairRegimeThresholds; now: Date },
+): PairRegimeDecision {
+  const { proxySymbol, thresholds, now } = opts
+  if (!validatePairRegimeThresholds(thresholds)) {
+    return unknown(proxySymbol, 'misconfigured thresholds (order must be bearEnter < bearExit < bullExit < bullEnter)')
+  }
+  // 完結済み bar のみ: 当日 (US 取引所の暦日) の bar は進行中の可能性があるので
+  // 落とす。これで intraday の価格が score に混ざらない (AC 3)。
+  const todayNy = NY_DATE_FMT.format(now)
+  const completed = bars.filter((b) => b.date < todayNy && Number.isFinite(b.close) && b.close > 0)
+  if (completed.length < SCORE_LOOKBACK + 1) {
+    return unknown(proxySymbol, `insufficient completed bars (${completed.length} < ${SCORE_LOOKBACK + 1})`)
+  }
+  const last = completed[completed.length - 1]!
+  const lastMs = Date.parse(`${last.date}T00:00:00.000Z`)
+  if (!Number.isFinite(lastMs) || now.getTime() - lastMs > STALE_CALENDAR_DAYS * 86_400_000) {
+    return unknown(proxySymbol, `stale proxy data (last completed bar ${last.date})`)
+  }
+  // score 列: S_i = C[i] / C[i-20] - 1。walk は直近 WALK_WINDOW 個。
+  const scores: number[] = []
+  for (let i = SCORE_LOOKBACK; i < completed.length; i += 1) {
+    const base = completed[i - SCORE_LOOKBACK]!.close
+    scores.push(completed[i]!.close / base - 1)
+  }
+  const walk = scores.slice(-WALK_WINDOW)
+  let zone: PairRegimeZone = 'neutral' // stateless seed (窓先頭を neutral と仮定)
+  for (const s of walk) {
+    if (!Number.isFinite(s)) {
+      return unknown(proxySymbol, 'non-finite score in walk window')
+    }
+    zone = stepZone(zone, s, thresholds)
+  }
+  const latest = walk[walk.length - 1]!
+  return {
+    zone,
+    score: latest,
+    proxySymbol,
+    asOfDate: last.date,
+    reason: `zone=${zone} score=${(latest * 100).toFixed(2)}% (proxy ${proxySymbol}, as of ${last.date})`,
+  }
+}
+
+/** ペア設定 (inverse_pairs の regime 列、検証済み or invalid 理由付き)。 */
+export interface PairRegimeEntry {
+  bullSymbol: string
+  bearSymbol: string
+  proxySymbol: string
+  /** repo 検証で見つけた misconfig。non-null なら zone=unknown 扱い (fail-closed)。 */
+  invalidConfig: string | null
+}
+
+export const PAIR_REGIME_ZONE_LABELS: Record<PairRegimeZone, string> = {
+  bull: '強気 (ブル側のみ)',
+  bear: '弱気 (ベア側のみ)',
+  neutral: '様子見 (両側不可)',
+  unknown: '判定不能 (両側不可)',
+}

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -39,6 +39,12 @@ import type { EarningsCalendarRepo } from '../../infrastructure/calendar/earning
 import type { MacroEventCalendarRepo } from '../../infrastructure/calendar/macroEventCalendarRepo'
 import { evaluatePerSymbolRisk } from '../risk/perSymbolRiskGate'
 import { deriveEntryStatusFromIndicators, type EntryStatus } from './entryStatus'
+import {
+  evaluatePairRegime,
+  type PairRegimeDecision,
+  type PairRegimeEntry,
+  type PairRegimeThresholds,
+} from './pairRegime'
 import type { EntrySnapshot } from './conditionalAllocation'
 
 const DEFAULT_BAR_LOOKBACK = 60
@@ -183,6 +189,17 @@ export interface PullbackSchedulerOptions {
    * (`runStrategyCron`) は `buildEntrySuppressedSymbols` の結果を渡す。
    */
   entrySuppressedSymbols?: Record<string, string>
+  /**
+   * ペアレジーム layer (#472)。mode='observe' は zone/score を trace に残すだけ
+   * (gate しない)、'enforce' は zone が許可しない側の BUY を REJECT し、保有と
+   * 反対 zone への flip で SELL (regime_flip) を出す。未注入 = 従来挙動。
+   * production (`runStrategyCron`) は global_config + inverse_pairs から組む。
+   */
+  pairRegime?: {
+    mode: 'observe' | 'enforce'
+    thresholds: PairRegimeThresholds
+    pairs: PairRegimeEntry[]
+  }
   /**
    * 段階判定 HALF (0.5x entry) を有効にする symbol 集合 (#452 PR 2)。role が
    * entry 有効 (core_trend / leveraged_trend) な銘柄のみ。**未注入 / 集合外の
@@ -414,6 +431,66 @@ export async function runPullbackScheduler(
     }
   }
 
+  // ペアレジーム評価 (#472): ペア単位で 1 回だけ proxy bars を独立 fetch して
+  // zone を決め、symbol → {decision, side} に展開する。fetch/評価の失敗は
+  // ペア単位で unknown に隔離 (= enforce では両側 BUY block) — cron は落とさない。
+  const regimeBySymbol = new Map<
+    string,
+    { decision: PairRegimeDecision; side: 'bull' | 'bear' }
+  >()
+  if (options.pairRegime) {
+    const runSymbols = new Set(options.symbols.map((s) => s.toUpperCase()))
+    const relevant = options.pairRegime.pairs.filter(
+      (p) => runSymbols.has(p.bullSymbol) || runSymbols.has(p.bearSymbol),
+    )
+    await Promise.all(
+      relevant.map(async (pair) => {
+        let decision: PairRegimeDecision
+        if (pair.invalidConfig !== null) {
+          decision = {
+            zone: 'unknown',
+            score: null,
+            proxySymbol: pair.proxySymbol,
+            asOfDate: null,
+            reason: `misconfig: ${pair.invalidConfig}`,
+          }
+        } else {
+          try {
+            const proxyBars = await options.barClient.getDailyBars(pair.proxySymbol, 80)
+            decision = evaluatePairRegime(proxyBars, {
+              proxySymbol: pair.proxySymbol,
+              thresholds: options.pairRegime!.thresholds,
+              now: now(),
+            })
+          } catch (err) {
+            decision = {
+              zone: 'unknown',
+              score: null,
+              proxySymbol: pair.proxySymbol,
+              asOfDate: null,
+              reason: `proxy bars fetch failed: ${messageOf(err)}`,
+            }
+          }
+        }
+        regimeBySymbol.set(pair.bullSymbol, { decision, side: 'bull' })
+        regimeBySymbol.set(pair.bearSymbol, { decision, side: 'bear' })
+        console.warn(
+          JSON.stringify({
+            event: 'pair_regime_evaluated',
+            requestId: options.requestId ?? null,
+            mode: options.pairRegime!.mode,
+            pair: `${pair.bullSymbol}/${pair.bearSymbol}`,
+            proxySymbol: decision.proxySymbol,
+            zone: decision.zone,
+            score: decision.score,
+            asOfDate: decision.asOfDate,
+            reason: decision.reason,
+          }),
+        )
+      }),
+    )
+  }
+
   for (const symbol of options.symbols) {
     summary.evaluated += 1
     const upper = symbol.toUpperCase()
@@ -519,6 +596,65 @@ export async function runPullbackScheduler(
       }
     }
 
+    // ペアレジーム (#472): zone/score を全評価の trace に残す (HOLD 含む —
+    // observe 期間の監査が目的なので BUY/REJECT 時だけでは足りない)。
+    const regime = regimeBySymbol.get(upper)
+    if (regime && options.pairRegime) {
+      const d = regime.decision
+      const allowed = (regime.side === 'bull' && d.zone === 'bull') || (regime.side === 'bear' && d.zone === 'bear')
+      const held =
+        state.position !== null && Number.isFinite(state.position.qty) && state.position.qty > 0
+      const observeNote =
+        options.pairRegime.mode === 'observe' && !allowed && signal.action === 'BUY'
+          ? ' [observe: enforce なら REJECT]'
+          : ''
+      const neutralHoldNote =
+        held && d.zone === 'neutral'
+          ? ' [hold_existing_position: neutral_does_not_force_exit]'
+          : ''
+      signal = {
+        ...signal,
+        trace: appendTrace(
+          signal.trace,
+          traceStep(
+            'regime.zone',
+            allowed,
+            d.score,
+            undefined,
+            undefined,
+            `${d.reason} side=${regime.side} mode=${options.pairRegime.mode}${observeNote}${neutralHoldNote}`,
+          ),
+        ),
+      }
+      // regime_flip exit (#472 §3a): 保有と**反対 zone** に flip したら全量 SELL。
+      // 既存 exit (stop/TP/time-stop) が先に SELL を出していればそれが優先 —
+      // その場合は副次理由として trace にだけ残す (効果測定用、review #4)。
+      // neutral では強制 exit しない (hysteresis 内の正常な押しで降ろさない)。
+      const flipped =
+        (regime.side === 'bull' && d.zone === 'bear') || (regime.side === 'bear' && d.zone === 'bull')
+      if (options.pairRegime.mode === 'enforce' && held && flipped) {
+        if (signal.action === 'SELL') {
+          signal = {
+            ...signal,
+            trace: appendTrace(
+              signal.trace,
+              traceStep('exit.regime_flip_secondary', true, undefined, undefined, undefined, `secondaryExitReasons: regime_flip (${d.reason})`),
+            ),
+          }
+        } else {
+          signal = {
+            ...signal,
+            action: 'SELL',
+            reason: `pair regime flip: zone=${d.zone} against held ${regime.side} side (${d.reason})`,
+            trace: appendTrace(
+              signal.trace,
+              traceStep('exit.regime_flip', true, d.score, undefined, undefined, d.reason),
+            ),
+          }
+        }
+      }
+    }
+
     // 段階判定 HALF (#452 PR 2)。strategy は全 gate 通過でしか BUY を出さない
     // (二値)。halfEntrySymbols の銘柄に限り、entry 系 HOLD を 4 段階判定に
     // かけ直し、HALF (未通過 1 gate が「程度もの」で許容バンド内) なら 0.5x の
@@ -569,6 +705,35 @@ export async function runPullbackScheduler(
         trace: signal.trace,
       })
       continue
+    }
+
+    // ペアレジーム BUY gate (#472、enforce のみ): zone が許可しない側の entry を
+    // REJECT。SELL / exit は一切妨げない。zone permits, gates decide — ここを
+    // 通っても以降の全 gate (role / sizing / risk / 余力) は従来どおり評価される。
+    if (options.pairRegime?.mode === 'enforce' && signal.action === 'BUY') {
+      const regimeGate = regimeBySymbol.get(upper)
+      if (regimeGate) {
+        const d = regimeGate.decision
+        const allowed =
+          (regimeGate.side === 'bull' && d.zone === 'bull') ||
+          (regimeGate.side === 'bear' && d.zone === 'bear')
+        if (!allowed) {
+          const reason = `pair_regime: zone=${d.zone} blocks ${regimeGate.side} entry (${d.reason})`
+          summary.rejected.push({ symbol: upper, reason })
+          await emitDecision({
+            symbol: upper,
+            decision: 'REJECT',
+            reason,
+            price: indicators.price,
+            indicatorsJson: JSON.stringify(indicators),
+            trace: appendTrace(
+              signal.trace,
+              traceStep('risk.pair_regime', false, d.score, undefined, undefined, reason),
+            ),
+          })
+          continue
+        }
+      }
     }
 
     // Entry 抑止 role gate (#452)。cash_parking / 定義のみの role / enum 外の
@@ -1435,6 +1600,10 @@ const TRACE_LABEL_JA: Record<string, string> = {
   'risk.role_entry_suppressed': 'ロール entry 抑止 (#452)',
   'entry.half_status': '段階判定 HALF (0.5x、#452)',
   'entry.cash_rebalance': '条件連動配分 cash rebalance (#452)',
+  'regime.zone': 'ペアレジーム判定 (#472)',
+  'risk.pair_regime': 'ペアレジーム gate (#472)',
+  'exit.regime_flip': 'レジーム反転 exit (#472)',
+  'exit.regime_flip_secondary': 'レジーム反転 (副次理由、#472)',
   'sizing.half_entry_quantity_positive': 'HALF 数量が1株/1単元以上ある',
   'risk.buying_power_pool': '口座買付余力プール (発注前)',
   'risk.sanity_failed_cooldown': 'sanity_failed cooldown (broker stub 疑い)',

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -443,7 +443,9 @@ export async function runPullbackScheduler(
     const relevant = options.pairRegime.pairs.filter(
       (p) => runSymbols.has(p.bullSymbol) || runSymbols.has(p.bearSymbol),
     )
-    await Promise.all(
+    // 評価は並列、Map への反映は**評価完了後に設定順で決定的に**行う
+    // (CodeRabbit #473: async 完了順の set は重複 symbol で run ごとに揺れる)。
+    const evaluated = await Promise.all(
       relevant.map(async (pair) => {
         let decision: PairRegimeDecision
         if (pair.invalidConfig !== null) {
@@ -472,23 +474,42 @@ export async function runPullbackScheduler(
             }
           }
         }
-        regimeBySymbol.set(pair.bullSymbol, { decision, side: 'bull' })
-        regimeBySymbol.set(pair.bearSymbol, { decision, side: 'bear' })
-        console.warn(
-          JSON.stringify({
-            event: 'pair_regime_evaluated',
-            requestId: options.requestId ?? null,
-            mode: options.pairRegime!.mode,
-            pair: `${pair.bullSymbol}/${pair.bearSymbol}`,
-            proxySymbol: decision.proxySymbol,
-            zone: decision.zone,
-            score: decision.score,
-            asOfDate: decision.asOfDate,
-            reason: decision.reason,
-          }),
-        )
+        return { pair, decision }
       }),
     )
+    for (const { pair, decision } of evaluated) {
+      // 同一 symbol が複数ペアに現れる重複設定は判定不能 → unknown (fail-closed)。
+      const duplicate = [pair.bullSymbol, pair.bearSymbol].find((sym) => regimeBySymbol.has(sym))
+      if (duplicate !== undefined) {
+        const dup: PairRegimeDecision = {
+          zone: 'unknown',
+          score: null,
+          proxySymbol: pair.proxySymbol,
+          asOfDate: null,
+          reason: `duplicate pair config for ${duplicate} (fail-closed)`,
+        }
+        regimeBySymbol.set(pair.bullSymbol, { decision: dup, side: 'bull' })
+        regimeBySymbol.set(pair.bearSymbol, { decision: dup, side: 'bear' })
+        const prev = regimeBySymbol.get(duplicate)!
+        regimeBySymbol.set(duplicate, { decision: dup, side: prev.side })
+      } else {
+        regimeBySymbol.set(pair.bullSymbol, { decision, side: 'bull' })
+        regimeBySymbol.set(pair.bearSymbol, { decision, side: 'bear' })
+      }
+      console.warn(
+        JSON.stringify({
+          event: 'pair_regime_evaluated',
+          requestId: options.requestId ?? null,
+          mode: options.pairRegime!.mode,
+          pair: `${pair.bullSymbol}/${pair.bearSymbol}`,
+          proxySymbol: decision.proxySymbol,
+          zone: regimeBySymbol.get(pair.bullSymbol)!.decision.zone,
+          score: decision.score,
+          asOfDate: decision.asOfDate,
+          reason: regimeBySymbol.get(pair.bullSymbol)!.decision.reason,
+        }),
+      )
+    }
   }
 
   for (const symbol of options.symbols) {

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -276,6 +276,21 @@ export async function runStrategyCron(
   // 段階判定 HALF (#452 PR 2): entry 有効 role を明示した銘柄のみ 0.5x entry を
   // 許可する。role NULL の既存銘柄は従来の二値挙動のまま。
   const halfEntrySymbols = buildHalfEntrySymbols(universe.symbolRole)
+  // ペアレジーム layer (#472)。mode='off' か対象ペアなしなら option ごと省略
+  // (= scheduler 側は完全に従来挙動)。
+  const pairRegimeOption =
+    global.pairRegimeMode !== 'off' && universe.pairRegimes.length > 0
+      ? {
+          mode: global.pairRegimeMode,
+          thresholds: {
+            bullEnter: global.pairRegimeThetaBullEnter,
+            bullExit: global.pairRegimeThetaBullExit,
+            bearEnter: global.pairRegimeThetaBearEnter,
+            bearExit: global.pairRegimeThetaBearExit,
+          },
+          pairs: universe.pairRegimes,
+        }
+      : undefined
   const byCurrency: Record<SymbolCurrency, string[]> = { USD: [], JPY: [] }
   for (const sym of universe.allowedSymbols) {
     const cur = universe.symbolCurrency[sym] ?? 'USD'
@@ -626,6 +641,7 @@ export async function runStrategyCron(
       entrySuppressedSymbols,
       halfEntrySymbols,
       ...(onTickerDeny ? { onTickerDeny } : {}),
+      ...(pairRegimeOption ? { pairRegime: pairRegimeOption } : {}),
       riskPerTradePct: scaledRiskPerTradePct,
       requestId: options.requestId,
       notifier,

--- a/test/helpers/configFixtures.ts
+++ b/test/helpers/configFixtures.ts
@@ -41,6 +41,11 @@ export function makeGlobalConfigSnapshot(
     vixCriticalThreshold: 30.0,
     vixWarningSizeScale: 0.5,
     cashFallbackOrdersEnabled: false,
+    pairRegimeMode: 'off',
+    pairRegimeThetaBullEnter: 0.03,
+    pairRegimeThetaBullExit: 0.01,
+    pairRegimeThetaBearEnter: -0.04,
+    pairRegimeThetaBearExit: -0.015,
     source: 'd1',
     ...overrides,
   }
@@ -74,6 +79,7 @@ export function makeSymbolUniverse(overrides: Partial<SymbolUniverse> = {}): Sym
     symbolAlwaysActive: {},
     symbolCashFallback: {},
     inversePairs: {},
+    pairRegimes: [],
     source: 'd1',
     ...overrides,
   }

--- a/test/infrastructure/db/symbolConfigRepo.test.ts
+++ b/test/infrastructure/db/symbolConfigRepo.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   deactivateSymbolForBrokerDeny,
   loadInversePairs,
+  loadPairRegimeConfigs,
   loadSymbolConfig,
 } from '../../../src/infrastructure/db/symbolConfigRepo'
 
@@ -445,5 +446,29 @@ describe('deactivateSymbolForBrokerDeny (#460)', () => {
     const { db, updates } = fakeRwDb([])
     expect(await deactivateSymbolForBrokerDeny(db, 'NOPE', 'reason', 't1')).toBeNull()
     expect(updates).toHaveLength(0)
+  })
+})
+
+describe('loadPairRegimeConfigs (#472)', () => {
+  it('regime_enabled=1 の行だけを bull/bear/proxy に正規化して返す', async () => {
+    const rows = [
+      { symbol: 'soxl', inverse: 'soxs', regimeEnabled: true, regimeProxySymbol: 'soxx', regimeBullSymbol: 'soxl' },
+      { symbol: 'TQQQ', inverse: 'SQQQ', regimeEnabled: false, regimeProxySymbol: 'QQQ', regimeBullSymbol: 'TQQQ' },
+    ]
+    const result = await loadPairRegimeConfigs(fakeDbAll(rows) as never)
+    expect(result).toEqual([
+      { bullSymbol: 'SOXL', bearSymbol: 'SOXS', proxySymbol: 'SOXX', invalidConfig: null },
+    ])
+  })
+
+  it('proxy 欠落 / bull がペア員でない misconfig は skip せず invalidConfig 付きで返す (fail-closed)', async () => {
+    const rows = [
+      { symbol: 'SOXL', inverse: 'SOXS', regimeEnabled: true, regimeProxySymbol: null, regimeBullSymbol: 'SOXL' },
+      { symbol: 'TQQQ', inverse: 'SQQQ', regimeEnabled: true, regimeProxySymbol: 'QQQ', regimeBullSymbol: 'SPXL' },
+    ]
+    const result = await loadPairRegimeConfigs(fakeDbAll(rows) as never)
+    expect(result).toHaveLength(2)
+    expect(result[0]!.invalidConfig).toContain('regime_proxy_symbol')
+    expect(result[1]!.invalidConfig).toContain('regime_bull_symbol')
   })
 })

--- a/test/infrastructure/db/symbolConfigRepo.test.ts
+++ b/test/infrastructure/db/symbolConfigRepo.test.ts
@@ -472,3 +472,13 @@ describe('loadPairRegimeConfigs (#472)', () => {
     expect(result[1]!.invalidConfig).toContain('regime_bull_symbol')
   })
 })
+
+describe('loadPairRegimeConfigs self-pair (#473 review)', () => {
+  it('自己参照ペアは invalidConfig (黙って有効扱いしない)', async () => {
+    const rows = [
+      { symbol: 'SOXL', inverse: 'SOXL', regimeEnabled: true, regimeProxySymbol: 'SOXX', regimeBullSymbol: 'SOXL' },
+    ]
+    const result = await loadPairRegimeConfigs(fakeDbAll(rows) as never)
+    expect(result[0]!.invalidConfig).toContain('distinct symbols')
+  })
+})

--- a/test/routes/admin.test.ts
+++ b/test/routes/admin.test.ts
@@ -1156,6 +1156,7 @@ describe('POST /admin/orders/sync-holdings', () => {
       symbolAlwaysActive: {},
       symbolCashFallback: {},
       inversePairs: {},
+      pairRegimes: [],
       source: 'd1',
     })
     const fakeWebull = {

--- a/test/trading/strategy/pairRegime.test.ts
+++ b/test/trading/strategy/pairRegime.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+import {
+  evaluatePairRegime,
+  validatePairRegimeThresholds,
+  type PairRegimeThresholds,
+} from '../../../src/trading/strategy/pairRegime'
+import type { DailyBar } from '../../../src/trading/strategy/indicators'
+
+const now = new Date('2026-04-20T14:30:00.000Z') // 月曜 (NY 2026-04-20)
+
+const T: PairRegimeThresholds = {
+  bullEnter: 0.03,
+  bullExit: 0.01,
+  bearEnter: -0.04,
+  bearExit: -0.015,
+}
+
+/** 終値列から、now の前日 (2026-04-19) で終わる連続日付の bars を作る。 */
+function barsOf(closes: number[], endDate = '2026-04-19'): DailyBar[] {
+  const end = Date.parse(`${endDate}T00:00:00.000Z`)
+  return closes.map((close, i) => ({
+    date: new Date(end - (closes.length - 1 - i) * 86_400_000).toISOString().slice(0, 10),
+    open: close,
+    high: close * 1.005,
+    low: close * 0.995,
+    close,
+  }))
+}
+
+const growth = (n: number, ratio: number, start = 100): number[] =>
+  Array.from({ length: n }, (_, i) => start * ratio ** i)
+
+describe('evaluatePairRegime (#472)', () => {
+  it('上昇系列 (20d +6%) は bull', () => {
+    const d = evaluatePairRegime(barsOf(growth(80, 1.003)), { proxySymbol: 'QQQ', thresholds: T, now })
+    expect(d.zone).toBe('bull')
+    expect(d.score).toBeGreaterThan(0.03)
+    expect(d.asOfDate).toBe('2026-04-19')
+  })
+
+  it('下落系列 (20d −6%) は bear', () => {
+    const d = evaluatePairRegime(barsOf(growth(80, 0.997)), { proxySymbol: 'QQQ', thresholds: T, now })
+    expect(d.zone).toBe('bear')
+    expect(d.score).toBeLessThan(-0.04)
+  })
+
+  it('横ばいは neutral', () => {
+    const d = evaluatePairRegime(barsOf(Array(80).fill(100)), { proxySymbol: 'QQQ', thresholds: T, now })
+    expect(d.zone).toBe('neutral')
+    expect(d.score).toBe(0)
+  })
+
+  it('hysteresis: bull 進入後に score が +2% (enter 未満 / exit 超) へ落ちても bull を維持', () => {
+    const closes = growth(80, 1.003)
+    // 最終 score をちょうど +2% に落とす (bullExit +1% は上回る)
+    closes[closes.length - 1] = closes[closes.length - 1 - 20]! * 1.02
+    const d = evaluatePairRegime(barsOf(closes), { proxySymbol: 'QQQ', thresholds: T, now })
+    expect(d.zone).toBe('bull')
+    expect(d.score).toBeCloseTo(0.02, 6)
+  })
+
+  it('bull → bear は直接遷移しない (急落 1 score では neutral 止まり、2 score 目で bear)', () => {
+    const base = growth(80, 1.003)
+    const crashOnce = [...base]
+    crashOnce[crashOnce.length - 1] = crashOnce[crashOnce.length - 1 - 20]! * 0.94 // score −6%
+    const d1 = evaluatePairRegime(barsOf(crashOnce), { proxySymbol: 'QQQ', thresholds: T, now })
+    expect(d1.zone).toBe('neutral')
+
+    const crashTwice = [...base]
+    crashTwice[crashTwice.length - 2] = crashTwice[crashTwice.length - 2 - 20]! * 0.94
+    crashTwice[crashTwice.length - 1] = crashTwice[crashTwice.length - 1 - 20]! * 0.94
+    const d2 = evaluatePairRegime(barsOf(crashTwice), { proxySymbol: 'QQQ', thresholds: T, now })
+    expect(d2.zone).toBe('bear')
+  })
+
+  it('当日 (進行中) の bar は無視される — intraday を混ぜても結果が変わらない (AC 3)', () => {
+    const base = barsOf(growth(80, 1.003))
+    const withToday = [
+      ...base,
+      { date: '2026-04-20', open: 1, high: 1, low: 1, close: 1 }, // 異常値の進行中 bar
+    ]
+    const a = evaluatePairRegime(base, { proxySymbol: 'QQQ', thresholds: T, now })
+    const b = evaluatePairRegime(withToday, { proxySymbol: 'QQQ', thresholds: T, now })
+    expect(b).toEqual(a)
+  })
+
+  it('bars 不足は unknown (fail-closed)', () => {
+    const d = evaluatePairRegime(barsOf(growth(15, 1.003)), { proxySymbol: 'QQQ', thresholds: T, now })
+    expect(d.zone).toBe('unknown')
+    expect(d.reason).toContain('insufficient')
+  })
+
+  it('最終完結 bar が 5 暦日超 stale なら unknown', () => {
+    const d = evaluatePairRegime(barsOf(growth(80, 1.003), '2026-04-10'), {
+      proxySymbol: 'QQQ',
+      thresholds: T,
+      now,
+    })
+    expect(d.zone).toBe('unknown')
+    expect(d.reason).toContain('stale')
+  })
+
+  it('閾値の順序破壊は unknown (黙って続行しない)', () => {
+    const bad = { ...T, bullExit: 0.05 } // bullExit > bullEnter
+    const d = evaluatePairRegime(barsOf(growth(80, 1.003)), { proxySymbol: 'QQQ', thresholds: bad, now })
+    expect(d.zone).toBe('unknown')
+    expect(d.reason).toContain('misconfigured')
+    expect(validatePairRegimeThresholds(bad)).toBe(false)
+    expect(validatePairRegimeThresholds(T)).toBe(true)
+  })
+
+  it('同じ入力からは常に同じ zone (stateless walk の決定論、AC 2)', () => {
+    const bars = barsOf(growth(80, 1.003))
+    const a = evaluatePairRegime(bars, { proxySymbol: 'QQQ', thresholds: T, now })
+    const b = evaluatePairRegime(bars, { proxySymbol: 'QQQ', thresholds: T, now })
+    expect(b).toEqual(a)
+  })
+})

--- a/test/trading/strategy/pullbackScheduler.test.ts
+++ b/test/trading/strategy/pullbackScheduler.test.ts
@@ -2382,4 +2382,26 @@ describe('runPullbackScheduler pair regime layer (#472)', () => {
     expect(summary.buys).toBe(0)
     expect(summary.rejected[0]?.reason).toContain('zone=unknown')
   })
+  it('重複ペア設定の symbol は unknown に倒れる (非決定性の排除、CodeRabbit #473)', async () => {
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['SOXL'],
+      equity: 100_000,
+      barClient: mapBarClient({ SOXL: uptrendBars(), SOXX: proxyBars(1.003), QQQ: proxyBars(1.003) }),
+      positionStore: makeStore({}),
+      execution,
+      pairRegime: {
+        mode: 'enforce',
+        thresholds: THRESHOLDS,
+        pairs: [
+          REGIME_PAIR,
+          { bullSymbol: 'SOXL', bearSymbol: 'SQQQ', proxySymbol: 'QQQ', invalidConfig: null },
+        ],
+      },
+      now: () => now,
+    })
+    expect(summary.buys).toBe(0)
+    expect(summary.rejected[0]?.reason).toContain('zone=unknown')
+    expect(summary.rejected[0]?.reason).toContain('duplicate pair config')
+  })
 })

--- a/test/trading/strategy/pullbackScheduler.test.ts
+++ b/test/trading/strategy/pullbackScheduler.test.ts
@@ -2201,3 +2201,185 @@ describe('runPullbackScheduler TICKER_IS_DENY hook (#460)', () => {
     expect(summary.errors).toHaveLength(1)
   })
 })
+
+describe('runPullbackScheduler pair regime layer (#472)', () => {
+  const REGIME_PAIR = {
+    bullSymbol: 'SOXL',
+    bearSymbol: 'SOXS',
+    proxySymbol: 'SOXX',
+    invalidConfig: null,
+  }
+  const THRESHOLDS = { bullEnter: 0.03, bullExit: 0.01, bearEnter: -0.04, bearExit: -0.015 }
+
+  /** now (2026-04-20) の前日で終わる proxy bars。ratio 1.003 → bull / 1.0 → neutral。 */
+  function proxyBars(ratio: number): DailyBar[] {
+    const end = Date.parse('2026-04-19T00:00:00.000Z')
+    return Array.from({ length: 80 }, (_, i) => {
+      const close = 100 * ratio ** i
+      return {
+        date: new Date(end - (79 - i) * 86_400_000).toISOString().slice(0, 10),
+        open: close,
+        high: close * 1.005,
+        low: close * 0.995,
+        close,
+      }
+    })
+  }
+
+  /** symbol ごとに bars を返す barClient (proxy と取引銘柄で別系列)。 */
+  function mapBarClient(map: Record<string, DailyBar[]>): BarClient {
+    return {
+      getDailyBars: vi.fn(async (symbol: string) => {
+        const bars = map[symbol.toUpperCase()]
+        if (!bars) throw new Error(`no bars for ${symbol}`)
+        return bars
+      }),
+    }
+  }
+
+  it('enforce: zone=bull はブル側 BUY を通し、ベア側 BUY を REJECT する', async () => {
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['SOXL', 'SOXS'],
+      equity: 100_000,
+      barClient: mapBarClient({ SOXL: uptrendBars(), SOXS: uptrendBars(), SOXX: proxyBars(1.003) }),
+      positionStore: makeStore({}),
+      execution,
+      pairRegime: { mode: 'enforce', thresholds: THRESHOLDS, pairs: [REGIME_PAIR] },
+      now: () => now,
+    })
+    expect(summary.buys).toBe(1)
+    expect((execution.calls[0] as { symbol: string }).symbol).toBe('SOXL')
+    const reject = summary.decisions.find((d) => d.decision === 'REJECT' && d.symbol === 'SOXS')
+    expect(reject?.reason).toContain('pair_regime: zone=bull blocks bear entry')
+    expect(reject?.trace?.map((s) => s.label)).toContain('risk.pair_regime')
+  })
+
+  it('enforce: zone=neutral は両側 BUY を REJECT する (chop 帯の遮断)', async () => {
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['SOXL', 'SOXS'],
+      equity: 100_000,
+      barClient: mapBarClient({ SOXL: uptrendBars(), SOXS: uptrendBars(), SOXX: proxyBars(1.0) }),
+      positionStore: makeStore({}),
+      execution,
+      pairRegime: { mode: 'enforce', thresholds: THRESHOLDS, pairs: [REGIME_PAIR] },
+      now: () => now,
+    })
+    expect(summary.buys).toBe(0)
+    expect(execution.calls).toHaveLength(0)
+    expect(summary.rejected.filter((r) => r.reason.includes('pair_regime'))).toHaveLength(2)
+  })
+
+  it('enforce: proxy fetch 失敗は unknown → 両側 BUY block (fail-closed)、exit は素通り', async () => {
+    const execution = mockExecution()
+    const heldState: SymbolState = {
+      ...emptySymbolState('SOXL', () => now),
+      position: {
+        qty: 5,
+        avgPrice: 80, // +47% → take_profit SELL が出る
+        openedAt: new Date('2026-04-17T00:00:00.000Z').toISOString(),
+      },
+    }
+    const summary = await runPullbackScheduler({
+      symbols: ['SOXL', 'SOXS'],
+      equity: 100_000,
+      barClient: mapBarClient({ SOXL: uptrendBars(), SOXS: uptrendBars() }), // SOXX なし → throw
+      positionStore: makeStore({ SOXL: heldState }),
+      execution,
+      pairRegime: { mode: 'enforce', thresholds: THRESHOLDS, pairs: [REGIME_PAIR] },
+      now: () => now,
+    })
+    // SOXL は保有中 → strategy の SELL (TP) がそのまま通る (unknown でも exit は妨げない)
+    expect(summary.sells).toBe(1)
+    // SOXS の BUY は unknown で block
+    const reject = summary.decisions.find((d) => d.decision === 'REJECT' && d.symbol === 'SOXS')
+    expect(reject?.reason).toContain('zone=unknown')
+  })
+
+  it('observe: gate せず trace に zone と「enforce なら REJECT」を残す', async () => {
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['SOXS'],
+      equity: 100_000,
+      barClient: mapBarClient({ SOXS: uptrendBars(), SOXX: proxyBars(1.003) }),
+      positionStore: makeStore({}),
+      execution,
+      pairRegime: { mode: 'observe', thresholds: THRESHOLDS, pairs: [REGIME_PAIR] },
+      now: () => now,
+    })
+    expect(summary.buys).toBe(1) // block しない
+    const buy = summary.decisions.find((d) => d.decision === 'BUY')
+    const regimeStep = buy?.trace?.find((s) => s.label === 'regime.zone')
+    expect(regimeStep).toBeDefined()
+    expect(JSON.stringify(regimeStep)).toContain('observe')
+  })
+
+  it('enforce: 保有と反対 zone への flip で regime_flip SELL を出す', async () => {
+    const execution = mockExecution()
+    const heldState: SymbolState = {
+      ...emptySymbolState('SOXS', () => now),
+      position: {
+        qty: 3,
+        avgPrice: 115, // +2.2% — TP/stop/time にかからない
+        openedAt: new Date('2026-04-17T00:00:00.000Z').toISOString(),
+      },
+    }
+    const summary = await runPullbackScheduler({
+      symbols: ['SOXS'],
+      equity: 100_000,
+      barClient: mapBarClient({ SOXS: uptrendBars(), SOXX: proxyBars(1.003) }), // zone=bull vs ベア保有
+      positionStore: makeStore({ SOXS: heldState }),
+      execution,
+      pairRegime: { mode: 'enforce', thresholds: THRESHOLDS, pairs: [REGIME_PAIR] },
+      now: () => now,
+    })
+    expect(summary.sells).toBe(1)
+    const sell = summary.decisions.find((d) => d.decision === 'SELL')
+    expect(sell?.reason).toContain('pair regime flip')
+    expect(sell?.trace?.map((s) => s.label)).toContain('exit.regime_flip')
+  })
+
+  it('enforce: 既存 exit (TP) が先に出ていれば regime_flip は副次理由として trace に残る', async () => {
+    const execution = mockExecution()
+    const heldState: SymbolState = {
+      ...emptySymbolState('SOXS', () => now),
+      position: {
+        qty: 3,
+        avgPrice: 80, // +47% → take_profit SELL
+        openedAt: new Date('2026-04-17T00:00:00.000Z').toISOString(),
+      },
+    }
+    const summary = await runPullbackScheduler({
+      symbols: ['SOXS'],
+      equity: 100_000,
+      barClient: mapBarClient({ SOXS: uptrendBars(), SOXX: proxyBars(1.003) }),
+      positionStore: makeStore({ SOXS: heldState }),
+      execution,
+      pairRegime: { mode: 'enforce', thresholds: THRESHOLDS, pairs: [REGIME_PAIR] },
+      now: () => now,
+    })
+    const sell = summary.decisions.find((d) => d.decision === 'SELL')
+    expect(sell?.reason).not.toContain('pair regime flip') // 主理由は既存 exit のまま
+    expect(sell?.trace?.map((s) => s.label)).toContain('exit.regime_flip_secondary')
+  })
+
+  it('misconfig ペアは unknown 扱いで BUY block (黙って無効化しない)', async () => {
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['SOXL'],
+      equity: 100_000,
+      barClient: mapBarClient({ SOXL: uptrendBars(), SOXX: proxyBars(1.003) }),
+      positionStore: makeStore({}),
+      execution,
+      pairRegime: {
+        mode: 'enforce',
+        thresholds: THRESHOLDS,
+        pairs: [{ ...REGIME_PAIR, invalidConfig: 'regime_bull_symbol must be SOXL or SOXS' }],
+      },
+      now: () => now,
+    })
+    expect(summary.buys).toBe(0)
+    expect(summary.rejected[0]?.reason).toContain('zone=unknown')
+  })
+})


### PR DESCRIPTION
## Summary

issue #472 + operator review コメントの実装。インバース対の「独立評価 + 先勝ち排他」を、ペア単位のレジーム採択に置き換える。

### コア (`pairRegime.ts`, pure)

- **score**: 非レバ proxy (SOXX/QQQ、review 反映) の 20 営業日リターン。**完結済み daily bar のみ** (当日 NY 暦日の bar は除外 = intraday を混ぜても結果不変、テストで固定)。1 日 1 回しか変化しない
- **Schmitt trigger** (1x 基準閾値: bull +3%/+1%、bear −4%/−1.5%): stateless walk (窓先頭 neutral seed)、1 score につき遷移最大 1 段 = **bull↔bear 直接遷移は構造的に不可能** (テストで固定)
- **unknown** (bars 不足 / stale 5 暦日 / fetch 失敗 / 閾値順序破壊 / ペア行 misconfig) → **両側 BUY block、exit は一切妨げない**

### Scheduler 統合

- zone gate は `entrySuppressedSymbols` (#452) と同型の **BUY 確定後 REJECT** (`risk.pair_regime`)。既存 7 gates / role preset / inverse_pairs 排他は無変更 (zone permits, gates decide)
- **regime_flip exit**: 保有と反対 zone への flip で SELL (既存 TP/stop/time-stop の**後**、既存 exit が先に出たら `exit.regime_flip_secondary` trace = 副次理由、review #4)
- neutral 保有は強制 exit せず `hold_existing_position` を trace に明示 (review #3)
- **全評価 (HOLD 含む) の trace に `regime.zone`** {zone/score/proxy/asOf/mode}。observe では「enforce なら REJECT」も明記
- **pair switch cooldown**: 片側の exit fill (理由・損益問わず) で反対 symbol に翌営業日 cooldown (reconcileFills、universe load 相乗りで追加 DB 呼び出しゼロ、構造化 log 付き、review #6)

### Schema / config (migration 0031)

- global_config: `pair_regime_mode` ('off' default / 'observe' / 'enforce') + 閾値 4 列。mode の不正値は loader が 'off' に倒す
- inverse_pairs: `regime_enabled` (default 0 = 挙動完全不変) / `regime_proxy_symbol` (非レバ ETF) / `regime_bull_symbol` (ブル側の明示 — convention 非依存)。misconfig は **skip せず unknown 扱い** (黙って無効化しない)

### 表示

チャート銘柄タブに「ペアレジーム: 強気/弱気/様子見/判定不能」行 (score / proxy / 判定日 / この銘柄のside と entry 可否、observe は gate 未適用と明示)

## Rollout (issue 記載どおり)

```sql
-- 1. observe (2–4 週間、log のみ)
UPDATE global_config SET pair_regime_mode = 'observe' WHERE id = 'default';
UPDATE inverse_pairs SET regime_enabled = 1, regime_proxy_symbol = 'SOXX', regime_bull_symbol = 'SOXL' WHERE symbol IN ('SOXL','SOXS');
-- 2. 監査後に enforce
UPDATE global_config SET pair_regime_mode = 'enforce' WHERE id = 'default';
```

## Test

`pnpm test`: 105 files / **1469 tests pass** (新規 19: pairRegime 10 / scheduler 7 / repo 2)。`mode=off` / `regime_enabled=0` は既存テスト全 green = 挙動完全不変 (AC 8)

Closes #472

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ペアレジーム機能を追加：市場レジーム（上昇/下落/中立/不明）を判定しダッシュボードに表示
  * グローバル設定でモードを「off / observe / enforce」選択、閾値のカスタマイズ対応
  * enforceモードで許可されない買いをブロック、observeは注記のみ。売却時に反対側へクールダウン適用
* **テスト**
  * 判定ロジック・スケジューラ・データ読み出しの包括的なテストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->