### PR TITLE
feat: Market Data API は trade host + v2 で稼働中 (probe で実証)

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -767,6 +767,8 @@ export const admin = new Hono<AppBindings>()
       instrumentStockQuotesAlt,
       instrumentQuotesHost,
       instrumentTradeHost,
+      snapshotTradeV2,
+      instrumentStockTradeV2,
     ] = await Promise.all([
       // path は WebullQuoteClient.DEFAULT_QUOTE_PATH と一致:
       // /openapi/market-data/stock/snapshot (× /openapi/quotes/v2/...)。
@@ -891,6 +893,28 @@ export const admin = new Hono<AppBindings>()
         query: { symbols: symbol, category },
         version: 'v1',
       }),
+      // JP docs (market-data-api/data-api) の再読で判明: **Market Data API の
+      // production host は api.webull.co.jp (trade host) + x-version v2
+      // (HMAC-SHA256)**。従来の probe は「market-data = data-api (別 host)」前提
+      // で trade host には v1 しか投げていなかった — trade host + v2 の組合せを
+      // ここで初めて検証する。
+      probeOnce({
+        method: 'GET',
+        path: '/openapi/market-data/stock/snapshot',
+        query: {
+          symbols: symbol,
+          category,
+          extend_hour_required: 'false',
+          overnight_required: 'false',
+        },
+        version: 'v2',
+      }),
+      probeOnce({
+        method: 'GET',
+        path: '/openapi/instrument/stock/list',
+        query: { symbols: symbol, category },
+        version: 'v2',
+      }),
     ])
 
     // #461 follow-up: **Preview Order = 発注しない注文検証** (JP docs 正式記載:
@@ -977,6 +1001,8 @@ export const admin = new Hono<AppBindings>()
       instrumentStockQuotesAlt,
       instrumentQuotesHost,
       instrumentTradeHost,
