### PR TITLE
fix: 持ち越し設定を 2 択ラジオで両状態明示に (symbol form)

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -9164,6 +9164,8 @@ function symbolFormBody(args: SymbolFormArgs): string {
     row?.takeProfitPctOverride === null || row?.takeProfitPctOverride === undefined
       ? ''
       : String(Math.round(row.takeProfitPctOverride * 1000) / 10)
+  // 持ち越し設定は radio 2 択で両状態を明示する (「持ち越し」ラベル + 「持ち越さ
+  // ない」checkbox の二重否定が ON/OFF どちらか読めない、という operator 指摘)。
   const intradayOnlyChecked = row?.intradayOnly ? ' checked' : ''
   // role / entry override / alternatives (#452)。pullback / trend / 過伸長は
   // DB に fraction 保存、表示は % (×100)。ATR 比は ratio 生値。
@@ -9427,10 +9429,14 @@ function symbolFormBody(args: SymbolFormArgs): string {
           <span class="muted" style="font-size:12px;margin-left:6px">% (正値)</span>
         </div>
         <label>持ち越し</label>
-        <label style="display:flex;align-items:center;gap:6px;font-size:13px">
-          <input type="hidden" name="intraday_only" value="false">
-          <input type="checkbox" name="intraday_only" value="true"${intradayOnlyChecked}> US 引け前に強制クローズ (持ち越さない)
-        </label>`,
+        <div style="display:flex;flex-direction:column;gap:4px;font-size:13px">
+          <label style="display:flex;align-items:center;gap:6px">
+            <input type="radio" name="intraday_only" value="false"${intradayOnlyChecked === '' ? ' checked' : ''}> 持ち越す <span class="muted" style="font-size:12px">(スイング — 既定)</span>
+          </label>
+          <label style="display:flex;align-items:center;gap:6px">
+            <input type="radio" name="intraday_only" value="true"${intradayOnlyChecked}> 持ち越さない <span class="muted" style="font-size:12px">(デイトレ — US 引け前に強制クローズ)</span>
+          </label>
+        </div>`,
       hasExitValues,
     )}
 

--- a/test/routes/dashboardSymbolsCrud.test.ts
+++ b/test/routes/dashboardSymbolsCrud.test.ts
@@ -909,6 +909,27 @@ describe('dashboard symbol_config CRUD UI (#292)', () => {
     expect(body).toContain('global default')
   })
 
+  // 持ち越し設定は radio 2 択で両状態を明示 (「持ち越し」+「持ち越さない」
+  // checkbox の二重否定が読めない、という operator 指摘の regression 防止)。
+  it('持ち越し setting renders as two explicit radios and reflects intradayOnly', async () => {
+    const db = fakeDb([row({ symbol: 'SOXL', intradayOnly: true })])
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const app = createApp()
+    const res = await app.request(
+      '/dashboard/symbols/SOXL/edit',
+      { headers: authHeader },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    const body = await res.text()
+    expect(body).toContain('持ち越す')
+    expect(body).toContain('持ち越さない')
+    // intradayOnly=true の行は radio value="true" 側が checked
+    expect(body).toMatch(/type="radio" name="intraday_only" value="true" checked/)
+    expect(body).not.toMatch(/type="radio" name="intraday_only" value="false" checked/)
+    // 旧 hidden+checkbox パターンが残っていない
+    expect(body).not.toContain('type="checkbox" name="intraday_only"')
+  })
+
   // --- #315 inverse-pair linked registration ---
   it('new form shows inverse_symbol input', async () => {
     const db = fakeDb([])


### PR DESCRIPTION
## 問題 (operator 指摘)

symbol form の「持ち越し」行が、行ラベル「持ち越し」+ checkbox「US 引け前に強制クローズ (**持ち越さない**)」という二重否定で、ON/OFF がどちらの状態か読めなかった。

## 変更

checkbox (+hidden fallback) → **radio 2 択**で両状態を明示:

- 「**持ち越す** (スイング — 既定)」
- 「**持ち越さない** (デイトレ — US 引け前に強制クローズ)」

radio は常にどちらか 1 値だけ POST されるので、hidden+checkbox の重複キー処理も不要になる (`parseFormBool` は 'true'/'false' 単値をそのまま処理)。保存値・cron 側の挙動は不変。

## 検証

- regression テスト追加 (両ラジオ描画 / intradayOnly=true で true 側 checked / 旧 checkbox 不在)
- 1501 tests pass、staging デプロイ済み (`/dashboard/symbols/SOXL/edit` で確認可)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ポジション持ち越し設定のUI をラジオボタンに変更し、「持ち越す」「持ち越さない」の選択肢をより明確に表示しました。

* **テスト**
  * ポジション持ち越し設定の UI 表示と動作を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->