### PR TITLE
feat: quote feed の Webull 回帰 — QUOTE_SOURCE flag + Yahoo fallback (issue #475)

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -112,3 +112,8 @@ ACCESS_DEV_BYPASS_USER=dev@local
 # テスト環境は 2FA 不要で auto-NORMAL、staging では未設定でも動くケース有り。
 # prod では設定漏れ → 401 で発覚させる方針 (= fail-closed ではなく throw しない)。
 WEBULL_ACCESS_TOKEN=
+
+# QUOTE_SOURCE (#475): 'webull' で quote を Webull Market Data API (bid/ask 付き、
+# trade host + v2) に切替。JP 銘柄と Webull 障害時は Yahoo に自動 fallback。
+# 未設定 = yahoo (現行 default)。
+# QUOTE_SOURCE=webull

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -485,3 +485,13 @@ export interface Env {
   FIRST_LIVE_MAX_ORDER_NOTIONAL_JPY?: string
   ROLLBACK_REHEARSAL_MAX_AGE_HOURS?: string
 }
+
+
+// #475: quote source の切替。'webull' で Market Data API (trade host + v2、
+// PR #474 で稼働実証) を primary にし、bid/ask 付き snapshot で spread guard
+// (issue #411) を実数評価に戻す。JP 銘柄と Webull 障害時は Yahoo に自動
+// fallback。未設定 / 他値は 'yahoo' (PR #334 以来の現行動作) — fail-safe 側が
+// 既定で、切替は env の明示 opt-in のみ。
+export interface Env {
+  QUOTE_SOURCE?: string
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -217,6 +217,10 @@ export default {
               persisted: summary.persisted,
               skipped: summary.skipped,
               errors: summary.errors,
+              // #475: QUOTE_SOURCE canary の観測用 — primary source と Yahoo
+              // fallback に回った銘柄をログで追えるようにする。
+              source: summary.source,
+              fallbackSymbols: summary.fallbackSymbols,
             }),
           )
           // Partial failure: getSnapshots() がカテゴリ単位で throw しても全体の