+      snapshotTradeV2,
+      instrumentStockTradeV2,
       previewVariants,
       readiness: {
         tokenOk: tokenResolved.source === 'do_normal',

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1918,7 +1918,8 @@ function brokerProbeBody(args: {
   </style>
 
   <div class="bp-card" style="margin-top:8px">
-    <h3>銘柄を選んで診断 <span class="muted" id="probe-status" style="font-weight:normal;font-size:12px">待機中</span></h3>
+    <h3>銘柄を選んで診断 <span class="muted" id="probe-status" style="font-weight:normal;font-size:12px">待機中</span>
+      <button type="button" id="probe-copy-ai" hidden style="float:right;padding:4px 12px;background:#fff;color:#333;border:1px solid #ccc;border-radius:6px;cursor:pointer;font-size:12px;font-weight:normal" title="probe 結果全文 (全 raw セクション + meta) をコピー">📋 AI 用コピー</button></h3>
     <div class="bp-body">
       <div style="margin-bottom:6px">${universeLinks}</div>
       ${controlChip}
@@ -2034,7 +2035,43 @@ function brokerProbeBody(args: {
     }
     var drift = document.getElementById('probe-drift-table');
     if (drift) drift.innerHTML = '<tr><td colspan="3" class="muted" style="padding:8px;text-align:center">...</td></tr>';
+    lastProbeResult = null;
+    if (copyAiBtn) copyAiBtn.hidden = true;
   }
+
+  // probe 結果の AI 用コピー (#alerts-trades-ui と同運用): UI で省略・整形した
+  // 情報ではなく admin endpoint のレスポンス全体 (全 raw セクション + meta) を
+  // 文脈ヘッダ付きで積む。スクリーンショット往復だとセクションが切れて
+  // どの probe の結果か特定できない問題への対策。
+  var lastProbeResult = null;
+  var copyAiBtn = document.getElementById('probe-copy-ai');
+  if (copyAiBtn) copyAiBtn.addEventListener('click', function () {
+    if (!lastProbeResult) return;
+    var text = '# webull-trading broker-probe / ' + lastProbeResult.symbol +
+      ' (' + lastProbeResult.category + ') / generated ' +
+      (lastProbeResult.body && lastProbeResult.body.timestamp ? lastProbeResult.body.timestamp : 'n/a') +
+      ' / admin status ' + lastProbeResult.status + '\\n' +
+      JSON.stringify(lastProbeResult.body, null, 1);
+    function done(ok) {
+      copyAiBtn.textContent = ok ? '✅' : '✗';
+      setTimeout(function () { copyAiBtn.textContent = '📋 AI 用コピー'; }, 1500);
+    }
+    function fallbackExecCommand() {
+      var ta = document.createElement('textarea');
+      ta.value = text;
+      document.body.appendChild(ta);
+      ta.select();
+      var ok = false;
+      try { ok = document.execCommand('copy'); } catch (_) {}
+      document.body.removeChild(ta);
+      done(ok);
+    }
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(function () { done(true); }, fallbackExecCommand);
+    } else {
+      fallbackExecCommand();
+    }
+  });
 
   // fetch abort (10s timeout) は raw の英語のまま出すと分かりにくいので日本語化。
   // data-api.webull.co.jp (JP market-data host) の無応答は既知 (#21、Yahoo 移行済み)。
@@ -2383,6 +2420,8 @@ function brokerProbeBody(args: {
           readiness: body.readiness,
           adminStatus: res.status,
         }, null, 2);
+        lastProbeResult = { symbol: symbol, category: category, status: res.status, body: body };
+        if (copyAiBtn) copyAiBtn.hidden = false;
       })
       .catch(function (e) {
         statusEl.textContent = 'fetch error: ' + (e && e.message ? e.message : String(e));

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -2078,6 +2078,7 @@ function brokerProbeBody(args: {
     // category 推定の取り違え対策 (CodeRabbit #462) で ETF/STOCK 両 category を
     // 並べる。末尾 2 つは汎用 SDK path の drift 検証用 (#251 方式)。
     var candidates = [
+      { label: 'stock/list (trade host, v2)', section: body.instrumentStockTradeV2 },
       { label: 'stock/list (trade host)', section: body.instrumentStockTrade },
       { label: 'stock/list (trade host, alt category)', section: body.instrumentStockTradeAlt },
       { label: 'stock/list (quotes host)', section: body.instrumentStockQuotes },
@@ -2355,8 +2356,10 @@ function brokerProbeBody(args: {
       .then(function (res) {
         var body = res.body;
         statusEl.textContent = res.status === 200 ? '完了' : ('admin endpoint status=' + res.status);
-        quoteEl.textContent = body.quote ? prettify(body.quote) : '(no data)';
-        renderQuoteCard('bp-quote-pill', 'bp-quote-body', body.quote || null, ['last_price', 'price', 'close', 'last']);
+        quoteEl.textContent = '--- snapshot (trade host, v2) ---\\n' + prettify(body.snapshotTradeV2) + '\\n\\n--- snapshot (quotes host) ---\\n' + (body.quote ? prettify(body.quote) : '(no data)');
+        // trade host + v2 の snapshot (JP docs の production host) が 200 なら優先表示。
+        var webullQuote = (body.snapshotTradeV2 && body.snapshotTradeV2.status === 200) ? body.snapshotTradeV2 : (body.quote || null);
+        renderQuoteCard('bp-quote-pill', 'bp-quote-body', webullQuote, ['last_price', 'price', 'close', 'last']);
         var quoteYahooEl = document.getElementById('probe-quote-yahoo');
         if (quoteYahooEl) quoteYahooEl.textContent = body.quoteYahoo ? prettify(body.quoteYahoo) : '(no data)';
         renderQuoteCard('bp-yahoo-pill', 'bp-yahoo-body', body.quoteYahoo || null, ['regularMarketPrice', 'price', 'close']);


### PR DESCRIPTION
## 発見 (operator 指摘の docs 再読 → staging 実測で確定)

JP docs ([market-data-api/data-api](https://developer.webull.co.jp/apis/docs/market-data-api/data-api/)) の記載どおり、**Market Data API の production host は `api.webull.co.jp` (trade host) + `x-version: v2`**。従来の「market-data = `data-api.webull.co.jp` (無応答)」は host の思い込みだった。

staging 実測 (AAPL):

- `/openapi/market-data/stock/snapshot` (trade host, v2) → **200**: close 291.58 + **bid/ask/size/quote_time** のリアルタイム quote、630ms (Yahoo 3366ms)
- `/openapi/instrument/stock/list` (trade host, v2) → **200** (548B) — **事前照会 API は実在** (v1 では 404 = gateway が x-version で routing)

## 変更

- probe に trade host + v2 の snapshot / instrument stock/list を追加
- Webull quote カードは v2 snapshot が 200 ならそれを優先表示

## Follow-up (別 issue)

- quote/bars の Webull 回帰 (bid/ask が取れる = spread guard の実数化)
- instrument 照会ベースの取扱事前チェック本実装
- 24h セッションデータ (`overnight_required` パラメータ実証)
- `checkMarketDataReachability` の監視対象 host 見直し

Refs #461 #21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 診断プローブが追加のv2データソースから並列取得できるよう対応
  * ダッシュボードに「AI用コピー」ボタンを追加し、プローブ結果のクリップボード出力が可能に
  * 表示ロジックを更新し、優先的に新しいv2スナップショット結果を表示するよう改善
  * 楽器（銘柄）候補探索の対象をv2取得結果まで拡張
<!-- end of auto-generated comment: release notes by coderabbit.ai -->