### PR TITLE
feat: strategy bars の Webull 回帰 — BAR_SOURCE flag + 銘柄ルーティング (issue #475)

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -117,3 +117,7 @@ WEBULL_ACCESS_TOKEN=
 # trade host + v2) に切替。JP 銘柄と Webull 障害時は Yahoo に自動 fallback。
 # 未設定 = yahoo (現行 default)。
 # QUOTE_SOURCE=webull
+
+# BAR_SOURCE (#475): 'webull' で daily/intraday bars を Webull Market Data API に
+# 切替。^VIX / JP 銘柄 / Webull 障害時は Yahoo に自動 fallback。未設定 = yahoo。
+# BAR_SOURCE=webull

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -495,3 +495,12 @@ export interface Env {
 export interface Env {
   QUOTE_SOURCE?: string
 }
+
+
+// #475: bar source の切替 (quote の QUOTE_SOURCE と同じ規約、独立 canary 用)。
+// 'webull' で Market Data API bars (trade host + v2) を primary に、^VIX
+// (index) / JP 銘柄 / Webull 障害時は Yahoo に自動 fallback。未設定 / 他値は
+// 'yahoo' (現行) — fail-safe 側が既定。
+export interface Env {
+  BAR_SOURCE?: string
+}

--- a/src/infrastructure/quotes/BarClient.ts
+++ b/src/infrastructure/quotes/BarClient.ts
@@ -69,16 +69,14 @@ interface WebullBarClientOptions {
 }
 
 /**
- * Minimal daily-bar client. The Webull JP UAT bar endpoint is not yet verified
- * from this POC, so the path is overridable via env (`WEBULL_BARS_PATH`) and
- * the response mapper is forgiving — any bar missing a usable close is
- * filtered out instead of throwing. Once the production path is known, this
- * client can be locked down.
+ * Webull market-data bars client (daily + intraday)。path は env
+ * (`WEBULL_BARS_PATH`) で override 可能、mapper は forgiving — close の無い
+ * bar は throw せず drop する。
  *
- * @deprecated since 2026-05-22 — JP 本番の market-data API がまだ稼働してない
- * ため、strategy cron は {@link YahooBarClient} を default で使う構造に切替済。
- * 本 class は将来 Webull JP が bars API を運用開始したときの切戻し用に残してある
- * のみで、現時点で実 callers は無い。
+ * 2026-05-22 に deprecated 化 (market-data 未稼働と誤認、PR #334 で Yahoo へ) →
+ * **2026-06-11 に解除** (#475): Market Data API は trade host + x-version v2 で
+ * 稼働中 (PR #474 実測)。`BAR_SOURCE=webull` のとき {@link FallbackBarClient}
+ * 経由で primary になる。
  */
 export class WebullBarClient implements BarClient {
   private readonly baseUrl: string
@@ -100,6 +98,22 @@ export class WebullBarClient implements BarClient {
   }
 
   async getDailyBars(symbol: string, lookback: number): Promise<DailyBar[]> {
+    return normalizeBars(await this.requestBars(symbol, 'D', lookback))
+  }
+
+  /**
+   * 最新の intraday bars (#475)。strategy cron が「当日最新 1h close」を fill
+   * 価格に使う optional contract ({@link BarClient.getIntradayBars}) の Webull
+   * 実装。v2 timespan enum は M5/M15/M30/M60。
+   */
+  async getIntradayBars(symbol: string, interval: IntradayInterval): Promise<IntradayBar[]> {
+    const timespan = { '5m': 'M5', '15m': 'M15', '30m': 'M30', '60m': 'M60' }[interval]
+    // 消費側は最新 bar の close しか見ないが、Yahoo 実装が当日分を返すのに
+    // 合わせて直近 8 本 (60m × 8 ≈ 1 営業日) を取る。
+    return normalizeIntradayBars(await this.requestBars(symbol, timespan, 8))
+  }
+
+  private async requestBars(symbol: string, timespan: string, count: number): Promise<unknown> {
     const category = resolveBarCategory(symbol)
     // v2 stock/bars timespan enum (from probe 417 body):
     //   M1, M5, M15, M30, M60, M120, M240, D, W, M, Y
@@ -112,8 +126,8 @@ export class WebullBarClient implements BarClient {
     const query = {
       symbol,
       category,
-      timespan: 'D',
-      count: String(lookback),
+      timespan,
+      count: String(count),
       real_time_required: 'true',
     }
 
@@ -167,21 +181,18 @@ export class WebullBarClient implements BarClient {
       )
     }
 
-    return normalizeBars((await response.json()) as unknown)
+    return (await response.json()) as unknown
   }
 }
 
 /**
- * Webull JP **production** quotes host (#21)。SDK region=jp の公開値。
- * UAT (1 ホスト束ね) は `WEBULL_QUOTES_API_BASE` env で override する。
- * `WebullQuoteClient` と同じ host を共有 (quotes は単一 host)。
+ * Webull JP **production** の Market Data API host (#475)。docs どおり trade
+ * host と同一 (`WebullQuoteClient` と同じ)。旧値 `data-api.webull.co.jp` は
+ * TCP 無応答で market-data を serve していなかった (PR #474 実測)。UAT
+ * (1 ホスト束ね) は `WEBULL_QUOTES_API_BASE` env で override する。
  */
-const DEFAULT_QUOTES_API_BASE = 'https://data-api.webull.co.jp'
+const DEFAULT_QUOTES_API_BASE = 'https://api.webull.co.jp'
 
-/**
- * @deprecated since 2026-05-22 — see {@link WebullBarClient}。default では
- * {@link YahooBarClient} を使う設計に移行済。
- */
 export function createWebullBarClient(
   env: WebullBarClientEnv,
   options?: {
@@ -260,4 +271,103 @@ function toNumber(value: number | string | undefined): number | null {
   if (value === undefined || value === null) return null
   const num = typeof value === 'number' ? value : Number(value)
   return Number.isFinite(num) ? num : null
+}
+
+function normalizeIntradayBars(json: unknown): IntradayBar[] {
+  const rawList = extractList(json)
+  const bars: IntradayBar[] = []
+  for (const raw of rawList) {
+    const timestamp = extractTimestamp(raw)
+    const open = toNumber(raw.open)
+    const high = toNumber(raw.high)
+    const low = toNumber(raw.low)
+    const close = toNumber(raw.close)
+    if (!timestamp || open === null || high === null || low === null || close === null) continue
+    bars.push({ timestamp, open, high, low, close })
+  }
+  // oldest-first — 消費側 (pullbackScheduler) は「最後の bar = 最新」を前提。
+  bars.sort((a, b) => a.timestamp.localeCompare(b.timestamp))
+  return bars
+}
+
+function extractTimestamp(raw: RawBar): string {
+  // v2 は "2026-04-17T04:00:00.000+0000" 形式。ISO UTC (秒精度) に正規化して
+  // Yahoo 実装 (`new Date(ts*1000).toISOString()`) と同じ shape を返す。
+  const value = raw.time ?? raw.trade_time ?? raw.date
+  if (typeof value !== 'string' || value.length < 10) return ''
+  const ms = Date.parse(value)
+  return Number.isFinite(ms) ? new Date(ms).toISOString() : ''
+}
+
+// ---------------------------------------------------------------------------
+// #475: BAR_SOURCE 切替と Webull primary + Yahoo fallback の composite。
+// ---------------------------------------------------------------------------
+
+import { YahooBarClient } from './YahooBarClient'
+import { resolveAccessToken } from '../webull/resolveAccessToken'
+import type { Env } from '../../config/env'
+
+/**
+ * Webull bars で取得**できない**銘柄か (#475)。
+ *   - `^` prefix の index (^VIX 等): Webull の instrument universe に無い
+ *   - JP 銘柄: JP quotes subscription が必要 (MCP 実測 "Market data requires
+ *     quotes subscription") で現契約では取れない
+ * これらは Yahoo に直行する。
+ */
+function isWebullBarUnsupported(symbol: string): boolean {
+  return symbol.startsWith('^') || inferWebullMarket(symbol) === 'JP'
+}
+
+/**
+ * Webull primary + Yahoo fallback の composite (#475)。quote feed
+ * (`quoteScheduler`) と同じ fail-safe 方針:
+ *   - 非対応銘柄 (^VIX / JP) は最初から Yahoo
+ *   - Webull の fetch 失敗は同じ呼び出しを Yahoo で再試行 (degraded but tradeable)
+ *   - Yahoo まで失敗したら throw (呼び出し側の既存エラー処理に乗る — daily 失敗
+ *     は per-symbol skip、intraday 失敗は daily close fallback)
+ */
+export class FallbackBarClient implements BarClient {
+  constructor(
+    private readonly primary: WebullBarClient,
+    private readonly fallback: YahooBarClient,
+  ) {}
+
+  async getDailyBars(symbol: string, lookback: number): Promise<DailyBar[]> {
+    if (isWebullBarUnsupported(symbol)) return this.fallback.getDailyBars(symbol, lookback)
+    try {
+      return await this.primary.getDailyBars(symbol, lookback)
+    } catch {
+      return this.fallback.getDailyBars(symbol, lookback)
+    }
+  }
+
+  async getIntradayBars(symbol: string, interval: IntradayInterval): Promise<IntradayBar[]> {
+    if (isWebullBarUnsupported(symbol)) return this.fallback.getIntradayBars(symbol, interval)
+    try {
+      return await this.primary.getIntradayBars(symbol, interval)
+    } catch {
+      return this.fallback.getIntradayBars(symbol, interval)
+    }
+  }
+}
+
+/**
+ * `BAR_SOURCE` env による bar client の選択 (#475)。quote の `QUOTE_SOURCE` と
+ * 同じ規約: `'webull'` で Webull primary (+ Yahoo fallback)、未設定 / 他値は
+ * Yahoo (現行 default) — **fail-safe 側が既定**で、切替は env の明示 opt-in のみ。
+ * 独立 flag にしているのは quote と bars を別々に canary できるようにするため。
+ */
+export async function selectBarClient(env: Env): Promise<BarClient> {
+  if ((env.BAR_SOURCE ?? '').trim().toLowerCase() === 'webull') {
+    // Phase B token (DO 優先)。失敗しても client は構築する — token 無しで
+    // broker が拒否すれば per-call エラー → Yahoo fallback。
+    const accessToken = await resolveAccessToken(env).catch(() => undefined)
+    return new FallbackBarClient(
+      createWebullBarClient(env, {
+        ...(accessToken !== undefined ? { accessToken } : {}),
+      }),
+      new YahooBarClient(),
+    )
+  }
+  return new YahooBarClient()
 }

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -1,5 +1,5 @@
 import type { Env } from '../../config/env'
-import { YahooBarClient } from '../../infrastructure/quotes/YahooBarClient'
+import { selectBarClient, type BarClient } from '../../infrastructure/quotes/BarClient'
 import { loadUsdJpyRate } from '../../infrastructure/quotes/fxRate'
 import type { WebullAccountBalanceDto } from '../../infrastructure/webull/dto'
 import {
@@ -496,10 +496,10 @@ export async function runStrategyCron(
   // notifier は関数冒頭で組み立て済み (#141)。BUY/SELL emit / per-symbol
   // bar fetch error / broker submit error は scheduler 内で注入された
   // notifier を使う (#199 経路のまま)。
-  // Yahoo Finance /v8/finance/chart is free, no auth, covers US + JP (7267.T
-  // style) in one endpoint — chosen over Webull's JP-subscription-gated
-  // market-data API (see #84). Webull is still the order-execution path.
-  const barClient = new YahooBarClient()
+  // BAR_SOURCE env で選択 (#475): default は Yahoo (/v8/finance/chart — free,
+  // no auth, US + JP + ^VIX を 1 endpoint でカバー)。'webull' で Market Data
+  // API bars が primary になり、^VIX / JP / 障害時は Yahoo に自動 fallback。
+  const barClient = await selectBarClient(env)
 
   // Earnings calendar gate (issue #196 1/3): table 未 migrate な環境で
   // `fetchByRange()` が `no such table` を吐くと fail-closed で全 BUY が
@@ -1001,7 +1001,7 @@ async function isEarningsCalendarReady(db: D1Database): Promise<boolean> {
  * だけ吐いて続行。
  */
 async function loadVixDecision(
-  barClient: YahooBarClient,
+  barClient: BarClient,
   global: { vixWarningThreshold: number; vixCriticalThreshold: number; vixWarningSizeScale: number },
   requestId: string | undefined,
 ): Promise<VixRegimeFilterDecision> {

--- a/test/infrastructure/quotes/webullBarClient.test.ts
+++ b/test/infrastructure/quotes/webullBarClient.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it, vi } from 'vitest'
-import { WebullBarClient } from '../../../src/infrastructure/quotes/BarClient'
+import {
+  FallbackBarClient,
+  WebullBarClient,
+  selectBarClient,
+} from '../../../src/infrastructure/quotes/BarClient'
+import { YahooBarClient } from '../../../src/infrastructure/quotes/YahooBarClient'
 import { WebullAuth } from '../../../src/infrastructure/webull/WebullAuth'
+import type { Env } from '../../../src/config/env'
 
 const baseAuth = new WebullAuth({ appKey: 'ak', appSecret: 'sk' })
 const TEST_BASE_URL = 'https://test.example'
@@ -120,5 +126,94 @@ describe('WebullBarClient.getDailyBars', () => {
 
     expect(capturedPath).toBe('/market-data/candles')
     expect(capturedPath).not.toBe('/openapi/market-data/stock/bars')
+  })
+})
+
+describe('WebullBarClient.getIntradayBars (#475)', () => {
+  it('maps 60m → timespan=M60 and normalizes time to ISO UTC, oldest-first', async () => {
+    let capturedUrl = ''
+    const fetchFn = vi.fn(async (input: Request | string | URL) => {
+      capturedUrl = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      return mockJsonResponse([
+        { time: '2026-06-11T14:30:00.000+0000', open: '100', high: '101', low: '99', close: '100.5' },
+        { time: '2026-06-11T13:30:00.000+0000', open: '99', high: '100', low: '98', close: '99.5' },
+      ])
+    }) as unknown as typeof fetch
+
+    const client = new WebullBarClient({ auth: baseAuth, baseUrl: TEST_BASE_URL, fetchFn })
+    const bars = await client.getIntradayBars('AAPL', '60m')
+
+    expect(capturedUrl).toContain('timespan=M60')
+    expect(bars).toHaveLength(2)
+    expect(bars[0]?.timestamp).toBe('2026-06-11T13:30:00.000Z')
+    expect(bars[1]?.close).toBeCloseTo(100.5)
+  })
+})
+
+describe('FallbackBarClient (#475 Webull primary + Yahoo fallback)', () => {
+  function stubClient(name: string, calls: string[], fail = false) {
+    return {
+      getDailyBars: async (symbol: string, lookback: number) => {
+        calls.push(`${name}:daily:${symbol}:${lookback}`)
+        if (fail) throw new Error(`${name} down`)
+        return [{ date: '2026-06-10', open: 1, high: 1, low: 1, close: 1 }]
+      },
+      getIntradayBars: async (symbol: string) => {
+        calls.push(`${name}:intraday:${symbol}`)
+        if (fail) throw new Error(`${name} down`)
+        return [{ timestamp: '2026-06-11T13:30:00.000Z', open: 1, high: 1, low: 1, close: 1 }]
+      },
+    }
+  }
+
+  it('US 銘柄は Webull primary、^VIX と JP 銘柄は Yahoo 直行', async () => {
+    const calls: string[] = []
+    const client = new FallbackBarClient(
+      stubClient('webull', calls) as unknown as WebullBarClient,
+      stubClient('yahoo', calls) as unknown as YahooBarClient,
+    )
+    await client.getDailyBars('AAPL', 60)
+    await client.getDailyBars('^VIX', 1)
+    await client.getDailyBars('1357', 60)
+    expect(calls).toEqual(['webull:daily:AAPL:60', 'yahoo:daily:^VIX:1', 'yahoo:daily:1357:60'])
+  })
+
+  it('Webull 失敗時は同じ呼び出しを Yahoo で再試行する (daily / intraday とも)', async () => {
+    const calls: string[] = []
+    const client = new FallbackBarClient(
+      stubClient('webull', calls, true) as unknown as WebullBarClient,
+      stubClient('yahoo', calls) as unknown as YahooBarClient,
+    )
+    const daily = await client.getDailyBars('AAPL', 60)
+    const intraday = await client.getIntradayBars('AAPL', '60m')
+    expect(daily).toHaveLength(1)
+    expect(intraday).toHaveLength(1)
+    expect(calls).toEqual([
+      'webull:daily:AAPL:60',
+      'yahoo:daily:AAPL:60',
+      'webull:intraday:AAPL',
+      'yahoo:intraday:AAPL',
+    ])
+  })
+})
+
+describe('selectBarClient (#475 BAR_SOURCE 切替)', () => {
+  it('未設定は Yahoo (現行 default、fail-safe)', async () => {
+    const client = await selectBarClient({} as unknown as Env)
+    expect(client).toBeInstanceOf(YahooBarClient)
+  })
+
+  it("BAR_SOURCE=webull で FallbackBarClient (Webull primary)", async () => {
+    const client = await selectBarClient({
+      BAR_SOURCE: 'webull',
+      WEBULL_APP_KEY: 'k'.repeat(32),
+      WEBULL_APP_SECRET: 's'.repeat(32),
+    } as unknown as Env)
+    expect(client).toBeInstanceOf(FallbackBarClient)
+  })
+
+  it('未知値は Yahoo に倒す', async () => {
+    const client = await selectBarClient({ BAR_SOURCE: 'alpaca' } as unknown as Env)
+    expect(client).toBeInstanceOf(YahooBarClient)
   })
 })

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -116,7 +116,10 @@
         // #475: staging のみ Webull Market Data API を primary に (canary)。
         // production は未設定 = Yahoo のまま — staging で bid/ask / spread guard
         // の挙動を観察してから昇格する。
-        "QUOTE_SOURCE": "webull"
+        "QUOTE_SOURCE": "webull",
+        // #475③: bars も staging のみ Webull primary (canary)。^VIX / JP /
+        // 障害時は Yahoo に自動 fallback。
+        "BAR_SOURCE": "webull"
       },
       "routes": [
         { "pattern": "trading-staging.chanu.co", "custom_domain": true }


### PR DESCRIPTION
## 概要 (#475 の ③)

quote (#478) と同じ補正を bars に適用。`WebullBarClient` (v2 `/openapi/market-data/stock/bars`) は実装済みのまま eternal standby だったが、host の誤認が解けたので戦略 cron に戻せるようにする。

### 変更

- **`WebullBarClient` の deprecation 解除 + default host 修正** (`data-api` → `api.webull.co.jp`)
- **`getIntradayBars` を実装** (60m → timespan M60): 戦略 cron の「最新 1h close を fill 価格に使う」contract を Webull でも満たす (従来 Webull client は省略 = daily close 退化だった)
- **`FallbackBarClient` (composite) + 銘柄ルーティング**:
  - `^VIX` (index — Webull instrument universe に無い) → Yahoo 直行
  - JP 銘柄 (quotes subscription が必要 — 公式 MCP 実測 "Market data requires quotes subscription") → Yahoo 直行
  - US 銘柄 → Webull、**fetch 失敗時は同呼び出しを Yahoo で再試行** (daily 失敗 = per-symbol skip、intraday 失敗 = daily close fallback という既存エラー処理の手前で救う)
- **`BAR_SOURCE` env flag (新設)**: 未設定 = Yahoo (現行)。**QUOTE_SOURCE と独立** — quote と bars を別々に canary / rollback できる
- **staging のみ `BAR_SOURCE=webull`**。production はこの PR では挙動不変

### Note

- Yahoo と Webull で日足の調整方式 (配当調整) が微差を生む可能性があるが、indicators は 20-60 日窓の相対比較なので影響は小さい。staging の戦略判定 trace で乖離を観察する
- dashboard のチャート表示は Yahoo のまま (表示専用、別 PR で検討)

## 検証

- 1500 tests pass (+6: M60 mapping / ルーティング / 障害 fallback / flag 選択)
- staging デプロイ済み — 次の :15 戦略 cron から bars が Webull になります

Refs #475 #478 #474 #334

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * バーデータソースの選択機能を追加（Webull または Yahoo を設定可能）
  * Webull からのインtraday バー取得に対応
  * Webull 利用不可時に Yahoo へ自動フォールバックする機能を実装
  * 環境変数 `BAR_SOURCE` で データソースを切り替え可能に

* **テスト**
  * バーデータソース選択およびフォールバック動作の検証テストを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->