--- a/src/infrastructure/quotes/WebullQuoteClient.ts
+++ b/src/infrastructure/quotes/WebullQuoteClient.ts
@@ -24,10 +24,11 @@ export interface WebullQuoteClientEnv {
   WEBULL_APP_KEY?: string
   WEBULL_APP_SECRET?: string
   /**
-   * Quotes host (#21)。JP 本番では trade とホストが分離 (`data-api.webull.co.jp`)。
-   * JP UAT (ALB) では trade と同じ URL を入れる。未設定 / 空 / whitespace なら
-   * JP prod default (`DEFAULT_QUOTES_API_BASE`) に fallback、env が explicit に
-   * セットされてれば override。
+   * Quotes host override。**JP 本番の Market Data API は trade host
+   * (`api.webull.co.jp`) + x-version v2 で稼働** (docs 明記 + PR #474 実測、
+   * #475)。「data-api.webull.co.jp に分離」は誤った前提だった。未設定 / 空 /
+   * whitespace なら trade host default に fallback。JP UAT (ALB 1 host 束ね)
+   * のみ explicit override を使う。
    */
   WEBULL_QUOTES_API_BASE?: string
   /** 2FA 発行 `x-access-token` (#21)。詳細は `WebullClientEnv.WEBULL_ACCESS_TOKEN`。 */
@@ -75,25 +76,30 @@ interface RawSnapshotEntry {
 //   (omitting them → 417 Expectation Failed; see probe trace in #84)
 const DEFAULT_QUOTE_PATH = '/openapi/market-data/stock/snapshot'
 /**
- * Webull JP **production** quotes host (#21)。SDK region=jp の公開値。
- * UAT (1 ホスト束ね) は `WEBULL_QUOTES_API_BASE` env で override する。
+ * Webull JP **production** の Market Data API host (#475)。docs (market-data-api/
+ * data-api) の明記どおり trade host と同一。旧値 `data-api.webull.co.jp` は
+ * SDK region=jp の公開値だが TCP 無応答で、そもそも market-data を serve して
+ * いなかった (2026-06-11 実測, PR #474)。UAT (1 ホスト束ね) は
+ * `WEBULL_QUOTES_API_BASE` env で override する。
  */
-const DEFAULT_QUOTES_API_BASE = 'https://data-api.webull.co.jp'
+const DEFAULT_QUOTES_API_BASE = 'https://api.webull.co.jp'
+
+/** QuoteSnapshot.source / spread guard の判定キー。 */
+export const WEBULL_QUOTE_SOURCE = 'webull-snapshot'
 
 /**
  * Minimal Webull market-data snapshot client. Signs requests with the same
- * HMAC-SHA1 canonical signing used by {@link WebullHttpClient}. Scope for #37-B
- * is read-only last-price + asOf so the cron handler can land a
+ * HMAC canonical signing used by {@link WebullHttpClient}. Read-only
+ * last-price + bid/ask + asOf so the cron handler can land a
  * {@link QuoteSnapshot} into each symbol's Durable Object.
  *
- * @deprecated since 2026-05-22 — JP 本番の market-data API がまだ稼働してない
- * (`data-api.webull.co.jp` の TCP 443 が応答せず、`api.webull.co.jp` 上の
- * `/openapi/market-data/*` は `404 Route Not Found`)。strategy cron は
- * {@link YahooQuoteClient} を default で使う構造に切替済 (PR #334)。本 class
- * は `/admin/broker/probe` で疎通監視用に残してあるのみ。Webull JP が
- * market-data API を運用開始したら deprecation 解除して default に戻す予定。
+ * 2026-05-22 に deprecated 化 (market-data 未稼働と誤認、PR #334 で Yahoo へ) →
+ * **2026-06-11 に解除** (#475): 正しい host (trade host + v2) で稼働確認済み。
+ * `QUOTE_SOURCE=webull` で primary に戻る。bid/ask が実データになるため
+ * spread guard (issue #411) が実数評価になる。
  */
 export class WebullQuoteClient {
+  readonly source = WEBULL_QUOTE_SOURCE
   private readonly baseUrl: string
   private readonly quotePath: string
   private readonly timeoutMs: number
@@ -187,10 +193,6 @@ export class WebullQuoteClient {
   }
 }
 
-/**
- * @deprecated since 2026-05-22 — see {@link WebullQuoteClient}。default では
- * {@link YahooQuoteClient} を使う設計に移行済。
- */
 export function createWebullQuoteClient(
   env: WebullQuoteClientEnv,
   options?: {

--- a/src/trading/quotes/quoteScheduler.ts
+++ b/src/trading/quotes/quoteScheduler.ts
@@ -1,11 +1,14 @@
 import type { Env } from '../../config/env'
 import { loadSymbolUniverse } from '../../infrastructure/db/symbolUniverse'
 import {
+  WEBULL_QUOTE_SOURCE,
+  createWebullQuoteClient,
   groupSymbolsByCategory,
   type QuoteResult,
   type WebullQuoteCategory,
 } from '../../infrastructure/quotes/WebullQuoteClient'
 import { YahooQuoteClient } from '../../infrastructure/quotes/YahooQuoteClient'
+import { resolveAccessToken } from '../../infrastructure/webull/resolveAccessToken'
 import type { QuoteSnapshot } from '../state/types'
 
 /**
@@ -23,14 +26,43 @@ export interface QuoteRunSummary {
   persisted: number
   skipped: string[]
   errors: Array<{ category: WebullQuoteCategory; message: string }>
-  /** 実際に使われた snapshot source (`'yahoo-snapshot'` / `'webull-snapshot'`)。 */
+  /** primary の snapshot source (`'yahoo-snapshot'` / `'webull-snapshot'`)。 */
   source: string
+  /**
+   * Yahoo fallback 経由で取得した銘柄 (#475)。primary=webull のとき、JP 銘柄
+   * (Webull snapshot 非対応) と Webull 障害時のリカバリがここに入る。各 quote の
+   * `QuoteSnapshot.source` は実際に使った client の値なので、spread guard は
+   * fallback 分を Yahoo として (= bid/ask 無しを許容して) 評価する。
+   */
+  fallbackSymbols: string[]
 }
 
 interface RunQuoteFeedOptions {
   env: Env
   client?: SnapshotClient
+  /** test seam。primary=webull のときの Yahoo fallback を差し替える。 */
+  fallbackClient?: SnapshotClient
   now?: () => Date
+}
+
+/**
+ * `QUOTE_SOURCE` env による primary client の選択 (#475)。
+ *   - `'webull'`: Market Data API (trade host + v2、PR #474 で稼働実証)。
+ *     bid/ask 付き snapshot で spread guard (issue #411) が実数評価になる。
+ *   - それ以外 / 未設定: Yahoo (PR #334 以来の現行 default)。**fail-safe 側が
+ *     既定** — 切替は env の明示 opt-in のみ。
+ */
+async function selectSnapshotClient(env: Env, now: () => Date): Promise<SnapshotClient> {
+  if ((env.QUOTE_SOURCE ?? '').trim().toLowerCase() === 'webull') {
+    // Phase B token (DO 優先)。失敗しても client は構築する — 署名は通り
+    // token 無しで broker が拒否すれば per-category エラー → Yahoo fallback。
+    const accessToken = await resolveAccessToken(env).catch(() => undefined)
+    return createWebullQuoteClient(env, {
+      now,
+      ...(accessToken !== undefined ? { accessToken } : {}),
+    })
+  }
+  return new YahooQuoteClient({ now })
 }
 
 /**
@@ -38,6 +70,12 @@ interface RunQuoteFeedOptions {
  * result into each symbol's Durable Object. Called from the Workers cron
  * handler so strategy logic can read {@link QuoteSnapshot} with an `asOf` <
  * maxAgeMs freshness guard.
+ *
+ * primary=webull のときの fallback 設計 (#475、fail-safe):
+ *   - JP 銘柄は Webull snapshot 非対応 → 最初から Yahoo で取得
+ *   - Webull の category fetch が throw → 同じ group を Yahoo で再試行
+ *   - Yahoo まで失敗した group はエラー記録のみ (quote は前回値のまま →
+ *     freshness guard が entry を止める。exit は止めない既存設計)
  */
 export async function runQuoteFeed(options: RunQuoteFeedOptions): Promise<QuoteRunSummary> {
   const { env } = options
@@ -45,12 +83,13 @@ export async function runQuoteFeed(options: RunQuoteFeedOptions): Promise<QuoteR
   const universe = await loadSymbolUniverse(env)
   const symbols = universe.allowedSymbols
 
-  // default は Yahoo Finance (#21 follow-up)。Webull JP の market-data API
-  // (`data-api.webull.co.jp`) がまだ運用開始してない (DNS は存在するが TCP 無応答
-  // + `api.webull.co.jp/openapi/market-data/*` が 404) ので、運用開始するまでは
-  // Yahoo 経由で snapshot を取る。Webull market-data が live になったら caller
-  // 側で `WebullQuoteClient` を `options.client` に渡せば切替可能。
-  const client: SnapshotClient = options.client ?? new YahooQuoteClient({ now })
+  const client: SnapshotClient = options.client ?? (await selectSnapshotClient(env, now))
+  // Yahoo fallback は primary が Webull のときだけ用意する (Yahoo primary の
+  // fallback 先は存在しない)。
+  const fallbackClient: SnapshotClient | null =
+    client.source === WEBULL_QUOTE_SOURCE
+      ? (options.fallbackClient ?? new YahooQuoteClient({ now }))
+      : null
 
   const summary: QuoteRunSummary = {
     fetched: 0,
@@ -58,46 +97,69 @@ export async function runQuoteFeed(options: RunQuoteFeedOptions): Promise<QuoteR
     skipped: [],
     errors: [],
     source: client.source,
+    fallbackSymbols: [],
   }
   if (symbols.length === 0) return summary
 
   const { grouped, unsupported } = groupSymbolsByCategory(symbols)
   const fetchedAt = now().toISOString()
 
-  // `groupSymbolsByCategory` は Webull の制約 (JP snapshot endpoint なし) で
-  // JP 銘柄を `unsupported` に分類する。Yahoo は `.T` suffix で JP も普通に
-  // 取得できるので、Yahoo 経路では unsupported を fetch 対象に戻す。
-  // Webull 経路では従来通り skip (CodeRabbit #334)。
-  const clientSupportsJp = client.source !== 'webull-snapshot'
+  // fetch 単位のジョブ列。primary が JP を扱えない場合、JP 銘柄は Yahoo
+  // fallback のジョブとして積む (従来は skip して quote が更新されなかった)。
+  const jobs: Array<{
+    client: SnapshotClient
+    category: WebullQuoteCategory
+    symbols: string[]
+    isFallback: boolean
+  }> = []
+
+  const clientSupportsJp = client.source !== WEBULL_QUOTE_SOURCE
   if (clientSupportsJp) {
     // Yahoo (or 将来の同等 client): unsupported (= JP) を US_STOCK に混ぜて投げる。
     // category は Yahoo 側で ignore されるので分類は便宜上のもの。
     if (unsupported.length > 0) {
       grouped.US_STOCK.push(...unsupported)
     }
+  } else if (fallbackClient && unsupported.length > 0) {
+    jobs.push({ client: fallbackClient, category: 'US_STOCK', symbols: unsupported, isFallback: true })
   } else {
-    // Webull: JP snapshot は依然 unsupported。summary に "known unfetchable"
-    // として残す (silent drop を避ける)。
     for (const symbol of unsupported) summary.skipped.push(symbol)
   }
 
   for (const [category, group] of Object.entries(grouped) as Array<[WebullQuoteCategory, string[]]>) {
     if (group.length === 0) continue
+    jobs.push({ client, category, symbols: group, isFallback: false })
+  }
+
+  for (const job of jobs) {
     let results: QuoteResult[]
+    let usedClient = job.client
     try {
-      results = await client.getSnapshots(group, category)
+      results = await job.client.getSnapshots(job.symbols, job.category)
     } catch (error) {
       summary.errors.push({
-        category,
+        category: job.category,
         message: error instanceof Error ? error.message : String(error),
       })
-      continue
+      // primary の障害は Yahoo で同 group を再試行 (#475)。fallback 自身の
+      // 失敗は再試行しない (二重 fallback 無し)。
+      if (job.isFallback || fallbackClient === null || job.client === fallbackClient) continue
+      try {
+        usedClient = fallbackClient
+        results = await fallbackClient.getSnapshots(job.symbols, job.category)
+      } catch (fallbackError) {
+        summary.errors.push({
+          category: job.category,
+          message: `fallback failed: ${fallbackError instanceof Error ? fallbackError.message : String(fallbackError)}`,
+        })
+        continue
+      }
     }
 
     const bySymbol = new Map(results.map((r) => [r.symbol, r]))
     summary.fetched += results.length
 
-    for (const symbol of group) {
+    for (const symbol of job.symbols) {
       const result = bySymbol.get(symbol)
       if (!result) {
         summary.skipped.push(symbol)
@@ -107,24 +169,25 @@ export async function runQuoteFeed(options: RunQuoteFeedOptions): Promise<QuoteR
         price: result.price,
         asOf: result.asOf,
         fetchedAt,
-        // `client.source` から取る ('yahoo-snapshot' / 'webull-snapshot')。
-        // hardcoded constant をやめ、実際に使った client から動的に取る事で
-        // 切替時の source 漏れを防ぐ。
-        source: client.source,
+        // 実際に fetch に使った client から取る ('yahoo-snapshot' /
+        // 'webull-snapshot')。fallback 時は Yahoo になり、spread guard は
+        // bid/ask 無しを「仕様」として扱う (issue #411 の source 判定)。
+        source: usedClient.source,
       }
       if (result.bid !== undefined) quote.bid = result.bid
       if (result.ask !== undefined) quote.ask = result.ask
+      if (usedClient !== job.client || job.isFallback) summary.fallbackSymbols.push(symbol)
       try {
         const stub = env.SYMBOL_STATE.get(env.SYMBOL_STATE.idFromName(symbol))
         if (!stub) {
-          summary.errors.push({ category, message: `Failed to get DO stub for ${symbol}` })
+          summary.errors.push({ category: job.category, message: `Failed to get DO stub for ${symbol}` })
           continue
         }
         await stub.setQuote(symbol, quote)
         summary.persisted += 1
       } catch (error) {
         summary.errors.push({
-          category,
+          category: job.category,
           message: `Failed to persist ${symbol}: ${error instanceof Error ? error.message : String(error)}`,
         })
       }

--- a/test/trading/quotes/quoteScheduler.test.ts
+++ b/test/trading/quotes/quoteScheduler.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { runQuoteFeed, type SnapshotClient } from '../../../src/trading/quotes/quoteScheduler'
+import { loadSymbolUniverse } from '../../../src/infrastructure/db/symbolUniverse'
+import type { Env } from '../../../src/config/env'
+import type { QuoteResult, WebullQuoteCategory } from '../../../src/infrastructure/quotes/WebullQuoteClient'
+
+vi.mock('../../../src/infrastructure/db/symbolUniverse', () => ({
+  loadSymbolUniverse: vi.fn(),
+}))
+
+interface PersistedQuote {
+  symbol: string
+  quote: { price: number; source: string; bid?: number; ask?: number }
+}
+
+function makeEnv(allowed: string[], extra: Record<string, unknown> = {}) {
+  const persisted: PersistedQuote[] = []
+  vi.mocked(loadSymbolUniverse).mockResolvedValue({
+    allowedSymbols: allowed,
+  } as unknown as Awaited<ReturnType<typeof loadSymbolUniverse>>)
+  const env = {
+    SYMBOL_STATE: {
+      idFromName: (name: string) => name,
+      get: (id: string) => ({
+        setQuote: async (symbol: string, quote: PersistedQuote['quote']) => {
+          void id
+          persisted.push({ symbol, quote })
+        },
+      }),
+    },
+    ...extra,
+  } as unknown as Env
+  return { env, persisted }
+}
+
+function clientOf(
+  source: string,
+  handler: (symbols: string[], category: WebullQuoteCategory) => QuoteResult[] | Promise<QuoteResult[]>,
+): SnapshotClient {
+  return {
+    source,
+    getSnapshots: async (symbols, category) => handler(symbols, category),
+  }
+}
+
+const quote = (symbol: string, price: number, bidAsk?: { bid: number; ask: number }): QuoteResult => ({
+  symbol,
+  price,
+  asOf: '2026-06-11T00:00:00.000Z',
+  ...(bidAsk ?? {}),
+})
+
+beforeEach(() => {
+  vi.mocked(loadSymbolUniverse).mockReset()
+})
+
+describe('runQuoteFeed の QUOTE_SOURCE 選択 (#475)', () => {
+  it("QUOTE_SOURCE 未設定は Yahoo (現行 default、fail-safe)", async () => {
+    const { env } = makeEnv([])
+    const summary = await runQuoteFeed({ env })
+    expect(summary.source).toBe('yahoo-snapshot')
+  })
+
+  it("QUOTE_SOURCE=webull で webull-snapshot が primary", async () => {
+    const { env } = makeEnv([], { QUOTE_SOURCE: 'webull' })
+    const summary = await runQuoteFeed({ env })
+    expect(summary.source).toBe('webull-snapshot')
+  })
+
+  it("QUOTE_SOURCE の未知値は Yahoo に倒す", async () => {
+    const { env } = makeEnv([], { QUOTE_SOURCE: 'alpaca' })
+    const summary = await runQuoteFeed({ env })
+    expect(summary.source).toBe('yahoo-snapshot')
+  })
+})
+
+describe('runQuoteFeed の Webull primary + Yahoo fallback (#475)', () => {
+  it('US は Webull (bid/ask 付き)、JP は Yahoo fallback で取得し source を書き分ける', async () => {
+    const { env, persisted } = makeEnv(['AAPL', 'SOXL', '1357'])
+    const webull = clientOf('webull-snapshot', (symbols) =>
+      symbols.map((s) => quote(s, 100, { bid: 99.9, ask: 100.1 })),
+    )
+    const yahoo = clientOf('yahoo-snapshot', (symbols) => symbols.map((s) => quote(s, 200)))
+
+    const summary = await runQuoteFeed({ env, client: webull, fallbackClient: yahoo })
+
+    expect(summary.errors).toEqual([])
+    expect(summary.persisted).toBe(3)
+    expect(summary.fallbackSymbols).toEqual(['1357'])
+    const bySymbol = new Map(persisted.map((p) => [p.symbol, p.quote]))
+    expect(bySymbol.get('AAPL')?.source).toBe('webull-snapshot')
+    expect(bySymbol.get('AAPL')?.bid).toBe(99.9)
+    expect(bySymbol.get('SOXL')?.source).toBe('webull-snapshot')
+    // JP は Yahoo 経由 → spread guard は bid/ask 無しを仕様として扱える
+    expect(bySymbol.get('1357')?.source).toBe('yahoo-snapshot')
+    expect(bySymbol.get('1357')?.bid).toBeUndefined()
+  })
+
+  it('Webull の category fetch 失敗は同 group を Yahoo で再試行する (degraded but tradeable)', async () => {
+    const { env, persisted } = makeEnv(['AAPL'])
+    const webull = clientOf('webull-snapshot', () => {
+      throw new Error('snapshot 500')
+    })
+    const yahoo = clientOf('yahoo-snapshot', (symbols) => symbols.map((s) => quote(s, 200)))
+
+    const summary = await runQuoteFeed({ env, client: webull, fallbackClient: yahoo })
+
+    expect(summary.errors.map((e) => e.message)).toContain('snapshot 500')
+    expect(summary.persisted).toBe(1)
+    expect(summary.fallbackSymbols).toEqual(['AAPL'])
+    expect(persisted[0]?.quote.source).toBe('yahoo-snapshot')
+  })
+
+  it('Yahoo fallback まで失敗したら quote は更新せずエラー記録のみ (freshness guard に委ねる)', async () => {
+    const { env, persisted } = makeEnv(['AAPL'])
+    const webull = clientOf('webull-snapshot', () => {
+      throw new Error('snapshot 500')
+    })
+    const yahoo = clientOf('yahoo-snapshot', () => {
+      throw new Error('yahoo down')
+    })
+
+    const summary = await runQuoteFeed({ env, client: webull, fallbackClient: yahoo })
+
+    expect(summary.persisted).toBe(0)
+    expect(persisted).toEqual([])
+    expect(summary.errors).toHaveLength(2)
+    expect(summary.errors[1]!.message).toContain('fallback failed')
+  })
+
+  it('Yahoo primary (現行構成) は従来どおり JP も同居で取得し fallback 無し', async () => {
+    const { env, persisted } = makeEnv(['AAPL', '1357'])
+    const yahoo = clientOf('yahoo-snapshot', (symbols) => symbols.map((s) => quote(s, 200)))
+
+    const summary = await runQuoteFeed({ env, client: yahoo })
+
+    expect(summary.persisted).toBe(2)
+    expect(summary.fallbackSymbols).toEqual([])
+    expect(persisted.every((p) => p.quote.source === 'yahoo-snapshot')).toBe(true)
+  })
+})

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -112,7 +112,11 @@
         // 1 user = 1 app の制約で staging/prod で API key 分離できないため、コード
         // 側で staging からの live order を絶対に止める。`WebullTradeClient` が
         // 'staging' を検知すると placeOrder で throw。
-        "ENVIRONMENT": "staging"
+        "ENVIRONMENT": "staging",
+        // #475: staging のみ Webull Market Data API を primary に (canary)。
+        // production は未設定 = Yahoo のまま — staging で bid/ask / spread guard
+        // の挙動を観察してから昇格する。
+        "QUOTE_SOURCE": "webull"
       },
       "routes": [
         { "pattern": "trading-staging.chanu.co", "custom_domain": true }


### PR DESCRIPTION
## 概要 (#475 の ②)

PR #334 で「JP market data 未稼働」と誤認して Yahoo に退避していた quote feed を、正しい host (trade host + v2、PR #474 実証) の Webull Market Data API に戻せるようにする。

### 変更

- **`WebullQuoteClient` の deprecation 解除 + default host 修正** (`data-api` → `api.webull.co.jp`)。v2 署名・bid/ask 正規化は当時の実装がそのまま生きていた
- **`QUOTE_SOURCE` env flag (新設)**: `'webull'` で Webull primary。**未設定 = Yahoo (現行) が既定** — fail-safe 側がデフォルトで、本番挙動はこの PR では変わらない
- **primary/fallback 構成** (scheduler):
  - JP 銘柄 (Webull snapshot 非対応) → 最初から Yahoo で取得 (従来の Webull 経路は skip して quote が更新されなかった)
  - Webull の category fetch 失敗 → 同 group を Yahoo で再試行 (degraded but tradeable)
  - Yahoo まで失敗 → エラー記録のみ。quote は前回値のままで freshness guard が entry を止める (exit は止めない既存設計)
  - **各 quote の `source` は実際に使った client の値** → spread guard (issue #411) は Webull 分を bid/ask 実数で fail-closed 評価、Yahoo fallback 分は従来どおり適用外
- **staging のみ `QUOTE_SOURCE=webull`** (wrangler.jsonc) — canary。summary に `fallbackSymbols` を追加し observability 確保

### 効果

- quote が 5 倍速 (Yahoo ~3.4s → Webull ~0.7s 実測) + **bid/ask 実データで spread guard が実数評価に**
- 1357 (JP) は Yahoo 継続なので欠測なし

## 検証

- 1494 tests pass (+7: source 選択 / JP fallback / 障害 fallback / 二重障害)
- staging デプロイ済み (Version 7bdaca14)。次の 5 分 cron 以降、ダッシュボードの quote source が `webull-snapshot` になり bid/ask が入ります

Refs #475 #474 #411 #334

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 相場データソースを Webull と Yahoo から選択可能に。Webull を primary として利用でき、日本銘柄や障害時は Yahoo に自動フォールバック。
  * 未設定時は従来どおり Yahoo を使用。

* **Documentation**
  * 相場データソース設定ガイドを追記し、切り替え方法と自動フォールバック動作を明示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->