### PR TITLE
feat: 代替銘柄 (表示専用) 機能の削除 — メモで足りるため

### DIFF
--- a/drizzle/0032_drop_alternatives.sql
+++ b/drizzle/0032_drop_alternatives.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `symbol_config` DROP COLUMN `alternatives`;

--- a/drizzle/meta/0032_snapshot.json
+++ b/drizzle/meta/0032_snapshot.json
@@ -1,0 +1,1499 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "9aebeb71-514e-46ee-99be-0e79c84ab1a2",
+  "prevId": "5b489c56-5f18-4992-92f5-fc6ada6c7210",
+  "tables": {
+    "config_audit_log": {
+      "name": "config_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before_json": {
+          "name": "before_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "after_json": {
+          "name": "after_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "config_audit_log_timestamp_id_idx": {
+          "name": "config_audit_log_timestamp_id_idx",
+          "columns": [
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "config_audit_log_actor_timestamp_id_idx": {
+          "name": "config_audit_log_actor_timestamp_id_idx",
+          "columns": [
+            "actor",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "config_audit_log_endpoint_timestamp_id_idx": {
+          "name": "config_audit_log_endpoint_timestamp_id_idx",
+          "columns": [
+            "endpoint",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "config_state_snapshot": {
+      "name": "config_state_snapshot",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "earnings_calendar": {
+      "name": "earnings_calendar",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "earnings_date": {
+          "name": "earnings_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "earnings_calendar_symbol_date_unique": {
+          "name": "earnings_calendar_symbol_date_unique",
+          "columns": [
+            "symbol",
+            "earnings_date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "global_config": {
+      "name": "global_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "trading_enabled": {
+          "name": "trading_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "market_hours_check": {
+          "name": "market_hours_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "max_order_notional": {
+          "name": "max_order_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "max_order_notional_usd": {
+          "name": "max_order_notional_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2000
+        },
+        "max_order_notional_jpy": {
+          "name": "max_order_notional_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100000
+        },
+        "total_capital_usd": {
+          "name": "total_capital_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_capital_jpy": {
+          "name": "total_capital_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_portfolio_exposure_pct": {
+          "name": "max_portfolio_exposure_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.6
+        },
+        "drawdown_kill_threshold": {
+          "name": "drawdown_kill_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.02
+        },
+        "stale_quote_ms": {
+          "name": "stale_quote_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 900000
+        },
+        "gap_reject_pct": {
+          "name": "gap_reject_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.03
+        },
+        "spread_limit_pct_us": {
+          "name": "spread_limit_pct_us",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.0025
+        },
+        "spread_limit_pct_jp": {
+          "name": "spread_limit_pct_jp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.006
+        },
+        "pullback_default_stop_pct": {
+          "name": "pullback_default_stop_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.04
+        },
+        "pullback_default_take_profit_pct": {
+          "name": "pullback_default_take_profit_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.07
+        },
+        "pullback_default_time_stop_days": {
+          "name": "pullback_default_time_stop_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "pullback_default_pullback_max": {
+          "name": "pullback_default_pullback_max",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.03
+        },
+        "pullback_default_pullback_min": {
+          "name": "pullback_default_pullback_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.06
+        },
+        "pullback_default_min_return_50d": {
+          "name": "pullback_default_min_return_50d",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.08
+        },
+        "pullback_default_require_above_sma50": {
+          "name": "pullback_default_require_above_sma50",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "pullback_default_k_atr": {
+          "name": "pullback_default_k_atr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "pullback_default_max_sma50_deviation_pct": {
+          "name": "pullback_default_max_sma50_deviation_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.6
+        },
+        "pullback_default_max_atr_ratio": {
+          "name": "pullback_default_max_atr_ratio",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1.5
+        },
+        "risk_base_per_trade_pct": {
+          "name": "risk_base_per_trade_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.004
+        },
+        "risk_dd_half_threshold": {
+          "name": "risk_dd_half_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.05
+        },
+        "risk_dd_halt_threshold": {
+          "name": "risk_dd_halt_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.1
+        },
+        "vix_warning_threshold": {
+          "name": "vix_warning_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 25
+        },
+        "vix_critical_threshold": {
+          "name": "vix_critical_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "vix_warning_size_scale": {
+          "name": "vix_warning_size_scale",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.5
+        },
+        "pair_regime_mode": {
+          "name": "pair_regime_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'off'"
+        },
+        "pair_regime_theta_bull_enter": {
+          "name": "pair_regime_theta_bull_enter",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.03
+        },
+        "pair_regime_theta_bull_exit": {
+          "name": "pair_regime_theta_bull_exit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.01
+        },
+        "pair_regime_theta_bear_enter": {
+          "name": "pair_regime_theta_bear_enter",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.04
+        },
+        "pair_regime_theta_bear_exit": {
+          "name": "pair_regime_theta_bear_exit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.015
+        },
+        "overview_panels": {
+          "name": "overview_panels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'kpi,equity,composition,recent'"
+        },
+        "cash_fallback_orders_enabled": {
+          "name": "cash_fallback_orders_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "global_config_max_order_notional_range": {
+          "name": "global_config_max_order_notional_range",
+          "value": "\"global_config\".\"max_order_notional\" > 0 AND \"global_config\".\"max_order_notional\" <= 10000000"
+        },
+        "global_config_max_order_notional_usd_range": {
+          "name": "global_config_max_order_notional_usd_range",
+          "value": "\"global_config\".\"max_order_notional_usd\" > 0 AND \"global_config\".\"max_order_notional_usd\" <= 1000000"
+        },
+        "global_config_max_order_notional_jpy_range": {
+          "name": "global_config_max_order_notional_jpy_range",
+          "value": "\"global_config\".\"max_order_notional_jpy\" > 0 AND \"global_config\".\"max_order_notional_jpy\" <= 100000000"
+        },
+        "global_config_total_capital_usd_range": {
+          "name": "global_config_total_capital_usd_range",
+          "value": "\"global_config\".\"total_capital_usd\" IS NULL OR \"global_config\".\"total_capital_usd\" > 0"
+        },
+        "global_config_total_capital_jpy_range": {
+          "name": "global_config_total_capital_jpy_range",
+          "value": "\"global_config\".\"total_capital_jpy\" IS NULL OR \"global_config\".\"total_capital_jpy\" > 0"
+        },
+        "global_config_max_portfolio_exposure_pct_range": {
+          "name": "global_config_max_portfolio_exposure_pct_range",
+          "value": "\"global_config\".\"max_portfolio_exposure_pct\" > 0 AND \"global_config\".\"max_portfolio_exposure_pct\" <= 1"
+        },
+        "global_config_drawdown_kill_threshold_range": {
+          "name": "global_config_drawdown_kill_threshold_range",
+          "value": "\"global_config\".\"drawdown_kill_threshold\" >= -1 AND \"global_config\".\"drawdown_kill_threshold\" <= 0"
+        },
+        "global_config_stale_quote_ms_range": {
+          "name": "global_config_stale_quote_ms_range",
+          "value": "\"global_config\".\"stale_quote_ms\" >= 0"
+        },
+        "global_config_gap_reject_pct_range": {
+          "name": "global_config_gap_reject_pct_range",
+          "value": "\"global_config\".\"gap_reject_pct\" >= 0 AND \"global_config\".\"gap_reject_pct\" <= 1"
+        },
+        "global_config_spread_limit_pct_us_range": {
+          "name": "global_config_spread_limit_pct_us_range",
+          "value": "\"global_config\".\"spread_limit_pct_us\" >= 0 AND \"global_config\".\"spread_limit_pct_us\" <= 1"
+        },
+        "global_config_spread_limit_pct_jp_range": {
+          "name": "global_config_spread_limit_pct_jp_range",
+          "value": "\"global_config\".\"spread_limit_pct_jp\" >= 0 AND \"global_config\".\"spread_limit_pct_jp\" <= 1"
+        },
+        "global_config_pullback_default_stop_pct_range": {
+          "name": "global_config_pullback_default_stop_pct_range",
+          "value": "\"global_config\".\"pullback_default_stop_pct\" < 0 AND \"global_config\".\"pullback_default_stop_pct\" >= -1"
+        },
+        "global_config_pullback_default_take_profit_pct_range": {
+          "name": "global_config_pullback_default_take_profit_pct_range",
+          "value": "\"global_config\".\"pullback_default_take_profit_pct\" > 0 AND \"global_config\".\"pullback_default_take_profit_pct\" <= 1"
+        },
+        "global_config_pullback_default_time_stop_days_range": {
+          "name": "global_config_pullback_default_time_stop_days_range",
+          "value": "\"global_config\".\"pullback_default_time_stop_days\" > 0 AND \"global_config\".\"pullback_default_time_stop_days\" <= ?"
+        },
+        "global_config_pullback_default_pullback_max_range": {
+          "name": "global_config_pullback_default_pullback_max_range",
+          "value": "\"global_config\".\"pullback_default_pullback_max\" <= 0 AND \"global_config\".\"pullback_default_pullback_max\" >= -1"
+        },
+        "global_config_pullback_default_pullback_min_range": {
+          "name": "global_config_pullback_default_pullback_min_range",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= 0 AND \"global_config\".\"pullback_default_pullback_min\" >= -1"
+        },
+        "global_config_pullback_default_min_return_50d_range": {
+          "name": "global_config_pullback_default_min_return_50d_range",
+          "value": "\"global_config\".\"pullback_default_min_return_50d\" >= -1 AND \"global_config\".\"pullback_default_min_return_50d\" <= 10"
+        },
+        "global_config_pullback_default_k_atr_range": {
+          "name": "global_config_pullback_default_k_atr_range",
+          "value": "\"global_config\".\"pullback_default_k_atr\" > 0 AND \"global_config\".\"pullback_default_k_atr\" <= 10"
+        },
+        "global_config_pullback_default_pullback_window_order": {
+          "name": "global_config_pullback_default_pullback_window_order",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= \"global_config\".\"pullback_default_pullback_max\""
+        },
+        "global_config_risk_base_per_trade_pct_range": {
+          "name": "global_config_risk_base_per_trade_pct_range",
+          "value": "\"global_config\".\"risk_base_per_trade_pct\" > 0 AND \"global_config\".\"risk_base_per_trade_pct\" <= 1"
+        },
+        "global_config_risk_dd_half_threshold_range": {
+          "name": "global_config_risk_dd_half_threshold_range",
+          "value": "\"global_config\".\"risk_dd_half_threshold\" < 0 AND \"global_config\".\"risk_dd_half_threshold\" >= -1"
+        },
+        "global_config_risk_dd_halt_threshold_range": {
+          "name": "global_config_risk_dd_halt_threshold_range",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" < 0 AND \"global_config\".\"risk_dd_halt_threshold\" >= -1"
+        },
+        "global_config_risk_dd_threshold_order": {
+          "name": "global_config_risk_dd_threshold_order",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" <= \"global_config\".\"risk_dd_half_threshold\""
+        },
+        "global_config_vix_warning_threshold_range": {
+          "name": "global_config_vix_warning_threshold_range",
+          "value": "\"global_config\".\"vix_warning_threshold\" > 0 AND \"global_config\".\"vix_warning_threshold\" <= 200"
+        },
+        "global_config_vix_critical_threshold_range": {
+          "name": "global_config_vix_critical_threshold_range",
+          "value": "\"global_config\".\"vix_critical_threshold\" > 0 AND \"global_config\".\"vix_critical_threshold\" <= 200"
+        },
+        "global_config_vix_threshold_order": {
+          "name": "global_config_vix_threshold_order",
+          "value": "\"global_config\".\"vix_warning_threshold\" <= \"global_config\".\"vix_critical_threshold\""
+        },
+        "global_config_vix_warning_size_scale_range": {
+          "name": "global_config_vix_warning_size_scale_range",
+          "value": "\"global_config\".\"vix_warning_size_scale\" >= 0 AND \"global_config\".\"vix_warning_size_scale\" <= 1"
+        }
+      }
+    },
+    "inverse_pairs": {
+      "name": "inverse_pairs",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inverse": {
+          "name": "inverse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "regime_enabled": {
+          "name": "regime_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "regime_proxy_symbol": {
+          "name": "regime_proxy_symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "regime_bull_symbol": {
+          "name": "regime_bull_symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "macro_event_calendar": {
+      "name": "macro_event_calendar",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_time": {
+          "name": "event_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "macro_event_calendar_type_date_unique": {
+          "name": "macro_event_calendar_type_date_unique",
+          "columns": [
+            "event_type",
+            "event_date"
+          ],
+          "isUnique": true
+        },
+        "macro_event_calendar_date_idx": {
+          "name": "macro_event_calendar_date_idx",
+          "columns": [
+            "event_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_emit_log": {
+      "name": "notification_emit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cause": {
+          "name": "cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notification_emit_log_timestamp_id_idx": {
+          "name": "notification_emit_log_timestamp_id_idx",
+          "columns": [
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "notification_emit_log_severity_timestamp_id_idx": {
+          "name": "notification_emit_log_severity_timestamp_id_idx",
+          "columns": [
+            "severity",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "notification_emit_log_event_type_timestamp_id_idx": {
+          "name": "notification_emit_log_event_type_timestamp_id_idx",
+          "columns": [
+            "event_type",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "portfolio_equity_snapshot": {
+      "name": "portfolio_equity_snapshot",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "daily_start_equity_usd": {
+          "name": "daily_start_equity_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_start_equity_jpy": {
+          "name": "daily_start_equity_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_realized_pnl_usd": {
+          "name": "daily_realized_pnl_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_realized_pnl_jpy": {
+          "name": "daily_realized_pnl_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "drawdown_pct": {
+          "name": "drawdown_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "portfolio_equity_snapshot_at_idx": {
+          "name": "portfolio_equity_snapshot_at_idx",
+          "columns": [
+            "snapshot_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "strategy_decision_log": {
+      "name": "strategy_decision_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indicators_json": {
+          "name": "indicators_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trace_json": {
+          "name": "trace_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "strategy_decision_log_symbol_id_idx": {
+          "name": "strategy_decision_log_symbol_id_idx",
+          "columns": [
+            "symbol",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "strategy_decision_log_coid_idx": {
+          "name": "strategy_decision_log_coid_idx",
+          "columns": [
+            "client_order_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "symbol_config": {
+      "name": "symbol_config",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "market": {
+          "name": "market",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_notional": {
+          "name": "max_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_stop_days_override": {
+          "name": "time_stop_days_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "k_atr_override": {
+          "name": "k_atr_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "budget_alloc_pct": {
+          "name": "budget_alloc_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lot_size": {
+          "name": "lot_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stop_pct_override": {
+          "name": "stop_pct_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "take_profit_pct_override": {
+          "name": "take_profit_pct_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "intraday_only": {
+          "name": "intraday_only",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pullback_max_override": {
+          "name": "pullback_max_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pullback_min_override": {
+          "name": "pullback_min_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "min_return_50d_override": {
+          "name": "min_return_50d_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_atr_ratio_override": {
+          "name": "max_atr_ratio_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_sma50_deviation_pct_override": {
+          "name": "max_sma50_deviation_pct_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "require_above_sma50_override": {
+          "name": "require_above_sma50_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_required": {
+          "name": "entry_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "always_active": {
+          "name": "always_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cash_fallback_symbol": {
+          "name": "cash_fallback_symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "symbol_config_currency_enum": {
+          "name": "symbol_config_currency_enum",
+          "value": "\"symbol_config\".\"currency\" IN ('USD', 'JPY')"
+        },
+        "symbol_config_time_stop_days_override_range": {
+          "name": "symbol_config_time_stop_days_override_range",
+          "value": "\"symbol_config\".\"time_stop_days_override\" IS NULL OR (\"symbol_config\".\"time_stop_days_override\" >= 1 AND \"symbol_config\".\"time_stop_days_override\" <= ?)"
+        },
+        "symbol_config_k_atr_override_range": {
+          "name": "symbol_config_k_atr_override_range",
+          "value": "\"symbol_config\".\"k_atr_override\" IS NULL OR (\"symbol_config\".\"k_atr_override\" >= 0.5 AND \"symbol_config\".\"k_atr_override\" <= 5.0)"
+        }
+      }
+    },
+    "trade_journal": {
+      "name": "trade_journal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trade_event_type": {
+          "name": "trade_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "strategy_name": {
+          "name": "strategy_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_action": {
+          "name": "signal_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_reason": {
+          "name": "signal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_allowed": {
+          "name": "risk_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_reasons": {
+          "name": "risk_reasons",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "limit_price": {
+          "name": "limit_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notional": {
+          "name": "notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "broker_status": {
+          "name": "broker_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "submitted": {
+          "name": "submitted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_qty": {
+          "name": "filled_qty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_price": {
+          "name": "filled_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "realized_pnl": {
+          "name": "realized_pnl",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hold_days": {
+          "name": "hold_days",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_reason": {
+          "name": "exit_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_applied_at": {
+          "name": "state_applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_error": {
+          "name": "state_apply_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_attempts": {
+          "name": "state_apply_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trading_toggle_history": {
+      "name": "trading_toggle_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before": {
+          "name": "before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "after": {
+          "name": "after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1781174769487,
       "tag": "0031_add_pair_regime",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "6",
+      "when": 1781193221867,
+      "tag": "0032_drop_alternatives",
+      "breakpoints": true
     }
   ]
 }

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -175,12 +175,6 @@ export const symbolConfig = sqliteTable(
     /** SMA50 上抜け必須条件 override (NULL = global default、boolean、#452)。 */
     requireAboveSma50Override: integer('require_above_sma50_override', { mode: 'boolean' }),
     /**
-     * 代替銘柄候補 (#452 / #449)。JSON 配列 text (例 `["SOXX","SMH"]`)。レバ ETF が
-     * NG/WATCH のときダッシュボードに代替候補を出す **表示専用** — 自動 routing には
-     * 使わない。NULL / 不正 JSON は「候補なし」扱い。
-     */
-    alternatives: text('alternatives'),
-    /**
      * 条件連動配分 (#452 Layer 3 / #450)。true = entry gate (ENTRY/HALF) 通過を
      * 実配分 (active weight) の必須条件にする。未通過の間は active=0 になり、
      * 浮いた配分は `cash_fallback_symbol` へ退避される。false (default) =

--- a/src/infrastructure/db/symbolConfigRepo.ts
+++ b/src/infrastructure/db/symbolConfigRepo.ts
@@ -32,10 +32,6 @@ export function isSymbolRole(value: unknown): value is SymbolRole {
   return typeof value === 'string' && (SYMBOL_ROLES as readonly string[]).includes(value)
 }
 
-/** alternatives の 1 ticker の文法 (admin parse / repo 検証で共用)。 */
-const ALTERNATIVE_SYMBOL_RE = /^[A-Z0-9]{1,10}$/
-/** alternatives の最大件数 (表示専用 list の防御的上限)。 */
-export const MAX_ALTERNATIVES = 8
 
 export interface SymbolConfigSnapshot {
   /** Uppercased symbols where `active = 1`. cron / risk gate はこの list だけを評価対象とする。 */
@@ -130,11 +126,6 @@ export interface SymbolConfigSnapshot {
   /** SMA50 上抜け必須 override (true / false 両方 map に含める。NULL は不在)。 */
   symbolRequireAboveSma50Override: Record<string, boolean>
   /**
-   * symbol → 代替銘柄候補 (#452、表示専用)。NULL / 不正 JSON / 空配列は map に
-   * 含めない。要素は大文字 ticker、self 参照と重複は除去、上限 MAX_ALTERNATIVES。
-   */
-  symbolAlternatives: Record<string, string[]>
-  /**
    * entry_required=true の symbol 集合 (#452 Layer 3)。gate 未通過の間
    * active weight = 0 になり cash fallback へ退避される。false は不在。
    */
@@ -146,32 +137,6 @@ export interface SymbolConfigSnapshot {
    * (= 退避しない、現金のまま)。
    */
   symbolCashFallback: Record<string, string>
-}
-
-/**
- * alternatives の JSON text を検証付きで配列に落とす。不正 (JSON でない /
- * 配列でない / ticker 文法外要素) は **null** (= 候補なし扱い)。表示専用 data
- * なので発注安全性には関与しないが、ゴミを下流に流さない。
- */
-export function parseAlternativesJson(raw: string | null | undefined, selfSymbol: string): string[] | null {
-  if (raw === null || raw === undefined) return null
-  let parsed: unknown
-  try {
-    parsed = JSON.parse(raw)
-  } catch {
-    return null
-  }
-  if (!Array.isArray(parsed)) return null
-  const out: string[] = []
-  for (const item of parsed) {
-    if (typeof item !== 'string') return null
-    const sym = item.trim().toUpperCase()
-    if (!ALTERNATIVE_SYMBOL_RE.test(sym)) return null
-    if (sym === selfSymbol.toUpperCase()) continue
-    if (!out.includes(sym)) out.push(sym)
-    if (out.length >= MAX_ALTERNATIVES) break
-  }
-  return out.length > 0 ? out : null
 }
 
 /**
@@ -209,7 +174,6 @@ export async function loadSymbolConfig(
   const symbolMaxAtrRatioOverride: Record<string, number> = {}
   const symbolMaxSma50DeviationPctOverride: Record<string, number> = {}
   const symbolRequireAboveSma50Override: Record<string, boolean> = {}
-  const symbolAlternatives: Record<string, string[]> = {}
   const symbolEntryRequired: Record<string, boolean> = {}
   const symbolAlwaysActive: Record<string, boolean> = {}
   const symbolCashFallback: Record<string, string> = {}
@@ -359,10 +323,6 @@ export async function loadSymbolConfig(
     if (row.requireAboveSma50Override === true || row.requireAboveSma50Override === false) {
       symbolRequireAboveSma50Override[symbol] = row.requireAboveSma50Override
     }
-    const alternatives = parseAlternativesJson(row.alternatives, symbol)
-    if (alternatives !== null) {
-      symbolAlternatives[symbol] = alternatives
-    }
     // 条件連動配分 (#452 Layer 3)。false は map に出さない (従来挙動 = 常時枠)。
     if (row.entryRequired === true) {
       symbolEntryRequired[symbol] = true
@@ -401,7 +361,6 @@ export async function loadSymbolConfig(
     symbolMaxAtrRatioOverride,
     symbolMaxSma50DeviationPctOverride,
     symbolRequireAboveSma50Override,
-    symbolAlternatives,
     symbolEntryRequired,
     symbolAlwaysActive,
     symbolCashFallback,
@@ -464,20 +423,12 @@ export interface SymbolConfigWriteInput {
   maxAtrRatioOverride: number | null
   maxSma50DeviationPctOverride: number | null
   requireAboveSma50Override: boolean | null
-  /** 代替銘柄候補 (表示専用、NULL = なし、#452)。DB には JSON text で保存。 */
-  alternatives: string[] | null
   /** 条件連動配分 (#452 Layer 3): gate 通過を実配分の必須条件にする。default false。 */
   entryRequired: boolean
   /** 常時 target = active (cash_parking 用、#452)。default false。 */
   alwaysActive: boolean
   /** 条件未通過時の退避先 symbol (NULL = 退避しない、#452)。 */
   cashFallbackSymbol: string | null
-}
-
-/** alternatives 配列 → DB 保存形式 (JSON text / NULL)。空配列は NULL に正規化。 */
-function alternativesToJson(alternatives: string[] | null): string | null {
-  if (alternatives === null || alternatives.length === 0) return null
-  return JSON.stringify(alternatives)
 }
 
 /**
@@ -516,7 +467,6 @@ export async function insertSymbolConfig(
       maxAtrRatioOverride: input.maxAtrRatioOverride,
       maxSma50DeviationPctOverride: input.maxSma50DeviationPctOverride,
       requireAboveSma50Override: input.requireAboveSma50Override,
-      alternatives: alternativesToJson(input.alternatives),
       entryRequired: input.entryRequired,
       alwaysActive: input.alwaysActive,
       cashFallbackSymbol: input.cashFallbackSymbol,
@@ -575,7 +525,6 @@ export async function updateSymbolConfig(
       maxAtrRatioOverride: input.maxAtrRatioOverride,
       maxSma50DeviationPctOverride: input.maxSma50DeviationPctOverride,
       requireAboveSma50Override: input.requireAboveSma50Override,
-      alternatives: alternativesToJson(input.alternatives),
       entryRequired: input.entryRequired,
       alwaysActive: input.alwaysActive,
       cashFallbackSymbol: input.cashFallbackSymbol,
@@ -891,7 +840,7 @@ export async function createSymbolPair(
       stopPctOverride: primary.stopPctOverride,
       takeProfitPctOverride: primary.takeProfitPctOverride,
       intradayOnly: primary.intradayOnly,
-      // role / entry override / alternatives は **継承しない** (#452)。インバース
+      // role / entry override は **継承しない** (#452)。インバース
       // 相手は方向が逆で entry 特性が異なる (bull 側の押し目閾値は bear 側に
       // 適用できない)。NULL = 従来挙動で開始し、必要なら個別編集で設定する。
       role: null,
@@ -901,7 +850,6 @@ export async function createSymbolPair(
       maxAtrRatioOverride: null,
       maxSma50DeviationPctOverride: null,
       requireAboveSma50Override: null,
-      alternatives: null,
       // 条件連動配分も継承しない (#452): 方向が逆の相手に同じ配分条件は適用
       // できない。default (false / NULL) = 従来挙動で開始。
       entryRequired: false,

--- a/src/infrastructure/db/symbolUniverse.ts
+++ b/src/infrastructure/db/symbolUniverse.ts
@@ -67,8 +67,6 @@ export interface SymbolUniverse {
   symbolMaxAtrRatioOverride: Record<string, number>
   symbolMaxSma50DeviationPctOverride: Record<string, number>
   symbolRequireAboveSma50Override: Record<string, boolean>
-  /** symbol → 代替銘柄候補 (#452、表示専用)。不在 = 候補なし。 */
-  symbolAlternatives: Record<string, string[]>
   /** entry_required=true の集合 (#452 Layer 3)。false は不在。 */
   symbolEntryRequired: Record<string, boolean>
   /** always_active=true の集合 (#452、cash_parking 用)。false は不在。 */
@@ -123,7 +121,6 @@ export async function loadSymbolUniverse(env: UniverseEnv): Promise<SymbolUniver
     symbolMaxAtrRatioOverride: config.symbolMaxAtrRatioOverride,
     symbolMaxSma50DeviationPctOverride: config.symbolMaxSma50DeviationPctOverride,
     symbolRequireAboveSma50Override: config.symbolRequireAboveSma50Override,
-    symbolAlternatives: config.symbolAlternatives,
     symbolEntryRequired: config.symbolEntryRequired,
     symbolAlwaysActive: config.symbolAlwaysActive,
     symbolCashFallback: config.symbolCashFallback,

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -43,7 +43,6 @@ import {
   updateBudgetAllocPct,
   updateSymbolConfig,
   isSymbolRole,
-  MAX_ALTERNATIVES,
   SYMBOL_ROLES,
   type SymbolConfigWriteInput,
   type SymbolRole,
@@ -2390,7 +2389,6 @@ function parseSymbolConfigBody(body: unknown): SymbolConfigWriteInput {
     maxSma50DeviationPctOverride?: unknown
     require_above_sma50_override?: unknown
     requireAboveSma50Override?: unknown
-    alternatives?: unknown
     entry_required?: unknown
     entryRequired?: unknown
     always_active?: unknown
@@ -2513,7 +2511,6 @@ function parseSymbolConfigBody(body: unknown): SymbolConfigWriteInput {
     raw.require_above_sma50_override ?? raw.requireAboveSma50Override,
     'requireAboveSma50Override',
   )
-  const alternatives = parseAlternativesInput(raw.alternatives, symbol)
   // 条件連動配分 (#452 Layer 3): checkbox 未送信は false (= 従来挙動)。退避先は
   // ticker 文法 + self 参照禁止。空 → NULL (= 退避しない)。
   const entryRequired = parseFormBool(raw.entry_required ?? raw.entryRequired, false)
@@ -2544,7 +2541,6 @@ function parseSymbolConfigBody(body: unknown): SymbolConfigWriteInput {
     maxAtrRatioOverride,
     maxSma50DeviationPctOverride,
     requireAboveSma50Override,
-    alternatives,
     entryRequired,
     alwaysActive,
     cashFallbackSymbol,
@@ -2607,48 +2603,6 @@ function parseOptionalTriStateBool(value: unknown, field: string): boolean | nul
     if (trimmed === 'false') return false
   }
   throw new ValidationError(`${field} must be '', 'true' or 'false'`, { field })
-}
-
-/**
- * alternatives (#452、表示専用): form はカンマ/空白区切り text、JSON はその文字列
- * or 配列を送る。ticker 文法 ([A-Za-z0-9]{1,10}) 外の要素は 400。self 参照と
- * 重複は除去、上限 MAX_ALTERNATIVES 超過は 400。空 → null。
- */
-function parseAlternativesInput(value: unknown, selfSymbol: string): string[] | null {
-  if (value === undefined || value === null) return null
-  let tokens: string[]
-  if (Array.isArray(value)) {
-    tokens = value.map((v) => {
-      if (typeof v !== 'string') {
-        throw new ValidationError('alternatives must be symbols', { field: 'alternatives' })
-      }
-      return v
-    })
-  } else if (typeof value === 'string') {
-    tokens = value.split(/[\s,]+/)
-  } else {
-    throw new ValidationError('alternatives must be a string or array of symbols', {
-      field: 'alternatives',
-    })
-  }
-  const out: string[] = []
-  for (const token of tokens) {
-    const sym = token.trim().toUpperCase()
-    if (sym === '') continue
-    if (!/^[A-Z0-9]{1,10}$/.test(sym)) {
-      throw new ValidationError(`alternatives contains an invalid symbol: ${sym}`, {
-        field: 'alternatives',
-      })
-    }
-    if (sym === selfSymbol.toUpperCase()) continue
-    if (!out.includes(sym)) out.push(sym)
-  }
-  if (out.length > MAX_ALTERNATIVES) {
-    throw new ValidationError(`alternatives must have at most ${MAX_ALTERNATIVES} symbols`, {
-      field: 'alternatives',
-    })
-  }
-  return out.length > 0 ? out : null
 }
 
 /**
@@ -2897,7 +2851,6 @@ function symbolConfigSnapshot(row: SymbolConfigRow): Record<string, unknown> {
     maxAtrRatioOverride: row.maxAtrRatioOverride,
     maxSma50DeviationPctOverride: row.maxSma50DeviationPctOverride,
     requireAboveSma50Override: row.requireAboveSma50Override,
-    alternatives: row.alternatives,
     updatedAt: row.updatedAt,
   }
 }

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -19,7 +19,7 @@ import { loadOverviewPanelsCsv, setOverviewPanels } from '../infrastructure/db/g
 import { resolveTradingEnabled } from '../trading/runtime/killSwitch'
 import { loadSymbolUniverse, type SymbolUniverse } from '../infrastructure/db/symbolUniverse'
 import type { SymbolCurrency, SymbolRole } from '../infrastructure/db/symbolConfigRepo'
-import { loadInversePairs, parseAlternativesJson, SYMBOL_ROLES } from '../infrastructure/db/symbolConfigRepo'
+import { loadInversePairs, SYMBOL_ROLES } from '../infrastructure/db/symbolConfigRepo'
 import { escapeHtml, formatSymbolDisplay } from '../shared/format'
 import { createDb } from '../infrastructure/db/tradeJournalRepo'
 import {
@@ -510,7 +510,6 @@ export const dashboard = new Hono<DashboardBindings>()
         ? buildBuyabilityView(symbolChart.evalIndicators, entryRule)
         : null
       // 段階判定 (#452 PR 2): 7 gates から ENTRY/HALF/WATCH/NG を導出して表示。
-      // WATCH/NG 時は alternatives (表示専用) を併記する。
       const entryStatus = buyability?.current ? deriveEntryStatus(buyability.current) : null
       // ペアレジーム (#472): focus symbol が regime 有効ペアの一員なら、cron と
       // 同じ pure 関数で zone を評価して表示する (mode=off では出さない)。
@@ -575,7 +574,6 @@ export const dashboard = new Hono<DashboardBindings>()
             entryStatus,
             decisionRows,
             pairRegime: pairRegimeView,
-            alternatives: focusSymbol ? universe.symbolAlternatives[focusSymbol] ?? [] : [],
             symbolPolicy: focusSymbol
               ? {
                   role: universe.symbolRole[focusSymbol] ?? null,
@@ -5807,8 +5805,6 @@ export interface ChartsBodySymbol {
   buyability?: BuyabilityView | null
   /** 段階判定 (#452 PR 2)。null = 評価データ無し。 */
   entryStatus?: EntryStatusResult | null
-  /** 代替銘柄候補 (#452、表示専用)。WATCH/NG 時に併記する。 */
-  alternatives?: string[]
   /** focus symbol のロール / 配分ポリシー要約 (#452)。 */
   symbolPolicy?: SymbolPolicySummary | null
   /**
@@ -7204,7 +7200,6 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
   ${renderPairRegimeLine(args.pairRegime ?? null)}
   ${renderBuyabilityPanel(args.buyability ?? null, {
     entryStatus: args.entryStatus ?? null,
-    alternatives: args.alternatives ?? [],
   })}
   ${renderDecisionPlotCaption(args.symbolChart)}
   <div id="decision-trace-panel" class="reason-panel" style="margin-top:10px">
@@ -8369,8 +8364,6 @@ function fmtGateValue(g: EntryGateStatus): string {
 export interface BuyabilityPanelContext {
   /** 段階判定 (#452 PR 2)。null = 出さない。 */
   entryStatus?: EntryStatusResult | null
-  /** 代替銘柄候補 (#452、表示専用)。WATCH/NG 時のみ表示する。 */
-  alternatives?: string[]
 }
 
 export function renderBuyabilityPanel(
@@ -8466,22 +8459,11 @@ export function renderBuyabilityPanel(
     })
     .join('')
 
-  // --- 段階判定 badge + HALF 説明 + 代替候補 (#452 PR 2) ---
+  // --- 段階判定 badge + HALF 説明 (#452 PR 2) ---
   const statusBadge = status ? entryStatusBadgeHtml(status.status) : ''
   let halfNote = ''
   if (status?.status === 'HALF' && status.halfGate) {
     halfNote = `<div style="margin-top:6px;font-size:12px;color:#b25000">HALF: 未通過は「${esc(status.halfGate.labelJa)}」のみで閾値の許容バンド内 → 0.5x サイジングで entry 候補 (role が entry 有効な銘柄のみ発注対象)。</div>`
-  }
-  let altBlock = ''
-  if (status && (status.status === 'WATCH' || status.status === 'NG') && ctx.alternatives?.length) {
-    const links = ctx.alternatives
-      .map(
-        (s) =>
-          `<a href="/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(s)}" style="font-weight:600">${esc(s)}</a>`,
-      )
-      .join(' / ')
-    altBlock = `<div style="margin-top:8px"><strong>代替候補</strong>: ${links}
-      <div class="muted" style="font-size:11px">この銘柄が entry 不可の間の代替 ETF 候補 (表示のみ — 自動で発注先を切り替えることはしない、#452)。</div></div>`
   }
 
   // 距離の推移 (+ETA) と 入場ゲート は 2 列 (narrow 画面は .panel-row の
@@ -8490,7 +8472,7 @@ export function renderBuyabilityPanel(
     <div style="font-size:13px;color:${headColor};margin-bottom:6px;display:flex;align-items:center;gap:8px;flex-wrap:wrap">${statusBadge}<span>${headline}</span></div>
     ${halfNote}
     <div class="panel-row" style="gap:8px 20px">
-      <div>${trendBlock}${etaBlock}${altBlock}</div>
+      <div>${trendBlock}${etaBlock}</div>
       <div style="margin-top:8px"><strong>入場ゲート</strong>(全条件。閾値は global 既定 + role preset + 銘柄 override、#452)
         <div style="margin-top:4px;display:flex;flex-direction:column;gap:3px">${gateRows}</div>
       </div>
@@ -9182,7 +9164,7 @@ function symbolFormBody(args: SymbolFormArgs): string {
   // 持ち越し設定は radio 2 択で両状態を明示する (「持ち越し」ラベル + 「持ち越さ
   // ない」checkbox の二重否定が ON/OFF どちらか読めない、という operator 指摘)。
   const intradayOnlyChecked = row?.intradayOnly ? ' checked' : ''
-  // role / entry override / alternatives (#452)。pullback / trend / 過伸長は
+  // role / entry override (#452)。pullback / trend / 過伸長は
   // DB に fraction 保存、表示は % (×100)。ATR 比は ratio 生値。
   // 不正 role 値 (enum 外の DB 直書き) の fail-closed をフォームで弱めない
   // (CodeRabbit #453): 一致 option が無いと先頭 '' が選択され、保存で意図せず
@@ -9216,7 +9198,6 @@ function symbolFormBody(args: SymbolFormArgs): string {
     row?.requireAboveSma50Override === null || row?.requireAboveSma50Override === undefined
       ? ''
       : String(row.requireAboveSma50Override)
-  const alternativesValue = (parseAlternativesJson(row?.alternatives ?? null, symbolValue) ?? []).join(', ')
   // 条件連動配分 (#452 Layer 3)。
   const entryRequiredChecked = row?.entryRequired ? ' checked' : ''
   const alwaysActiveChecked = row?.alwaysActive ? ' checked' : ''
@@ -9292,8 +9273,7 @@ function symbolFormBody(args: SymbolFormArgs): string {
     minReturn50dOverrideValue !== '' ||
     maxAtrRatioOverrideValue !== '' ||
     maxSma50DeviationPctOverrideValue !== '' ||
-    requireAboveSma50OverrideValue !== '' ||
-    alternativesValue !== ''
+    requireAboveSma50OverrideValue !== ''
   const hasExitValues =
     timeStopDaysOverrideValue !== '' ||
     kAtrOverrideValue !== '' ||
@@ -9412,11 +9392,7 @@ function symbolFormBody(args: SymbolFormArgs): string {
           <option value="true"${requireAboveSma50OverrideValue === 'true' ? ' selected' : ''}>必須 (price &gt; SMA50)</option>
           <option value="false"${requireAboveSma50OverrideValue === 'false' ? ' selected' : ''}>不要</option>
         </select>
-        <label>代替銘柄</label>
-        <div>
-          <input type="text" name="alternatives" value="${esc(alternativesValue)}" maxlength="120" placeholder="例: SOXX, SMH" style="padding:6px;width:240px">
-          <span class="muted" style="font-size:12px;margin-left:6px">entry 不可時に表示する候補 (表示のみ・最大 8)</span>
-        </div>`,
+        `,
       hasStrategyValues,
     )}
 

--- a/test/helpers/configFixtures.ts
+++ b/test/helpers/configFixtures.ts
@@ -74,7 +74,6 @@ export function makeSymbolUniverse(overrides: Partial<SymbolUniverse> = {}): Sym
     symbolMaxAtrRatioOverride: {},
     symbolMaxSma50DeviationPctOverride: {},
     symbolRequireAboveSma50Override: {},
-    symbolAlternatives: {},
     symbolEntryRequired: {},
     symbolAlwaysActive: {},
     symbolCashFallback: {},

--- a/test/infrastructure/db/symbolConfigRepo.test.ts
+++ b/test/infrastructure/db/symbolConfigRepo.test.ts
@@ -260,7 +260,6 @@ const writeInput = (symbol: string): SymbolConfigWriteInput => ({
   maxAtrRatioOverride: null,
   maxSma50DeviationPctOverride: null,
   requireAboveSma50Override: null,
-  alternatives: null,
   entryRequired: false,
   alwaysActive: false,
   cashFallbackSymbol: null,
@@ -319,7 +318,7 @@ describe('createSymbolPair', () => {
   })
 })
 
-describe('loadSymbolConfig role / entry overrides / alternatives (#452)', () => {
+describe('loadSymbolConfig role / entry overrides (#452)', () => {
   it('maps valid roles and normalizes unknown DB values to "unknown" (not NULL fallback)', async () => {
     const rows = [
       { symbol: 'sgov', market: 'US', active: true, maxNotional: null, role: 'cash_parking' },
@@ -376,18 +375,6 @@ describe('loadSymbolConfig role / entry overrides / alternatives (#452)', () => 
     expect(result.symbolRequireAboveSma50Override).toEqual({ QQQ: false })
   })
 
-  it('parses alternatives JSON, uppercases, dedupes, drops self-reference and bad JSON', async () => {
-    const rows = [
-      { symbol: 'soxl', market: 'US', active: true, maxNotional: null, alternatives: '["soxx","SMH","soxx","SOXL"]' },
-      { symbol: 'tqqq', market: 'US', active: true, maxNotional: null, alternatives: 'not-json' },
-      { symbol: 'qqq', market: 'US', active: true, maxNotional: null, alternatives: '["BAD SYMBOL!"]' },
-      { symbol: 'voo', market: 'US', active: true, maxNotional: null, alternatives: '[]' },
-      { symbol: 'spy', market: 'US', active: true, maxNotional: null, alternatives: null },
-    ]
-    const result = await loadSymbolConfig(fakeDb(rows))
-    // self (SOXL) と重複は除去。不正 JSON / 不正 ticker / 空配列 / NULL は map 不在。
-    expect(result.symbolAlternatives).toEqual({ SOXL: ['SOXX', 'SMH'] })
-  })
 })
 
 describe('deactivateSymbolForBrokerDeny (#460)', () => {

--- a/test/routes/admin.test.ts
+++ b/test/routes/admin.test.ts
@@ -1151,7 +1151,6 @@ describe('POST /admin/orders/sync-holdings', () => {
       symbolMaxAtrRatioOverride: {},
       symbolMaxSma50DeviationPctOverride: {},
       symbolRequireAboveSma50Override: {},
-      symbolAlternatives: {},
       symbolEntryRequired: {},
       symbolAlwaysActive: {},
       symbolCashFallback: {},

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -2598,25 +2598,7 @@ describe('段階判定の表示 (#452 PR 2)', () => {
     expect(html).toContain('>ENTRY<')
   })
 
-  it('WATCH/NG で alternatives があれば代替候補リンクを出す (表示のみ)', () => {
-    const view = viewFor(99) // 押し目不足 → WATCH
-    const status = deriveEntryStatus(view.current!)
-    expect(status.positionMultiplier).toBe(0)
-    const html = renderBuyabilityPanel(view, {
-      entryStatus: status,
-      alternatives: ['SOXX', 'SMH'],
-    })
-    expect(html).toContain('代替候補')
-    expect(html).toContain('symbol=SOXX')
-    expect(html).toContain('自動で発注先を切り替えることはしない')
-  })
 
-  it('ENTRY では代替候補を出さない', () => {
-    const view = viewFor(95)
-    const status = deriveEntryStatus(view.current!)
-    const html = renderBuyabilityPanel(view, { entryStatus: status, alternatives: ['SOXX'] })
-    expect(html).not.toContain('代替候補')
-  })
 
   it('grid を ENTRY > HALF > WATCH > NG > cash_parking > データ無し > inactive で並べる', () => {
     const charts = ['SGOV', 'NODATA', 'NG1', 'WATCH1', 'HALF1', 'ENTRY1', 'OFF'].map((symbol) => ({

--- a/test/routes/dashboardSymbolsCrud.test.ts
+++ b/test/routes/dashboardSymbolsCrud.test.ts
@@ -176,7 +176,6 @@ function fakeDb(
               maxAtrRatioOverride: (v.maxAtrRatioOverride as number | null) ?? null,
               maxSma50DeviationPctOverride: (v.maxSma50DeviationPctOverride as number | null) ?? null,
               requireAboveSma50Override: (v.requireAboveSma50Override as boolean | null) ?? null,
-              alternatives: (v.alternatives as string | null) ?? null,
               entryRequired: v.entryRequired === true || v.entryRequired === 1,
               alwaysActive: v.alwaysActive === true || v.alwaysActive === 1,
               cashFallbackSymbol: (v.cashFallbackSymbol as string | null) ?? null,
@@ -246,7 +245,6 @@ function row(overrides: Partial<SymbolConfigRow> = {}): SymbolConfigRow {
     maxAtrRatioOverride: null,
     maxSma50DeviationPctOverride: null,
     requireAboveSma50Override: null,
-    alternatives: null,
     entryRequired: false,
     alwaysActive: false,
     cashFallbackSymbol: null,
@@ -1328,13 +1326,13 @@ describe('#315 inverse-pair list grouping', () => {
   })
 })
 
-describe('dashboard symbol_config role / entry override / alternatives (#452)', () => {
+describe('dashboard symbol_config role / entry override (#452)', () => {
   beforeEach(() => {
     vi.mocked(loadGlobalConfigFrom).mockResolvedValue(makeGlobalConfigSnapshot())
   })
   afterEach(() => vi.resetAllMocks())
 
-  it('POST persists role, entry overrides (% → fraction) and alternatives (JSON text)', async () => {
+  it('POST persists role and entry overrides (% → fraction)', async () => {
     const db = fakeDb([])
     vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
     const app = createApp()
@@ -1351,7 +1349,6 @@ describe('dashboard symbol_config role / entry override / alternatives (#452)', 
       max_atr_ratio_override: '1.8', // ratio 生値
       max_sma50_deviation_pct_override: '20', // +20% → 0.2
       require_above_sma50_override: 'false',
-      alternatives: 'voo, SPLG voo', // 区切り混在 + 重複
     })
     const res = await app.request(
       '/admin/symbol-config',
@@ -1371,7 +1368,6 @@ describe('dashboard symbol_config role / entry override / alternatives (#452)', 
     expect(inserted.values.maxAtrRatioOverride).toBeCloseTo(1.8, 6)
     expect(inserted.values.maxSma50DeviationPctOverride).toBeCloseTo(0.2, 6)
     expect(inserted.values.requireAboveSma50Override).toBe(false)
-    expect(inserted.values.alternatives).toBe('["VOO","SPLG"]')
   })
 
   it('POST with empty role / overrides persists NULLs (従来挙動)', async () => {
@@ -1386,7 +1382,6 @@ describe('dashboard symbol_config role / entry override / alternatives (#452)', 
       lot_size: '1',
       role: '',
       pullback_max_override: '',
-      alternatives: '',
     })
     const res = await app.request(
       '/admin/symbol-config',
@@ -1401,7 +1396,6 @@ describe('dashboard symbol_config role / entry override / alternatives (#452)', 
     const inserted = db.inserts.find((i) => i.table === 'symbol_config')!
     expect(inserted.values.role).toBeNull()
     expect(inserted.values.pullbackMaxOverride).toBeNull()
-    expect(inserted.values.alternatives).toBeNull()
   })
 
   it('rejects an out-of-enum role with 400 (typo を従来挙動に黙って倒さない)', async () => {
@@ -1451,28 +1445,6 @@ describe('dashboard symbol_config role / entry override / alternatives (#452)', 
     expect(res.status).toBe(400)
   })
 
-  it('rejects alternatives containing an invalid ticker with 400', async () => {
-    const db = fakeDb([])
-    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
-    const app = createApp()
-    const res = await app.request(
-      '/admin/symbol-config',
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...authHeader },
-        body: new URLSearchParams({
-          symbol: 'SOXL',
-          market: 'US',
-          currency: 'USD',
-          active: 'true',
-          lot_size: '1',
-          alternatives: 'SOXX, BAD&SYM',
-        }).toString(),
-      },
-      { ...baseEnv, DB: {} as D1Database },
-    )
-    expect(res.status).toBe(400)
-  })
 
   it('edit form shows role select / entry override fields with current values', async () => {
     const db = fakeDb([
@@ -1482,7 +1454,6 @@ describe('dashboard symbol_config role / entry override / alternatives (#452)', 
         pullbackMaxOverride: -0.015,
         minReturn50dOverride: 0.03,
         requireAboveSma50Override: false,
-        alternatives: '["VOO","SPLG"]',
       }),
     ])
     vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
@@ -1499,7 +1470,6 @@ describe('dashboard symbol_config role / entry override / alternatives (#452)', 
     expect(body).toMatch(/name="pullback_max_override"[^>]*value="-1\.5"/)
     expect(body).toMatch(/name="min_return_50d_override"[^>]*value="3"/)
     expect(body).toMatch(/name="require_above_sma50_override"/)
-    expect(body).toMatch(/name="alternatives"[^>]*value="VOO, SPLG"/)
   })
 })
 


### PR DESCRIPTION
## 背景 (operator 判断)

銘柄管理の「代替銘柄」と「退避先」の違いが分かりづらい、という指摘の整理で:

- **代替銘柄** = WATCH/NG 時にダッシュボードへ候補を表示するだけ (表示専用、売買に影響なし)
- **退避先** (`cash_fallback_symbol`) = 条件連動配分で浮いた予算枠の振り向け先 (実配分に影響)

→ 「代替銘柄はメモ (notes) で分かるからいらない。退避先だけ残す」との判断で、**代替銘柄機能を削除**する。

## 変更

- form 入力・admin parse (`parseAlternativesInput`)・repo の JSON 検証 (`parseAlternativesJson`)・universe の `symbolAlternatives`・チャートの「代替候補」ブロックを削除
- **migration 0032**: `ALTER TABLE symbol_config DROP COLUMN alternatives` (staging 適用済み。production は release 時)
- 退避先 (`cashFallbackSymbol`) と条件連動配分は無変更

## 検証

- 1499 tests pass (機能テスト 3 本は機能ごと削除)
- staging: migration 適用 + デプロイ済み — symbol form から「代替銘柄」欄が消え、既存データ (VUG の SGOV,USMV,VOO 等) は破棄されます

Refs #452 #449

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * シンボル設定から代替銘柄候補機能を削除しました。

**単語数: 11語**

<!-- end of auto-generated comment: release notes by coderabbit.ai -->