### PR TITLE
feat: 配分マップ (口座ツリー) + 編集キャンバス (1/枝 配分・退避先の線編集)

### DIFF
--- a/drizzle/0032_drop_alternatives.sql
+++ b/drizzle/0032_drop_alternatives.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `symbol_config` DROP COLUMN `alternatives`;

--- a/drizzle/meta/0032_snapshot.json
+++ b/drizzle/meta/0032_snapshot.json
@@ -1,0 +1,1499 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "9aebeb71-514e-46ee-99be-0e79c84ab1a2",
+  "prevId": "5b489c56-5f18-4992-92f5-fc6ada6c7210",
+  "tables": {
+    "config_audit_log": {
+      "name": "config_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before_json": {
+          "name": "before_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "after_json": {
+          "name": "after_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "config_audit_log_timestamp_id_idx": {
+          "name": "config_audit_log_timestamp_id_idx",
+          "columns": [
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "config_audit_log_actor_timestamp_id_idx": {
+          "name": "config_audit_log_actor_timestamp_id_idx",
+          "columns": [
+            "actor",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "config_audit_log_endpoint_timestamp_id_idx": {
+          "name": "config_audit_log_endpoint_timestamp_id_idx",
+          "columns": [
+            "endpoint",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "config_state_snapshot": {
+      "name": "config_state_snapshot",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "earnings_calendar": {
+      "name": "earnings_calendar",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "earnings_date": {
+          "name": "earnings_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "earnings_calendar_symbol_date_unique": {
+          "name": "earnings_calendar_symbol_date_unique",
+          "columns": [
+            "symbol",
+            "earnings_date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "global_config": {
+      "name": "global_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "trading_enabled": {
+          "name": "trading_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "market_hours_check": {
+          "name": "market_hours_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "max_order_notional": {
+          "name": "max_order_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "max_order_notional_usd": {
+          "name": "max_order_notional_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2000
+        },
+        "max_order_notional_jpy": {
+          "name": "max_order_notional_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100000
+        },
+        "total_capital_usd": {
+          "name": "total_capital_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_capital_jpy": {
+          "name": "total_capital_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_portfolio_exposure_pct": {
+          "name": "max_portfolio_exposure_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.6
+        },
+        "drawdown_kill_threshold": {
+          "name": "drawdown_kill_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.02
+        },
+        "stale_quote_ms": {
+          "name": "stale_quote_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 900000
+        },
+        "gap_reject_pct": {
+          "name": "gap_reject_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.03
+        },
+        "spread_limit_pct_us": {
+          "name": "spread_limit_pct_us",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.0025
+        },
+        "spread_limit_pct_jp": {
+          "name": "spread_limit_pct_jp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.006
+        },
+        "pullback_default_stop_pct": {
+          "name": "pullback_default_stop_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.04
+        },
+        "pullback_default_take_profit_pct": {
+          "name": "pullback_default_take_profit_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.07
+        },
+        "pullback_default_time_stop_days": {
+          "name": "pullback_default_time_stop_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "pullback_default_pullback_max": {
+          "name": "pullback_default_pullback_max",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.03
+        },
+        "pullback_default_pullback_min": {
+          "name": "pullback_default_pullback_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.06
+        },
+        "pullback_default_min_return_50d": {
+          "name": "pullback_default_min_return_50d",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.08
+        },
+        "pullback_default_require_above_sma50": {
+          "name": "pullback_default_require_above_sma50",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "pullback_default_k_atr": {
+          "name": "pullback_default_k_atr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "pullback_default_max_sma50_deviation_pct": {
+          "name": "pullback_default_max_sma50_deviation_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.6
+        },
+        "pullback_default_max_atr_ratio": {
+          "name": "pullback_default_max_atr_ratio",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1.5
+        },
+        "risk_base_per_trade_pct": {
+          "name": "risk_base_per_trade_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.004
+        },
+        "risk_dd_half_threshold": {
+          "name": "risk_dd_half_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.05
+        },
+        "risk_dd_halt_threshold": {
+          "name": "risk_dd_halt_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.1
+        },
+        "vix_warning_threshold": {
+          "name": "vix_warning_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 25
+        },
+        "vix_critical_threshold": {
+          "name": "vix_critical_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "vix_warning_size_scale": {
+          "name": "vix_warning_size_scale",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.5
+        },
+        "pair_regime_mode": {
+          "name": "pair_regime_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'off'"
+        },
+        "pair_regime_theta_bull_enter": {
+          "name": "pair_regime_theta_bull_enter",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.03
+        },
+        "pair_regime_theta_bull_exit": {
+          "name": "pair_regime_theta_bull_exit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.01
+        },
+        "pair_regime_theta_bear_enter": {
+          "name": "pair_regime_theta_bear_enter",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.04
+        },
+        "pair_regime_theta_bear_exit": {
+          "name": "pair_regime_theta_bear_exit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.015
+        },
+        "overview_panels": {
+          "name": "overview_panels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'kpi,equity,composition,recent'"
+        },
+        "cash_fallback_orders_enabled": {
+          "name": "cash_fallback_orders_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "global_config_max_order_notional_range": {
+          "name": "global_config_max_order_notional_range",
+          "value": "\"global_config\".\"max_order_notional\" > 0 AND \"global_config\".\"max_order_notional\" <= 10000000"
+        },
+        "global_config_max_order_notional_usd_range": {
+          "name": "global_config_max_order_notional_usd_range",
+          "value": "\"global_config\".\"max_order_notional_usd\" > 0 AND \"global_config\".\"max_order_notional_usd\" <= 1000000"
+        },
+        "global_config_max_order_notional_jpy_range": {
+          "name": "global_config_max_order_notional_jpy_range",
+          "value": "\"global_config\".\"max_order_notional_jpy\" > 0 AND \"global_config\".\"max_order_notional_jpy\" <= 100000000"
+        },
+        "global_config_total_capital_usd_range": {
+          "name": "global_config_total_capital_usd_range",
+          "value": "\"global_config\".\"total_capital_usd\" IS NULL OR \"global_config\".\"total_capital_usd\" > 0"
+        },
+        "global_config_total_capital_jpy_range": {
+          "name": "global_config_total_capital_jpy_range",
+          "value": "\"global_config\".\"total_capital_jpy\" IS NULL OR \"global_config\".\"total_capital_jpy\" > 0"
+        },
+        "global_config_max_portfolio_exposure_pct_range": {
+          "name": "global_config_max_portfolio_exposure_pct_range",
+          "value": "\"global_config\".\"max_portfolio_exposure_pct\" > 0 AND \"global_config\".\"max_portfolio_exposure_pct\" <= 1"
+        },
+        "global_config_drawdown_kill_threshold_range": {
+          "name": "global_config_drawdown_kill_threshold_range",
+          "value": "\"global_config\".\"drawdown_kill_threshold\" >= -1 AND \"global_config\".\"drawdown_kill_threshold\" <= 0"
+        },
+        "global_config_stale_quote_ms_range": {
+          "name": "global_config_stale_quote_ms_range",
+          "value": "\"global_config\".\"stale_quote_ms\" >= 0"
+        },
+        "global_config_gap_reject_pct_range": {
+          "name": "global_config_gap_reject_pct_range",
+          "value": "\"global_config\".\"gap_reject_pct\" >= 0 AND \"global_config\".\"gap_reject_pct\" <= 1"
+        },
+        "global_config_spread_limit_pct_us_range": {
+          "name": "global_config_spread_limit_pct_us_range",
+          "value": "\"global_config\".\"spread_limit_pct_us\" >= 0 AND \"global_config\".\"spread_limit_pct_us\" <= 1"
+        },
+        "global_config_spread_limit_pct_jp_range": {
+          "name": "global_config_spread_limit_pct_jp_range",
+          "value": "\"global_config\".\"spread_limit_pct_jp\" >= 0 AND \"global_config\".\"spread_limit_pct_jp\" <= 1"
+        },
+        "global_config_pullback_default_stop_pct_range": {
+          "name": "global_config_pullback_default_stop_pct_range",
+          "value": "\"global_config\".\"pullback_default_stop_pct\" < 0 AND \"global_config\".\"pullback_default_stop_pct\" >= -1"
+        },
+        "global_config_pullback_default_take_profit_pct_range": {
+          "name": "global_config_pullback_default_take_profit_pct_range",
+          "value": "\"global_config\".\"pullback_default_take_profit_pct\" > 0 AND \"global_config\".\"pullback_default_take_profit_pct\" <= 1"
+        },
+        "global_config_pullback_default_time_stop_days_range": {
+          "name": "global_config_pullback_default_time_stop_days_range",
+          "value": "\"global_config\".\"pullback_default_time_stop_days\" > 0 AND \"global_config\".\"pullback_default_time_stop_days\" <= ?"
+        },
+        "global_config_pullback_default_pullback_max_range": {
+          "name": "global_config_pullback_default_pullback_max_range",
+          "value": "\"global_config\".\"pullback_default_pullback_max\" <= 0 AND \"global_config\".\"pullback_default_pullback_max\" >= -1"
+        },
+        "global_config_pullback_default_pullback_min_range": {
+          "name": "global_config_pullback_default_pullback_min_range",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= 0 AND \"global_config\".\"pullback_default_pullback_min\" >= -1"
+        },
+        "global_config_pullback_default_min_return_50d_range": {
+          "name": "global_config_pullback_default_min_return_50d_range",
+          "value": "\"global_config\".\"pullback_default_min_return_50d\" >= -1 AND \"global_config\".\"pullback_default_min_return_50d\" <= 10"
+        },
+        "global_config_pullback_default_k_atr_range": {
+          "name": "global_config_pullback_default_k_atr_range",
+          "value": "\"global_config\".\"pullback_default_k_atr\" > 0 AND \"global_config\".\"pullback_default_k_atr\" <= 10"
+        },
+        "global_config_pullback_default_pullback_window_order": {
+          "name": "global_config_pullback_default_pullback_window_order",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= \"global_config\".\"pullback_default_pullback_max\""
+        },
+        "global_config_risk_base_per_trade_pct_range": {
+          "name": "global_config_risk_base_per_trade_pct_range",
+          "value": "\"global_config\".\"risk_base_per_trade_pct\" > 0 AND \"global_config\".\"risk_base_per_trade_pct\" <= 1"
+        },
+        "global_config_risk_dd_half_threshold_range": {
+          "name": "global_config_risk_dd_half_threshold_range",
+          "value": "\"global_config\".\"risk_dd_half_threshold\" < 0 AND \"global_config\".\"risk_dd_half_threshold\" >= -1"
+        },
+        "global_config_risk_dd_halt_threshold_range": {
+          "name": "global_config_risk_dd_halt_threshold_range",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" < 0 AND \"global_config\".\"risk_dd_halt_threshold\" >= -1"
+        },
+        "global_config_risk_dd_threshold_order": {
+          "name": "global_config_risk_dd_threshold_order",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" <= \"global_config\".\"risk_dd_half_threshold\""
+        },
+        "global_config_vix_warning_threshold_range": {
+          "name": "global_config_vix_warning_threshold_range",
+          "value": "\"global_config\".\"vix_warning_threshold\" > 0 AND \"global_config\".\"vix_warning_threshold\" <= 200"
+        },
+        "global_config_vix_critical_threshold_range": {
+          "name": "global_config_vix_critical_threshold_range",
+          "value": "\"global_config\".\"vix_critical_threshold\" > 0 AND \"global_config\".\"vix_critical_threshold\" <= 200"
+        },
+        "global_config_vix_threshold_order": {
+          "name": "global_config_vix_threshold_order",
+          "value": "\"global_config\".\"vix_warning_threshold\" <= \"global_config\".\"vix_critical_threshold\""
+        },
+        "global_config_vix_warning_size_scale_range": {
+          "name": "global_config_vix_warning_size_scale_range",
+          "value": "\"global_config\".\"vix_warning_size_scale\" >= 0 AND \"global_config\".\"vix_warning_size_scale\" <= 1"
+        }
+      }
+    },
+    "inverse_pairs": {
+      "name": "inverse_pairs",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inverse": {
+          "name": "inverse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "regime_enabled": {
+          "name": "regime_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "regime_proxy_symbol": {
+          "name": "regime_proxy_symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "regime_bull_symbol": {
+          "name": "regime_bull_symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "macro_event_calendar": {
+      "name": "macro_event_calendar",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_time": {
+          "name": "event_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "macro_event_calendar_type_date_unique": {
+          "name": "macro_event_calendar_type_date_unique",
+          "columns": [
+            "event_type",
+            "event_date"
+          ],
+          "isUnique": true
+        },
+        "macro_event_calendar_date_idx": {
+          "name": "macro_event_calendar_date_idx",
+          "columns": [
+            "event_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_emit_log": {
+      "name": "notification_emit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cause": {
+          "name": "cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notification_emit_log_timestamp_id_idx": {
+          "name": "notification_emit_log_timestamp_id_idx",
+          "columns": [
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "notification_emit_log_severity_timestamp_id_idx": {
+          "name": "notification_emit_log_severity_timestamp_id_idx",
+          "columns": [
+            "severity",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "notification_emit_log_event_type_timestamp_id_idx": {
+          "name": "notification_emit_log_event_type_timestamp_id_idx",
+          "columns": [
+            "event_type",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "portfolio_equity_snapshot": {
+      "name": "portfolio_equity_snapshot",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "daily_start_equity_usd": {
+          "name": "daily_start_equity_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_start_equity_jpy": {
+          "name": "daily_start_equity_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_realized_pnl_usd": {
+          "name": "daily_realized_pnl_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_realized_pnl_jpy": {
+          "name": "daily_realized_pnl_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "drawdown_pct": {
+          "name": "drawdown_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "portfolio_equity_snapshot_at_idx": {
+          "name": "portfolio_equity_snapshot_at_idx",
+          "columns": [
+            "snapshot_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "strategy_decision_log": {
+      "name": "strategy_decision_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indicators_json": {
+          "name": "indicators_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trace_json": {
+          "name": "trace_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "strategy_decision_log_symbol_id_idx": {
+          "name": "strategy_decision_log_symbol_id_idx",
+          "columns": [
+            "symbol",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "strategy_decision_log_coid_idx": {
+          "name": "strategy_decision_log_coid_idx",
+          "columns": [
+            "client_order_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "symbol_config": {
+      "name": "symbol_config",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "market": {
+          "name": "market",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_notional": {
+          "name": "max_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_stop_days_override": {
+          "name": "time_stop_days_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "k_atr_override": {
+          "name": "k_atr_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "budget_alloc_pct": {
+          "name": "budget_alloc_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lot_size": {
+          "name": "lot_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stop_pct_override": {
+          "name": "stop_pct_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "take_profit_pct_override": {
+          "name": "take_profit_pct_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "intraday_only": {
+          "name": "intraday_only",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pullback_max_override": {
+          "name": "pullback_max_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pullback_min_override": {
+          "name": "pullback_min_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "min_return_50d_override": {
+          "name": "min_return_50d_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_atr_ratio_override": {
+          "name": "max_atr_ratio_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_sma50_deviation_pct_override": {
+          "name": "max_sma50_deviation_pct_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "require_above_sma50_override": {
+          "name": "require_above_sma50_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_required": {
+          "name": "entry_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "always_active": {
+          "name": "always_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cash_fallback_symbol": {
+          "name": "cash_fallback_symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "symbol_config_currency_enum": {
+          "name": "symbol_config_currency_enum",
+          "value": "\"symbol_config\".\"currency\" IN ('USD', 'JPY')"
+        },
+        "symbol_config_time_stop_days_override_range": {
+          "name": "symbol_config_time_stop_days_override_range",
+          "value": "\"symbol_config\".\"time_stop_days_override\" IS NULL OR (\"symbol_config\".\"time_stop_days_override\" >= 1 AND \"symbol_config\".\"time_stop_days_override\" <= ?)"
+        },
+        "symbol_config_k_atr_override_range": {
+          "name": "symbol_config_k_atr_override_range",
+          "value": "\"symbol_config\".\"k_atr_override\" IS NULL OR (\"symbol_config\".\"k_atr_override\" >= 0.5 AND \"symbol_config\".\"k_atr_override\" <= 5.0)"
+        }
+      }
+    },
+    "trade_journal": {
+      "name": "trade_journal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trade_event_type": {
+          "name": "trade_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "strategy_name": {
+          "name": "strategy_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_action": {
+          "name": "signal_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_reason": {
+          "name": "signal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_allowed": {
+          "name": "risk_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_reasons": {
+          "name": "risk_reasons",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "limit_price": {
+          "name": "limit_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notional": {
+          "name": "notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "broker_status": {
+          "name": "broker_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "submitted": {
+          "name": "submitted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_qty": {
+          "name": "filled_qty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_price": {
+          "name": "filled_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "realized_pnl": {
+          "name": "realized_pnl",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hold_days": {
+          "name": "hold_days",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_reason": {
+          "name": "exit_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_applied_at": {
+          "name": "state_applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_error": {
+          "name": "state_apply_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_attempts": {
+          "name": "state_apply_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trading_toggle_history": {
+      "name": "trading_toggle_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before": {
+          "name": "before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "after": {
+          "name": "after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1781174769487,
       "tag": "0031_add_pair_regime",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "6",
+      "when": 1781193221867,
+      "tag": "0032_drop_alternatives",
+      "breakpoints": true
     }
   ]
 }

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -175,12 +175,6 @@ export const symbolConfig = sqliteTable(
     /** SMA50 上抜け必須条件 override (NULL = global default、boolean、#452)。 */
     requireAboveSma50Override: integer('require_above_sma50_override', { mode: 'boolean' }),
     /**
-     * 代替銘柄候補 (#452 / #449)。JSON 配列 text (例 `["SOXX","SMH"]`)。レバ ETF が
-     * NG/WATCH のときダッシュボードに代替候補を出す **表示専用** — 自動 routing には
-     * 使わない。NULL / 不正 JSON は「候補なし」扱い。
-     */
-    alternatives: text('alternatives'),
-    /**
      * 条件連動配分 (#452 Layer 3 / #450)。true = entry gate (ENTRY/HALF) 通過を
      * 実配分 (active weight) の必須条件にする。未通過の間は active=0 になり、
      * 浮いた配分は `cash_fallback_symbol` へ退避される。false (default) =

--- a/src/infrastructure/db/symbolConfigRepo.ts
+++ b/src/infrastructure/db/symbolConfigRepo.ts
@@ -32,10 +32,6 @@ export function isSymbolRole(value: unknown): value is SymbolRole {
   return typeof value === 'string' && (SYMBOL_ROLES as readonly string[]).includes(value)
 }
 
-/** alternatives の 1 ticker の文法 (admin parse / repo 検証で共用)。 */
-const ALTERNATIVE_SYMBOL_RE = /^[A-Z0-9]{1,10}$/
-/** alternatives の最大件数 (表示専用 list の防御的上限)。 */
-export const MAX_ALTERNATIVES = 8
 
 export interface SymbolConfigSnapshot {
   /** Uppercased symbols where `active = 1`. cron / risk gate はこの list だけを評価対象とする。 */
@@ -130,11 +126,6 @@ export interface SymbolConfigSnapshot {
   /** SMA50 上抜け必須 override (true / false 両方 map に含める。NULL は不在)。 */
   symbolRequireAboveSma50Override: Record<string, boolean>
   /**
-   * symbol → 代替銘柄候補 (#452、表示専用)。NULL / 不正 JSON / 空配列は map に
-   * 含めない。要素は大文字 ticker、self 参照と重複は除去、上限 MAX_ALTERNATIVES。
-   */
-  symbolAlternatives: Record<string, string[]>
-  /**
    * entry_required=true の symbol 集合 (#452 Layer 3)。gate 未通過の間
    * active weight = 0 になり cash fallback へ退避される。false は不在。
    */
@@ -146,32 +137,6 @@ export interface SymbolConfigSnapshot {
    * (= 退避しない、現金のまま)。
    */
   symbolCashFallback: Record<string, string>
-}
-
-/**
- * alternatives の JSON text を検証付きで配列に落とす。不正 (JSON でない /
- * 配列でない / ticker 文法外要素) は **null** (= 候補なし扱い)。表示専用 data
- * なので発注安全性には関与しないが、ゴミを下流に流さない。
- */
-export function parseAlternativesJson(raw: string | null | undefined, selfSymbol: string): string[] | null {
-  if (raw === null || raw === undefined) return null
-  let parsed: unknown
-  try {
-    parsed = JSON.parse(raw)
-  } catch {
-    return null
-  }
-  if (!Array.isArray(parsed)) return null
-  const out: string[] = []
-  for (const item of parsed) {
-    if (typeof item !== 'string') return null
-    const sym = item.trim().toUpperCase()
-    if (!ALTERNATIVE_SYMBOL_RE.test(sym)) return null
-    if (sym === selfSymbol.toUpperCase()) continue
-    if (!out.includes(sym)) out.push(sym)
-    if (out.length >= MAX_ALTERNATIVES) break
-  }
-  return out.length > 0 ? out : null
 }
 
 /**
@@ -209,7 +174,6 @@ export async function loadSymbolConfig(
   const symbolMaxAtrRatioOverride: Record<string, number> = {}
   const symbolMaxSma50DeviationPctOverride: Record<string, number> = {}
   const symbolRequireAboveSma50Override: Record<string, boolean> = {}
-  const symbolAlternatives: Record<string, string[]> = {}
   const symbolEntryRequired: Record<string, boolean> = {}
   const symbolAlwaysActive: Record<string, boolean> = {}
   const symbolCashFallback: Record<string, string> = {}
@@ -359,10 +323,6 @@ export async function loadSymbolConfig(
     if (row.requireAboveSma50Override === true || row.requireAboveSma50Override === false) {
       symbolRequireAboveSma50Override[symbol] = row.requireAboveSma50Override
     }
-    const alternatives = parseAlternativesJson(row.alternatives, symbol)
-    if (alternatives !== null) {
-      symbolAlternatives[symbol] = alternatives
-    }
     // 条件連動配分 (#452 Layer 3)。false は map に出さない (従来挙動 = 常時枠)。
     if (row.entryRequired === true) {
       symbolEntryRequired[symbol] = true
@@ -401,7 +361,6 @@ export async function loadSymbolConfig(
     symbolMaxAtrRatioOverride,
     symbolMaxSma50DeviationPctOverride,
     symbolRequireAboveSma50Override,
-    symbolAlternatives,
     symbolEntryRequired,
     symbolAlwaysActive,
     symbolCashFallback,
@@ -464,20 +423,12 @@ export interface SymbolConfigWriteInput {
   maxAtrRatioOverride: number | null
   maxSma50DeviationPctOverride: number | null
   requireAboveSma50Override: boolean | null
-  /** 代替銘柄候補 (表示専用、NULL = なし、#452)。DB には JSON text で保存。 */
-  alternatives: string[] | null
   /** 条件連動配分 (#452 Layer 3): gate 通過を実配分の必須条件にする。default false。 */
   entryRequired: boolean
   /** 常時 target = active (cash_parking 用、#452)。default false。 */
   alwaysActive: boolean
   /** 条件未通過時の退避先 symbol (NULL = 退避しない、#452)。 */
   cashFallbackSymbol: string | null
-}
-
-/** alternatives 配列 → DB 保存形式 (JSON text / NULL)。空配列は NULL に正規化。 */
-function alternativesToJson(alternatives: string[] | null): string | null {
-  if (alternatives === null || alternatives.length === 0) return null
-  return JSON.stringify(alternatives)
 }
 
 /**
@@ -516,7 +467,6 @@ export async function insertSymbolConfig(
       maxAtrRatioOverride: input.maxAtrRatioOverride,
       maxSma50DeviationPctOverride: input.maxSma50DeviationPctOverride,
       requireAboveSma50Override: input.requireAboveSma50Override,
-      alternatives: alternativesToJson(input.alternatives),
       entryRequired: input.entryRequired,
       alwaysActive: input.alwaysActive,
       cashFallbackSymbol: input.cashFallbackSymbol,
@@ -575,7 +525,6 @@ export async function updateSymbolConfig(
       maxAtrRatioOverride: input.maxAtrRatioOverride,
       maxSma50DeviationPctOverride: input.maxSma50DeviationPctOverride,
       requireAboveSma50Override: input.requireAboveSma50Override,
-      alternatives: alternativesToJson(input.alternatives),
       entryRequired: input.entryRequired,
       alwaysActive: input.alwaysActive,
       cashFallbackSymbol: input.cashFallbackSymbol,
@@ -891,7 +840,7 @@ export async function createSymbolPair(
       stopPctOverride: primary.stopPctOverride,
       takeProfitPctOverride: primary.takeProfitPctOverride,
       intradayOnly: primary.intradayOnly,
-      // role / entry override / alternatives は **継承しない** (#452)。インバース
+      // role / entry override は **継承しない** (#452)。インバース
       // 相手は方向が逆で entry 特性が異なる (bull 側の押し目閾値は bear 側に
       // 適用できない)。NULL = 従来挙動で開始し、必要なら個別編集で設定する。
       role: null,
@@ -901,7 +850,6 @@ export async function createSymbolPair(
       maxAtrRatioOverride: null,
       maxSma50DeviationPctOverride: null,
       requireAboveSma50Override: null,
-      alternatives: null,
       // 条件連動配分も継承しない (#452): 方向が逆の相手に同じ配分条件は適用
       // できない。default (false / NULL) = 従来挙動で開始。
       entryRequired: false,

--- a/src/infrastructure/db/symbolConfigRepo.ts
+++ b/src/infrastructure/db/symbolConfigRepo.ts
@@ -597,6 +597,40 @@ export async function toggleSymbolActive(
  * `pct` は fraction (0<pct<=1) or null (= risk-% sizing に戻す)。存在しなければ null。
  * before/after を返し caller が audit / inverse 同期に使う。
  */
+/**
+ * 退避先 (cash_fallback_symbol) の set / clear (#symbol-relation-map 編集
+ * キャンバス用)。set 時は entry_required も同時に ON する — 退避先だけ設定して
+ * 条件連動 OFF の「眠った設定」(operator が実際に踏んだ罠) を作らせない。
+ * clear は entry_required を触らない (条件連動自体の意図は別设定)。
+ * 同値なら UPDATE しない (updatedAt だけ無監査で進むのを防ぐ)。
+ */
+export async function updateCashFallback(
+  db: DrizzleD1Database,
+  symbol: string,
+  target: string | null,
+  nowIso: string,
+): Promise<{ before: SymbolConfigRow; after: SymbolConfigRow } | null> {
+  const before = await findSymbolConfig(db, symbol)
+  if (before === null) return null
+  const beforeSnapshot: SymbolConfigRow = { ...before }
+  const sameTarget = (before.cashFallbackSymbol ?? null) === (target ?? null)
+  const needsEntryRequired = target !== null && before.entryRequired !== true
+  if (sameTarget && !needsEntryRequired) {
+    return { before: beforeSnapshot, after: beforeSnapshot }
+  }
+  await db
+    .update(symbolConfig)
+    .set({
+      cashFallbackSymbol: target,
+      ...(target !== null ? { entryRequired: true } : {}),
+      updatedAt: nowIso,
+    })
+    .where(eq(symbolConfig.symbol, symbol))
+  const after = await findSymbolConfig(db, symbol)
+  if (after === null) return null
+  return { before: beforeSnapshot, after }
+}
+
 export async function updateBudgetAllocPct(
   db: DrizzleD1Database,
   symbol: string,

--- a/src/infrastructure/db/symbolUniverse.ts
+++ b/src/infrastructure/db/symbolUniverse.ts
@@ -67,8 +67,6 @@ export interface SymbolUniverse {
   symbolMaxAtrRatioOverride: Record<string, number>
   symbolMaxSma50DeviationPctOverride: Record<string, number>
   symbolRequireAboveSma50Override: Record<string, boolean>
-  /** symbol → 代替銘柄候補 (#452、表示専用)。不在 = 候補なし。 */
-  symbolAlternatives: Record<string, string[]>
   /** entry_required=true の集合 (#452 Layer 3)。false は不在。 */
   symbolEntryRequired: Record<string, boolean>
   /** always_active=true の集合 (#452、cash_parking 用)。false は不在。 */
@@ -123,7 +121,6 @@ export async function loadSymbolUniverse(env: UniverseEnv): Promise<SymbolUniver
     symbolMaxAtrRatioOverride: config.symbolMaxAtrRatioOverride,
     symbolMaxSma50DeviationPctOverride: config.symbolMaxSma50DeviationPctOverride,
     symbolRequireAboveSma50Override: config.symbolRequireAboveSma50Override,
-    symbolAlternatives: config.symbolAlternatives,
     symbolEntryRequired: config.symbolEntryRequired,
     symbolAlwaysActive: config.symbolAlwaysActive,
     symbolCashFallback: config.symbolCashFallback,

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -41,6 +41,7 @@ import {
   loadInversePairs,
   toggleSymbolActive,
   updateBudgetAllocPct,
+  updateCashFallback,
   updateSymbolConfig,
   isSymbolRole,
   SYMBOL_ROLES,
@@ -1716,6 +1717,61 @@ export const admin = new Hono<AppBindings>()
     )
     if (isForm) return c.redirect('/dashboard/symbols', 303)
     return c.json({ symbol: symbolPath, deleted: true })
+  })
+  /**
+   * 退避先の set / clear (#symbol-relation-map 編集キャンバス)。
+   * body: { target: 'SGOV' } で設定 (entry_required も同時に ON)、
+   * { target: null } で解除。検証: 両銘柄が登録済み・同一通貨・self 禁止。
+   */
+  .post('/symbol-config/:symbol/cash-fallback', rateLimit('ADMIN_WRITE'), async (c) => {
+    if (!c.env.DB) {
+      throw new ValidationError('DB binding is not configured', { field: 'env' })
+    }
+    const symbol = normalizeSymbol(c.req.param('symbol'))
+    const body = (await c.req.json().catch(() => null)) as { target?: unknown } | null
+    if (body === null || !('target' in body)) {
+      throw new ValidationError("body must be JSON { target: string | null }", { field: 'target' })
+    }
+    let target: string | null = null
+    if (body.target !== null) {
+      if (typeof body.target !== 'string' || !/^[A-Za-z0-9]{1,10}$/.test(body.target.trim())) {
+        throw new ValidationError('target must be a ticker or null', { field: 'target' })
+      }
+      target = normalizeSymbol(body.target)
+      if (target === symbol) {
+        throw new ValidationError('target must differ from the symbol itself', { field: 'target' })
+      }
+    }
+    const db = createDb(c.env.DB)
+    const source = await findSymbolConfig(db, symbol)
+    if (source === null) return c.json({ error: 'symbol not found' }, 404)
+    if (target !== null) {
+      const targetRow = await findSymbolConfig(db, target)
+      if (targetRow === null) {
+        throw new ValidationError(`target ${target} is not a registered symbol`, { field: 'target' })
+      }
+      // 通貨跨ぎの退避は配分計算側で skip される (fail-closed) ため、入力時点で拒否する。
+      if (targetRow.currency !== source.currency) {
+        throw new ValidationError(
+          `target currency ${targetRow.currency} must match ${source.currency}`,
+          { field: 'target' },
+        )
+      }
+    }
+    const result = await updateCashFallback(db, symbol, target, new Date().toISOString())
+    if (result === null) return c.json({ error: 'symbol not found' }, 404)
+    await writeAuditLog(
+      c,
+      '/admin/symbol-config/cash-fallback',
+      `symbol=${symbol}`,
+      { cashFallbackSymbol: result.before.cashFallbackSymbol, entryRequired: result.before.entryRequired },
+      { cashFallbackSymbol: result.after.cashFallbackSymbol, entryRequired: result.after.entryRequired },
+    )
+    return c.json({
+      symbol,
+      cashFallbackSymbol: result.after.cashFallbackSymbol,
+      entryRequired: result.after.entryRequired,
+    })
   })
   /**
    * 予算配分% の一括更新 (#budget-alloc ラダー)。一覧の各 slider が

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1728,16 +1728,19 @@ export const admin = new Hono<AppBindings>()
       throw new ValidationError('DB binding is not configured', { field: 'env' })
     }
     const symbol = normalizeSymbol(c.req.param('symbol'))
-    const body = (await c.req.json().catch(() => null)) as { target?: unknown } | null
-    if (body === null || !('target' in body)) {
+    const body = (await c.req.json().catch(() => null)) as unknown
+    // primitive / 配列 JSON で `'target' in body` が TypeError → 500 になるのを防ぐ
+    // (CodeRabbit #485): 先に object 判定して 400 に落とす。
+    if (body === null || typeof body !== 'object' || Array.isArray(body) || !('target' in body)) {
       throw new ValidationError("body must be JSON { target: string | null }", { field: 'target' })
     }
+    const payload = body as { target?: unknown }
     let target: string | null = null
-    if (body.target !== null) {
-      if (typeof body.target !== 'string' || !/^[A-Za-z0-9]{1,10}$/.test(body.target.trim())) {
+    if (payload.target !== null) {
+      if (typeof payload.target !== 'string' || !/^[A-Za-z0-9]{1,10}$/.test(payload.target.trim())) {
         throw new ValidationError('target must be a ticker or null', { field: 'target' })
       }
-      target = normalizeSymbol(body.target)
+      target = normalizeSymbol(payload.target)
       if (target === symbol) {
         throw new ValidationError('target must differ from the symbol itself', { field: 'target' })
       }

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -43,7 +43,6 @@ import {
   updateBudgetAllocPct,
   updateSymbolConfig,
   isSymbolRole,
-  MAX_ALTERNATIVES,
   SYMBOL_ROLES,
   type SymbolConfigWriteInput,
   type SymbolRole,
@@ -2390,7 +2389,6 @@ function parseSymbolConfigBody(body: unknown): SymbolConfigWriteInput {
     maxSma50DeviationPctOverride?: unknown
     require_above_sma50_override?: unknown
     requireAboveSma50Override?: unknown
-    alternatives?: unknown
     entry_required?: unknown
     entryRequired?: unknown
     always_active?: unknown
@@ -2513,7 +2511,6 @@ function parseSymbolConfigBody(body: unknown): SymbolConfigWriteInput {
     raw.require_above_sma50_override ?? raw.requireAboveSma50Override,
     'requireAboveSma50Override',
   )
-  const alternatives = parseAlternativesInput(raw.alternatives, symbol)
   // 条件連動配分 (#452 Layer 3): checkbox 未送信は false (= 従来挙動)。退避先は
   // ticker 文法 + self 参照禁止。空 → NULL (= 退避しない)。
   const entryRequired = parseFormBool(raw.entry_required ?? raw.entryRequired, false)
@@ -2544,7 +2541,6 @@ function parseSymbolConfigBody(body: unknown): SymbolConfigWriteInput {
     maxAtrRatioOverride,
     maxSma50DeviationPctOverride,
     requireAboveSma50Override,
-    alternatives,
     entryRequired,
     alwaysActive,
     cashFallbackSymbol,
@@ -2607,48 +2603,6 @@ function parseOptionalTriStateBool(value: unknown, field: string): boolean | nul
     if (trimmed === 'false') return false
   }
   throw new ValidationError(`${field} must be '', 'true' or 'false'`, { field })
-}
-
-/**
- * alternatives (#452、表示専用): form はカンマ/空白区切り text、JSON はその文字列
- * or 配列を送る。ticker 文法 ([A-Za-z0-9]{1,10}) 外の要素は 400。self 参照と
- * 重複は除去、上限 MAX_ALTERNATIVES 超過は 400。空 → null。
- */
-function parseAlternativesInput(value: unknown, selfSymbol: string): string[] | null {
-  if (value === undefined || value === null) return null
-  let tokens: string[]
-  if (Array.isArray(value)) {
-    tokens = value.map((v) => {
-      if (typeof v !== 'string') {
-        throw new ValidationError('alternatives must be symbols', { field: 'alternatives' })
-      }
-      return v
-    })
-  } else if (typeof value === 'string') {
-    tokens = value.split(/[\s,]+/)
-  } else {
-    throw new ValidationError('alternatives must be a string or array of symbols', {
-      field: 'alternatives',
-    })
-  }
-  const out: string[] = []
-  for (const token of tokens) {
-    const sym = token.trim().toUpperCase()
-    if (sym === '') continue
-    if (!/^[A-Z0-9]{1,10}$/.test(sym)) {
-      throw new ValidationError(`alternatives contains an invalid symbol: ${sym}`, {
-        field: 'alternatives',
-      })
-    }
-    if (sym === selfSymbol.toUpperCase()) continue
-    if (!out.includes(sym)) out.push(sym)
-  }
-  if (out.length > MAX_ALTERNATIVES) {
-    throw new ValidationError(`alternatives must have at most ${MAX_ALTERNATIVES} symbols`, {
-      field: 'alternatives',
-    })
-  }
-  return out.length > 0 ? out : null
 }
 
 /**
@@ -2897,7 +2851,6 @@ function symbolConfigSnapshot(row: SymbolConfigRow): Record<string, unknown> {
     maxAtrRatioOverride: row.maxAtrRatioOverride,
     maxSma50DeviationPctOverride: row.maxSma50DeviationPctOverride,
     requireAboveSma50Override: row.requireAboveSma50Override,
-    alternatives: row.alternatives,
     updatedAt: row.updatedAt,
   }
 }

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -8818,6 +8818,8 @@ export function symbolMapEditorBody(
   #symbol-map-editor .drawflow .drawflow-node.sm-dirty{border-color:#e6a23c;box-shadow:0 0 0 3px rgba(230,162,60,0.25)}
   /* 通貨で塗り分け: 口座 = 濃グレー、JPY = 桜、USD = 薄青 (operator 要望) */
   #symbol-map-editor .drawflow .drawflow-node.sm-account{background:#5f6368;border-color:#3c4043}
+  #symbol-map-editor .drawflow .drawflow-node.sm-jpy{background:#fdf3f2;border-color:#d4a09a}
+  #symbol-map-editor .drawflow .drawflow-node.sm-usd{background:#f0f6ff;border-color:#9ab8dd}
   /* 接続ポートの◯もグレーに (default の白丸 + 黒枠は浮く) */
   #symbol-map-editor .drawflow .drawflow-node .input,
   #symbol-map-editor .drawflow .drawflow-node .output{background:#9aa0a6;border:2px solid #6e6e73;width:14px;height:14px}
@@ -9000,6 +9002,15 @@ export function symbolMapEditorBody(
         draft[dst].connected = true;
         markConnectionPending(info.output_id, info.input_id);
         renderChanges();
+        return;
+      }
+      // 異通貨の退避先は server 側 (cash-fallback API) で拒否される — 適用時に
+      // 落ちて部分保存になる前に、この場で理由付きで弾く (CodeRabbit #485)。
+      if (nodeBySym[src].currency !== nodeBySym[dst].currency) {
+        programmatic = true;
+        editor.removeSingleConnection(info.output_id, info.input_id, info.output_class, info.input_class);
+        programmatic = false;
+        alert(src + ' は ' + nodeBySym[src].currency + '、' + dst + ' は ' + nodeBySym[dst].currency + ' です。異通貨の退避先は設定できません (同一通貨のみ)。');
         return;
       }
       // 退避先は 1 銘柄 1 本 — 既存の出力接続を visual からも外す。

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -8719,16 +8719,16 @@ function applySymbolsListFilter(rows: SymbolConfigRow[], f: SymbolsListFilter): 
 }
 
 /**
- * 銘柄関係マップ (#symbol-relation-map)。インバース対 / regime proxy / 退避先と
- * いう「銘柄同士の依存関係」が一覧テーブルではセル単位に散らばって読めない、
- * という operator 要望でグラフ可視化する。関係が 1 つも無ければ出さない。
+ * 配分マップ (#symbol-relation-map)。予算がどのロール / 銘柄に流れ、条件未通過
+ * 時にどこへ退避するかを Sankey で可視化する (operator 指定: 家計簿アプリの
+ * キャッシュフロー図のイメージ)。
  *
- * 表現 (repree.net 系カード + operator 指定の軸):
- *   - 1 カード = 1 銘柄 (symbol + 配分% + 投入額)
- *   - **横軸 = ロール** (列。リスク低 → 高で左から)、**縦軸 = 投入金額**
- *     (DO position の qty × avgPrice、円換算。上ほど大きい。0 = 最下段)
- *   - エッジ: インバース対 (赤) / regime proxy (紫破線) / 退避先 (緑矢印、
- *     ラベル % = 条件未通過時に流れる予算枠)
+ *   予算 100% → ロール (リスク低→高で上から) → 銘柄 (配分% + 投入額) → 退避先
+ *
+ * 退避リンク (緑) は「条件連動 ON の銘柄が entry 未通過のときに流れる先」で、
+ * 量は同銘柄の配分%。退避先ノードの太さは自前配分 + 退避受け皿の合計になる
+ * (最悪ケースの受け入れ量)。インバース対 / regime proxy は量の流れではない
+ * 構造情報なので Sankey に混ぜず脚注チップで出す。
  * 表示専用 — 判定・発注には一切関与しない。
  */
 const ROLE_NODE_COLORS: Record<string, string> = {
@@ -8740,8 +8740,8 @@ const ROLE_NODE_COLORS: Record<string, string> = {
   inverse_hedge: '#c22d2d',
 }
 
-/** 関係マップの列順 (リスク低 → 高)。'none' = role 未設定、'ref' = 未登録 (proxy 参照のみ)。 */
-const MAP_ROLE_COLUMNS = [
+/** Sankey のロール段の並び (リスク低 → 高で上から)。 */
+const MAP_ROLE_ORDER = [
   'cash_parking',
   'low_volatility',
   'core_trend',
@@ -8749,7 +8749,6 @@ const MAP_ROLE_COLUMNS = [
   'leveraged_trend',
   'inverse_hedge',
   'none',
-  'ref',
 ] as const
 
 export function renderSymbolRelationMap(
@@ -8758,135 +8757,111 @@ export function renderSymbolRelationMap(
   pairRegimes: PairRegimeEntry[],
   amounts: Record<string, { native: string; jpy: number }> = {},
 ): string {
-  const known = new Map(rows.map((r) => [r.symbol.toUpperCase(), r]))
-  interface MapNode {
+  const pctOf = (r: SymbolConfigRow): number =>
+    r.budgetAllocPct != null ? Math.round(r.budgetAllocPct * 1000) / 10 : 0
+  const roleOf = (r: SymbolConfigRow): string => r.role ?? 'none'
+  const roleLabel = (role: string): string =>
+    role === 'none' ? 'ロール未設定' : SYMBOL_ROLE_LABELS_SHORT[role as SymbolRole] ?? role
+  const colorOf = (role: string): string => ROLE_NODE_COLORS[role] ?? '#5f6368'
+
+  // Sankey は配分のある有効銘柄だけで構成する (0% は流量が無く描けない)。
+  const allocated = rows.filter((r) => r.active && pctOf(r) > 0)
+  interface SankeyNode {
     name: string
-    pct: number
-    role: string | null
-    active: boolean
-    registered: boolean
+    label: string
+    color: string
+    depth?: number
   }
-  const nodes = new Map<string, MapNode>()
-  const ensureNode = (symRaw: string): MapNode => {
-    const sym = symRaw.toUpperCase()
-    const existing = nodes.get(sym)
-    if (existing) return existing
-    const row = known.get(sym)
-    const node: MapNode = {
-      name: sym,
-      pct: row?.budgetAllocPct != null ? Math.round(row.budgetAllocPct * 1000) / 10 : 0,
-      role: row?.role ?? null,
-      active: row?.active ?? false,
-      registered: row !== undefined,
-    }
-    nodes.set(sym, node)
-    return node
-  }
-  interface MapEdge {
+  interface SankeyLink {
     source: string
     target: string
-    kind: 'inverse' | 'proxy' | 'fallback'
-    /** エッジラベル (退避 = 流れる配分%、他は関係名)。 */
-    label: string
+    value: number
+    kind: 'role' | 'symbol' | 'fallback'
   }
-  const edges: MapEdge[] = []
-  // インバース対 (両方向で格納されているので sym < inverse の片向きに dedup)。
+  const nodes: SankeyNode[] = []
+  const links: SankeyLink[] = []
+  const nodeNames = new Set<string>()
+  const addNode = (n: SankeyNode): void => {
+    if (nodeNames.has(n.name)) return
+    nodeNames.add(n.name)
+    nodes.push(n)
+  }
+  if (allocated.length > 0) {
+    const total = allocated.reduce((sum, r) => sum + pctOf(r), 0)
+    addNode({ name: '予算', label: `予算 ${Math.round(total * 10) / 10}%`, color: '#46637f', depth: 0 })
+    for (const role of MAP_ROLE_ORDER) {
+      const members = allocated.filter((r) => roleOf(r) === role)
+      if (members.length === 0) continue
+      const rolePct = members.reduce((sum, r) => sum + pctOf(r), 0)
+      const roleName = `role:${role}`
+      addNode({
+        name: roleName,
+        label: `${roleLabel(role)} ${Math.round(rolePct * 10) / 10}%`,
+        color: colorOf(role),
+        depth: 1,
+      })
+      links.push({ source: '予算', target: roleName, value: rolePct, kind: 'role' })
+      for (const r of members) {
+        const sym = r.symbol.toUpperCase()
+        const amount = amounts[sym]?.native
+        addNode({
+          name: sym,
+          label: `${sym} ${pctOf(r)}%${amount ? ` (${amount})` : ''}`,
+          color: colorOf(role),
+          depth: 2,
+        })
+        links.push({ source: roleName, target: sym, value: pctOf(r), kind: 'symbol' })
+      }
+    }
+    // 退避先 (#452 Layer 3): 条件連動銘柄の配分が entry 未通過時に流れる先。
+    for (const r of allocated) {
+      if (!r.cashFallbackSymbol) continue
+      const sym = r.symbol.toUpperCase()
+      const target = r.cashFallbackSymbol.toUpperCase()
+      if (sym === target) continue
+      const targetRow = rows.find((x) => x.symbol.toUpperCase() === target)
+      addNode({
+        name: target,
+        label: `${target}${amounts[target]?.native ? ` (${amounts[target]!.native})` : ''}`,
+        color: targetRow ? colorOf(roleOf(targetRow)) : '#9aa0a6',
+      })
+      links.push({ source: sym, target, value: pctOf(r), kind: 'fallback' })
+    }
+  }
+
+  // 構造情報 (量ではない) は脚注チップで: インバース対 / regime proxy。
+  const chips: string[] = []
+  const seenPair = new Set<string>()
   for (const [sym, inverse] of Object.entries(inversePairs)) {
     const a = sym.toUpperCase()
     const b = inverse.toUpperCase()
-    if (a >= b) continue
-    ensureNode(a)
-    ensureNode(b)
-    edges.push({ source: a, target: b, kind: 'inverse', label: 'インバース対' })
+    const key = [a, b].sort().join('/')
+    if (seenPair.has(key)) continue
+    seenPair.add(key)
+    chips.push(`<span style="padding:2px 8px;border-radius:10px;background:#fdecec;color:#c22d2d;font-size:11px">インバース対 ${esc(a)} ⇄ ${esc(b)}</span>`)
   }
-  // regime proxy (#472): proxy → bull / bear。misconfig は proxy 不明のため skip。
   for (const pair of pairRegimes) {
     if (pair.invalidConfig !== null) continue
-    ensureNode(pair.proxySymbol)
-    for (const side of [pair.bullSymbol, pair.bearSymbol]) {
-      ensureNode(side)
-      edges.push({
-        source: pair.proxySymbol.toUpperCase(),
-        target: side.toUpperCase(),
-        kind: 'proxy',
-        label: 'regime proxy',
-      })
-    }
+    chips.push(`<span style="padding:2px 8px;border-radius:10px;background:#f1ebfd;color:#7e3af2;font-size:11px">regime proxy ${esc(pair.proxySymbol.toUpperCase())} → ${esc(pair.bullSymbol.toUpperCase())}/${esc(pair.bearSymbol.toUpperCase())}</span>`)
   }
-  // 退避先 (#452 Layer 3): 条件未通過時に予算枠が流れる先。流れる量 = 配分%。
-  for (const r of rows) {
-    if (!r.cashFallbackSymbol) continue
-    const src = ensureNode(r.symbol)
-    ensureNode(r.cashFallbackSymbol)
-    edges.push({
-      source: r.symbol.toUpperCase(),
-      target: r.cashFallbackSymbol.toUpperCase(),
-      kind: 'fallback',
-      label: src.pct > 0 ? `退避 ${src.pct}%` : '退避',
-    })
-  }
-  if (edges.length === 0) return ''
 
-  // 列割当: 横軸 = ロール。未登録 (proxy 参照のみ) は 'ref' 列。
-  const columnOf = (n: MapNode): string => {
-    if (!n.registered) return 'ref'
-    return n.role ?? 'none'
-  }
-  const usedColumns = MAP_ROLE_COLUMNS.filter((col) =>
-    [...nodes.values()].some((n) => columnOf(n) === col),
-  )
-  const COL_W = 190
-  const PLOT_H = 300
-  const TOP_PAD = 56
-  const BOTTOM_Y = TOP_PAD + PLOT_H
-  const maxJpy = Math.max(1, ...[...nodes.values()].map((n) => amounts[n.name]?.jpy ?? 0))
-  const positioned = new Map<string, { x: number; y: number }>()
-  usedColumns.forEach((col, ci) => {
-    const colNodes = [...nodes.values()].filter((n) => columnOf(n) === col)
-    // 金額の大きい順に縦位置を計算し、近接 (カード高さ未満) は下へ押し出して重なり回避。
-    colNodes.sort((a, b) => (amounts[b.name]?.jpy ?? 0) - (amounts[a.name]?.jpy ?? 0))
-    let lastY = -Infinity
-    for (const n of colNodes) {
-      const jpy = amounts[n.name]?.jpy ?? 0
-      let y = TOP_PAD + (1 - jpy / maxJpy) * PLOT_H
-      if (y - lastY < 56) y = lastY + 56
-      lastY = y
-      positioned.set(n.name, { x: 110 + ci * COL_W, y })
-    }
-  })
-  const mapHeight = Math.max(
-    320,
-    Math.ceil(Math.max(...[...positioned.values()].map((p2) => p2.y), BOTTOM_Y) + 60),
-  )
-
-  const roleHeader = (col: string): string =>
-    col === 'ref' ? '参照のみ' : col === 'none' ? 'ロール未設定' : SYMBOL_ROLE_LABELS_SHORT[col as SymbolRole] ?? col
-
-  const payload = {
-    headers: usedColumns.map((col, ci) => ({ label: roleHeader(col), x: 110 + ci * COL_W })),
-    nodes: [...nodes.values()].map((n) => ({
-      name: n.name,
-      pct: n.pct,
-      amountLabel: amounts[n.name]?.native ?? null,
-      role: n.role,
-      col: columnOf(n),
-      active: n.active,
-      registered: n.registered,
-      color: !n.active || !n.registered ? '#9aa0a6' : ROLE_NODE_COLORS[n.role ?? ''] ?? '#5f6368',
-      x: positioned.get(n.name)?.x ?? 110,
-      y: positioned.get(n.name)?.y ?? BOTTOM_Y,
-    })),
-    edges,
-  }
-  return `<details open style="margin:0 0 12px">
-    <summary style="cursor:pointer;font-size:13px;font-weight:600">関係マップ <span class="muted" style="font-weight:normal">— 横 = ロール ／ 縦 = 投入金額 (表示専用)</span></summary>
-    <div id="symbol-relation-map" style="height:${mapHeight}px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;margin-top:6px"></div>
+  if (links.length === 0 && chips.length === 0) return ''
+  const mapHeight = Math.max(220, nodes.length * 34 + 60)
+  const chipRow = chips.length > 0
+    ? `<div style="display:flex;gap:6px;flex-wrap:wrap;margin-top:6px">${chips.join('')}</div>`
+    : ''
+  const sankeyDiv = links.length > 0
+    ? `<div id="symbol-relation-map" style="height:${mapHeight}px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;margin-top:6px"></div>
     <p class="muted" style="font-size:11px;margin:4px 0 0">
-      1 カード = 1 銘柄 (予算配分% ・ 投入額 = position の取得コスト。上ほど大きい / 未保有は最下段。グレー = 無効・未登録)。
-      <span style="color:#c22d2d">赤実線</span> = インバース対 ・
-      <span style="color:#7e3af2">紫破線</span> = regime proxy (判定材料) ・
-      <span style="color:#0e9f6e">緑矢印</span> = 退避先 (ラベル % = 条件未通過時に流れる予算枠)。
-    </p>
+      予算 → ロール → 銘柄 (配分% ・ 括弧内 = 現在の投入額)。
+      <span style="color:#0e9f6e">緑の流れ</span> = 退避先 (条件連動 ON の銘柄が entry 未通過の間、その配分が流れる先 — 受け皿側の太さは最悪ケースの合計)。
+    </p>`
+    : ''
+  const payload = { nodes, links }
+  return `<details open style="margin:0 0 12px">
+    <summary style="cursor:pointer;font-size:13px;font-weight:600">配分マップ <span class="muted" style="font-weight:normal">— 予算 → ロール → 銘柄 → 退避先 (表示専用)</span></summary>
+    ${sankeyDiv}
+    ${chipRow}
   </details>
   <script src="${ECHARTS_CDN}" defer></script>
   ${safeJsonScript('__symbolRelationMap', payload)}
@@ -8895,97 +8870,50 @@ export function renderSymbolRelationMap(
     if (typeof echarts === 'undefined') return;
     var data = window.__symbolRelationMap;
     var el = document.getElementById('symbol-relation-map');
-    if (!data || !el) return;
-    var EDGE_STYLE = {
-      inverse: { color: '#c22d2d', type: 'solid', width: 2, symbol: ['none', 'none'] },
-      proxy: { color: '#7e3af2', type: 'dashed', width: 1.5, symbol: ['none', 'arrow'] },
-      fallback: { color: '#0e9f6e', type: 'solid', width: 1.8, symbol: ['none', 'arrow'] },
-    };
-    // 列ヘッダはドラッグ/ズームに追従するよう「ラベルだけの不可視ノード」で表現する。
-    var headerNodes = data.headers.map(function (h, i) {
-      return {
-        name: '__header_' + i,
-        x: h.x,
-        y: 14,
-        symbol: 'rect',
-        symbolSize: [1, 1],
-        itemStyle: { color: 'rgba(0,0,0,0)' },
-        label: { show: true, formatter: h.label, fontSize: 11, fontWeight: 700, color: '#6e6e73' },
-        tooltip: { show: false },
-        silent: true,
-      };
-    });
+    if (!data || !el || data.links.length === 0) return;
+    var labelOf = {};
+    data.nodes.forEach(function (n) { labelOf[n.name] = n.label; });
     var chart = echarts.init(el);
     chart.setOption({
       tooltip: {
         formatter: function (p) {
           if (p.dataType === 'edge') {
-            return p.data.source + ' → ' + p.data.target + '<br>' + p.data.label;
+            var head = labelOf[p.data.source] + ' → ' + labelOf[p.data.target];
+            if (p.data.kind === 'fallback') {
+              return head + '<br>条件未通過時に ' + p.data.value + '% が退避';
+            }
+            return head + '<br>' + p.data.value + '%';
           }
-          var d = p.data;
-          var lines = ['<strong>' + d.name + '</strong>'];
-          if (!d.registered) lines.push('未登録 (proxy 参照のみ)');
-          else {
-            lines.push(d.active ? '有効' : '無効');
-            lines.push('予算配分: ' + d.pct + '%');
-            lines.push('投入額: ' + (d.amountLabel || 'なし (未保有)'));
-          }
-          return lines.join('<br>');
+          return labelOf[p.name] || p.name;
         },
       },
       series: [{
-        type: 'graph',
-        layout: 'none',
-        roam: true,
+        type: 'sankey',
+        left: 10,
+        right: 200,
+        top: 14,
+        bottom: 14,
+        nodeWidth: 14,
+        nodeGap: 14,
+        draggable: false,
+        emphasis: { focus: 'adjacency' },
         data: data.nodes.map(function (n) {
-          var sub = [];
-          if (n.registered && n.pct > 0) sub.push(n.pct + '%');
-          if (n.amountLabel) sub.push(n.amountLabel);
-          if (!n.registered) sub.push('未登録 proxy');
           return {
             name: n.name,
-            x: n.x,
-            y: n.y,
-            pct: n.pct,
-            amountLabel: n.amountLabel,
-            active: n.active,
-            registered: n.registered,
-            symbol: 'roundRect',
-            symbolSize: [128, 46],
-            itemStyle: {
-              color: '#fff',
-              borderColor: n.color,
-              borderWidth: 2,
-              opacity: n.active || !n.registered ? 1 : 0.55,
-              shadowBlur: 4,
-              shadowColor: 'rgba(0,0,0,0.08)',
-            },
-            label: {
-              show: true,
-              formatter: '{sym|' + n.name + '}' + (sub.length ? '\\n{sub|' + sub.join(' ・ ') + '}' : ''),
-              rich: {
-                sym: { fontSize: 13, fontWeight: 700, color: '#1d1d1f', lineHeight: 18 },
-                sub: { fontSize: 10, color: '#6e6e73', lineHeight: 14 },
-              },
-            },
+            depth: n.depth,
+            itemStyle: { color: n.color, borderRadius: 3 },
+            label: { formatter: n.label, fontSize: 12, color: '#1d1d1f' },
           };
-        }).concat(headerNodes),
-        edges: data.edges.map(function (e) {
-          var st = EDGE_STYLE[e.kind];
+        }),
+        links: data.links.map(function (l) {
           return {
-            source: e.source,
-            target: e.target,
-            kind: e.kind,
-            label: e.label,
-            lineStyle: { color: st.color, type: st.type, width: st.width, curveness: 0.12 },
-            symbol: st.symbol,
-            symbolSize: 9,
-            edgeLabel: e.kind === 'fallback' ? {
-              show: true,
-              formatter: e.label,
-              fontSize: 10,
-              color: '#0e9f6e',
-            } : { show: false },
+            source: l.source,
+            target: l.target,
+            value: l.value,
+            kind: l.kind,
+            lineStyle: l.kind === 'fallback'
+              ? { color: '#0e9f6e', opacity: 0.45, curveness: 0.5 }
+              : { color: 'gradient', opacity: 0.3, curveness: 0.5 },
           };
         }),
       }],

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -8738,13 +8738,18 @@ function applySymbolsListFilter(rows: SymbolConfigRow[], f: SymbolsListFilter): 
 }
 
 /**
- * 配分マップ編集キャンバス (#symbol-relation-map)。read-only マップと違い
- * **設定を書く** UI なので、操作は 3 つに限定する:
- *   - 線を引く (銘柄 → 銘柄) = 退避先を設定 (entry_required も ON)
- *   - 線を消す = 退避先を解除
- *   - カード内 % input = 予算配分の更新 (インバース対は server 側で同期)
- * 各操作は confirm → admin API → location.reload() — canvas 上の見た目と DB の
- * drift を作らない (楽観更新しない)。インバース対 / proxy はカード内に表示のみ。
+ * 配分マップ編集キャンバス (#symbol-relation-map)。**draft 編集モデル**:
+ * 線を引く / 消す / % を変えても即保存はせず、ローカル draft に積んで
+ * 変更箇所をハイライト + サマリ表示し、「適用」で一括保存 → reload する
+ * (operator 指定: つど confirm ではなく、編集中は視覚的フィードバック、最後に
+ * 適用ボタン)。リセット = reload で破棄。
+ *
+ * 操作の意味:
+ *   - 口座 → 銘柄の線: 配分 (引く = 配分対象に追加。% はカードの入力欄 / 消す = 配分解除)
+ *   - 銘柄 → 銘柄の線: 退避先 (引く = 設定 + 条件連動 ON / 消す = 解除)。1 銘柄 1 本
+ *   - カードの % 入力: 予算配分の変更 (インバース対は server 側で同期)
+ * 適用時は budget-alloc (一括) → cash-fallback (銘柄ごと) の順で POST する。
+ * インバース対 / proxy はカード内に表示のみ (不変条件があるためキャンバス編集不可)。
  */
 export function symbolMapEditorBody(
   rows: SymbolConfigRow[],
@@ -8772,19 +8777,43 @@ export function symbolMapEditorBody(
   if (nodes.length === 0) {
     return `<p class="muted">有効な銘柄がありません。</p>`
   }
-  const payload = { nodes }
+  // 口座カードの予算合計はインバース対の枠共有 (#315) を反映 (対は max)。
+  const counted = new Set<string>()
+  let totalPct = 0
+  for (const n of nodes) {
+    if (counted.has(n.sym)) continue
+    counted.add(n.sym)
+    const partnerNode = n.inverse ? nodes.find((x) => x.sym === n.inverse) : undefined
+    if (partnerNode) {
+      counted.add(n.inverse!)
+      totalPct += Math.max(n.pct, partnerNode.pct)
+    } else {
+      totalPct += n.pct
+    }
+  }
+  const payload = { nodes, accountTotalPct: Math.round(totalPct * 10) / 10 }
   return `<p style="margin:0 0 10px;display:flex;gap:12px;align-items:center;flex-wrap:wrap">
     <a href="/dashboard/symbols" style="font-size:13px">← 銘柄管理へ戻る</a>
     <span class="muted" style="font-size:12px">
-      カードの出力 (右の点) から相手の入力 (左の点) へ<strong>線を引く = 退避先を設定</strong> (条件連動も ON になります) ・
-      線をクリックして Delete = 解除 ・ % 欄 = 予算配分。各操作は確認後に即保存されます。
+      <strong>口座 → 銘柄の線</strong> = 配分 ・ <strong>銘柄 → 銘柄の線</strong> = 退避先 (1 銘柄 1 本、条件連動も ON) ・ % 欄 = 配分変更。
+      変更は即保存されません — 下のサマリを確認して<strong>「適用」で一括保存</strong>します。
     </span>
   </p>
+  <div id="sm-changes-bar" hidden style="position:sticky;top:0;z-index:10;display:flex;gap:10px;align-items:flex-start;padding:8px 12px;background:#fff8e6;border:1px solid #e6c46a;border-radius:8px;margin-bottom:8px">
+    <div style="flex:1;min-width:0">
+      <strong style="font-size:12px">未適用の変更</strong>
+      <ul id="sm-changes-list" style="margin:4px 0 0 16px;padding:0;font-size:12px"></ul>
+    </div>
+    <button type="button" id="sm-apply" style="padding:6px 18px;background:#06c;color:#fff;border:none;border-radius:6px;cursor:pointer;font-size:13px;font-weight:600">適用</button>
+    <button type="button" id="sm-reset" style="padding:6px 12px;background:#fff;border:1px solid #ccc;border-radius:6px;cursor:pointer;font-size:13px">リセット</button>
+  </div>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/drawflow@0.0.60/dist/drawflow.min.css">
   <style>
-  #symbol-map-editor{height:calc(100vh - 180px);min-height:480px;background:#fafafa;border:1px solid #d0d0d5;border-radius:8px}
+  #symbol-map-editor{height:calc(100vh - 220px);min-height:480px;background:#fafafa;border:1px solid #d0d0d5;border-radius:8px}
   #symbol-map-editor .drawflow .drawflow-node{background:#fff;border:2px solid #d0d0d5;border-radius:10px;padding:0;width:200px;box-shadow:0 1px 4px rgba(0,0,0,0.08)}
   #symbol-map-editor .drawflow .drawflow-node.selected{border-color:#06c}
+  #symbol-map-editor .drawflow .drawflow-node.sm-dirty{border-color:#e6a23c;box-shadow:0 0 0 3px rgba(230,162,60,0.25)}
+  #symbol-map-editor svg.connection.sm-pending path{stroke:#0e9f6e !important;stroke-dasharray:7 5;stroke-width:3px}
   .sm-card{padding:8px 10px;font-size:12px}
   .sm-card .sm-title{font-size:14px;font-weight:700}
   .sm-card .sm-status-active{color:#0e9f6e;font-size:11px}
@@ -8794,7 +8823,6 @@ export function symbolMapEditorBody(
   </style>
   <div id="symbol-map-editor"></div>
   ${safeJsonScript('__symbolMapEditor', payload)}
-  <script src="${ECHARTS_CDN}" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/drawflow@0.0.60/dist/drawflow.min.js"></script>
   <script>
   document.addEventListener('DOMContentLoaded', function () {
@@ -8804,9 +8832,23 @@ export function symbolMapEditorBody(
     var editor = new Drawflow(el);
     editor.reroute = true;
     editor.start();
-    var idOf = {};   // symbol -> drawflow node id
-    var symOf = {};  // node id -> symbol
+    var idOf = {};
+    var symOf = {};
+    var baseline = {};   // sym -> { pct, fallback }
+    var draft = {};      // sym -> { pct, fallback } (編集中の値)
+    var programmatic = false;
+
+    var allocated = data.nodes.filter(function (n) { return n.pct > 0; });
+    var accountY = Math.max(30, 30 + ((allocated.length - 1) * 120) / 2);
+    var accountId = editor.addNode('口座', 0, 1, 40, accountY, 'sm-node sm-account',
+      { sym: '口座' },
+      '<div class="sm-card"><div class="sm-title" style="color:#46637f">口座</div>' +
+      '<div class="sm-meta">原資 ・ 予算 ' + data.accountTotalPct + '% (対は枠共有で max)</div></div>');
+    symOf[accountId] = '__account__';
+
     data.nodes.forEach(function (n) {
+      baseline[n.sym] = { pct: n.pct, fallback: n.fallback };
+      draft[n.sym] = { pct: n.pct, fallback: n.fallback };
       var statusHtml = n.held
         ? '<div class="sm-status-active">Active ・ ' + n.held + '</div>'
         : '<div class="sm-status-pending">Pending (様子見' + (n.entryRequired ? '・条件連動 ON' : '') + ')</div>';
@@ -8820,72 +8862,138 @@ export function symbolMapEditorBody(
         '<div style="margin-top:4px">配分 <input type="number" min="0" max="100" step="1" value="' + n.pct + '" data-sym="' + n.sym + '" class="sm-pct"> %</div>' +
         '<div class="sm-meta">' + metaParts.join(' ・ ') + '</div>' +
         '</div>';
-      var id = editor.addNode(n.sym, 1, 1, n.pct > 0 ? 80 : 480, n.y, 'sm-node', { sym: n.sym }, html);
+      var id = editor.addNode(n.sym, 1, 1, n.pct > 0 ? 360 : 760, n.y, 'sm-node', { sym: n.sym }, html);
       idOf[n.sym] = id;
       symOf[id] = n.sym;
     });
-    // 既存の退避先を線として描く (プログラム描画中は connectionCreated を無視)。
-    var seeding = true;
-    data.nodes.forEach(function (n) {
-      if (n.fallback && idOf[n.fallback]) {
-        editor.addConnection(idOf[n.sym], idOf[n.fallback], 'output_1', 'input_1');
-      }
-    });
-    seeding = false;
 
-    function apiFallback(sym, target) {
-      return fetch('/admin/symbol-config/' + encodeURIComponent(sym) + '/cash-fallback', {
-        method: 'POST',
-        credentials: 'same-origin',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ target: target }),
-      }).then(function (r) {
-        if (!r.ok) return r.json().then(function (b) { throw new Error(b.error || ('HTTP ' + r.status)); });
-      });
+    programmatic = true;
+    data.nodes.forEach(function (n) {
+      if (n.pct > 0) editor.addConnection(accountId, idOf[n.sym], 'output_1', 'input_1');
+      if (n.fallback && idOf[n.fallback]) editor.addConnection(idOf[n.sym], idOf[n.fallback], 'output_1', 'input_1');
+    });
+    programmatic = false;
+
+    function markConnectionPending(srcId, dstId) {
+      var conn = el.querySelector('svg.connection.node_in_node-' + dstId + '.node_out_node-' + srcId);
+      if (conn) conn.classList.add('sm-pending');
     }
+    function setCardDirty(sym, dirty) {
+      var nodeEl = document.getElementById('node-' + idOf[sym]);
+      if (nodeEl) nodeEl.classList.toggle('sm-dirty', dirty);
+    }
+    function isDirty(sym) {
+      return draft[sym].pct !== baseline[sym].pct || (draft[sym].fallback || null) !== (baseline[sym].fallback || null);
+    }
+    function renderChanges() {
+      var bar = document.getElementById('sm-changes-bar');
+      var list = document.getElementById('sm-changes-list');
+      var items = [];
+      Object.keys(draft).forEach(function (sym) {
+        var b = baseline[sym];
+        var d = draft[sym];
+        if (d.pct !== b.pct) {
+          items.push(sym + ': 配分 ' + (b.pct || 'なし') + (b.pct ? '%' : '') + ' → ' + (d.pct ? d.pct + '%' : '解除'));
+        }
+        if ((d.fallback || null) !== (b.fallback || null)) {
+          if (d.fallback) items.push(sym + ': 退避先 → ' + d.fallback + ' (条件連動 ON)');
+          else items.push(sym + ': 退避先を解除');
+        }
+        setCardDirty(sym, isDirty(sym));
+      });
+      list.innerHTML = items.map(function (t) { return '<li>' + t + '</li>'; }).join('');
+      bar.hidden = items.length === 0;
+    }
+
     editor.on('connectionCreated', function (info) {
-      if (seeding) return;
+      if (programmatic) return;
+      var src = symOf[info.output_id];
+      var dst = symOf[info.input_id];
+      if (!src || !dst || dst === '__account__') {
+        programmatic = true;
+        editor.removeSingleConnection(info.output_id, info.input_id, info.output_class, info.input_class);
+        programmatic = false;
+        return;
+      }
+      if (src === '__account__') {
+        // 配分対象に追加。% はカードの入力欄で指定する (0 のままなら適用対象外)。
+        if (draft[dst].pct === 0) {
+          draft[dst].pct = 5; // 仮の初期値。入力欄に反映して編集を促す。
+          var input = el.querySelector('input.sm-pct[data-sym="' + dst + '"]');
+          if (input) { input.value = '5'; input.focus(); }
+        }
+        markConnectionPending(info.output_id, info.input_id);
+        renderChanges();
+        return;
+      }
+      // 退避先は 1 銘柄 1 本 — 既存の出力接続を visual からも外す。
+      if (draft[src].fallback && idOf[draft[src].fallback]) {
+        programmatic = true;
+        editor.removeSingleConnection(idOf[src], idOf[draft[src].fallback], 'output_1', 'input_1');
+        programmatic = false;
+      }
+      draft[src].fallback = dst;
+      markConnectionPending(info.output_id, info.input_id);
+      renderChanges();
+    });
+
+    editor.on('connectionRemoved', function (info) {
+      if (programmatic) return;
       var src = symOf[info.output_id];
       var dst = symOf[info.input_id];
       if (!src || !dst) return;
-      if (!confirm(src + ' の退避先を ' + dst + ' に設定します (条件連動も ON になります)。よろしいですか？')) {
-        location.reload();
+      if (src === '__account__') {
+        draft[dst].pct = 0;
+        var input = el.querySelector('input.sm-pct[data-sym="' + dst + '"]');
+        if (input) input.value = '0';
+        renderChanges();
         return;
       }
-      apiFallback(src, dst)
-        .then(function () { location.reload(); })
-        .catch(function (e) { alert('設定に失敗: ' + e.message); location.reload(); });
+      if (draft[src].fallback === dst) draft[src].fallback = null;
+      renderChanges();
     });
-    editor.on('connectionRemoved', function (info) {
-      if (seeding) return;
-      var src = symOf[info.output_id];
-      if (!src) return;
-      if (!confirm(src + ' の退避先を解除します (枠は現金待機になります)。よろしいですか？')) {
-        location.reload();
-        return;
-      }
-      apiFallback(src, null)
-        .then(function () { location.reload(); })
-        .catch(function (e) { alert('解除に失敗: ' + e.message); location.reload(); });
-    });
-    // 配分% の編集。blur 時に確認して保存 (budget-alloc はインバース対を server 側で同期)。
+
     el.addEventListener('change', function (ev) {
       var input = ev.target;
       if (!input.classList || !input.classList.contains('sm-pct')) return;
       var sym = input.getAttribute('data-sym');
-      var v = String(input.value).trim();
-      if (!confirm(sym + ' の予算配分を ' + (v === '' ? '未設定' : v + '%') + ' に変更します。よろしいですか？')) {
-        location.reload();
-        return;
+      var v = Number(String(input.value).trim());
+      draft[sym].pct = Number.isFinite(v) && v > 0 ? v : 0;
+      renderChanges();
+    });
+
+    document.getElementById('sm-reset').addEventListener('click', function () { location.reload(); });
+    document.getElementById('sm-apply').addEventListener('click', function () {
+      var pctChanges = Object.keys(draft).filter(function (sym) { return draft[sym].pct !== baseline[sym].pct; });
+      var fbChanges = Object.keys(draft).filter(function (sym) { return (draft[sym].fallback || null) !== (baseline[sym].fallback || null); });
+      if (pctChanges.length === 0 && fbChanges.length === 0) return;
+      if (!confirm('表示中の変更をまとめて適用します。よろしいですか？')) return;
+      var steps = Promise.resolve();
+      if (pctChanges.length > 0) {
+        var form = new FormData();
+        pctChanges.forEach(function (sym) {
+          form.append('pct_' + sym, draft[sym].pct > 0 ? String(draft[sym].pct) : '');
+        });
+        steps = steps.then(function () {
+          return fetch('/admin/symbol-config/budget-alloc', { method: 'POST', credentials: 'same-origin', body: form })
+            .then(function (r) { if (!r.ok) throw new Error('配分の保存に失敗 (HTTP ' + r.status + ')'); });
+        });
       }
-      var form = new FormData();
-      form.append('pct_' + sym, v);
-      fetch('/admin/symbol-config/budget-alloc', { method: 'POST', credentials: 'same-origin', body: form })
-        .then(function (r) {
-          if (!r.ok) throw new Error('HTTP ' + r.status);
-          location.reload();
-        })
-        .catch(function (e) { alert('保存に失敗: ' + e.message); location.reload(); });
+      fbChanges.forEach(function (sym) {
+        steps = steps.then(function () {
+          return fetch('/admin/symbol-config/' + encodeURIComponent(sym) + '/cash-fallback', {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ target: draft[sym].fallback }),
+          }).then(function (r) {
+            if (!r.ok) return r.json().then(function (b) { throw new Error(sym + ' の退避先の保存に失敗: ' + (b.error || 'HTTP ' + r.status)); });
+          });
+        });
+      });
+      steps
+        .then(function () { location.reload(); })
+        .catch(function (e) { alert(e.message + ' — 再読込して状態を確認してください。'); location.reload(); });
     });
   });
   </script>`

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -832,6 +832,43 @@ export const dashboard = new Hono<DashboardBindings>()
       return c.html(renderLayout(c, '銘柄管理', unavailable(messageOf(err))))
     }
   })
+  /**
+   * 配分マップの編集キャンバス (#symbol-relation-map)。Drawflow で銘柄カードを
+   * 並べ、線を引く = 退避先を設定 (entry_required も ON)、線を消す = 解除、
+   * カード内の % input = 予算配分の更新。変更は都度 confirm → admin API →
+   * reload (canvas 状態と DB の drift を作らない最小実装)。
+   */
+  .get('/symbols/map', async (c) => {
+    if (!c.env.DB) {
+      return c.html(renderLayout(c, '配分マップ編集', unavailable('DB not bound')))
+    }
+    try {
+      const rows = await loadAllSymbolConfigRows(c.env.DB)
+      const inversePairs = await loadInversePairs(createDb(c.env.DB)).catch(
+        () => ({}) as Record<string, string>,
+      )
+      const mapAmounts: Record<string, { native: string; jpy: number }> = {}
+      if (c.env.SYMBOL_STATE) {
+        const stateClient = new SymbolStateClient(c.env.SYMBOL_STATE)
+        await Promise.all(
+          rows.map(async (r) => {
+            const sym = r.symbol.toUpperCase()
+            const state = await stateClient.getState(sym).catch(() => null)
+            const pos = state?.position
+            if (!pos || pos.qty <= 0) return
+            const cost = pos.qty * pos.avgPrice
+            mapAmounts[sym] = {
+              native: r.currency === 'USD' ? `$${cost.toFixed(0)}` : `¥${Math.round(cost).toLocaleString('en-US')}`,
+              jpy: cost,
+            }
+          }),
+        )
+      }
+      return c.html(renderLayout(c, '配分マップ編集', symbolMapEditorBody(rows, inversePairs, mapAmounts)))
+    } catch (err) {
+      return c.html(renderLayout(c, '配分マップ編集', unavailable(messageOf(err))))
+    }
+  })
   .get('/symbols/new', async (c) => {
     if (!c.env.DB) {
       return c.html(renderLayout(c, '銘柄管理 - 新規追加', unavailable('DB not bound')))
@@ -8701,6 +8738,160 @@ function applySymbolsListFilter(rows: SymbolConfigRow[], f: SymbolsListFilter): 
 }
 
 /**
+ * 配分マップ編集キャンバス (#symbol-relation-map)。read-only マップと違い
+ * **設定を書く** UI なので、操作は 3 つに限定する:
+ *   - 線を引く (銘柄 → 銘柄) = 退避先を設定 (entry_required も ON)
+ *   - 線を消す = 退避先を解除
+ *   - カード内 % input = 予算配分の更新 (インバース対は server 側で同期)
+ * 各操作は confirm → admin API → location.reload() — canvas 上の見た目と DB の
+ * drift を作らない (楽観更新しない)。インバース対 / proxy はカード内に表示のみ。
+ */
+export function symbolMapEditorBody(
+  rows: SymbolConfigRow[],
+  inversePairs: Record<string, string>,
+  amounts: Record<string, { native: string; jpy: number }>,
+): string {
+  const active = rows.filter((r) => r.active)
+  const pctOf = (r: SymbolConfigRow): number =>
+    r.budgetAllocPct != null ? Math.round(r.budgetAllocPct * 1000) / 10 : 0
+  const nodes = active.map((r, i) => {
+    const sym = r.symbol.toUpperCase()
+    return {
+      sym,
+      pct: pctOf(r),
+      role: r.role ?? null,
+      color: ROLE_NODE_COLORS[r.role ?? ''] ?? '#5f6368',
+      held: amounts[sym]?.native ?? null,
+      entryRequired: r.entryRequired === true,
+      fallback: r.cashFallbackSymbol?.toUpperCase() ?? null,
+      inverse: inversePairs[sym]?.toUpperCase() ?? null,
+      currency: r.currency,
+      y: 30 + i * 120,
+    }
+  })
+  if (nodes.length === 0) {
+    return `<p class="muted">有効な銘柄がありません。</p>`
+  }
+  const payload = { nodes }
+  return `<p style="margin:0 0 10px;display:flex;gap:12px;align-items:center;flex-wrap:wrap">
+    <a href="/dashboard/symbols" style="font-size:13px">← 銘柄管理へ戻る</a>
+    <span class="muted" style="font-size:12px">
+      カードの出力 (右の点) から相手の入力 (左の点) へ<strong>線を引く = 退避先を設定</strong> (条件連動も ON になります) ・
+      線をクリックして Delete = 解除 ・ % 欄 = 予算配分。各操作は確認後に即保存されます。
+    </span>
+  </p>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/drawflow@0.0.60/dist/drawflow.min.css">
+  <style>
+  #symbol-map-editor{height:calc(100vh - 180px);min-height:480px;background:#fafafa;border:1px solid #d0d0d5;border-radius:8px}
+  #symbol-map-editor .drawflow .drawflow-node{background:#fff;border:2px solid #d0d0d5;border-radius:10px;padding:0;width:200px;box-shadow:0 1px 4px rgba(0,0,0,0.08)}
+  #symbol-map-editor .drawflow .drawflow-node.selected{border-color:#06c}
+  .sm-card{padding:8px 10px;font-size:12px}
+  .sm-card .sm-title{font-size:14px;font-weight:700}
+  .sm-card .sm-status-active{color:#0e9f6e;font-size:11px}
+  .sm-card .sm-status-pending{color:#b25000;font-size:11px}
+  .sm-card .sm-meta{color:#6e6e73;font-size:10px;margin-top:2px}
+  .sm-card input{width:64px;padding:2px 4px;font-size:12px}
+  </style>
+  <div id="symbol-map-editor"></div>
+  ${safeJsonScript('__symbolMapEditor', payload)}
+  <script src="${ECHARTS_CDN}" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/drawflow@0.0.60/dist/drawflow.min.js"></script>
+  <script>
+  document.addEventListener('DOMContentLoaded', function () {
+    var data = window.__symbolMapEditor;
+    var el = document.getElementById('symbol-map-editor');
+    if (!data || !el || typeof Drawflow === 'undefined') return;
+    var editor = new Drawflow(el);
+    editor.reroute = true;
+    editor.start();
+    var idOf = {};   // symbol -> drawflow node id
+    var symOf = {};  // node id -> symbol
+    data.nodes.forEach(function (n) {
+      var statusHtml = n.held
+        ? '<div class="sm-status-active">Active ・ ' + n.held + '</div>'
+        : '<div class="sm-status-pending">Pending (様子見' + (n.entryRequired ? '・条件連動 ON' : '') + ')</div>';
+      var metaParts = [];
+      if (n.role) metaParts.push(n.role);
+      if (n.inverse) metaParts.push('⇄ ' + n.inverse);
+      metaParts.push(n.currency);
+      var html = '<div class="sm-card">' +
+        '<div class="sm-title" style="color:' + n.color + '">' + n.sym + '</div>' +
+        statusHtml +
+        '<div style="margin-top:4px">配分 <input type="number" min="0" max="100" step="1" value="' + n.pct + '" data-sym="' + n.sym + '" class="sm-pct"> %</div>' +
+        '<div class="sm-meta">' + metaParts.join(' ・ ') + '</div>' +
+        '</div>';
+      var id = editor.addNode(n.sym, 1, 1, n.pct > 0 ? 80 : 480, n.y, 'sm-node', { sym: n.sym }, html);
+      idOf[n.sym] = id;
+      symOf[id] = n.sym;
+    });
+    // 既存の退避先を線として描く (プログラム描画中は connectionCreated を無視)。
+    var seeding = true;
+    data.nodes.forEach(function (n) {
+      if (n.fallback && idOf[n.fallback]) {
+        editor.addConnection(idOf[n.sym], idOf[n.fallback], 'output_1', 'input_1');
+      }
+    });
+    seeding = false;
+
+    function apiFallback(sym, target) {
+      return fetch('/admin/symbol-config/' + encodeURIComponent(sym) + '/cash-fallback', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ target: target }),
+      }).then(function (r) {
+        if (!r.ok) return r.json().then(function (b) { throw new Error(b.error || ('HTTP ' + r.status)); });
+      });
+    }
+    editor.on('connectionCreated', function (info) {
+      if (seeding) return;
+      var src = symOf[info.output_id];
+      var dst = symOf[info.input_id];
+      if (!src || !dst) return;
+      if (!confirm(src + ' の退避先を ' + dst + ' に設定します (条件連動も ON になります)。よろしいですか？')) {
+        location.reload();
+        return;
+      }
+      apiFallback(src, dst)
+        .then(function () { location.reload(); })
+        .catch(function (e) { alert('設定に失敗: ' + e.message); location.reload(); });
+    });
+    editor.on('connectionRemoved', function (info) {
+      if (seeding) return;
+      var src = symOf[info.output_id];
+      if (!src) return;
+      if (!confirm(src + ' の退避先を解除します (枠は現金待機になります)。よろしいですか？')) {
+        location.reload();
+        return;
+      }
+      apiFallback(src, null)
+        .then(function () { location.reload(); })
+        .catch(function (e) { alert('解除に失敗: ' + e.message); location.reload(); });
+    });
+    // 配分% の編集。blur 時に確認して保存 (budget-alloc はインバース対を server 側で同期)。
+    el.addEventListener('change', function (ev) {
+      var input = ev.target;
+      if (!input.classList || !input.classList.contains('sm-pct')) return;
+      var sym = input.getAttribute('data-sym');
+      var v = String(input.value).trim();
+      if (!confirm(sym + ' の予算配分を ' + (v === '' ? '未設定' : v + '%') + ' に変更します。よろしいですか？')) {
+        location.reload();
+        return;
+      }
+      var form = new FormData();
+      form.append('pct_' + sym, v);
+      fetch('/admin/symbol-config/budget-alloc', { method: 'POST', credentials: 'same-origin', body: form })
+        .then(function (r) {
+          if (!r.ok) throw new Error('HTTP ' + r.status);
+          location.reload();
+        })
+        .catch(function (e) { alert('保存に失敗: ' + e.message); location.reload(); });
+    });
+  });
+  </script>`
+}
+
+/**
  * 配分マップ (#symbol-relation-map)。「口座 (原資) から各銘柄へ何% 割り当て、
  * 参加できていない銘柄の枠はいまどこへ譲られているか」をノードツリーで示す
  * (operator 指定の絵: 口座 ─ SOXL ┈┈▶ TQQQ / ┗ TQQQ)。
@@ -8915,7 +9106,7 @@ export function renderSymbolRelationMap(
     : ''
   const payload = { nodes, edges }
   return `<details open style="margin:0 0 12px">
-    <summary style="cursor:pointer;font-size:13px;font-weight:600">配分マップ <span class="muted" style="font-weight:normal">— 口座 → 銘柄 → 譲り先 (現在形・表示専用)</span></summary>
+    <summary style="cursor:pointer;font-size:13px;font-weight:600">配分マップ <span class="muted" style="font-weight:normal">— 口座 → 銘柄 → 譲り先 (現在形・表示専用)</span> <a href="/dashboard/symbols/map" style="font-size:12px;font-weight:normal;margin-left:8px">✏️ 編集モード</a></summary>
     ${mapDiv}
     ${chipRow}
   </details>

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -8767,7 +8767,8 @@ export function renderSymbolRelationMap(
   interface MapEdge {
     source: string
     target: string
-    kind: 'alloc' | 'yield' | 'idle'
+    /** inert = 退避先設定済みだが条件連動 OFF で不使用 (設定ミスの警告表示)。 */
+    kind: 'alloc' | 'yield' | 'idle' | 'inert'
     label: string
     width: number
   }
@@ -8784,7 +8785,23 @@ export function renderSymbolRelationMap(
   const SYMBOL_X = 360
   const CASH_X = 640
   if (allocated.length > 0) {
-    const total = allocated.reduce((sum, r) => sum + pctOf(r), 0)
+    // 予算合計はインバース対の枠共有 (#315 の共有 slider と同じ) を反映して
+    // 「対は max、単独はそのまま」で数える — 単純合計だと 200% 等に見えて誤読する。
+    const counted = new Set<string>()
+    let total = 0
+    for (const r of allocated) {
+      const sym = r.symbol.toUpperCase()
+      if (counted.has(sym)) continue
+      counted.add(sym)
+      const partner = inversePairs[sym]?.toUpperCase()
+      const partnerRow = partner ? allocated.find((x) => x.symbol.toUpperCase() === partner) : undefined
+      if (partnerRow) {
+        counted.add(partner!)
+        total += Math.max(pctOf(r), pctOf(partnerRow))
+      } else {
+        total += pctOf(r)
+      }
+    }
     const centerY = 40 + ((allocated.length - 1) * ROW_H) / 2
     addNode({
       name: '口座',
@@ -8821,11 +8838,18 @@ export function renderSymbolRelationMap(
         const target = conditional && r.cashFallbackSymbol ? r.cashFallbackSymbol.toUpperCase() : '現金待機'
         if (target !== sym) {
           if (target === '現金待機') needCash = true
+          // 退避先が設定されているのに条件連動 OFF = 設定が効いていない状態。
+          // 黙って無視せず inert (琥珀) で警告表示する (operator が SOXL で踏んだ罠)。
+          const inert = !conditional && r.cashFallbackSymbol !== null
           edges.push({
             source: sym,
             target,
-            kind: conditional ? 'yield' : 'idle',
-            label: conditional ? `代替 ${pctOf(r)}%` : `待機 ${pctOf(r)}% (枠確保)`,
+            kind: conditional ? 'yield' : inert ? 'inert' : 'idle',
+            label: conditional
+              ? `代替 ${pctOf(r)}%`
+              : inert
+                ? `待機 ${pctOf(r)}% ⚠ 退避先${r.cashFallbackSymbol!.toUpperCase()}未使用`
+                : `待機 ${pctOf(r)}% (枠確保)`,
             width: Math.max(1.5, Math.min(8, pctOf(r) / 5)),
           })
         }
@@ -8885,7 +8909,8 @@ export function renderSymbolRelationMap(
       口座 → 銘柄 = 配分% (実線、太さ ∝ %)。<strong>Active</strong> = 建玉保有で参加中 (実線枠 + 投入額) ／
       <strong>Pending</strong> = 様子見 (破線枠) で、点線矢印が「いま枠が行っている先」:
       <span style="color:#0e9f6e">緑 = 退避先へ代替割当 (条件連動 ON)</span> ・
-      <span style="color:#9aa0a6">グレー = 枠確保のまま現金待機</span>。
+      <span style="color:#9aa0a6">グレー = 枠確保のまま現金待機</span> ・
+      <span style="color:#b25000">琥珀 ⚠ = 退避先が設定済みなのに条件連動 OFF で不使用</span>。
     </p>`
     : ''
   const payload = { nodes, edges }
@@ -8906,6 +8931,7 @@ export function renderSymbolRelationMap(
       alloc: { color: '#8a8f98', type: 'solid' },
       yield: { color: '#0e9f6e', type: 'dotted' },
       idle: { color: '#9aa0a6', type: 'dotted' },
+      inert: { color: '#b25000', type: 'dotted' },
     };
     var chart = echarts.init(el);
     chart.setOption({
@@ -8914,6 +8940,7 @@ export function renderSymbolRelationMap(
           if (p.dataType === 'edge') {
             if (p.data.kind === 'yield') return p.data.source + ' は様子見のため ' + p.data.label.replace('代替 ', '') + ' を ' + p.data.target + ' に代替割当中';
             if (p.data.kind === 'idle') return p.data.source + ' は様子見。枠は確保したまま現金待機';
+            if (p.data.kind === 'inert') return p.data.source + ' は退避先が設定されていますが<br><strong>条件連動が OFF のため使われていません</strong>。<br>銘柄編集で「条件連動」を ON にすると退避が有効になります。';
             return '口座 → ' + p.data.target + ': 配分 ' + p.data.label;
           }
           var d = p.data;
@@ -9762,7 +9789,7 @@ function symbolFormBody(args: SymbolFormArgs): string {
         <label>退避先</label>
         <div>
           <input type="text" name="cash_fallback_symbol" value="${esc(cashFallbackValue)}" maxlength="10" pattern="[A-Za-z0-9]{0,10}" placeholder="例: SGOV" style="padding:6px;width:160px;text-transform:uppercase">
-          <span class="muted" style="font-size:12px;margin-left:6px">同一通貨のみ。自動発注は flag (default off) を on にするまで無し</span>
+          <span class="muted" style="font-size:12px;margin-left:6px"><strong>条件連動 ON のときのみ有効</strong>。同一通貨のみ。自動発注は flag (default off) を on にするまで無し</span>
         </div>`,
       hasAllocValues,
     )}

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -8797,7 +8797,7 @@ export function symbolMapEditorBody(
     <span class="muted" style="font-size:12px">
       <strong>口座 → 銘柄の線</strong> = 配分 ・ <strong>銘柄 → 銘柄の線</strong> = 退避先 (1 銘柄 1 本、条件連動も ON) ・ % 欄 = 配分変更。
       変更は即保存されません — 下のサマリを確認して<strong>「適用」で一括保存</strong>します。
-      カードの塗り: <span style="background:#eef2f7;border:1px solid #46637f;padding:0 6px;border-radius:4px">口座</span>
+      カードの塗り: <span style="background:#5f6368;border:1px solid #3c4043;color:#fff;padding:0 6px;border-radius:4px">口座</span>
       <span style="background:#fdf3f2;border:1px solid #d4a09a;padding:0 6px;border-radius:4px">JPY</span>
       <span style="background:#f0f6ff;border:1px solid #9ab8dd;padding:0 6px;border-radius:4px">USD</span>
     </span>
@@ -8814,8 +8814,13 @@ export function symbolMapEditorBody(
   <style>
   #symbol-map-editor{height:calc(100vh - 220px);min-height:480px;background:#fafafa;border:1px solid #d0d0d5;border-radius:8px}
   #symbol-map-editor .drawflow .drawflow-node{background:#fff;border:2px solid #d0d0d5;border-radius:10px;padding:0;width:200px;box-shadow:0 1px 4px rgba(0,0,0,0.08)}
-  /* 通貨で塗り分け: 口座 = 紺、JPY = 桜、USD = 薄青 (operator 要望) */
-  #symbol-map-editor .drawflow .drawflow-node.sm-account{background:#eef2f7;border-color:#46637f}
+  /* 通貨で塗り分け: 口座 = 濃グレー、JPY = 桜、USD = 薄青 (operator 要望) */
+  #symbol-map-editor .drawflow .drawflow-node.sm-account{background:#5f6368;border-color:#3c4043}
+  /* 接続ポートの◯もグレーに (default の白丸 + 黒枠は浮く) */
+  #symbol-map-editor .drawflow .drawflow-node .input,
+  #symbol-map-editor .drawflow .drawflow-node .output{background:#9aa0a6;border:2px solid #6e6e73;width:14px;height:14px}
+  #symbol-map-editor .drawflow .drawflow-node .input:hover,
+  #symbol-map-editor .drawflow .drawflow-node .output:hover{background:#6e6e73}
   #symbol-map-editor .drawflow .drawflow-node.sm-jpy{background:#fdf3f2;border-color:#d4a09a}
   #symbol-map-editor .drawflow .drawflow-node.sm-usd{background:#f0f6ff;border-color:#9ab8dd}
   #symbol-map-editor .drawflow .drawflow-node.selected{border-color:#06c}
@@ -8849,8 +8854,8 @@ export function symbolMapEditorBody(
     var accountY = Math.max(30, 30 + ((allocated.length - 1) * 120) / 2);
     var accountId = editor.addNode('口座', 0, 1, 40, accountY, 'sm-node sm-account',
       { sym: '口座' },
-      '<div class="sm-card"><div class="sm-title" style="color:#46637f">口座</div>' +
-      '<div class="sm-meta">原資 ・ 予算 ' + data.accountTotalPct + '% (対は枠共有で max)</div></div>');
+      '<div class="sm-card"><div class="sm-title" style="color:#fff">口座</div>' +
+      '<div class="sm-meta" style="color:#e8eaed">原資 ・ 予算 ' + data.accountTotalPct + '% (対は枠共有で max)</div></div>');
     symOf[accountId] = '__account__';
 
     data.nodes.forEach(function (n) {
@@ -9116,8 +9121,8 @@ export function renderSymbolRelationMap(
       name: '口座',
       title: `口座 (予算 ${Math.round(total * 10) / 10}%)`,
       sub: '原資',
-      color: '#46637f',
-      fill: '#eef2f7',
+      color: '#3c4043',
+      fill: '#5f6368',
       status: 'account',
       x: 90,
       y: centerY,
@@ -9219,7 +9224,7 @@ export function renderSymbolRelationMap(
   const mapDiv = edges.length > 0
     ? `<div id="symbol-relation-map" style="height:${mapHeight}px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;margin-top:6px"></div>
     <p class="muted" style="font-size:11px;margin:4px 0 0">
-      口座 → 銘柄 = 配分% (実線、太さ ∝ %)。塗り: 紺 = 口座 ・ 桜 = JPY 銘柄 ・ 薄青 = USD 銘柄。<strong>Active</strong> = 建玉保有で参加中 (実線枠 + 投入額) ／
+      口座 → 銘柄 = 配分% (実線、太さ ∝ %)。塗り: 濃グレー = 口座 ・ 桜 = JPY 銘柄 ・ 薄青 = USD 銘柄。<strong>Active</strong> = 建玉保有で参加中 (実線枠 + 投入額) ／
       <strong>Pending</strong> = 様子見 (破線枠) で、点線矢印が「いま枠が行っている先」:
       <span style="color:#0e9f6e">緑 = 退避先へ代替割当 (条件連動 ON)</span> ・
       <span style="color:#9aa0a6">グレー = 枠確保のまま現金待機</span> ・
@@ -9287,10 +9292,10 @@ export function renderSymbolRelationMap(
               show: true,
               formatter: '{t|' + n.title + '}\\n{s|' + n.sub + '}',
               rich: {
-                t: { fontSize: 13, fontWeight: 700, color: '#1d1d1f', lineHeight: 18 },
+                t: { fontSize: 13, fontWeight: 700, color: n.status === 'account' ? '#fff' : '#1d1d1f', lineHeight: 18 },
                 s: {
                   fontSize: 10,
-                  color: n.status === 'active' ? '#0e9f6e' : n.status === 'pending' ? '#b25000' : '#6e6e73',
+                  color: n.status === 'account' ? '#e8eaed' : n.status === 'active' ? '#0e9f6e' : n.status === 'pending' ? '#b25000' : '#6e6e73',
                   lineHeight: 14,
                 },
               },

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -8886,6 +8886,8 @@ export function symbolMapEditorBody(
       if (n.fallback && idOf[n.fallback]) editor.addConnection(idOf[n.sym], idOf[n.fallback], 'output_1', 'input_1');
     });
     programmatic = false;
+    // 初期表示でも合計を draft 基準で描く (server 計算値と同じはずだが一元化)。
+    setTimeout(function () { renderAccountTotal(); }, 0);
 
     function markConnectionPending(srcId, dstId) {
       var conn = el.querySelector('svg.connection.node_in_node-' + dstId + '.node_out_node-' + srcId);
@@ -8898,7 +8900,36 @@ export function symbolMapEditorBody(
     function isDirty(sym) {
       return draft[sym].pct !== baseline[sym].pct || (draft[sym].fallback || null) !== (baseline[sym].fallback || null);
     }
+    // draft 合計 (インバース対は枠共有 = max で集計) をリアルタイム表示。
+    // 100% 超過 = 早い者勝ちの取り合い (settled cash gate で実際は買えない) なので赤警告。
+    function draftTotalPct() {
+      var counted = {};
+      var total = 0;
+      data.nodes.forEach(function (n) {
+        if (counted[n.sym]) return;
+        counted[n.sym] = true;
+        var mine = draft[n.sym].pct || 0;
+        if (n.inverse && draft[n.inverse]) {
+          counted[n.inverse] = true;
+          total += Math.max(mine, draft[n.inverse].pct || 0);
+        } else {
+          total += mine;
+        }
+      });
+      return Math.round(total * 10) / 10;
+    }
+    function renderAccountTotal() {
+      var nodeEl = document.getElementById('node-' + accountId);
+      if (!nodeEl) return;
+      var meta = nodeEl.querySelector('.sm-meta');
+      if (!meta) return;
+      var total = draftTotalPct();
+      var over = total > 100;
+      meta.innerHTML = '原資 ・ 予算 <strong style="color:' + (over ? '#ff8a80' : '#e8eaed') + '">' + total + '%</strong>' +
+        (over ? ' ⚠ 100% 超過' : '') + ' (対は枠共有で max)';
+    }
     function renderChanges() {
+      renderAccountTotal();
       var bar = document.getElementById('sm-changes-bar');
       var list = document.getElementById('sm-changes-list');
       var items = [];
@@ -8980,7 +9011,11 @@ export function symbolMapEditorBody(
       var pctChanges = Object.keys(draft).filter(function (sym) { return draft[sym].pct !== baseline[sym].pct; });
       var fbChanges = Object.keys(draft).filter(function (sym) { return (draft[sym].fallback || null) !== (baseline[sym].fallback || null); });
       if (pctChanges.length === 0 && fbChanges.length === 0) return;
-      if (!confirm('表示中の変更をまとめて適用します。よろしいですか？')) return;
+      var total = draftTotalPct();
+      var warn = total > 100
+        ? '⚠ 配分合計が ' + total + '% で 100% を超えています。超過分は買付余力 (settled cash gate) により先着順でしか約定しません。このまま適用しますか？'
+        : '表示中の変更をまとめて適用します (配分合計 ' + total + '%)。よろしいですか？';
+      if (!confirm(warn)) return;
       var steps = Promise.resolve();
       if (pctChanges.length > 0) {
         var form = new FormData();

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -8758,7 +8758,7 @@ export function renderSymbolRelationMap(
     source: string
     target: string
     value: number
-    kind: 'role' | 'symbol' | 'fallback'
+    kind: 'role' | 'symbol' | 'fallback' | 'idle'
   }
   const nodes: SankeyNode[] = []
   const links: SankeyLink[] = []
@@ -8786,25 +8786,31 @@ export function renderSymbolRelationMap(
       for (const r of members) {
         const sym = r.symbol.toUpperCase()
         const amount = amounts[sym]?.native
+        const status = amount !== undefined ? `使用中 ${amount}` : r.entryRequired === true ? '譲り中' : '待機'
         addNode({
           name: sym,
-          label: `${sym} ${pctOf(r)}%${amount ? ` (${amount})` : ''}`,
+          label: `${sym} ${pctOf(r)}% ・ ${status}`,
           color: colorOf(role),
           depth: 2,
         })
         links.push({ source: roleName, target: sym, value: pctOf(r), kind: 'symbol' })
       }
     }
-    // 退避先 (#452 Layer 3): **条件連動 ON** の銘柄の配分が entry 未通過時に
-    // 流れる先。退避先未設定は「現金のまま待機」なので現金待機ノードへ —
-    // 連動だけ ON にして退避先を入れていない設定 (VUG 等) もここで可視化される。
+    // 現在形の資金フロー: 参加 (= 建玉保有) していない銘柄の枠は先へ流れる。
+    //   - 保有中: 帯は銘柄で止まる (使用中)
+    //   - 未保有 + 条件連動 ON (#452 Layer 3): 退避先 (なければ現金待機) へ譲る
+    //   - 未保有 + 条件連動 OFF: 枠はその銘柄に確保されたまま現金で待機
+    // 「参加」の基準は DO position (qty > 0) — 当日 ENTRY 判定で未約定の瞬間は
+    // 待機側に出るが、現金の所在としてはそれが事実。
     for (const r of allocated) {
-      if (r.entryRequired !== true) continue
       const sym = r.symbol.toUpperCase()
-      const target = r.cashFallbackSymbol ? r.cashFallbackSymbol.toUpperCase() : '現金待機'
+      const held = amounts[sym] !== undefined
+      if (held) continue
+      const conditional = r.entryRequired === true
+      const target = conditional && r.cashFallbackSymbol ? r.cashFallbackSymbol.toUpperCase() : '現金待機'
       if (sym === target) continue
       if (target === '現金待機') {
-        addNode({ name: '現金待機', label: '現金待機 (退避先なし)', color: '#9aa0a6' })
+        addNode({ name: '現金待機', label: '現金待機', color: '#9aa0a6' })
       } else {
         const targetRow = rows.find((x) => x.symbol.toUpperCase() === target)
         addNode({
@@ -8813,7 +8819,7 @@ export function renderSymbolRelationMap(
           color: targetRow ? colorOf(roleOf(targetRow)) : '#9aa0a6',
         })
       }
-      links.push({ source: sym, target, value: pctOf(r), kind: 'fallback' })
+      links.push({ source: sym, target, value: pctOf(r), kind: conditional ? 'fallback' : 'idle' })
     }
   }
 
@@ -8841,8 +8847,9 @@ export function renderSymbolRelationMap(
   const sankeyDiv = links.length > 0
     ? `<div id="symbol-relation-map" style="height:${mapHeight}px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;margin-top:6px"></div>
     <p class="muted" style="font-size:11px;margin:4px 0 0">
-      予算 → ロール → 銘柄 (配分% ・ 括弧内 = 現在の投入額)。
-      <span style="color:#0e9f6e">緑の流れ</span> = 退避 (条件連動 ON の銘柄が entry 未通過の間、その配分が流れる先 — 受け皿側の太さは最悪ケースの合計。退避先未設定は「現金待機」へ)。
+      予算 → ロール → 銘柄 → (未保有なら) 譲り先、の<strong>現在形</strong>。「参加」の基準は建玉保有。
+      <span style="color:#0e9f6e">緑の流れ</span> = 条件連動 ON の枠を退避先 / 現金待機に譲り中 ・
+      <span style="color:#9aa0a6">グレーの流れ</span> = 枠は銘柄に確保したまま現金待機 (誰にも譲らない)。
     </p>`
     : ''
   const payload = { nodes, links }
@@ -8868,7 +8875,10 @@ export function renderSymbolRelationMap(
           if (p.dataType === 'edge') {
             var head = labelOf[p.data.source] + ' → ' + labelOf[p.data.target];
             if (p.data.kind === 'fallback') {
-              return head + '<br>条件未通過時に ' + p.data.value + '% が退避';
+              return head + '<br>未保有のため ' + p.data.value + '% を譲り中 (条件連動 ON)';
+            }
+            if (p.data.kind === 'idle') {
+              return head + '<br>未保有。枠 ' + p.data.value + '% は銘柄に確保したまま現金待機';
             }
             return head + '<br>' + p.data.value + '%';
           }
@@ -8901,7 +8911,9 @@ export function renderSymbolRelationMap(
             kind: l.kind,
             lineStyle: l.kind === 'fallback'
               ? { color: '#0e9f6e', opacity: 0.45, curveness: 0.5 }
-              : { color: 'gradient', opacity: 0.3, curveness: 0.5 },
+              : l.kind === 'idle'
+                ? { color: '#9aa0a6', opacity: 0.3, curveness: 0.5 }
+                : { color: 'gradient', opacity: 0.3, curveness: 0.5 },
           };
         }),
       }],

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -8738,17 +8738,17 @@ function applySymbolsListFilter(rows: SymbolConfigRow[], f: SymbolsListFilter): 
 }
 
 /**
- * 配分マップ編集キャンバス (#symbol-relation-map)。**draft 編集モデル**:
- * 線を引く / 消す / % を変えても即保存はせず、ローカル draft に積んで
- * 変更箇所をハイライト + サマリ表示し、「適用」で一括保存 → reload する
- * (operator 指定: つど confirm ではなく、編集中は視覚的フィードバック、最後に
- * 適用ボタン)。リセット = reload で破棄。
+ * 配分マップ編集キャンバス (#symbol-relation-map)。**draft 編集 + 1/枝 配分**:
  *
- * 操作の意味:
- *   - 口座 → 銘柄の線: 配分 (引く = 配分対象に追加。% はカードの入力欄 / 消す = 配分解除)
- *   - 銘柄 → 銘柄の線: 退避先 (引く = 設定 + 条件連動 ON / 消す = 解除)。1 銘柄 1 本
- *   - カードの % 入力: 予算配分の変更 (インバース対は server 側で同期)
- * 適用時は budget-alloc (一括) → cash-fallback (銘柄ごと) の順で POST する。
+ *   - 配分は % 入力ではなく**トポロジーから導出**する (operator 指定)。
+ *     口座に繋がっている枝数 N に対し各枝 = 100/N %。インバース対は両方
+ *     繋がっていても **1 枝** として数え、両側に同じ % を書く (枠共有 #315 と
+ *     同じ意味)。合計は構造的に常に 100% — % の手管理によるカオスを排除する。
+ *   - 線を引く / 消すは draft に積み、変更箇所をハイライト + サマリ表示して
+ *     「適用」で一括保存 → reload。DB / cron は従来どおり budget_alloc_pct
+ *     (fraction) を読む — 変換はこのエディタの適用時のみ。
+ *   - 銘柄 → 銘柄の線 = 退避先 (1 銘柄 1 本、設定時に条件連動も ON)
+ *   - 口座から切断 = 配分解除 (NULL = risk-% サイジングに戻る)
  * インバース対 / proxy はカード内に表示のみ (不変条件があるためキャンバス編集不可)。
  */
 export function symbolMapEditorBody(
@@ -8777,31 +8777,18 @@ export function symbolMapEditorBody(
   if (nodes.length === 0) {
     return `<p class="muted">有効な銘柄がありません。</p>`
   }
-  // 口座カードの予算合計はインバース対の枠共有 (#315) を反映 (対は max)。
-  const counted = new Set<string>()
-  let totalPct = 0
-  for (const n of nodes) {
-    if (counted.has(n.sym)) continue
-    counted.add(n.sym)
-    const partnerNode = n.inverse ? nodes.find((x) => x.sym === n.inverse) : undefined
-    if (partnerNode) {
-      counted.add(n.inverse!)
-      totalPct += Math.max(n.pct, partnerNode.pct)
-    } else {
-      totalPct += n.pct
-    }
-  }
-  const payload = { nodes, accountTotalPct: Math.round(totalPct * 10) / 10 }
+  const payload = { nodes }
   return `<p style="margin:0 0 10px;display:flex;gap:12px;align-items:center;flex-wrap:wrap">
     <a href="/dashboard/symbols" style="font-size:13px">← 銘柄管理へ戻る</a>
     <span class="muted" style="font-size:12px">
-      <strong>口座 → 銘柄の線</strong> = 配分 ・ <strong>銘柄 → 銘柄の線</strong> = 退避先 (1 銘柄 1 本、条件連動も ON) ・ % 欄 = 配分変更。
+      <strong>口座 → 銘柄の線</strong> = 配分。各枝は均等 (<strong>1/枝</strong>、対は 1 枝扱い) で % は自動計算 ・
+      <strong>銘柄 → 銘柄の線</strong> = 退避先 (1 銘柄 1 本、条件連動も ON)。
       <strong>線の削除</strong> = 線をクリックして選択 → Backspace / Delete。
     </span>
     <button type="button" id="sm-delete-conn" disabled style="padding:4px 12px;background:#fff;border:1px solid #ccc;color:#999;border-radius:6px;cursor:pointer;font-size:12px">選択中の線を削除</button>
     <span class="muted" style="font-size:12px">
-      変更は即保存されません — 下のサマリを確認して<strong>「適用」で一括保存</strong>します。
-      カードの塗り: <span style="background:#5f6368;border:1px solid #3c4043;color:#fff;padding:0 6px;border-radius:4px">口座</span>
+      変更は即保存されません — サマリを確認して<strong>「適用」で一括保存</strong>。
+      塗り: <span style="background:#5f6368;border:1px solid #3c4043;color:#fff;padding:0 6px;border-radius:4px">口座</span>
       <span style="background:#fdf3f2;border:1px solid #d4a09a;padding:0 6px;border-radius:4px">JPY</span>
       <span style="background:#f0f6ff;border:1px solid #9ab8dd;padding:0 6px;border-radius:4px">USD</span>
     </span>
@@ -8818,6 +8805,8 @@ export function symbolMapEditorBody(
   <style>
   #symbol-map-editor{height:calc(100vh - 220px);min-height:480px;background:#fafafa;border:1px solid #d0d0d5;border-radius:8px}
   #symbol-map-editor .drawflow .drawflow-node{background:#fff;border:2px solid #d0d0d5;border-radius:10px;padding:0;width:200px;box-shadow:0 1px 4px rgba(0,0,0,0.08)}
+  #symbol-map-editor .drawflow .drawflow-node.selected{border-color:#06c}
+  #symbol-map-editor .drawflow .drawflow-node.sm-dirty{border-color:#e6a23c;box-shadow:0 0 0 3px rgba(230,162,60,0.25)}
   /* 通貨で塗り分け: 口座 = 濃グレー、JPY = 桜、USD = 薄青 (operator 要望) */
   #symbol-map-editor .drawflow .drawflow-node.sm-account{background:#5f6368;border-color:#3c4043}
   /* 接続ポートの◯もグレーに (default の白丸 + 黒枠は浮く) */
@@ -8825,17 +8814,13 @@ export function symbolMapEditorBody(
   #symbol-map-editor .drawflow .drawflow-node .output{background:#9aa0a6;border:2px solid #6e6e73;width:14px;height:14px}
   #symbol-map-editor .drawflow .drawflow-node .input:hover,
   #symbol-map-editor .drawflow .drawflow-node .output:hover{background:#6e6e73}
-  #symbol-map-editor .drawflow .drawflow-node.sm-jpy{background:#fdf3f2;border-color:#d4a09a}
-  #symbol-map-editor .drawflow .drawflow-node.sm-usd{background:#f0f6ff;border-color:#9ab8dd}
-  #symbol-map-editor .drawflow .drawflow-node.selected{border-color:#06c}
-  #symbol-map-editor .drawflow .drawflow-node.sm-dirty{border-color:#e6a23c;box-shadow:0 0 0 3px rgba(230,162,60,0.25)}
   #symbol-map-editor svg.connection.sm-pending path{stroke:#0e9f6e !important;stroke-dasharray:7 5;stroke-width:3px}
   .sm-card{padding:8px 10px;font-size:12px}
   .sm-card .sm-title{font-size:14px;font-weight:700}
   .sm-card .sm-status-active{color:#0e9f6e;font-size:11px}
   .sm-card .sm-status-pending{color:#b25000;font-size:11px}
   .sm-card .sm-meta{color:#6e6e73;font-size:10px;margin-top:2px}
-  .sm-card input{width:64px;padding:2px 4px;font-size:12px}
+  .sm-card .sm-share{font-weight:600}
   </style>
   <div id="symbol-map-editor"></div>
   ${safeJsonScript('__symbolMapEditor', payload)}
@@ -8850,8 +8835,9 @@ export function symbolMapEditorBody(
     editor.start();
     var idOf = {};
     var symOf = {};
+    var nodeBySym = {};
     var baseline = {};   // sym -> { pct, fallback }
-    var draft = {};      // sym -> { pct, fallback } (編集中の値)
+    var draft = {};      // sym -> { connected, fallback }
     var programmatic = false;
 
     var allocated = data.nodes.filter(function (n) { return n.pct > 0; });
@@ -8859,12 +8845,13 @@ export function symbolMapEditorBody(
     var accountId = editor.addNode('口座', 0, 1, 40, accountY, 'sm-node sm-account',
       { sym: '口座' },
       '<div class="sm-card"><div class="sm-title" style="color:#fff">口座</div>' +
-      '<div class="sm-meta" style="color:#e8eaed">原資 ・ 予算 ' + data.accountTotalPct + '% (対は枠共有で max)</div></div>');
+      '<div class="sm-meta" style="color:#e8eaed">原資 ・ 予算 100% を枝数で均等割</div></div>');
     symOf[accountId] = '__account__';
 
     data.nodes.forEach(function (n) {
+      nodeBySym[n.sym] = n;
       baseline[n.sym] = { pct: n.pct, fallback: n.fallback };
-      draft[n.sym] = { pct: n.pct, fallback: n.fallback };
+      draft[n.sym] = { connected: n.pct > 0, fallback: n.fallback };
       var statusHtml = n.held
         ? '<div class="sm-status-active">Active ・ ' + n.held + '</div>'
         : '<div class="sm-status-pending">Pending (様子見' + (n.entryRequired ? '・条件連動 ON' : '') + ')</div>';
@@ -8875,11 +8862,10 @@ export function symbolMapEditorBody(
       var html = '<div class="sm-card">' +
         '<div class="sm-title" style="color:' + n.color + '">' + n.sym + '</div>' +
         statusHtml +
-        '<div style="margin-top:4px">配分 <input type="number" min="0" max="100" step="1" value="' + n.pct + '" data-sym="' + n.sym + '" class="sm-pct"> %</div>' +
+        '<div style="margin-top:4px">配分 <span class="sm-share" id="sm-share-' + n.sym + '">—</span></div>' +
         '<div class="sm-meta">' + metaParts.join(' ・ ') + '</div>' +
         '</div>';
-      var ccyClass = n.currency === 'JPY' ? 'sm-jpy' : 'sm-usd';
-      var id = editor.addNode(n.sym, 1, 1, n.pct > 0 ? 360 : 760, n.y, 'sm-node ' + ccyClass, { sym: n.sym }, html);
+      var id = editor.addNode(n.sym, 1, 1, n.pct > 0 ? 360 : 760, n.y, 'sm-node ' + (n.currency === 'JPY' ? 'sm-jpy' : 'sm-usd'), { sym: n.sym }, html);
       idOf[n.sym] = id;
       symOf[id] = n.sym;
     });
@@ -8890,8 +8876,40 @@ export function symbolMapEditorBody(
       if (n.fallback && idOf[n.fallback]) editor.addConnection(idOf[n.sym], idOf[n.fallback], 'output_1', 'input_1');
     });
     programmatic = false;
-    // 初期表示でも合計を draft 基準で描く (server 計算値と同じはずだが一元化)。
-    setTimeout(function () { renderAccountTotal(); }, 0);
+
+    // 1/枝 の導出: 接続中の銘柄を対 (インバース) ごとに 1 枝として数え、
+    // 各枝 = round(100/N, 1dp)。接続中の銘柄は対の両側とも同じ % (枠共有)。
+    function deriveShares() {
+      var branches = 0;
+      var seen = {};
+      Object.keys(draft).forEach(function (sym) {
+        if (!draft[sym].connected || seen[sym]) return;
+        seen[sym] = true;
+        var inv = nodeBySym[sym].inverse;
+        if (inv && draft[inv] && draft[inv].connected) seen[inv] = true;
+        branches += 1;
+      });
+      var share = branches > 0 ? Math.round((100 / branches) * 10) / 10 : 0;
+      var shares = {};
+      Object.keys(draft).forEach(function (sym) {
+        shares[sym] = draft[sym].connected ? share : 0;
+      });
+      return { branches: branches, share: share, shares: shares };
+    }
+    function renderShares() {
+      var d = deriveShares();
+      Object.keys(draft).forEach(function (sym) {
+        var span = document.getElementById('sm-share-' + sym);
+        if (!span) return;
+        span.textContent = draft[sym].connected ? '1/' + d.branches + ' = ' + d.share + '%' : 'なし (risk-%)';
+      });
+      var accountEl = document.getElementById('node-' + accountId);
+      if (accountEl) {
+        var meta = accountEl.querySelector('.sm-meta');
+        if (meta) meta.textContent = '原資 ・ ' + d.branches + ' 枝 ・ 1 枝 = ' + (d.branches > 0 ? d.share + '%' : '—');
+      }
+      return d;
+    }
 
     function markConnectionPending(srcId, dstId) {
       var conn = el.querySelector('svg.connection.node_in_node-' + dstId + '.node_out_node-' + srcId);
@@ -8901,57 +8919,30 @@ export function symbolMapEditorBody(
       var nodeEl = document.getElementById('node-' + idOf[sym]);
       if (nodeEl) nodeEl.classList.toggle('sm-dirty', dirty);
     }
-    function isDirty(sym) {
-      return draft[sym].pct !== baseline[sym].pct || (draft[sym].fallback || null) !== (baseline[sym].fallback || null);
-    }
-    // draft 合計 (インバース対は枠共有 = max で集計) をリアルタイム表示。
-    // 100% 超過 = 早い者勝ちの取り合い (settled cash gate で実際は買えない) なので赤警告。
-    function draftTotalPct() {
-      var counted = {};
-      var total = 0;
-      data.nodes.forEach(function (n) {
-        if (counted[n.sym]) return;
-        counted[n.sym] = true;
-        var mine = draft[n.sym].pct || 0;
-        if (n.inverse && draft[n.inverse]) {
-          counted[n.inverse] = true;
-          total += Math.max(mine, draft[n.inverse].pct || 0);
-        } else {
-          total += mine;
-        }
-      });
-      return Math.round(total * 10) / 10;
-    }
-    function renderAccountTotal() {
-      var nodeEl = document.getElementById('node-' + accountId);
-      if (!nodeEl) return;
-      var meta = nodeEl.querySelector('.sm-meta');
-      if (!meta) return;
-      var total = draftTotalPct();
-      var over = total > 100;
-      meta.innerHTML = '原資 ・ 予算 <strong style="color:' + (over ? '#ff8a80' : '#e8eaed') + '">' + total + '%</strong>' +
-        (over ? ' ⚠ 100% 超過' : '') + ' (対は枠共有で max)';
-    }
     function renderChanges() {
-      renderAccountTotal();
+      var d = renderShares();
       var bar = document.getElementById('sm-changes-bar');
       var list = document.getElementById('sm-changes-list');
       var items = [];
       Object.keys(draft).forEach(function (sym) {
         var b = baseline[sym];
-        var d = draft[sym];
-        if (d.pct !== b.pct) {
-          items.push(sym + ': 配分 ' + (b.pct || 'なし') + (b.pct ? '%' : '') + ' → ' + (d.pct ? d.pct + '%' : '解除'));
+        var newPct = d.shares[sym];
+        var pctChanged = newPct !== b.pct;
+        var fbChanged = (draft[sym].fallback || null) !== (b.fallback || null);
+        if (pctChanged) {
+          items.push(sym + ': 配分 ' + (b.pct ? b.pct + '%' : 'なし') + ' → ' + (newPct ? '1/' + d.branches + ' = ' + newPct + '%' : '解除 (risk-%)'));
         }
-        if ((d.fallback || null) !== (b.fallback || null)) {
-          if (d.fallback) items.push(sym + ': 退避先 → ' + d.fallback + ' (条件連動 ON)');
+        if (fbChanged) {
+          if (draft[sym].fallback) items.push(sym + ': 退避先 → ' + draft[sym].fallback + ' (条件連動 ON)');
           else items.push(sym + ': 退避先を解除');
         }
-        setCardDirty(sym, isDirty(sym));
+        setCardDirty(sym, pctChanged || fbChanged);
       });
       list.innerHTML = items.map(function (t) { return '<li>' + t + '</li>'; }).join('');
       bar.hidden = items.length === 0;
+      return d;
     }
+    renderChanges();
 
     editor.on('connectionCreated', function (info) {
       if (programmatic) return;
@@ -8964,12 +8955,7 @@ export function symbolMapEditorBody(
         return;
       }
       if (src === '__account__') {
-        // 配分対象に追加。% はカードの入力欄で指定する (0 のままなら適用対象外)。
-        if (draft[dst].pct === 0) {
-          draft[dst].pct = 5; // 仮の初期値。入力欄に反映して編集を促す。
-          var input = el.querySelector('input.sm-pct[data-sym="' + dst + '"]');
-          if (input) { input.value = '5'; input.focus(); }
-        }
+        draft[dst].connected = true;
         markConnectionPending(info.output_id, info.input_id);
         renderChanges();
         return;
@@ -8991,22 +8977,11 @@ export function symbolMapEditorBody(
       var dst = symOf[info.input_id];
       if (!src || !dst) return;
       if (src === '__account__') {
-        draft[dst].pct = 0;
-        var input = el.querySelector('input.sm-pct[data-sym="' + dst + '"]');
-        if (input) input.value = '0';
+        draft[dst].connected = false;
         renderChanges();
         return;
       }
       if (draft[src].fallback === dst) draft[src].fallback = null;
-      renderChanges();
-    });
-
-    el.addEventListener('change', function (ev) {
-      var input = ev.target;
-      if (!input.classList || !input.classList.contains('sm-pct')) return;
-      var sym = input.getAttribute('data-sym');
-      var v = Number(String(input.value).trim());
-      draft[sym].pct = Number.isFinite(v) && v > 0 ? v : 0;
       renderChanges();
     });
 
@@ -9034,21 +9009,19 @@ export function symbolMapEditorBody(
         refreshDeleteBtn();
       }
     });
+
     document.getElementById('sm-reset').addEventListener('click', function () { location.reload(); });
     document.getElementById('sm-apply').addEventListener('click', function () {
-      var pctChanges = Object.keys(draft).filter(function (sym) { return draft[sym].pct !== baseline[sym].pct; });
+      var d = deriveShares();
+      var pctChanges = Object.keys(draft).filter(function (sym) { return d.shares[sym] !== baseline[sym].pct; });
       var fbChanges = Object.keys(draft).filter(function (sym) { return (draft[sym].fallback || null) !== (baseline[sym].fallback || null); });
       if (pctChanges.length === 0 && fbChanges.length === 0) return;
-      var total = draftTotalPct();
-      var warn = total > 100
-        ? '⚠ 配分合計が ' + total + '% で 100% を超えています。超過分は買付余力 (settled cash gate) により先着順でしか約定しません。このまま適用しますか？'
-        : '表示中の変更をまとめて適用します (配分合計 ' + total + '%)。よろしいですか？';
-      if (!confirm(warn)) return;
+      if (!confirm('表示中の変更をまとめて適用します (' + d.branches + ' 枝 ・ 1 枝 = ' + d.share + '%)。よろしいですか？')) return;
       var steps = Promise.resolve();
       if (pctChanges.length > 0) {
         var form = new FormData();
         pctChanges.forEach(function (sym) {
-          form.append('pct_' + sym, draft[sym].pct > 0 ? String(draft[sym].pct) : '');
+          form.append('pct_' + sym, d.shares[sym] > 0 ? String(d.shares[sym]) : '');
         });
         steps = steps.then(function () {
           return fetch('/admin/symbol-config/budget-alloc', { method: 'POST', credentials: 'same-origin', body: form })

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -8797,6 +8797,9 @@ export function symbolMapEditorBody(
     <span class="muted" style="font-size:12px">
       <strong>口座 → 銘柄の線</strong> = 配分 ・ <strong>銘柄 → 銘柄の線</strong> = 退避先 (1 銘柄 1 本、条件連動も ON) ・ % 欄 = 配分変更。
       変更は即保存されません — 下のサマリを確認して<strong>「適用」で一括保存</strong>します。
+      カードの塗り: <span style="background:#eef2f7;border:1px solid #46637f;padding:0 6px;border-radius:4px">口座</span>
+      <span style="background:#fdf3f2;border:1px solid #d4a09a;padding:0 6px;border-radius:4px">JPY</span>
+      <span style="background:#f0f6ff;border:1px solid #9ab8dd;padding:0 6px;border-radius:4px">USD</span>
     </span>
   </p>
   <div id="sm-changes-bar" hidden style="position:sticky;top:0;z-index:10;display:flex;gap:10px;align-items:flex-start;padding:8px 12px;background:#fff8e6;border:1px solid #e6c46a;border-radius:8px;margin-bottom:8px">
@@ -8811,6 +8814,10 @@ export function symbolMapEditorBody(
   <style>
   #symbol-map-editor{height:calc(100vh - 220px);min-height:480px;background:#fafafa;border:1px solid #d0d0d5;border-radius:8px}
   #symbol-map-editor .drawflow .drawflow-node{background:#fff;border:2px solid #d0d0d5;border-radius:10px;padding:0;width:200px;box-shadow:0 1px 4px rgba(0,0,0,0.08)}
+  /* 通貨で塗り分け: 口座 = 紺、JPY = 桜、USD = 薄青 (operator 要望) */
+  #symbol-map-editor .drawflow .drawflow-node.sm-account{background:#eef2f7;border-color:#46637f}
+  #symbol-map-editor .drawflow .drawflow-node.sm-jpy{background:#fdf3f2;border-color:#d4a09a}
+  #symbol-map-editor .drawflow .drawflow-node.sm-usd{background:#f0f6ff;border-color:#9ab8dd}
   #symbol-map-editor .drawflow .drawflow-node.selected{border-color:#06c}
   #symbol-map-editor .drawflow .drawflow-node.sm-dirty{border-color:#e6a23c;box-shadow:0 0 0 3px rgba(230,162,60,0.25)}
   #symbol-map-editor svg.connection.sm-pending path{stroke:#0e9f6e !important;stroke-dasharray:7 5;stroke-width:3px}
@@ -8862,7 +8869,8 @@ export function symbolMapEditorBody(
         '<div style="margin-top:4px">配分 <input type="number" min="0" max="100" step="1" value="' + n.pct + '" data-sym="' + n.sym + '" class="sm-pct"> %</div>' +
         '<div class="sm-meta">' + metaParts.join(' ・ ') + '</div>' +
         '</div>';
-      var id = editor.addNode(n.sym, 1, 1, n.pct > 0 ? 360 : 760, n.y, 'sm-node', { sym: n.sym }, html);
+      var ccyClass = n.currency === 'JPY' ? 'sm-jpy' : 'sm-usd';
+      var id = editor.addNode(n.sym, 1, 1, n.pct > 0 ? 360 : 760, n.y, 'sm-node ' + ccyClass, { sym: n.sym }, html);
       idOf[n.sym] = id;
       symOf[id] = n.sym;
     });
@@ -9059,6 +9067,8 @@ export function renderSymbolRelationMap(
     /** カード 2 行目 (状態)。 */
     sub: string
     color: string
+    /** カードの塗り (通貨で分ける: 口座 = 紺系 / JPY = 桜 / USD = 薄青)。 */
+    fill: string
     status: 'account' | 'active' | 'pending' | 'cash'
     x: number
     y: number
@@ -9107,6 +9117,7 @@ export function renderSymbolRelationMap(
       title: `口座 (予算 ${Math.round(total * 10) / 10}%)`,
       sub: '原資',
       color: '#46637f',
+      fill: '#eef2f7',
       status: 'account',
       x: 90,
       y: centerY,
@@ -9121,6 +9132,7 @@ export function renderSymbolRelationMap(
         title: `${sym} ${pctOf(r)}%`,
         sub: held ? `Active ・ ${amounts[sym]!.native}` : 'Pending (様子見)',
         color: colorOf(roleOf(r)),
+        fill: r.currency === 'JPY' ? '#fdf3f2' : '#f0f6ff',
         status: held ? 'active' : 'pending',
         x: SYMBOL_X,
         y: 40 + i * ROW_H,
@@ -9160,6 +9172,7 @@ export function renderSymbolRelationMap(
         title: '現金待機',
         sub: '未参加分の置き場',
         color: '#9aa0a6',
+        fill: '#f5f5f7',
         status: 'cash',
         x: CASH_X,
         y: centerY,
@@ -9174,6 +9187,7 @@ export function renderSymbolRelationMap(
         title: e.target,
         sub: amounts[e.target] ? `Active ・ ${amounts[e.target]!.native}` : '受け皿',
         color: row ? colorOf(roleOf(row)) : '#9aa0a6',
+        fill: row ? (row.currency === 'JPY' ? '#fdf3f2' : '#f0f6ff') : '#f5f5f7',
         status: amounts[e.target] ? 'active' : 'pending',
         x: CASH_X,
         y: 40 + nodes.length * 8,
@@ -9205,7 +9219,7 @@ export function renderSymbolRelationMap(
   const mapDiv = edges.length > 0
     ? `<div id="symbol-relation-map" style="height:${mapHeight}px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;margin-top:6px"></div>
     <p class="muted" style="font-size:11px;margin:4px 0 0">
-      口座 → 銘柄 = 配分% (実線、太さ ∝ %)。<strong>Active</strong> = 建玉保有で参加中 (実線枠 + 投入額) ／
+      口座 → 銘柄 = 配分% (実線、太さ ∝ %)。塗り: 紺 = 口座 ・ 桜 = JPY 銘柄 ・ 薄青 = USD 銘柄。<strong>Active</strong> = 建玉保有で参加中 (実線枠 + 投入額) ／
       <strong>Pending</strong> = 様子見 (破線枠) で、点線矢印が「いま枠が行っている先」:
       <span style="color:#0e9f6e">緑 = 退避先へ代替割当 (条件連動 ON)</span> ・
       <span style="color:#9aa0a6">グレー = 枠確保のまま現金待機</span> ・
@@ -9261,7 +9275,7 @@ export function renderSymbolRelationMap(
             symbol: 'roundRect',
             symbolSize: [150, 46],
             itemStyle: {
-              color: '#fff',
+              color: n.fill || '#fff',
               borderColor: n.color,
               borderWidth: 2,
               borderType: isPending ? 'dashed' : 'solid',

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -8701,16 +8701,16 @@ function applySymbolsListFilter(rows: SymbolConfigRow[], f: SymbolsListFilter): 
 }
 
 /**
- * 配分マップ (#symbol-relation-map)。予算がどのロール / 銘柄に流れ、条件未通過
- * 時にどこへ退避するかを Sankey で可視化する (operator 指定: 家計簿アプリの
- * キャッシュフロー図のイメージ)。
+ * 配分マップ (#symbol-relation-map)。「口座 (原資) から各銘柄へ何% 割り当て、
+ * 参加できていない銘柄の枠はいまどこへ譲られているか」をノードツリーで示す
+ * (operator 指定の絵: 口座 ─ SOXL ┈┈▶ TQQQ / ┗ TQQQ)。
  *
- *   予算 100% → ロール (リスク低→高で上から) → 銘柄 (配分% + 投入額) → 退避先
- *
- * 退避リンク (緑) は「条件連動 ON の銘柄が entry 未通過のときに流れる先」で、
- * 量は同銘柄の配分%。退避先ノードの太さは自前配分 + 退避受け皿の合計になる
- * (最悪ケースの受け入れ量)。インバース対 / regime proxy は量の流れではない
- * 構造情報なので Sankey に混ぜず脚注チップで出す。
+ *   - 口座 → 銘柄: 実線 + 配分% (帯の太さも %)
+ *   - 銘柄カード: Active (建玉保有 = 参加中、実線枠 + 投入額) /
+ *     Pending (未保有 = 様子見、破線枠)
+ *   - Pending 銘柄 ┈┈▶ 譲り先: 点線矢印。条件連動 ON は退避先 (なければ現金待機)、
+ *     OFF は枠を銘柄に確保したまま現金待機 (グレー点線)
+ * インバース対 / regime proxy は量の流れではないので脚注チップ。
  * 表示専用 — 判定・発注には一切関与しない。
  */
 const ROLE_NODE_COLORS: Record<string, string> = {
@@ -8722,7 +8722,7 @@ const ROLE_NODE_COLORS: Record<string, string> = {
   inverse_hedge: '#c22d2d',
 }
 
-/** Sankey のロール段の並び (リスク低 → 高で上から)。 */
+/** 銘柄列の並び (リスク低 → 高で上から)。 */
 const MAP_ROLE_ORDER = [
   'cash_parking',
   'low_volatility',
@@ -8742,84 +8742,119 @@ export function renderSymbolRelationMap(
   const pctOf = (r: SymbolConfigRow): number =>
     r.budgetAllocPct != null ? Math.round(r.budgetAllocPct * 1000) / 10 : 0
   const roleOf = (r: SymbolConfigRow): string => r.role ?? 'none'
-  const roleLabel = (role: string): string =>
-    role === 'none' ? 'ロール未設定' : SYMBOL_ROLE_LABELS_SHORT[role as SymbolRole] ?? role
   const colorOf = (role: string): string => ROLE_NODE_COLORS[role] ?? '#5f6368'
 
-  // Sankey は配分のある有効銘柄だけで構成する (0% は流量が無く描けない)。
-  const allocated = rows.filter((r) => r.active && pctOf(r) > 0)
-  interface SankeyNode {
+  // 配分のある有効銘柄が対象 (0% は口座から線が引けない)。
+  const allocated = rows
+    .filter((r) => r.active && pctOf(r) > 0)
+    .sort(
+      (a, b) =>
+        MAP_ROLE_ORDER.indexOf(roleOf(a) as (typeof MAP_ROLE_ORDER)[number]) -
+          MAP_ROLE_ORDER.indexOf(roleOf(b) as (typeof MAP_ROLE_ORDER)[number]) || pctOf(b) - pctOf(a),
+    )
+
+  interface MapNode {
     name: string
-    label: string
+    /** カード 1 行目。 */
+    title: string
+    /** カード 2 行目 (状態)。 */
+    sub: string
     color: string
-    depth?: number
+    status: 'account' | 'active' | 'pending' | 'cash'
+    x: number
+    y: number
   }
-  interface SankeyLink {
+  interface MapEdge {
     source: string
     target: string
-    value: number
-    kind: 'role' | 'symbol' | 'fallback' | 'idle'
+    kind: 'alloc' | 'yield' | 'idle'
+    label: string
+    width: number
   }
-  const nodes: SankeyNode[] = []
-  const links: SankeyLink[] = []
+  const nodes: MapNode[] = []
+  const edges: MapEdge[] = []
   const nodeNames = new Set<string>()
-  const addNode = (n: SankeyNode): void => {
+  const addNode = (n: MapNode): void => {
     if (nodeNames.has(n.name)) return
     nodeNames.add(n.name)
     nodes.push(n)
   }
+
+  const ROW_H = 64
+  const SYMBOL_X = 360
+  const CASH_X = 640
   if (allocated.length > 0) {
     const total = allocated.reduce((sum, r) => sum + pctOf(r), 0)
-    addNode({ name: '予算', label: `予算 ${Math.round(total * 10) / 10}%`, color: '#46637f', depth: 0 })
-    for (const role of MAP_ROLE_ORDER) {
-      const members = allocated.filter((r) => roleOf(r) === role)
-      if (members.length === 0) continue
-      const rolePct = members.reduce((sum, r) => sum + pctOf(r), 0)
-      const roleName = `role:${role}`
-      addNode({
-        name: roleName,
-        label: `${roleLabel(role)} ${Math.round(rolePct * 10) / 10}%`,
-        color: colorOf(role),
-        depth: 1,
-      })
-      links.push({ source: '予算', target: roleName, value: rolePct, kind: 'role' })
-      for (const r of members) {
-        const sym = r.symbol.toUpperCase()
-        const amount = amounts[sym]?.native
-        const status = amount !== undefined ? `使用中 ${amount}` : r.entryRequired === true ? '譲り中' : '待機'
-        addNode({
-          name: sym,
-          label: `${sym} ${pctOf(r)}% ・ ${status}`,
-          color: colorOf(role),
-          depth: 2,
-        })
-        links.push({ source: roleName, target: sym, value: pctOf(r), kind: 'symbol' })
-      }
-    }
-    // 現在形の資金フロー: 参加 (= 建玉保有) していない銘柄の枠は先へ流れる。
-    //   - 保有中: 帯は銘柄で止まる (使用中)
-    //   - 未保有 + 条件連動 ON (#452 Layer 3): 退避先 (なければ現金待機) へ譲る
-    //   - 未保有 + 条件連動 OFF: 枠はその銘柄に確保されたまま現金で待機
-    // 「参加」の基準は DO position (qty > 0) — 当日 ENTRY 判定で未約定の瞬間は
-    // 待機側に出るが、現金の所在としてはそれが事実。
-    for (const r of allocated) {
+    const centerY = 40 + ((allocated.length - 1) * ROW_H) / 2
+    addNode({
+      name: '口座',
+      title: `口座 (予算 ${Math.round(total * 10) / 10}%)`,
+      sub: '原資',
+      color: '#46637f',
+      status: 'account',
+      x: 90,
+      y: centerY,
+    })
+    let needCash = false
+    allocated.forEach((r, i) => {
       const sym = r.symbol.toUpperCase()
       const held = amounts[sym] !== undefined
-      if (held) continue
       const conditional = r.entryRequired === true
-      const target = conditional && r.cashFallbackSymbol ? r.cashFallbackSymbol.toUpperCase() : '現金待機'
-      if (sym === target) continue
-      if (target === '現金待機') {
-        addNode({ name: '現金待機', label: '現金待機', color: '#9aa0a6' })
-      } else {
-        const targetRow = rows.find((x) => x.symbol.toUpperCase() === target)
-        addNode({
-          name: target,
-          label: `${target}${amounts[target]?.native ? ` (${amounts[target]!.native})` : ''}`,
-          color: targetRow ? colorOf(roleOf(targetRow)) : '#9aa0a6',
-        })
+      addNode({
+        name: sym,
+        title: `${sym} ${pctOf(r)}%`,
+        sub: held ? `Active ・ ${amounts[sym]!.native}` : 'Pending (様子見)',
+        color: colorOf(roleOf(r)),
+        status: held ? 'active' : 'pending',
+        x: SYMBOL_X,
+        y: 40 + i * ROW_H,
+      })
+      edges.push({
+        source: '口座',
+        target: sym,
+        kind: 'alloc',
+        label: `${pctOf(r)}%`,
+        width: Math.max(1.5, Math.min(8, pctOf(r) / 5)),
+      })
+      // 未保有 (Pending) の枠の現在の行き先。
+      if (!held) {
+        const target = conditional && r.cashFallbackSymbol ? r.cashFallbackSymbol.toUpperCase() : '現金待機'
+        if (target !== sym) {
+          if (target === '現金待機') needCash = true
+          edges.push({
+            source: sym,
+            target,
+            kind: conditional ? 'yield' : 'idle',
+            label: conditional ? `代替 ${pctOf(r)}%` : `待機 ${pctOf(r)}% (枠確保)`,
+            width: Math.max(1.5, Math.min(8, pctOf(r) / 5)),
+          })
+        }
       }
-      links.push({ source: sym, target, value: pctOf(r), kind: conditional ? 'fallback' : 'idle' })
+    })
+    if (needCash) {
+      addNode({
+        name: '現金待機',
+        title: '現金待機',
+        sub: '未参加分の置き場',
+        color: '#9aa0a6',
+        status: 'cash',
+        x: CASH_X,
+        y: centerY,
+      })
+    }
+    // 譲り先が未登場の銘柄 (配分 0% の退避先等) は右列に補完する。
+    for (const e of edges) {
+      if (nodeNames.has(e.target)) continue
+      const row = rows.find((x) => x.symbol.toUpperCase() === e.target)
+      addNode({
+        name: e.target,
+        title: e.target,
+        sub: amounts[e.target] ? `Active ・ ${amounts[e.target]!.native}` : '受け皿',
+        color: row ? colorOf(roleOf(row)) : '#9aa0a6',
+        status: amounts[e.target] ? 'active' : 'pending',
+        x: CASH_X,
+        y: 40 + nodes.length * 8,
+      })
     }
   }
 
@@ -8839,23 +8874,24 @@ export function renderSymbolRelationMap(
     chips.push(`<span style="padding:2px 8px;border-radius:10px;background:#f1ebfd;color:#7e3af2;font-size:11px">regime proxy ${esc(pair.proxySymbol.toUpperCase())} → ${esc(pair.bullSymbol.toUpperCase())}/${esc(pair.bearSymbol.toUpperCase())}</span>`)
   }
 
-  if (links.length === 0 && chips.length === 0) return ''
-  const mapHeight = Math.max(220, nodes.length * 34 + 60)
+  if (edges.length === 0 && chips.length === 0) return ''
+  const mapHeight = Math.max(220, allocated.length * ROW_H + 80)
   const chipRow = chips.length > 0
     ? `<div style="display:flex;gap:6px;flex-wrap:wrap;margin-top:6px">${chips.join('')}</div>`
     : ''
-  const sankeyDiv = links.length > 0
+  const mapDiv = edges.length > 0
     ? `<div id="symbol-relation-map" style="height:${mapHeight}px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;margin-top:6px"></div>
     <p class="muted" style="font-size:11px;margin:4px 0 0">
-      予算 → ロール → 銘柄 → (未保有なら) 譲り先、の<strong>現在形</strong>。「参加」の基準は建玉保有。
-      <span style="color:#0e9f6e">緑の流れ</span> = 条件連動 ON の枠を退避先 / 現金待機に譲り中 ・
-      <span style="color:#9aa0a6">グレーの流れ</span> = 枠は銘柄に確保したまま現金待機 (誰にも譲らない)。
+      口座 → 銘柄 = 配分% (実線、太さ ∝ %)。<strong>Active</strong> = 建玉保有で参加中 (実線枠 + 投入額) ／
+      <strong>Pending</strong> = 様子見 (破線枠) で、点線矢印が「いま枠が行っている先」:
+      <span style="color:#0e9f6e">緑 = 退避先へ代替割当 (条件連動 ON)</span> ・
+      <span style="color:#9aa0a6">グレー = 枠確保のまま現金待機</span>。
     </p>`
     : ''
-  const payload = { nodes, links }
+  const payload = { nodes, edges }
   return `<details open style="margin:0 0 12px">
-    <summary style="cursor:pointer;font-size:13px;font-weight:600">配分マップ <span class="muted" style="font-weight:normal">— 予算 → ロール → 銘柄 → 退避先 (表示専用)</span></summary>
-    ${sankeyDiv}
+    <summary style="cursor:pointer;font-size:13px;font-weight:600">配分マップ <span class="muted" style="font-weight:normal">— 口座 → 銘柄 → 譲り先 (現在形・表示専用)</span></summary>
+    ${mapDiv}
     ${chipRow}
   </details>
   <script src="${ECHARTS_CDN}" defer></script>
@@ -8865,55 +8901,78 @@ export function renderSymbolRelationMap(
     if (typeof echarts === 'undefined') return;
     var data = window.__symbolRelationMap;
     var el = document.getElementById('symbol-relation-map');
-    if (!data || !el || data.links.length === 0) return;
-    var labelOf = {};
-    data.nodes.forEach(function (n) { labelOf[n.name] = n.label; });
+    if (!data || !el || data.edges.length === 0) return;
+    var EDGE_STYLE = {
+      alloc: { color: '#8a8f98', type: 'solid' },
+      yield: { color: '#0e9f6e', type: 'dotted' },
+      idle: { color: '#9aa0a6', type: 'dotted' },
+    };
     var chart = echarts.init(el);
     chart.setOption({
       tooltip: {
         formatter: function (p) {
           if (p.dataType === 'edge') {
-            var head = labelOf[p.data.source] + ' → ' + labelOf[p.data.target];
-            if (p.data.kind === 'fallback') {
-              return head + '<br>未保有のため ' + p.data.value + '% を譲り中 (条件連動 ON)';
-            }
-            if (p.data.kind === 'idle') {
-              return head + '<br>未保有。枠 ' + p.data.value + '% は銘柄に確保したまま現金待機';
-            }
-            return head + '<br>' + p.data.value + '%';
+            if (p.data.kind === 'yield') return p.data.source + ' は様子見のため ' + p.data.label.replace('代替 ', '') + ' を ' + p.data.target + ' に代替割当中';
+            if (p.data.kind === 'idle') return p.data.source + ' は様子見。枠は確保したまま現金待機';
+            return '口座 → ' + p.data.target + ': 配分 ' + p.data.label;
           }
-          return labelOf[p.name] || p.name;
+          var d = p.data;
+          return '<strong>' + d.title + '</strong><br>' + d.sub;
         },
       },
       series: [{
-        type: 'sankey',
-        left: 10,
-        right: 200,
-        top: 14,
-        bottom: 14,
-        nodeWidth: 14,
-        nodeGap: 14,
-        draggable: false,
-        emphasis: { focus: 'adjacency' },
+        type: 'graph',
+        layout: 'none',
+        roam: true,
         data: data.nodes.map(function (n) {
+          var isPending = n.status === 'pending';
           return {
             name: n.name,
-            depth: n.depth,
-            itemStyle: { color: n.color, borderRadius: 3 },
-            label: { formatter: n.label, fontSize: 12, color: '#1d1d1f' },
+            x: n.x,
+            y: n.y,
+            title: n.title,
+            sub: n.sub,
+            symbol: 'roundRect',
+            symbolSize: [150, 46],
+            itemStyle: {
+              color: '#fff',
+              borderColor: n.color,
+              borderWidth: 2,
+              borderType: isPending ? 'dashed' : 'solid',
+              opacity: isPending ? 0.75 : 1,
+              shadowBlur: 4,
+              shadowColor: 'rgba(0,0,0,0.08)',
+            },
+            label: {
+              show: true,
+              formatter: '{t|' + n.title + '}\\n{s|' + n.sub + '}',
+              rich: {
+                t: { fontSize: 13, fontWeight: 700, color: '#1d1d1f', lineHeight: 18 },
+                s: {
+                  fontSize: 10,
+                  color: n.status === 'active' ? '#0e9f6e' : n.status === 'pending' ? '#b25000' : '#6e6e73',
+                  lineHeight: 14,
+                },
+              },
+            },
           };
         }),
-        links: data.links.map(function (l) {
+        edges: data.edges.map(function (e) {
+          var st = EDGE_STYLE[e.kind];
           return {
-            source: l.source,
-            target: l.target,
-            value: l.value,
-            kind: l.kind,
-            lineStyle: l.kind === 'fallback'
-              ? { color: '#0e9f6e', opacity: 0.45, curveness: 0.5 }
-              : l.kind === 'idle'
-                ? { color: '#9aa0a6', opacity: 0.3, curveness: 0.5 }
-                : { color: 'gradient', opacity: 0.3, curveness: 0.5 },
+            source: e.source,
+            target: e.target,
+            kind: e.kind,
+            label: e.label,
+            lineStyle: { color: st.color, type: st.type, width: e.width, curveness: 0.15 },
+            symbol: ['none', 'arrow'],
+            symbolSize: 8,
+            edgeLabel: {
+              show: e.kind !== 'alloc',
+              formatter: e.label,
+              fontSize: 10,
+              color: st.color,
+            },
           };
         }),
       }],

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -19,7 +19,7 @@ import { loadOverviewPanelsCsv, setOverviewPanels } from '../infrastructure/db/g
 import { resolveTradingEnabled } from '../trading/runtime/killSwitch'
 import { loadSymbolUniverse, type SymbolUniverse } from '../infrastructure/db/symbolUniverse'
 import type { SymbolCurrency, SymbolRole } from '../infrastructure/db/symbolConfigRepo'
-import { loadInversePairs, parseAlternativesJson, SYMBOL_ROLES } from '../infrastructure/db/symbolConfigRepo'
+import { loadInversePairs, loadPairRegimeConfigs, parseAlternativesJson, SYMBOL_ROLES } from '../infrastructure/db/symbolConfigRepo'
 import { escapeHtml, formatSymbolDisplay } from '../shared/format'
 import { createDb } from '../infrastructure/db/tradeJournalRepo'
 import {
@@ -64,6 +64,7 @@ import {
   evaluatePairRegime,
   PAIR_REGIME_ZONE_LABELS,
   type PairRegimeDecision,
+  type PairRegimeEntry,
 } from '../trading/strategy/pairRegime'
 import {
   computeConditionalAllocation,
@@ -787,9 +788,11 @@ export const dashboard = new Hono<DashboardBindings>()
       return c.html(renderLayout(c, '銘柄管理', unavailable('DB not bound')))
     }
     try {
-      const [rows, inversePairs] = await Promise.all([
+      const [rows, inversePairs, pairRegimes] = await Promise.all([
         loadAllSymbolConfigRows(c.env.DB),
         loadInversePairs(createDb(c.env.DB)).catch(() => ({}) as Record<string, string>),
+        // 関係マップ用 (#symbol-relation-map)。読めなくても一覧は出す。
+        loadPairRegimeConfigs(createDb(c.env.DB)).catch(() => []),
       ])
       const errorCode = c.req.query('error') ?? null
       const errorSymbol = c.req.query('symbol') ?? null
@@ -799,7 +802,7 @@ export const dashboard = new Hono<DashboardBindings>()
         q: c.req.query('q') ?? '',
       }
       return c.html(
-        renderLayout(c, '銘柄管理', symbolsListBody({ rows, inversePairs, errorCode, errorSymbol, filter })),
+        renderLayout(c, '銘柄管理', symbolsListBody({ rows, inversePairs, pairRegimes, errorCode, errorSymbol, filter })),
       )
     } catch (err) {
       return c.html(renderLayout(c, '銘柄管理', unavailable(messageOf(err))))
@@ -8689,14 +8692,183 @@ function applySymbolsListFilter(rows: SymbolConfigRow[], f: SymbolsListFilter): 
   })
 }
 
+/**
+ * 銘柄関係マップ (#symbol-relation-map)。インバース対 / regime proxy / 退避先と
+ * いう「銘柄同士の依存関係」が一覧テーブルではセル単位に散らばって読めない、
+ * という operator 要望でグラフ可視化する。関係が 1 つも無ければ出さない。
+ *   - ノード: 大きさ = 予算配分%、色 = ロール、無効銘柄はグレー
+ *   - エッジ: インバース対 (赤・双方向) / regime proxy (紫・破線) / 退避先 (緑・矢印)
+ * 表示専用 — 判定・発注には一切関与しない。
+ */
+const ROLE_NODE_COLORS: Record<string, string> = {
+  cash_parking: '#5b8c5a',
+  core_trend: '#1a56db',
+  leveraged_trend: '#d97706',
+  low_volatility: '#7e3af2',
+  sector_trend: '#0e9f9f',
+  inverse_hedge: '#c22d2d',
+}
+
+export function renderSymbolRelationMap(
+  rows: SymbolConfigRow[],
+  inversePairs: Record<string, string>,
+  pairRegimes: PairRegimeEntry[],
+): string {
+  const known = new Map(rows.map((r) => [r.symbol.toUpperCase(), r]))
+  interface MapNode {
+    name: string
+    value: number
+    role: string | null
+    active: boolean
+    registered: boolean
+  }
+  const nodes = new Map<string, MapNode>()
+  const ensureNode = (symRaw: string): void => {
+    const sym = symRaw.toUpperCase()
+    if (nodes.has(sym)) return
+    const row = known.get(sym)
+    nodes.set(sym, {
+      name: sym,
+      value: row?.budgetAllocPct != null ? Math.round(row.budgetAllocPct * 1000) / 10 : 0,
+      role: row?.role ?? null,
+      active: row?.active ?? false,
+      registered: row !== undefined,
+    })
+  }
+  interface MapEdge {
+    source: string
+    target: string
+    kind: 'inverse' | 'proxy' | 'fallback'
+  }
+  const edges: MapEdge[] = []
+  // インバース対 (両方向で格納されているので sym < inverse の片向きに dedup)。
+  for (const [sym, inverse] of Object.entries(inversePairs)) {
+    const a = sym.toUpperCase()
+    const b = inverse.toUpperCase()
+    if (a >= b) continue
+    ensureNode(a)
+    ensureNode(b)
+    edges.push({ source: a, target: b, kind: 'inverse' })
+  }
+  // regime proxy (#472): proxy → bull / bear。misconfig は proxy 不明のため skip。
+  for (const pair of pairRegimes) {
+    if (pair.invalidConfig !== null) continue
+    ensureNode(pair.proxySymbol)
+    for (const side of [pair.bullSymbol, pair.bearSymbol]) {
+      ensureNode(side)
+      edges.push({ source: pair.proxySymbol.toUpperCase(), target: side.toUpperCase(), kind: 'proxy' })
+    }
+  }
+  // 退避先 (#452 Layer 3): 条件未通過時に予算枠が流れる先。
+  for (const r of rows) {
+    if (!r.cashFallbackSymbol) continue
+    ensureNode(r.symbol)
+    ensureNode(r.cashFallbackSymbol)
+    edges.push({
+      source: r.symbol.toUpperCase(),
+      target: r.cashFallbackSymbol.toUpperCase(),
+      kind: 'fallback',
+    })
+  }
+  if (edges.length === 0) return ''
+
+  const payload = {
+    nodes: [...nodes.values()].map((n) => ({
+      name: n.name,
+      pct: n.value,
+      role: n.role,
+      active: n.active,
+      registered: n.registered,
+      color: !n.active || !n.registered ? '#9aa0a6' : ROLE_NODE_COLORS[n.role ?? ''] ?? '#5f6368',
+    })),
+    edges,
+  }
+  return `<details open style="margin:0 0 12px">
+    <summary style="cursor:pointer;font-size:13px;font-weight:600">関係マップ <span class="muted" style="font-weight:normal">— インバース対 / regime proxy / 退避先 (表示専用)</span></summary>
+    <div id="symbol-relation-map" style="height:300px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;margin-top:6px"></div>
+    <p class="muted" style="font-size:11px;margin:4px 0 0">
+      ノードの大きさ = 予算配分%、色 = ロール (グレー = 無効 / 未登録)。
+      <span style="color:#c22d2d">赤実線</span> = インバース対 ・
+      <span style="color:#7e3af2">紫破線</span> = regime proxy (判定材料) ・
+      <span style="color:#0e9f6e">緑矢印</span> = 退避先 (条件未通過時に予算枠が流れる先)。
+    </p>
+  </details>
+  <script src="${ECHARTS_CDN}" defer></script>
+  ${safeJsonScript('__symbolRelationMap', payload)}
+  <script>
+  document.addEventListener('DOMContentLoaded', function () {
+    if (typeof echarts === 'undefined') return;
+    var data = window.__symbolRelationMap;
+    var el = document.getElementById('symbol-relation-map');
+    if (!data || !el) return;
+    var EDGE_STYLE = {
+      inverse: { color: '#c22d2d', type: 'solid', width: 2, symbol: ['none', 'none'], label: 'インバース対' },
+      proxy: { color: '#7e3af2', type: 'dashed', width: 1.5, symbol: ['none', 'arrow'], label: 'regime proxy' },
+      fallback: { color: '#0e9f6e', type: 'solid', width: 1.5, symbol: ['none', 'arrow'], label: '退避先' },
+    };
+    var chart = echarts.init(el);
+    chart.setOption({
+      tooltip: {
+        formatter: function (p) {
+          if (p.dataType === 'edge') {
+            var st = EDGE_STYLE[p.data.kind];
+            return p.data.source + ' → ' + p.data.target + '<br>' + st.label;
+          }
+          var d = p.data;
+          var lines = ['<strong>' + d.name + '</strong>'];
+          if (!d.registered) lines.push('未登録 (proxy 参照のみ)');
+          else {
+            lines.push(d.active ? '有効' : '無効');
+            if (d.role) lines.push('ロール: ' + d.role);
+            lines.push('予算配分: ' + d.pct + '%');
+          }
+          return lines.join('<br>');
+        },
+      },
+      series: [{
+        type: 'graph',
+        layout: 'force',
+        roam: true,
+        force: { repulsion: 320, edgeLength: 110, gravity: 0.12 },
+        label: { show: true, fontSize: 12, fontWeight: 600 },
+        data: data.nodes.map(function (n) {
+          return {
+            name: n.name,
+            pct: n.pct,
+            role: n.role,
+            active: n.active,
+            registered: n.registered,
+            symbolSize: Math.max(18, Math.min(60, 18 + n.pct * 1.4)),
+            itemStyle: { color: n.color, opacity: n.active ? 1 : 0.55 },
+          };
+        }),
+        edges: data.edges.map(function (e) {
+          var st = EDGE_STYLE[e.kind];
+          return {
+            source: e.source,
+            target: e.target,
+            kind: e.kind,
+            lineStyle: { color: st.color, type: st.type, width: st.width, curveness: 0.1 },
+            symbol: st.symbol,
+            symbolSize: 8,
+          };
+        }),
+      }],
+    });
+    window.addEventListener('resize', function () { chart.resize(); });
+  });
+  </script>`
+}
+
 function symbolsListBody(args: {
   rows: SymbolConfigRow[]
   inversePairs?: Record<string, string>
+  pairRegimes?: PairRegimeEntry[]
   errorCode?: string | null
   errorSymbol?: string | null
   filter: SymbolsListFilter
 }): string {
-  const { rows, inversePairs = {}, errorCode = null, errorSymbol = null, filter } = args
+  const { rows, inversePairs = {}, pairRegimes = [], errorCode = null, errorSymbol = null, filter } = args
   // #415: 買付余力バッジをページ最上部に (全 return が ${errorBanner} を先頭に持つので
   // ここに前置すると一覧・空・フィルタ 0 件の全ケースで表示される)。
   const errorBanner = buyingPowerBadge() + renderSymbolErrorBanner(errorCode, errorSymbol)
@@ -8725,6 +8897,8 @@ function symbolsListBody(args: {
     <a href="/dashboard/symbols/new" style="padding:6px 12px;background:#06c;color:#fff;border-radius:4px;text-decoration:none">+ 新規追加</a>
     <span class="muted" style="font-size:12px">${filtered.length} / ${rows.length} 件表示 (有効 ${activeCount} / 無効 ${inactiveCount})</span>
   </p>`
+
+  const relationMap = renderSymbolRelationMap(rows, inversePairs, pairRegimes)
 
   if (rows.length === 0) {
     return `${errorBanner}${headerBar}<p class="muted">登録銘柄なし。「+ 新規追加」から最初の symbol を登録してください。</p>`
@@ -8837,7 +9011,7 @@ function symbolsListBody(args: {
       </tr>`
     })
     .join('')
-  return `${errorBanner}${filterBar}${headerBar}
+  return `${errorBanner}${relationMap}${filterBar}${headerBar}
   <table>
     <thead><tr>
       <th style="width:28px" title="インバース対のツリー表記"></th>

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -8771,9 +8771,18 @@ export function symbolMapEditorBody(
       fallback: r.cashFallbackSymbol?.toUpperCase() ?? null,
       inverse: inversePairs[sym]?.toUpperCase() ?? null,
       currency: r.currency,
-      y: 30 + i * 120,
+      y: 0, // 後段で通貨グループ順に再計算する (JPY 群 → USD 群)
+      order: i,
     }
   })
+  // JPY 銘柄を上群、USD 銘柄を下群に並べ、それぞれの口座カードの近くに置く。
+  let yCursor = 30
+  for (const ccy of ['JPY', 'USD']) {
+    for (const n of nodes.filter((x) => x.currency === ccy)) {
+      n.y = yCursor
+      yCursor += 120
+    }
+  }
   if (nodes.length === 0) {
     return `<p class="muted">有効な銘柄がありません。</p>`
   }
@@ -8781,7 +8790,7 @@ export function symbolMapEditorBody(
   return `<p style="margin:0 0 10px;display:flex;gap:12px;align-items:center;flex-wrap:wrap">
     <a href="/dashboard/symbols" style="font-size:13px">← 銘柄管理へ戻る</a>
     <span class="muted" style="font-size:12px">
-      <strong>口座 → 銘柄の線</strong> = 配分。各枝は均等 (<strong>1/枝</strong>、対は 1 枝扱い) で % は自動計算 ・
+      <strong>口座 (日本/米国) → 銘柄の線</strong> = 配分。各枝は均等 (<strong>1/枝</strong>、対は 1 枝扱い、予算プールは全体共通) で % は自動計算 ・
       <strong>銘柄 → 銘柄の線</strong> = 退避先 (1 銘柄 1 本、条件連動も ON)。
       <strong>線の削除</strong> = 線をクリックして選択 → Backspace / Delete。
     </span>
@@ -8840,13 +8849,25 @@ export function symbolMapEditorBody(
     var draft = {};      // sym -> { connected, fallback }
     var programmatic = false;
 
-    var allocated = data.nodes.filter(function (n) { return n.pct > 0; });
-    var accountY = Math.max(30, 30 + ((allocated.length - 1) * 120) / 2);
-    var accountId = editor.addNode('口座', 0, 1, 40, accountY, 'sm-node sm-account',
-      { sym: '口座' },
-      '<div class="sm-card"><div class="sm-title" style="color:#fff">口座</div>' +
-      '<div class="sm-meta" style="color:#e8eaed">原資 ・ 予算 100% を枝数で均等割</div></div>');
-    symOf[accountId] = '__account__';
+    // 起点は通貨別の口座カード (operator 指定)。予算プール自体は単一 (JPY 換算
+    // ベース #budget-jpy-base-fx) なので 1/枝 は全体共通 — カードには通貨内訳を出す。
+    var currencies = [];
+    data.nodes.forEach(function (n) { if (currencies.indexOf(n.currency) === -1) currencies.push(n.currency); });
+    currencies.sort(); // JPY, USD の順
+    var accountIds = {};
+    var accountSymOf = {};
+    var nJpy = data.nodes.filter(function (n) { return n.currency === 'JPY'; }).length;
+    currencies.forEach(function (ccy, i) {
+      var label = ccy === 'JPY' ? '日本口座 (JPY)' : '米国口座 (USD)';
+      var y = ccy === 'JPY' ? 30 + ((Math.max(nJpy, 1) - 1) * 120) / 2 : 30 + nJpy * 120 + ((Math.max(data.nodes.length - nJpy, 1) - 1) * 120) / 2;
+      var id = editor.addNode('口座' + ccy, 0, 1, 40, y, 'sm-node sm-account',
+        { sym: '口座' + ccy },
+        '<div class="sm-card"><div class="sm-title" style="color:#fff">' + label + '</div>' +
+        '<div class="sm-meta" style="color:#e8eaed">—</div></div>');
+      accountIds[ccy] = id;
+      symOf[id] = '__account_' + ccy + '__';
+      accountSymOf['__account_' + ccy + '__'] = ccy;
+    });
 
     data.nodes.forEach(function (n) {
       nodeBySym[n.sym] = n;
@@ -8872,7 +8893,7 @@ export function symbolMapEditorBody(
 
     programmatic = true;
     data.nodes.forEach(function (n) {
-      if (n.pct > 0) editor.addConnection(accountId, idOf[n.sym], 'output_1', 'input_1');
+      if (n.pct > 0) editor.addConnection(accountIds[n.currency], idOf[n.sym], 'output_1', 'input_1');
       if (n.fallback && idOf[n.fallback]) editor.addConnection(idOf[n.sym], idOf[n.fallback], 'output_1', 'input_1');
     });
     programmatic = false;
@@ -8903,11 +8924,24 @@ export function symbolMapEditorBody(
         if (!span) return;
         span.textContent = draft[sym].connected ? '1/' + d.branches + ' = ' + d.share + '%' : 'なし (risk-%)';
       });
-      var accountEl = document.getElementById('node-' + accountId);
-      if (accountEl) {
+      currencies.forEach(function (ccy) {
+        var accountEl = document.getElementById('node-' + accountIds[ccy]);
+        if (!accountEl) return;
         var meta = accountEl.querySelector('.sm-meta');
-        if (meta) meta.textContent = '原資 ・ ' + d.branches + ' 枝 ・ 1 枝 = ' + (d.branches > 0 ? d.share + '%' : '—');
-      }
+        if (!meta) return;
+        // 通貨内訳: この口座配下の枝数と小計% (対は 1 枝)。予算プールは全体共通。
+        var seenCcy = {};
+        var ccyBranches = 0;
+        Object.keys(draft).forEach(function (sym) {
+          if (!draft[sym].connected || nodeBySym[sym].currency !== ccy || seenCcy[sym]) return;
+          seenCcy[sym] = true;
+          var inv = nodeBySym[sym].inverse;
+          if (inv && draft[inv] && draft[inv].connected) seenCcy[inv] = true;
+          ccyBranches += 1;
+        });
+        var subtotal = Math.round(ccyBranches * d.share * 10) / 10;
+        meta.textContent = ccyBranches + ' 枝 ・ 小計 ' + subtotal + '% (全体 ' + d.branches + ' 枝 ・ 1 枝 = ' + (d.branches > 0 ? d.share + '%' : '—') + ')';
+      });
       return d;
     }
 
@@ -8948,13 +8982,21 @@ export function symbolMapEditorBody(
       if (programmatic) return;
       var src = symOf[info.output_id];
       var dst = symOf[info.input_id];
-      if (!src || !dst || dst === '__account__') {
+      if (!src || !dst || accountSymOf[dst]) {
         programmatic = true;
         editor.removeSingleConnection(info.output_id, info.input_id, info.output_class, info.input_class);
         programmatic = false;
         return;
       }
-      if (src === '__account__') {
+      if (accountSymOf[src]) {
+        // 通貨の合わない口座からの線は弾く (JPY 口座 → USD 銘柄等)。
+        if (nodeBySym[dst].currency !== accountSymOf[src]) {
+          programmatic = true;
+          editor.removeSingleConnection(info.output_id, info.input_id, info.output_class, info.input_class);
+          programmatic = false;
+          alert(dst + ' は ' + nodeBySym[dst].currency + ' 銘柄です。' + accountSymOf[src] + ' 口座からは接続できません。');
+          return;
+        }
         draft[dst].connected = true;
         markConnectionPending(info.output_id, info.input_id);
         renderChanges();
@@ -8976,7 +9018,7 @@ export function symbolMapEditorBody(
       var src = symOf[info.output_id];
       var dst = symOf[info.input_id];
       if (!src || !dst) return;
-      if (src === '__account__') {
+      if (accountSymOf[src]) {
         draft[dst].connected = false;
         renderChanges();
         return;

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -8796,6 +8796,10 @@ export function symbolMapEditorBody(
     <a href="/dashboard/symbols" style="font-size:13px">← 銘柄管理へ戻る</a>
     <span class="muted" style="font-size:12px">
       <strong>口座 → 銘柄の線</strong> = 配分 ・ <strong>銘柄 → 銘柄の線</strong> = 退避先 (1 銘柄 1 本、条件連動も ON) ・ % 欄 = 配分変更。
+      <strong>線の削除</strong> = 線をクリックして選択 → Backspace / Delete。
+    </span>
+    <button type="button" id="sm-delete-conn" disabled style="padding:4px 12px;background:#fff;border:1px solid #ccc;color:#999;border-radius:6px;cursor:pointer;font-size:12px">選択中の線を削除</button>
+    <span class="muted" style="font-size:12px">
       変更は即保存されません — 下のサマリを確認して<strong>「適用」で一括保存</strong>します。
       カードの塗り: <span style="background:#5f6368;border:1px solid #3c4043;color:#fff;padding:0 6px;border-radius:4px">口座</span>
       <span style="background:#fdf3f2;border:1px solid #d4a09a;padding:0 6px;border-radius:4px">JPY</span>
@@ -9006,6 +9010,30 @@ export function symbolMapEditorBody(
       renderChanges();
     });
 
+    // 線の削除を Mac でも自然に: Backspace 単体 (入力欄フォーカス時は除く) と
+    // 明示ボタンの両方をサポートする。Drawflow 素の対応は Delete / Cmd+Backspace のみ。
+    var deleteBtn = document.getElementById('sm-delete-conn');
+    function refreshDeleteBtn() {
+      var has = editor.connection_selected != null;
+      deleteBtn.disabled = !has;
+      deleteBtn.style.color = has ? '#c22' : '#999';
+      deleteBtn.style.borderColor = has ? '#c22' : '#ccc';
+    }
+    el.addEventListener('click', function () { setTimeout(refreshDeleteBtn, 0); });
+    deleteBtn.addEventListener('click', function () {
+      if (editor.connection_selected != null) editor.removeConnection();
+      refreshDeleteBtn();
+    });
+    document.addEventListener('keydown', function (ev) {
+      if (ev.key !== 'Backspace') return;
+      var tag = document.activeElement && document.activeElement.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+      if (editor.connection_selected != null) {
+        ev.preventDefault();
+        editor.removeConnection();
+        refreshDeleteBtn();
+      }
+    });
     document.getElementById('sm-reset').addEventListener('click', function () { location.reload(); });
     document.getElementById('sm-apply').addEventListener('click', function () {
       var pctChanges = Object.keys(draft).filter(function (sym) { return draft[sym].pct !== baseline[sym].pct; });

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -19,7 +19,7 @@ import { loadOverviewPanelsCsv, setOverviewPanels } from '../infrastructure/db/g
 import { resolveTradingEnabled } from '../trading/runtime/killSwitch'
 import { loadSymbolUniverse, type SymbolUniverse } from '../infrastructure/db/symbolUniverse'
 import type { SymbolCurrency, SymbolRole } from '../infrastructure/db/symbolConfigRepo'
-import { loadInversePairs, parseAlternativesJson, SYMBOL_ROLES } from '../infrastructure/db/symbolConfigRepo'
+import { loadInversePairs, SYMBOL_ROLES } from '../infrastructure/db/symbolConfigRepo'
 import { escapeHtml, formatSymbolDisplay } from '../shared/format'
 import { createDb } from '../infrastructure/db/tradeJournalRepo'
 import {
@@ -510,7 +510,6 @@ export const dashboard = new Hono<DashboardBindings>()
         ? buildBuyabilityView(symbolChart.evalIndicators, entryRule)
         : null
       // 段階判定 (#452 PR 2): 7 gates から ENTRY/HALF/WATCH/NG を導出して表示。
-      // WATCH/NG 時は alternatives (表示専用) を併記する。
       const entryStatus = buyability?.current ? deriveEntryStatus(buyability.current) : null
       // ペアレジーム (#472): focus symbol が regime 有効ペアの一員なら、cron と
       // 同じ pure 関数で zone を評価して表示する (mode=off では出さない)。
@@ -575,7 +574,6 @@ export const dashboard = new Hono<DashboardBindings>()
             entryStatus,
             decisionRows,
             pairRegime: pairRegimeView,
-            alternatives: focusSymbol ? universe.symbolAlternatives[focusSymbol] ?? [] : [],
             symbolPolicy: focusSymbol
               ? {
                   role: universe.symbolRole[focusSymbol] ?? null,
@@ -5807,8 +5805,6 @@ export interface ChartsBodySymbol {
   buyability?: BuyabilityView | null
   /** 段階判定 (#452 PR 2)。null = 評価データ無し。 */
   entryStatus?: EntryStatusResult | null
-  /** 代替銘柄候補 (#452、表示専用)。WATCH/NG 時に併記する。 */
-  alternatives?: string[]
   /** focus symbol のロール / 配分ポリシー要約 (#452)。 */
   symbolPolicy?: SymbolPolicySummary | null
   /**
@@ -7204,7 +7200,6 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
   ${renderPairRegimeLine(args.pairRegime ?? null)}
   ${renderBuyabilityPanel(args.buyability ?? null, {
     entryStatus: args.entryStatus ?? null,
-    alternatives: args.alternatives ?? [],
   })}
   ${renderDecisionPlotCaption(args.symbolChart)}
   <div id="decision-trace-panel" class="reason-panel" style="margin-top:10px">
@@ -8369,8 +8364,6 @@ function fmtGateValue(g: EntryGateStatus): string {
 export interface BuyabilityPanelContext {
   /** 段階判定 (#452 PR 2)。null = 出さない。 */
   entryStatus?: EntryStatusResult | null
-  /** 代替銘柄候補 (#452、表示専用)。WATCH/NG 時のみ表示する。 */
-  alternatives?: string[]
 }
 
 export function renderBuyabilityPanel(
@@ -8466,22 +8459,11 @@ export function renderBuyabilityPanel(
     })
     .join('')
 
-  // --- 段階判定 badge + HALF 説明 + 代替候補 (#452 PR 2) ---
+  // --- 段階判定 badge + HALF 説明 (#452 PR 2) ---
   const statusBadge = status ? entryStatusBadgeHtml(status.status) : ''
   let halfNote = ''
   if (status?.status === 'HALF' && status.halfGate) {
     halfNote = `<div style="margin-top:6px;font-size:12px;color:#b25000">HALF: 未通過は「${esc(status.halfGate.labelJa)}」のみで閾値の許容バンド内 → 0.5x サイジングで entry 候補 (role が entry 有効な銘柄のみ発注対象)。</div>`
-  }
-  let altBlock = ''
-  if (status && (status.status === 'WATCH' || status.status === 'NG') && ctx.alternatives?.length) {
-    const links = ctx.alternatives
-      .map(
-        (s) =>
-          `<a href="/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(s)}" style="font-weight:600">${esc(s)}</a>`,
-      )
-      .join(' / ')
-    altBlock = `<div style="margin-top:8px"><strong>代替候補</strong>: ${links}
-      <div class="muted" style="font-size:11px">この銘柄が entry 不可の間の代替 ETF 候補 (表示のみ — 自動で発注先を切り替えることはしない、#452)。</div></div>`
   }
 
   // 距離の推移 (+ETA) と 入場ゲート は 2 列 (narrow 画面は .panel-row の
@@ -8490,7 +8472,7 @@ export function renderBuyabilityPanel(
     <div style="font-size:13px;color:${headColor};margin-bottom:6px;display:flex;align-items:center;gap:8px;flex-wrap:wrap">${statusBadge}<span>${headline}</span></div>
     ${halfNote}
     <div class="panel-row" style="gap:8px 20px">
-      <div>${trendBlock}${etaBlock}${altBlock}</div>
+      <div>${trendBlock}${etaBlock}</div>
       <div style="margin-top:8px"><strong>入場ゲート</strong>(全条件。閾値は global 既定 + role preset + 銘柄 override、#452)
         <div style="margin-top:4px;display:flex;flex-direction:column;gap:3px">${gateRows}</div>
       </div>
@@ -9182,7 +9164,7 @@ function symbolFormBody(args: SymbolFormArgs): string {
   // 持ち越し設定は radio 2 択で両状態を明示する (「持ち越し」ラベル + 「持ち越さ
   // ない」checkbox の二重否定が ON/OFF どちらか読めない、という operator 指摘)。
   const intradayOnlyChecked = row?.intradayOnly ? ' checked' : ''
-  // role / entry override / alternatives (#452)。pullback / trend / 過伸長は
+  // role / entry override (#452)。pullback / trend / 過伸長は
   // DB に fraction 保存、表示は % (×100)。ATR 比は ratio 生値。
   // 不正 role 値 (enum 外の DB 直書き) の fail-closed をフォームで弱めない
   // (CodeRabbit #453): 一致 option が無いと先頭 '' が選択され、保存で意図せず
@@ -9216,7 +9198,6 @@ function symbolFormBody(args: SymbolFormArgs): string {
     row?.requireAboveSma50Override === null || row?.requireAboveSma50Override === undefined
       ? ''
       : String(row.requireAboveSma50Override)
-  const alternativesValue = (parseAlternativesJson(row?.alternatives ?? null, symbolValue) ?? []).join(', ')
   // 条件連動配分 (#452 Layer 3)。
   const entryRequiredChecked = row?.entryRequired ? ' checked' : ''
   const alwaysActiveChecked = row?.alwaysActive ? ' checked' : ''
@@ -9292,8 +9273,7 @@ function symbolFormBody(args: SymbolFormArgs): string {
     minReturn50dOverrideValue !== '' ||
     maxAtrRatioOverrideValue !== '' ||
     maxSma50DeviationPctOverrideValue !== '' ||
-    requireAboveSma50OverrideValue !== '' ||
-    alternativesValue !== ''
+    requireAboveSma50OverrideValue !== ''
   const hasExitValues =
     timeStopDaysOverrideValue !== '' ||
     kAtrOverrideValue !== '' ||
@@ -9412,11 +9392,7 @@ function symbolFormBody(args: SymbolFormArgs): string {
           <option value="true"${requireAboveSma50OverrideValue === 'true' ? ' selected' : ''}>必須 (price &gt; SMA50)</option>
           <option value="false"${requireAboveSma50OverrideValue === 'false' ? ' selected' : ''}>不要</option>
         </select>
-        <label>代替銘柄</label>
-        <div>
-          <input type="text" name="alternatives" value="${esc(alternativesValue)}" maxlength="120" placeholder="例: SOXX, SMH" style="padding:6px;width:240px">
-          <span class="muted" style="font-size:12px;margin-left:6px">entry 不可時に表示する候補 (表示のみ・最大 8)</span>
-        </div>`,
+        `,
       hasStrategyValues,
     )}
 

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -8813,18 +8813,24 @@ export function renderSymbolRelationMap(
         links.push({ source: roleName, target: sym, value: pctOf(r), kind: 'symbol' })
       }
     }
-    // 退避先 (#452 Layer 3): 条件連動銘柄の配分が entry 未通過時に流れる先。
+    // 退避先 (#452 Layer 3): **条件連動 ON** の銘柄の配分が entry 未通過時に
+    // 流れる先。退避先未設定は「現金のまま待機」なので現金待機ノードへ —
+    // 連動だけ ON にして退避先を入れていない設定 (VUG 等) もここで可視化される。
     for (const r of allocated) {
-      if (!r.cashFallbackSymbol) continue
+      if (r.entryRequired !== true) continue
       const sym = r.symbol.toUpperCase()
-      const target = r.cashFallbackSymbol.toUpperCase()
+      const target = r.cashFallbackSymbol ? r.cashFallbackSymbol.toUpperCase() : '現金待機'
       if (sym === target) continue
-      const targetRow = rows.find((x) => x.symbol.toUpperCase() === target)
-      addNode({
-        name: target,
-        label: `${target}${amounts[target]?.native ? ` (${amounts[target]!.native})` : ''}`,
-        color: targetRow ? colorOf(roleOf(targetRow)) : '#9aa0a6',
-      })
+      if (target === '現金待機') {
+        addNode({ name: '現金待機', label: '現金待機 (退避先なし)', color: '#9aa0a6' })
+      } else {
+        const targetRow = rows.find((x) => x.symbol.toUpperCase() === target)
+        addNode({
+          name: target,
+          label: `${target}${amounts[target]?.native ? ` (${amounts[target]!.native})` : ''}`,
+          color: targetRow ? colorOf(roleOf(targetRow)) : '#9aa0a6',
+        })
+      }
       links.push({ source: sym, target, value: pctOf(r), kind: 'fallback' })
     }
   }
@@ -8854,7 +8860,7 @@ export function renderSymbolRelationMap(
     ? `<div id="symbol-relation-map" style="height:${mapHeight}px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;margin-top:6px"></div>
     <p class="muted" style="font-size:11px;margin:4px 0 0">
       予算 → ロール → 銘柄 (配分% ・ 括弧内 = 現在の投入額)。
-      <span style="color:#0e9f6e">緑の流れ</span> = 退避先 (条件連動 ON の銘柄が entry 未通過の間、その配分が流れる先 — 受け皿側の太さは最悪ケースの合計)。
+      <span style="color:#0e9f6e">緑の流れ</span> = 退避 (条件連動 ON の銘柄が entry 未通過の間、その配分が流れる先 — 受け皿側の太さは最悪ケースの合計。退避先未設定は「現金待機」へ)。
     </p>`
     : ''
   const payload = { nodes, links }

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -77,6 +77,7 @@ import type {
 import { and, asc, desc, eq, gte, inArray, isNotNull, lte, or } from 'drizzle-orm'
 import { PortfolioStateClient } from '../trading/state/PortfolioStateClient'
 import { SymbolStateClient } from '../trading/state/SymbolStateClient'
+import { loadUsdJpyRate } from '../infrastructure/quotes/fxRate'
 import type { SymbolState } from '../trading/state/types'
 import { YahooBarClient } from '../infrastructure/quotes/YahooBarClient'
 // #293 calendar events management UI (earnings + macro)。dashboard 側に form
@@ -794,6 +795,31 @@ export const dashboard = new Hono<DashboardBindings>()
         // 関係マップ用 (#symbol-relation-map)。読めなくても一覧は出す。
         loadPairRegimeConfigs(createDb(c.env.DB)).catch(() => []),
       ])
+      // 関係マップの縦軸 = 投入金額 (DO position の qty × avgPrice、ground truth)。
+      // 取得失敗・position 無しは 0 (最下段)。fx は表示位置の換算のみに使う。
+      const mapAmounts: Record<string, { native: string; jpy: number }> = {}
+      if (c.env.SYMBOL_STATE) {
+        const stateClient = new SymbolStateClient(c.env.SYMBOL_STATE)
+        const usdJpy = await loadUsdJpyRate().catch(() => null)
+        await Promise.all(
+          rows.map(async (r) => {
+            const sym = r.symbol.toUpperCase()
+            const state = await stateClient.getState(sym).catch(() => null)
+            const pos = state?.position
+            if (!pos || pos.qty <= 0) return
+            const cost = pos.qty * pos.avgPrice
+            if (r.currency === 'USD') {
+              // fx 不達時は概算 150 で位置決めだけ行う (表示専用、tooltip は native 額)。
+              mapAmounts[sym] = {
+                native: `$${cost.toFixed(0)}`,
+                jpy: cost * (usdJpy ?? 150),
+              }
+            } else {
+              mapAmounts[sym] = { native: `¥${Math.round(cost).toLocaleString('en-US')}`, jpy: cost }
+            }
+          }),
+        )
+      }
       const errorCode = c.req.query('error') ?? null
       const errorSymbol = c.req.query('symbol') ?? null
       const filter: SymbolsListFilter = {
@@ -802,7 +828,7 @@ export const dashboard = new Hono<DashboardBindings>()
         q: c.req.query('q') ?? '',
       }
       return c.html(
-        renderLayout(c, '銘柄管理', symbolsListBody({ rows, inversePairs, pairRegimes, errorCode, errorSymbol, filter })),
+        renderLayout(c, '銘柄管理', symbolsListBody({ rows, inversePairs, pairRegimes, mapAmounts, errorCode, errorSymbol, filter })),
       )
     } catch (err) {
       return c.html(renderLayout(c, '銘柄管理', unavailable(messageOf(err))))
@@ -8697,10 +8723,12 @@ function applySymbolsListFilter(rows: SymbolConfigRow[], f: SymbolsListFilter): 
  * いう「銘柄同士の依存関係」が一覧テーブルではセル単位に散らばって読めない、
  * という operator 要望でグラフ可視化する。関係が 1 つも無ければ出さない。
  *
- * 表現は repree.net (React Flow 系) 準拠の operator 指定:
- *   - 1 カード = 1 銘柄 (symbol + ロール + 配分% をカード内に表示)
- *   - 左→右のレイヤー配置: regime proxy → 銘柄 → 退避先
- *   - 退避エッジには配分% をラベル表示 (条件未通過時にその枠が流れるため)
+ * 表現 (repree.net 系カード + operator 指定の軸):
+ *   - 1 カード = 1 銘柄 (symbol + 配分% + 投入額)
+ *   - **横軸 = ロール** (列。リスク低 → 高で左から)、**縦軸 = 投入金額**
+ *     (DO position の qty × avgPrice、円換算。上ほど大きい。0 = 最下段)
+ *   - エッジ: インバース対 (赤) / regime proxy (紫破線) / 退避先 (緑矢印、
+ *     ラベル % = 条件未通過時に流れる予算枠)
  * 表示専用 — 判定・発注には一切関与しない。
  */
 const ROLE_NODE_COLORS: Record<string, string> = {
@@ -8712,10 +8740,23 @@ const ROLE_NODE_COLORS: Record<string, string> = {
   inverse_hedge: '#c22d2d',
 }
 
+/** 関係マップの列順 (リスク低 → 高)。'none' = role 未設定、'ref' = 未登録 (proxy 参照のみ)。 */
+const MAP_ROLE_COLUMNS = [
+  'cash_parking',
+  'low_volatility',
+  'core_trend',
+  'sector_trend',
+  'leveraged_trend',
+  'inverse_hedge',
+  'none',
+  'ref',
+] as const
+
 export function renderSymbolRelationMap(
   rows: SymbolConfigRow[],
   inversePairs: Record<string, string>,
   pairRegimes: PairRegimeEntry[],
+  amounts: Record<string, { native: string; jpy: number }> = {},
 ): string {
   const known = new Map(rows.map((r) => [r.symbol.toUpperCase(), r]))
   interface MapNode {
@@ -8786,69 +8827,62 @@ export function renderSymbolRelationMap(
   }
   if (edges.length === 0) return ''
 
-  // レイヤー割当 (左→右): 0 = proxy 専用ノード、1 = 銘柄、2 = 退避先。
-  // 退避先かつ通常銘柄 (SGOV 等) は右列に置く。proxy かつ登録銘柄は中央。
-  const proxySyms = new Set(
-    pairRegimes.filter((p) => p.invalidConfig === null).map((p) => p.proxySymbol.toUpperCase()),
-  )
-  const fallbackTargets = new Set(
-    edges.filter((e) => e.kind === 'fallback').map((e) => e.target),
-  )
-  const layerOf = (n: MapNode): number => {
-    if (fallbackTargets.has(n.name)) return 2
-    if (proxySyms.has(n.name) && !n.registered) return 0
-    return 1
+  // 列割当: 横軸 = ロール。未登録 (proxy 参照のみ) は 'ref' 列。
+  const columnOf = (n: MapNode): string => {
+    if (!n.registered) return 'ref'
+    return n.role ?? 'none'
   }
-  // 中央列はインバース対が縦に隣接するよう並べる。
-  const layer1 = [...nodes.values()].filter((n) => layerOf(n) === 1).map((n) => n.name)
-  layer1.sort()
-  const orderedLayer1: string[] = []
-  for (const sym of layer1) {
-    if (orderedLayer1.includes(sym)) continue
-    orderedLayer1.push(sym)
-    const partner = inversePairs[sym]?.toUpperCase()
-    if (partner && layer1.includes(partner) && !orderedLayer1.includes(partner)) {
-      orderedLayer1.push(partner)
-    }
-  }
-  const layers: string[][] = [
-    [...nodes.values()].filter((n) => layerOf(n) === 0).map((n) => n.name).sort(),
-    orderedLayer1,
-    [...nodes.values()].filter((n) => layerOf(n) === 2).map((n) => n.name).sort(),
-  ]
-  const CARD_W = 132
-  const ROW_H = 78
+  const usedColumns = MAP_ROLE_COLUMNS.filter((col) =>
+    [...nodes.values()].some((n) => columnOf(n) === col),
+  )
+  const COL_W = 190
+  const PLOT_H = 300
+  const TOP_PAD = 56
+  const BOTTOM_Y = TOP_PAD + PLOT_H
+  const maxJpy = Math.max(1, ...[...nodes.values()].map((n) => amounts[n.name]?.jpy ?? 0))
   const positioned = new Map<string, { x: number; y: number }>()
-  const maxRows = Math.max(...layers.map((l) => l.length), 1)
-  layers.forEach((layer, li) => {
-    // 列内は縦中央寄せ。
-    const offset = ((maxRows - layer.length) * ROW_H) / 2
-    layer.forEach((sym, ri) => {
-      positioned.set(sym, { x: 90 + li * 300, y: 50 + offset + ri * ROW_H })
-    })
+  usedColumns.forEach((col, ci) => {
+    const colNodes = [...nodes.values()].filter((n) => columnOf(n) === col)
+    // 金額の大きい順に縦位置を計算し、近接 (カード高さ未満) は下へ押し出して重なり回避。
+    colNodes.sort((a, b) => (amounts[b.name]?.jpy ?? 0) - (amounts[a.name]?.jpy ?? 0))
+    let lastY = -Infinity
+    for (const n of colNodes) {
+      const jpy = amounts[n.name]?.jpy ?? 0
+      let y = TOP_PAD + (1 - jpy / maxJpy) * PLOT_H
+      if (y - lastY < 56) y = lastY + 56
+      lastY = y
+      positioned.set(n.name, { x: 110 + ci * COL_W, y })
+    }
   })
-  const mapHeight = Math.max(240, maxRows * ROW_H + 70)
+  const mapHeight = Math.max(
+    320,
+    Math.ceil(Math.max(...[...positioned.values()].map((p2) => p2.y), BOTTOM_Y) + 60),
+  )
+
+  const roleHeader = (col: string): string =>
+    col === 'ref' ? '参照のみ' : col === 'none' ? 'ロール未設定' : SYMBOL_ROLE_LABELS_SHORT[col as SymbolRole] ?? col
 
   const payload = {
-    cardW: CARD_W,
+    headers: usedColumns.map((col, ci) => ({ label: roleHeader(col), x: 110 + ci * COL_W })),
     nodes: [...nodes.values()].map((n) => ({
       name: n.name,
       pct: n.pct,
+      amountLabel: amounts[n.name]?.native ?? null,
       role: n.role,
-      roleShort: n.role !== null ? SYMBOL_ROLE_LABELS_SHORT[n.role as SymbolRole] ?? n.role : null,
+      col: columnOf(n),
       active: n.active,
       registered: n.registered,
       color: !n.active || !n.registered ? '#9aa0a6' : ROLE_NODE_COLORS[n.role ?? ''] ?? '#5f6368',
-      x: positioned.get(n.name)?.x ?? 90,
-      y: positioned.get(n.name)?.y ?? 50,
+      x: positioned.get(n.name)?.x ?? 110,
+      y: positioned.get(n.name)?.y ?? BOTTOM_Y,
     })),
     edges,
   }
   return `<details open style="margin:0 0 12px">
-    <summary style="cursor:pointer;font-size:13px;font-weight:600">関係マップ <span class="muted" style="font-weight:normal">— regime proxy → 銘柄 → 退避先 (表示専用)</span></summary>
+    <summary style="cursor:pointer;font-size:13px;font-weight:600">関係マップ <span class="muted" style="font-weight:normal">— 横 = ロール ／ 縦 = 投入金額 (表示専用)</span></summary>
     <div id="symbol-relation-map" style="height:${mapHeight}px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;margin-top:6px"></div>
     <p class="muted" style="font-size:11px;margin:4px 0 0">
-      1 カード = 1 銘柄 (ロール / 予算配分%。グレー = 無効 / 未登録)。
+      1 カード = 1 銘柄 (予算配分% ・ 投入額 = position の取得コスト。上ほど大きい / 未保有は最下段。グレー = 無効・未登録)。
       <span style="color:#c22d2d">赤実線</span> = インバース対 ・
       <span style="color:#7e3af2">紫破線</span> = regime proxy (判定材料) ・
       <span style="color:#0e9f6e">緑矢印</span> = 退避先 (ラベル % = 条件未通過時に流れる予算枠)。
@@ -8867,6 +8901,20 @@ export function renderSymbolRelationMap(
       proxy: { color: '#7e3af2', type: 'dashed', width: 1.5, symbol: ['none', 'arrow'] },
       fallback: { color: '#0e9f6e', type: 'solid', width: 1.8, symbol: ['none', 'arrow'] },
     };
+    // 列ヘッダはドラッグ/ズームに追従するよう「ラベルだけの不可視ノード」で表現する。
+    var headerNodes = data.headers.map(function (h, i) {
+      return {
+        name: '__header_' + i,
+        x: h.x,
+        y: 14,
+        symbol: 'rect',
+        symbolSize: [1, 1],
+        itemStyle: { color: 'rgba(0,0,0,0)' },
+        label: { show: true, formatter: h.label, fontSize: 11, fontWeight: 700, color: '#6e6e73' },
+        tooltip: { show: false },
+        silent: true,
+      };
+    });
     var chart = echarts.init(el);
     chart.setOption({
       tooltip: {
@@ -8879,8 +8927,8 @@ export function renderSymbolRelationMap(
           if (!d.registered) lines.push('未登録 (proxy 参照のみ)');
           else {
             lines.push(d.active ? '有効' : '無効');
-            if (d.roleShort) lines.push('ロール: ' + d.roleShort);
             lines.push('予算配分: ' + d.pct + '%');
+            lines.push('投入額: ' + (d.amountLabel || 'なし (未保有)'));
           }
           return lines.join('<br>');
         },
@@ -8891,19 +8939,19 @@ export function renderSymbolRelationMap(
         roam: true,
         data: data.nodes.map(function (n) {
           var sub = [];
-          if (n.registered && n.roleShort) sub.push(n.roleShort);
           if (n.registered && n.pct > 0) sub.push(n.pct + '%');
+          if (n.amountLabel) sub.push(n.amountLabel);
           if (!n.registered) sub.push('未登録 proxy');
           return {
             name: n.name,
             x: n.x,
             y: n.y,
             pct: n.pct,
-            roleShort: n.roleShort,
+            amountLabel: n.amountLabel,
             active: n.active,
             registered: n.registered,
             symbol: 'roundRect',
-            symbolSize: [data.cardW, 46],
+            symbolSize: [128, 46],
             itemStyle: {
               color: '#fff',
               borderColor: n.color,
@@ -8921,7 +8969,7 @@ export function renderSymbolRelationMap(
               },
             },
           };
-        }),
+        }).concat(headerNodes),
         edges: data.edges.map(function (e) {
           var st = EDGE_STYLE[e.kind];
           return {
@@ -8951,11 +8999,12 @@ function symbolsListBody(args: {
   rows: SymbolConfigRow[]
   inversePairs?: Record<string, string>
   pairRegimes?: PairRegimeEntry[]
+  mapAmounts?: Record<string, { native: string; jpy: number }>
   errorCode?: string | null
   errorSymbol?: string | null
   filter: SymbolsListFilter
 }): string {
-  const { rows, inversePairs = {}, pairRegimes = [], errorCode = null, errorSymbol = null, filter } = args
+  const { rows, inversePairs = {}, pairRegimes = [], mapAmounts = {}, errorCode = null, errorSymbol = null, filter } = args
   // #415: 買付余力バッジをページ最上部に (全 return が ${errorBanner} を先頭に持つので
   // ここに前置すると一覧・空・フィルタ 0 件の全ケースで表示される)。
   const errorBanner = buyingPowerBadge() + renderSymbolErrorBanner(errorCode, errorSymbol)
@@ -8985,7 +9034,7 @@ function symbolsListBody(args: {
     <span class="muted" style="font-size:12px">${filtered.length} / ${rows.length} 件表示 (有効 ${activeCount} / 無効 ${inactiveCount})</span>
   </p>`
 
-  const relationMap = renderSymbolRelationMap(rows, inversePairs, pairRegimes)
+  const relationMap = renderSymbolRelationMap(rows, inversePairs, pairRegimes, mapAmounts)
 
   if (rows.length === 0) {
     return `${errorBanner}${headerBar}<p class="muted">登録銘柄なし。「+ 新規追加」から最初の symbol を登録してください。</p>`

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -8696,8 +8696,11 @@ function applySymbolsListFilter(rows: SymbolConfigRow[], f: SymbolsListFilter): 
  * 銘柄関係マップ (#symbol-relation-map)。インバース対 / regime proxy / 退避先と
  * いう「銘柄同士の依存関係」が一覧テーブルではセル単位に散らばって読めない、
  * という operator 要望でグラフ可視化する。関係が 1 つも無ければ出さない。
- *   - ノード: 大きさ = 予算配分%、色 = ロール、無効銘柄はグレー
- *   - エッジ: インバース対 (赤・双方向) / regime proxy (紫・破線) / 退避先 (緑・矢印)
+ *
+ * 表現は repree.net (React Flow 系) 準拠の operator 指定:
+ *   - 1 カード = 1 銘柄 (symbol + ロール + 配分% をカード内に表示)
+ *   - 左→右のレイヤー配置: regime proxy → 銘柄 → 退避先
+ *   - 退避エッジには配分% をラベル表示 (条件未通過時にその枠が流れるため)
  * 表示専用 — 判定・発注には一切関与しない。
  */
 const ROLE_NODE_COLORS: Record<string, string> = {
@@ -8717,28 +8720,33 @@ export function renderSymbolRelationMap(
   const known = new Map(rows.map((r) => [r.symbol.toUpperCase(), r]))
   interface MapNode {
     name: string
-    value: number
+    pct: number
     role: string | null
     active: boolean
     registered: boolean
   }
   const nodes = new Map<string, MapNode>()
-  const ensureNode = (symRaw: string): void => {
+  const ensureNode = (symRaw: string): MapNode => {
     const sym = symRaw.toUpperCase()
-    if (nodes.has(sym)) return
+    const existing = nodes.get(sym)
+    if (existing) return existing
     const row = known.get(sym)
-    nodes.set(sym, {
+    const node: MapNode = {
       name: sym,
-      value: row?.budgetAllocPct != null ? Math.round(row.budgetAllocPct * 1000) / 10 : 0,
+      pct: row?.budgetAllocPct != null ? Math.round(row.budgetAllocPct * 1000) / 10 : 0,
       role: row?.role ?? null,
       active: row?.active ?? false,
       registered: row !== undefined,
-    })
+    }
+    nodes.set(sym, node)
+    return node
   }
   interface MapEdge {
     source: string
     target: string
     kind: 'inverse' | 'proxy' | 'fallback'
+    /** エッジラベル (退避 = 流れる配分%、他は関係名)。 */
+    label: string
   }
   const edges: MapEdge[] = []
   // インバース対 (両方向で格納されているので sym < inverse の片向きに dedup)。
@@ -8748,7 +8756,7 @@ export function renderSymbolRelationMap(
     if (a >= b) continue
     ensureNode(a)
     ensureNode(b)
-    edges.push({ source: a, target: b, kind: 'inverse' })
+    edges.push({ source: a, target: b, kind: 'inverse', label: 'インバース対' })
   }
   // regime proxy (#472): proxy → bull / bear。misconfig は proxy 不明のため skip。
   for (const pair of pairRegimes) {
@@ -8756,41 +8764,94 @@ export function renderSymbolRelationMap(
     ensureNode(pair.proxySymbol)
     for (const side of [pair.bullSymbol, pair.bearSymbol]) {
       ensureNode(side)
-      edges.push({ source: pair.proxySymbol.toUpperCase(), target: side.toUpperCase(), kind: 'proxy' })
+      edges.push({
+        source: pair.proxySymbol.toUpperCase(),
+        target: side.toUpperCase(),
+        kind: 'proxy',
+        label: 'regime proxy',
+      })
     }
   }
-  // 退避先 (#452 Layer 3): 条件未通過時に予算枠が流れる先。
+  // 退避先 (#452 Layer 3): 条件未通過時に予算枠が流れる先。流れる量 = 配分%。
   for (const r of rows) {
     if (!r.cashFallbackSymbol) continue
-    ensureNode(r.symbol)
+    const src = ensureNode(r.symbol)
     ensureNode(r.cashFallbackSymbol)
     edges.push({
       source: r.symbol.toUpperCase(),
       target: r.cashFallbackSymbol.toUpperCase(),
       kind: 'fallback',
+      label: src.pct > 0 ? `退避 ${src.pct}%` : '退避',
     })
   }
   if (edges.length === 0) return ''
 
+  // レイヤー割当 (左→右): 0 = proxy 専用ノード、1 = 銘柄、2 = 退避先。
+  // 退避先かつ通常銘柄 (SGOV 等) は右列に置く。proxy かつ登録銘柄は中央。
+  const proxySyms = new Set(
+    pairRegimes.filter((p) => p.invalidConfig === null).map((p) => p.proxySymbol.toUpperCase()),
+  )
+  const fallbackTargets = new Set(
+    edges.filter((e) => e.kind === 'fallback').map((e) => e.target),
+  )
+  const layerOf = (n: MapNode): number => {
+    if (fallbackTargets.has(n.name)) return 2
+    if (proxySyms.has(n.name) && !n.registered) return 0
+    return 1
+  }
+  // 中央列はインバース対が縦に隣接するよう並べる。
+  const layer1 = [...nodes.values()].filter((n) => layerOf(n) === 1).map((n) => n.name)
+  layer1.sort()
+  const orderedLayer1: string[] = []
+  for (const sym of layer1) {
+    if (orderedLayer1.includes(sym)) continue
+    orderedLayer1.push(sym)
+    const partner = inversePairs[sym]?.toUpperCase()
+    if (partner && layer1.includes(partner) && !orderedLayer1.includes(partner)) {
+      orderedLayer1.push(partner)
+    }
+  }
+  const layers: string[][] = [
+    [...nodes.values()].filter((n) => layerOf(n) === 0).map((n) => n.name).sort(),
+    orderedLayer1,
+    [...nodes.values()].filter((n) => layerOf(n) === 2).map((n) => n.name).sort(),
+  ]
+  const CARD_W = 132
+  const ROW_H = 78
+  const positioned = new Map<string, { x: number; y: number }>()
+  const maxRows = Math.max(...layers.map((l) => l.length), 1)
+  layers.forEach((layer, li) => {
+    // 列内は縦中央寄せ。
+    const offset = ((maxRows - layer.length) * ROW_H) / 2
+    layer.forEach((sym, ri) => {
+      positioned.set(sym, { x: 90 + li * 300, y: 50 + offset + ri * ROW_H })
+    })
+  })
+  const mapHeight = Math.max(240, maxRows * ROW_H + 70)
+
   const payload = {
+    cardW: CARD_W,
     nodes: [...nodes.values()].map((n) => ({
       name: n.name,
-      pct: n.value,
+      pct: n.pct,
       role: n.role,
+      roleShort: n.role !== null ? SYMBOL_ROLE_LABELS_SHORT[n.role as SymbolRole] ?? n.role : null,
       active: n.active,
       registered: n.registered,
       color: !n.active || !n.registered ? '#9aa0a6' : ROLE_NODE_COLORS[n.role ?? ''] ?? '#5f6368',
+      x: positioned.get(n.name)?.x ?? 90,
+      y: positioned.get(n.name)?.y ?? 50,
     })),
     edges,
   }
   return `<details open style="margin:0 0 12px">
-    <summary style="cursor:pointer;font-size:13px;font-weight:600">関係マップ <span class="muted" style="font-weight:normal">— インバース対 / regime proxy / 退避先 (表示専用)</span></summary>
-    <div id="symbol-relation-map" style="height:300px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;margin-top:6px"></div>
+    <summary style="cursor:pointer;font-size:13px;font-weight:600">関係マップ <span class="muted" style="font-weight:normal">— regime proxy → 銘柄 → 退避先 (表示専用)</span></summary>
+    <div id="symbol-relation-map" style="height:${mapHeight}px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;margin-top:6px"></div>
     <p class="muted" style="font-size:11px;margin:4px 0 0">
-      ノードの大きさ = 予算配分%、色 = ロール (グレー = 無効 / 未登録)。
+      1 カード = 1 銘柄 (ロール / 予算配分%。グレー = 無効 / 未登録)。
       <span style="color:#c22d2d">赤実線</span> = インバース対 ・
       <span style="color:#7e3af2">紫破線</span> = regime proxy (判定材料) ・
-      <span style="color:#0e9f6e">緑矢印</span> = 退避先 (条件未通過時に予算枠が流れる先)。
+      <span style="color:#0e9f6e">緑矢印</span> = 退避先 (ラベル % = 条件未通過時に流れる予算枠)。
     </p>
   </details>
   <script src="${ECHARTS_CDN}" defer></script>
@@ -8802,24 +8863,23 @@ export function renderSymbolRelationMap(
     var el = document.getElementById('symbol-relation-map');
     if (!data || !el) return;
     var EDGE_STYLE = {
-      inverse: { color: '#c22d2d', type: 'solid', width: 2, symbol: ['none', 'none'], label: 'インバース対' },
-      proxy: { color: '#7e3af2', type: 'dashed', width: 1.5, symbol: ['none', 'arrow'], label: 'regime proxy' },
-      fallback: { color: '#0e9f6e', type: 'solid', width: 1.5, symbol: ['none', 'arrow'], label: '退避先' },
+      inverse: { color: '#c22d2d', type: 'solid', width: 2, symbol: ['none', 'none'] },
+      proxy: { color: '#7e3af2', type: 'dashed', width: 1.5, symbol: ['none', 'arrow'] },
+      fallback: { color: '#0e9f6e', type: 'solid', width: 1.8, symbol: ['none', 'arrow'] },
     };
     var chart = echarts.init(el);
     chart.setOption({
       tooltip: {
         formatter: function (p) {
           if (p.dataType === 'edge') {
-            var st = EDGE_STYLE[p.data.kind];
-            return p.data.source + ' → ' + p.data.target + '<br>' + st.label;
+            return p.data.source + ' → ' + p.data.target + '<br>' + p.data.label;
           }
           var d = p.data;
           var lines = ['<strong>' + d.name + '</strong>'];
           if (!d.registered) lines.push('未登録 (proxy 参照のみ)');
           else {
             lines.push(d.active ? '有効' : '無効');
-            if (d.role) lines.push('ロール: ' + d.role);
+            if (d.roleShort) lines.push('ロール: ' + d.roleShort);
             lines.push('予算配分: ' + d.pct + '%');
           }
           return lines.join('<br>');
@@ -8827,19 +8887,39 @@ export function renderSymbolRelationMap(
       },
       series: [{
         type: 'graph',
-        layout: 'force',
+        layout: 'none',
         roam: true,
-        force: { repulsion: 320, edgeLength: 110, gravity: 0.12 },
-        label: { show: true, fontSize: 12, fontWeight: 600 },
         data: data.nodes.map(function (n) {
+          var sub = [];
+          if (n.registered && n.roleShort) sub.push(n.roleShort);
+          if (n.registered && n.pct > 0) sub.push(n.pct + '%');
+          if (!n.registered) sub.push('未登録 proxy');
           return {
             name: n.name,
+            x: n.x,
+            y: n.y,
             pct: n.pct,
-            role: n.role,
+            roleShort: n.roleShort,
             active: n.active,
             registered: n.registered,
-            symbolSize: Math.max(18, Math.min(60, 18 + n.pct * 1.4)),
-            itemStyle: { color: n.color, opacity: n.active ? 1 : 0.55 },
+            symbol: 'roundRect',
+            symbolSize: [data.cardW, 46],
+            itemStyle: {
+              color: '#fff',
+              borderColor: n.color,
+              borderWidth: 2,
+              opacity: n.active || !n.registered ? 1 : 0.55,
+              shadowBlur: 4,
+              shadowColor: 'rgba(0,0,0,0.08)',
+            },
+            label: {
+              show: true,
+              formatter: '{sym|' + n.name + '}' + (sub.length ? '\\n{sub|' + sub.join(' ・ ') + '}' : ''),
+              rich: {
+                sym: { fontSize: 13, fontWeight: 700, color: '#1d1d1f', lineHeight: 18 },
+                sub: { fontSize: 10, color: '#6e6e73', lineHeight: 14 },
+              },
+            },
           };
         }),
         edges: data.edges.map(function (e) {
@@ -8848,9 +8928,16 @@ export function renderSymbolRelationMap(
             source: e.source,
             target: e.target,
             kind: e.kind,
-            lineStyle: { color: st.color, type: st.type, width: st.width, curveness: 0.1 },
+            label: e.label,
+            lineStyle: { color: st.color, type: st.type, width: st.width, curveness: 0.12 },
             symbol: st.symbol,
-            symbolSize: 8,
+            symbolSize: 9,
+            edgeLabel: e.kind === 'fallback' ? {
+              show: true,
+              formatter: e.label,
+              fontSize: 10,
+              color: '#0e9f6e',
+            } : { show: false },
           };
         }),
       }],

--- a/test/helpers/configFixtures.ts
+++ b/test/helpers/configFixtures.ts
@@ -74,7 +74,6 @@ export function makeSymbolUniverse(overrides: Partial<SymbolUniverse> = {}): Sym
     symbolMaxAtrRatioOverride: {},
     symbolMaxSma50DeviationPctOverride: {},
     symbolRequireAboveSma50Override: {},
-    symbolAlternatives: {},
     symbolEntryRequired: {},
     symbolAlwaysActive: {},
     symbolCashFallback: {},

--- a/test/infrastructure/db/symbolConfigRepo.test.ts
+++ b/test/infrastructure/db/symbolConfigRepo.test.ts
@@ -260,7 +260,6 @@ const writeInput = (symbol: string): SymbolConfigWriteInput => ({
   maxAtrRatioOverride: null,
   maxSma50DeviationPctOverride: null,
   requireAboveSma50Override: null,
-  alternatives: null,
   entryRequired: false,
   alwaysActive: false,
   cashFallbackSymbol: null,
@@ -319,7 +318,7 @@ describe('createSymbolPair', () => {
   })
 })
 
-describe('loadSymbolConfig role / entry overrides / alternatives (#452)', () => {
+describe('loadSymbolConfig role / entry overrides (#452)', () => {
   it('maps valid roles and normalizes unknown DB values to "unknown" (not NULL fallback)', async () => {
     const rows = [
       { symbol: 'sgov', market: 'US', active: true, maxNotional: null, role: 'cash_parking' },
@@ -376,18 +375,6 @@ describe('loadSymbolConfig role / entry overrides / alternatives (#452)', () => 
     expect(result.symbolRequireAboveSma50Override).toEqual({ QQQ: false })
   })
 
-  it('parses alternatives JSON, uppercases, dedupes, drops self-reference and bad JSON', async () => {
-    const rows = [
-      { symbol: 'soxl', market: 'US', active: true, maxNotional: null, alternatives: '["soxx","SMH","soxx","SOXL"]' },
-      { symbol: 'tqqq', market: 'US', active: true, maxNotional: null, alternatives: 'not-json' },
-      { symbol: 'qqq', market: 'US', active: true, maxNotional: null, alternatives: '["BAD SYMBOL!"]' },
-      { symbol: 'voo', market: 'US', active: true, maxNotional: null, alternatives: '[]' },
-      { symbol: 'spy', market: 'US', active: true, maxNotional: null, alternatives: null },
-    ]
-    const result = await loadSymbolConfig(fakeDb(rows))
-    // self (SOXL) と重複は除去。不正 JSON / 不正 ticker / 空配列 / NULL は map 不在。
-    expect(result.symbolAlternatives).toEqual({ SOXL: ['SOXX', 'SMH'] })
-  })
 })
 
 describe('deactivateSymbolForBrokerDeny (#460)', () => {

--- a/test/routes/admin.test.ts
+++ b/test/routes/admin.test.ts
@@ -1151,7 +1151,6 @@ describe('POST /admin/orders/sync-holdings', () => {
       symbolMaxAtrRatioOverride: {},
       symbolMaxSma50DeviationPctOverride: {},
       symbolRequireAboveSma50Override: {},
-      symbolAlternatives: {},
       symbolEntryRequired: {},
       symbolAlwaysActive: {},
       symbolCashFallback: {},

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -2835,3 +2835,53 @@ describe('renderSymbolRelationMap (#symbol-relation-map 口座ツリー)', () =>
     }
   })
 })
+
+import { symbolMapEditorBody } from '../../src/routes/dashboard'
+
+describe('symbolMapEditorBody (#symbol-relation-map 編集キャンバス)', () => {
+  const edRow = (over: Partial<SymbolConfigRow>): SymbolConfigRow =>
+    ({
+      symbol: 'X',
+      active: true,
+      role: null,
+      currency: 'USD',
+      budgetAllocPct: null,
+      cashFallbackSymbol: null,
+      entryRequired: false,
+      ...over,
+    }) as SymbolConfigRow
+
+  it('銘柄カード payload (配分% / 状態 / 退避先 / インバース) を積む', () => {
+    const html = symbolMapEditorBody(
+      [
+        edRow({ symbol: 'SOXL', role: 'leveraged_trend', budgetAllocPct: 0.5, cashFallbackSymbol: 'SGOV', entryRequired: true }),
+        edRow({ symbol: 'SGOV', role: 'cash_parking', budgetAllocPct: 0.1 }),
+        edRow({ symbol: 'GONE', active: false }),
+      ],
+      { SOXL: 'SOXS' },
+      { SGOV: { native: '$100', jpy: 15000 } },
+    )
+    const payload = JSON.parse(html.match(/__symbolMapEditor = ([\s\S]*?);<\/script>/)?.[1] ?? 'null')
+    expect(payload.nodes.map((n: { sym: string }) => n.sym)).toEqual(['SOXL', 'SGOV'])
+    const soxl = payload.nodes.find((n: { sym: string }) => n.sym === 'SOXL')
+    expect(soxl).toMatchObject({ pct: 50, fallback: 'SGOV', entryRequired: true, inverse: 'SOXS' })
+    const sgov = payload.nodes.find((n: { sym: string }) => n.sym === 'SGOV')
+    expect(sgov.held).toBe('$100')
+    // 編集 API への参照が script に含まれる
+    expect(html).toContain('/cash-fallback')
+    expect(html).toContain('/admin/symbol-config/budget-alloc')
+  })
+
+  it('inline script は構文エラーなく parse できる (#462 regression 防止)', () => {
+    const html = symbolMapEditorBody(
+      [edRow({ symbol: 'AAPL', budgetAllocPct: 0.2 })],
+      {},
+      {},
+    )
+    const blocks = [...html.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]!)
+    expect(blocks.length).toBeGreaterThan(0)
+    for (const code of blocks) {
+      expect(() => new Function(code)).not.toThrow()
+    }
+  })
+})

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -2796,3 +2796,47 @@ describe('renderSymbolRelationMap (#symbol-relation-map)', () => {
     }
   })
 })
+
+describe('renderSymbolRelationMap 軸 (横=ロール / 縦=投入金額)', () => {
+  const mapRow2 = (over: Partial<SymbolConfigRow>): SymbolConfigRow =>
+    ({
+      symbol: 'X',
+      active: true,
+      role: null,
+      budgetAllocPct: null,
+      cashFallbackSymbol: null,
+      ...over,
+    }) as SymbolConfigRow
+
+  it('列 = ロール、縦位置 = 投入額 (大きいほど上 = y が小さい)', () => {
+    const rows = [
+      mapRow2({ symbol: 'SOXL', role: 'leveraged_trend' }),
+      mapRow2({ symbol: 'SOXS', role: 'inverse_hedge' }),
+      mapRow2({ symbol: 'SGOV', role: 'cash_parking' }),
+      mapRow2({ symbol: 'VUG', role: 'core_trend', cashFallbackSymbol: 'SGOV' }),
+    ]
+    const html = renderSymbolRelationMap(
+      rows,
+      { SOXL: 'SOXS', SOXS: 'SOXL' },
+      [],
+      { SOXL: { native: '$300', jpy: 45000 }, SGOV: { native: '$100', jpy: 15000 } },
+    )
+    const payload = JSON.parse(
+      html.match(/<script type="application\/json"[^>]*>([\s\S]*?)<\/script>/)?.[1] ?? 'null',
+    )
+    const byName = new Map(payload.nodes.map((n: { name: string }) => [n.name, n]))
+    // ロール列の割当
+    expect((byName.get('SOXL') as { col: string }).col).toBe('leveraged_trend')
+    expect((byName.get('SGOV') as { col: string }).col).toBe('cash_parking')
+    // 投入額が大きい SOXL (max) は最上段、未保有 VUG は SGOV より下
+    const y = (sym: string) => (byName.get(sym) as { y: number }).y
+    expect(y('SOXL')).toBeLessThan(y('SGOV'))
+    expect(y('SGOV')).toBeLessThan(y('VUG'))
+    // 列ヘッダ payload (使用中ロールのみ)
+    const headers = payload.headers.map((h: { label: string }) => h.label)
+    expect(headers).toContain('待機資金ETF')
+    expect(headers).toContain('レバETF・トレンド')
+    // 投入額ラベルがカード payload に乗る
+    expect((byName.get('SOXL') as { amountLabel: string }).amountLabel).toBe('$300')
+  })
+})

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -2765,7 +2765,7 @@ describe('renderSymbolRelationMap (#symbol-relation-map 口座ツリー)', () =>
     expect(flows).toHaveLength(2)
     expect(flows.find((e: { source: string }) => e.source === 'AAPL')).toMatchObject({
       target: '現金待機',
-      kind: 'idle',
+      kind: 'inert', // 退避先設定済みなのに条件連動 OFF → 警告表示
     })
     expect(flows.find((e: { source: string }) => e.source === 'VUG')).toMatchObject({
       target: '現金待機',
@@ -2773,6 +2773,23 @@ describe('renderSymbolRelationMap (#symbol-relation-map 口座ツリー)', () =>
     })
     // 保有中 SGOV は流れない + 現金待機ノードが存在
     expect(payload.nodes.some((n: { name: string }) => n.name === '現金待機')).toBe(true)
+  })
+
+  it('インバース対は枠共有 (#315) として予算合計に max で数える + inert 警告ラベル', () => {
+    const rows = [
+      mapRow({ symbol: 'SOXL', role: 'leveraged_trend', budgetAllocPct: 0.5, cashFallbackSymbol: 'SGOV' }),
+      mapRow({ symbol: 'SOXS', role: 'inverse_hedge', budgetAllocPct: 0.5 }),
+      mapRow({ symbol: 'VUG', role: 'core_trend', budgetAllocPct: 0.3 }),
+    ]
+    const payload = payloadOf(
+      renderSymbolRelationMap(rows, { SOXL: 'SOXS', SOXS: 'SOXL' }, []),
+    )
+    const account = payload.nodes.find((n: { name: string }) => n.name === '口座')
+    // 単純合計 130% ではなく、対は max(50,50)=50 + VUG 30 = 80%
+    expect(account.title).toBe('口座 (予算 80%)')
+    const inert = payload.edges.find((e: { kind: string }) => e.kind === 'inert')
+    expect(inert).toMatchObject({ source: 'SOXL' })
+    expect(inert.label).toContain('退避先SGOV未使用')
   })
 
   it('配分 0% / 無効銘柄は口座から線を引かない', () => {

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -2726,7 +2726,7 @@ describe('renderSymbolPolicyLine (#452 個別銘柄タブのロール表示)', (
 })
 
 import { renderSymbolRelationMap } from '../../src/routes/dashboard'
-import type { SymbolConfigRow } from '../../src/infrastructure/db/symbolConfigRepo'
+import type { SymbolConfigRow } from '../../src/infrastructure/db/schema'
 
 describe('renderSymbolRelationMap (#symbol-relation-map)', () => {
   const mapRow = (over: Partial<SymbolConfigRow>): SymbolConfigRow =>

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -2749,7 +2749,7 @@ describe('renderSymbolRelationMap (#symbol-relation-map Sankey)', () => {
   it('予算 → ロール → 銘柄 → 退避先のリンクを配分% で積み、投入額をラベルに併記', () => {
     const rows = [
       mapRow({ symbol: 'SOXL', role: 'leveraged_trend', budgetAllocPct: 0.2 }),
-      mapRow({ symbol: 'VUG', role: 'core_trend', budgetAllocPct: 0.3, cashFallbackSymbol: 'SGOV' }),
+      mapRow({ symbol: 'VUG', role: 'core_trend', budgetAllocPct: 0.3, cashFallbackSymbol: 'SGOV', entryRequired: true }),
       mapRow({ symbol: 'SGOV', role: 'cash_parking', budgetAllocPct: 0.1 }),
     ]
     const html = renderSymbolRelationMap(rows, {}, [], {
@@ -2769,6 +2769,19 @@ describe('renderSymbolRelationMap (#symbol-relation-map Sankey)', () => {
     // 予算ノードは合計%
     const budget = payload.nodes.find((n: { name: string }) => n.name === '予算')
     expect(budget.label).toBe('予算 60%')
+  })
+
+  it('退避フローは条件連動 ON のみ。退避先未設定の連動銘柄は現金待機ノードへ', () => {
+    const rows = [
+      // 連動 OFF + 退避先あり → 流れない (設定だけでは退避は発生しない)
+      mapRow({ symbol: 'AAPL', role: 'core_trend', budgetAllocPct: 0.2, cashFallbackSymbol: 'SGOV' }),
+      // 連動 ON + 退避先なし → 現金待機へ
+      mapRow({ symbol: 'VUG', role: 'core_trend', budgetAllocPct: 0.3, entryRequired: true }),
+    ]
+    const payload = payloadOf(renderSymbolRelationMap(rows, {}, []))
+    const fallback = payload.links.filter((l: { kind: string }) => l.kind === 'fallback')
+    expect(fallback).toEqual([{ source: 'VUG', target: '現金待機', value: 30, kind: 'fallback' }])
+    expect(payload.nodes.some((n: { name: string }) => n.name === '現金待機')).toBe(true)
   })
 
   it('配分 0% / 無効銘柄は Sankey に出さない', () => {
@@ -2803,7 +2816,7 @@ describe('renderSymbolRelationMap (#symbol-relation-map Sankey)', () => {
 
   it('inline script は構文エラーなく parse できる (#462 regression 防止)', () => {
     const html = renderSymbolRelationMap(
-      [mapRow({ symbol: 'VUG', role: 'core_trend', budgetAllocPct: 0.3, cashFallbackSymbol: 'SGOV' })],
+      [mapRow({ symbol: 'VUG', role: 'core_trend', budgetAllocPct: 0.3, cashFallbackSymbol: 'SGOV', entryRequired: true })],
       {},
       [],
     )

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -2598,25 +2598,7 @@ describe('段階判定の表示 (#452 PR 2)', () => {
     expect(html).toContain('>ENTRY<')
   })
 
-  it('WATCH/NG で alternatives があれば代替候補リンクを出す (表示のみ)', () => {
-    const view = viewFor(99) // 押し目不足 → WATCH
-    const status = deriveEntryStatus(view.current!)
-    expect(status.positionMultiplier).toBe(0)
-    const html = renderBuyabilityPanel(view, {
-      entryStatus: status,
-      alternatives: ['SOXX', 'SMH'],
-    })
-    expect(html).toContain('代替候補')
-    expect(html).toContain('symbol=SOXX')
-    expect(html).toContain('自動で発注先を切り替えることはしない')
-  })
 
-  it('ENTRY では代替候補を出さない', () => {
-    const view = viewFor(95)
-    const status = deriveEntryStatus(view.current!)
-    const html = renderBuyabilityPanel(view, { entryStatus: status, alternatives: ['SOXX'] })
-    expect(html).not.toContain('代替候補')
-  })
 
   it('grid を ENTRY > HALF > WATCH > NG > cash_parking > データ無し > inactive で並べる', () => {
     const charts = ['SGOV', 'NODATA', 'NG1', 'WATCH1', 'HALF1', 'ENTRY1', 'OFF'].map((symbol) => ({

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -2724,3 +2724,75 @@ describe('renderSymbolPolicyLine (#452 個別銘柄タブのロール表示)', (
     expect(html).toContain('⚠ unknown')
   })
 })
+
+import { renderSymbolRelationMap } from '../../src/routes/dashboard'
+import type { SymbolConfigRow } from '../../src/infrastructure/db/symbolConfigRepo'
+
+describe('renderSymbolRelationMap (#symbol-relation-map)', () => {
+  const mapRow = (over: Partial<SymbolConfigRow>): SymbolConfigRow =>
+    ({
+      symbol: 'AAPL',
+      active: true,
+      role: null,
+      budgetAllocPct: null,
+      cashFallbackSymbol: null,
+      ...over,
+    }) as SymbolConfigRow
+
+  it('関係が 1 つも無ければ何も描画しない', () => {
+    expect(renderSymbolRelationMap([mapRow({})], {}, [])).toBe('')
+  })
+
+  it('インバース対 / regime proxy / 退避先の 3 種エッジと未登録 proxy ノードを payload に積む', () => {
+    const rows = [
+      mapRow({ symbol: 'SOXL', role: 'leveraged_trend', budgetAllocPct: 0.2 }),
+      mapRow({ symbol: 'SOXS', role: 'inverse_hedge' }),
+      mapRow({ symbol: 'VUG', role: 'core_trend', cashFallbackSymbol: 'SGOV' }),
+      mapRow({ symbol: 'SGOV', role: 'cash_parking', active: false }),
+    ]
+    const html = renderSymbolRelationMap(
+      rows,
+      { SOXL: 'SOXS', SOXS: 'SOXL' },
+      [{ bullSymbol: 'SOXL', bearSymbol: 'SOXS', proxySymbol: 'SOXX', invalidConfig: null }],
+    )
+    expect(html).toContain('関係マップ')
+    expect(html).toContain('__symbolRelationMap')
+    // インバース対は片向きに dedup、proxy は bull/bear へ 2 本、退避先 1 本
+    const payload = JSON.parse(
+      html.match(/<script type="application\/json"[^>]*>([\s\S]*?)<\/script>/)?.[1] ??
+        html.match(/__symbolRelationMap\s*=\s*(\{[\s\S]*?\});?\s*<\/script>/)?.[1] ??
+        'null',
+    )
+    expect(payload).not.toBeNull()
+    const kinds = payload.edges.map((e: { kind: string }) => e.kind).sort()
+    expect(kinds).toEqual(['fallback', 'inverse', 'proxy', 'proxy'])
+    // SOXX は未登録 proxy としてノード化される
+    const soxx = payload.nodes.find((n: { name: string }) => n.name === 'SOXX')
+    expect(soxx?.registered).toBe(false)
+    // 無効銘柄 (SGOV) はグレー
+    const sgov = payload.nodes.find((n: { name: string }) => n.name === 'SGOV')
+    expect(sgov?.color).toBe('#9aa0a6')
+  })
+
+  it('misconfig な regime pair は proxy エッジを張らない (fail-safe)', () => {
+    const html = renderSymbolRelationMap(
+      [mapRow({ symbol: 'SOXL' }), mapRow({ symbol: 'SOXS' })],
+      { SOXL: 'SOXS', SOXS: 'SOXL' },
+      [{ bullSymbol: 'SOXL', bearSymbol: 'SOXS', proxySymbol: 'SOXL', invalidConfig: 'self-proxy' }],
+    )
+    expect(html).not.toContain('"kind":"proxy"')
+  })
+
+  it('inline script は構文エラーなく parse できる (#462 regression 防止)', () => {
+    const html = renderSymbolRelationMap(
+      [mapRow({ symbol: 'VUG', cashFallbackSymbol: 'SGOV' }), mapRow({ symbol: 'SGOV' })],
+      {},
+      [],
+    )
+    const blocks = [...html.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]!)
+    expect(blocks.length).toBeGreaterThan(0)
+    for (const code of blocks) {
+      expect(() => new Function(code)).not.toThrow()
+    }
+  })
+})

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -2710,7 +2710,7 @@ describe('renderSymbolPolicyLine (#452 個別銘柄タブのロール表示)', (
 import { renderSymbolRelationMap } from '../../src/routes/dashboard'
 import type { SymbolConfigRow } from '../../src/infrastructure/db/schema'
 
-describe('renderSymbolRelationMap (#symbol-relation-map Sankey)', () => {
+describe('renderSymbolRelationMap (#symbol-relation-map 口座ツリー)', () => {
   const mapRow = (over: Partial<SymbolConfigRow>): SymbolConfigRow =>
     ({
       symbol: 'X',
@@ -2728,52 +2728,54 @@ describe('renderSymbolRelationMap (#symbol-relation-map Sankey)', () => {
     expect(renderSymbolRelationMap([mapRow({})], {}, [])).toBe('')
   })
 
-  it('現在形フロー: 保有中は銘柄で止まり、未保有の条件連動 ON は退避先へ譲る', () => {
+  it('口座 → 銘柄の実線 + Pending 銘柄から譲り先への点線 (代替割当)', () => {
     const rows = [
-      mapRow({ symbol: 'SOXL', role: 'leveraged_trend', budgetAllocPct: 0.2 }),
-      mapRow({ symbol: 'VUG', role: 'core_trend', budgetAllocPct: 0.3, cashFallbackSymbol: 'SGOV', entryRequired: true }),
-      mapRow({ symbol: 'SGOV', role: 'cash_parking', budgetAllocPct: 0.1 }),
+      mapRow({ symbol: 'SOXL', role: 'leveraged_trend', budgetAllocPct: 0.5, cashFallbackSymbol: 'TQQQ', entryRequired: true }),
+      mapRow({ symbol: 'TQQQ', role: 'leveraged_trend', budgetAllocPct: 0.2 }),
     ]
     const html = renderSymbolRelationMap(rows, {}, [], {
-      SOXL: { native: '$300', jpy: 45000 },
-      SGOV: { native: '$100', jpy: 15000 },
+      TQQQ: { native: '$200', jpy: 30000 },
     })
     const payload = payloadOf(html)
-    const link = (kind: string) => payload.links.filter((l: { kind: string }) => l.kind === kind)
-    expect(link('role')).toHaveLength(3)
-    expect(link('symbol')).toHaveLength(3)
-    // 未保有 + 条件連動 ON の VUG だけが退避先へ譲る (保有中 SOXL/SGOV は流れない)
-    expect(link('fallback')).toEqual([
-      { source: 'VUG', target: 'SGOV', value: 30, kind: 'fallback' },
-    ])
-    expect(link('idle')).toHaveLength(0)
-    // 状態がラベルに出る
-    const soxl = payload.nodes.find((n: { name: string }) => n.name === 'SOXL')
-    expect(soxl.label).toBe('SOXL 20% ・ 使用中 $300')
-    const vug = payload.nodes.find((n: { name: string }) => n.name === 'VUG')
-    expect(vug.label).toBe('VUG 30% ・ 譲り中')
-    const budget = payload.nodes.find((n: { name: string }) => n.name === '予算')
-    expect(budget.label).toBe('予算 60%')
+    const byName = new Map(payload.nodes.map((n: { name: string }) => [n.name, n]))
+    // SOXL = Pending (様子見)、TQQQ = Active + 投入額
+    expect((byName.get('SOXL') as { status: string }).status).toBe('pending')
+    expect((byName.get('SOXL') as { sub: string }).sub).toBe('Pending (様子見)')
+    expect((byName.get('TQQQ') as { sub: string }).sub).toBe('Active ・ $200')
+    // 口座 → 両銘柄の実線 + SOXL ┈▶ TQQQ の代替点線 (50%)
+    const alloc = payload.edges.filter((e: { kind: string }) => e.kind === 'alloc')
+    expect(alloc.map((e: { target: string }) => e.target).sort()).toEqual(['SOXL', 'TQQQ'])
+    const yields = payload.edges.filter((e: { kind: string }) => e.kind === 'yield')
+    expect(yields).toHaveLength(1)
+    expect(yields[0]).toMatchObject({ source: 'SOXL', target: 'TQQQ', label: '代替 50%' })
+    // 口座ノードは合計%
+    expect((byName.get('口座') as { title: string }).title).toBe('口座 (予算 70%)')
   })
 
-  it('未保有 + 条件連動 OFF は枠確保のまま現金待機 (idle、グレー)', () => {
+  it('未保有 + 条件連動 OFF は枠確保のまま現金待機 (idle)、Active は流れない', () => {
     const rows = [
-      // 連動 OFF + 未保有 → idle で現金待機へ (退避先設定は無視 = 譲らない)
       mapRow({ symbol: 'AAPL', role: 'core_trend', budgetAllocPct: 0.2, cashFallbackSymbol: 'SGOV' }),
-      // 連動 ON + 退避先なし + 未保有 → fallback で現金待機へ
       mapRow({ symbol: 'VUG', role: 'core_trend', budgetAllocPct: 0.3, entryRequired: true }),
+      mapRow({ symbol: 'SGOV', role: 'cash_parking', budgetAllocPct: 0.1 }),
     ]
-    const payload = payloadOf(renderSymbolRelationMap(rows, {}, []))
-    const links = payload.links.filter((l: { kind: string }) => l.kind === 'fallback' || l.kind === 'idle')
-    expect(links).toEqual([
-      { source: 'AAPL', target: '現金待機', value: 20, kind: 'idle' },
-      { source: 'VUG', target: '現金待機', value: 30, kind: 'fallback' },
-    ])
-    const aapl = payload.nodes.find((n: { name: string }) => n.name === 'AAPL')
-    expect(aapl.label).toBe('AAPL 20% ・ 待機')
+    const payload = payloadOf(
+      renderSymbolRelationMap(rows, {}, [], { SGOV: { native: '$100', jpy: 15000 } }),
+    )
+    const flows = payload.edges.filter((e: { kind: string }) => e.kind !== 'alloc')
+    expect(flows).toHaveLength(2)
+    expect(flows.find((e: { source: string }) => e.source === 'AAPL')).toMatchObject({
+      target: '現金待機',
+      kind: 'idle',
+    })
+    expect(flows.find((e: { source: string }) => e.source === 'VUG')).toMatchObject({
+      target: '現金待機',
+      kind: 'yield',
+    })
+    // 保有中 SGOV は流れない + 現金待機ノードが存在
+    expect(payload.nodes.some((n: { name: string }) => n.name === '現金待機')).toBe(true)
   })
 
-  it('配分 0% / 無効銘柄は Sankey に出さない', () => {
+  it('配分 0% / 無効銘柄は口座から線を引かない', () => {
     const rows = [
       mapRow({ symbol: 'AAPL', role: 'core_trend', budgetAllocPct: 0.2 }),
       mapRow({ symbol: 'ZERO', role: 'core_trend' }),
@@ -2786,7 +2788,7 @@ describe('renderSymbolRelationMap (#symbol-relation-map Sankey)', () => {
     expect(names).not.toContain('OFF')
   })
 
-  it('インバース対 / regime proxy は Sankey ではなく脚注チップに出す (misconfig pair は出さない)', () => {
+  it('インバース対 / regime proxy は脚注チップに出す (misconfig pair は出さない)', () => {
     const html = renderSymbolRelationMap(
       [
         mapRow({ symbol: 'SOXL', role: 'leveraged_trend', budgetAllocPct: 0.2 }),

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -2728,77 +2728,8 @@ describe('renderSymbolPolicyLine (#452 個別銘柄タブのロール表示)', (
 import { renderSymbolRelationMap } from '../../src/routes/dashboard'
 import type { SymbolConfigRow } from '../../src/infrastructure/db/schema'
 
-describe('renderSymbolRelationMap (#symbol-relation-map)', () => {
+describe('renderSymbolRelationMap (#symbol-relation-map Sankey)', () => {
   const mapRow = (over: Partial<SymbolConfigRow>): SymbolConfigRow =>
-    ({
-      symbol: 'AAPL',
-      active: true,
-      role: null,
-      budgetAllocPct: null,
-      cashFallbackSymbol: null,
-      ...over,
-    }) as SymbolConfigRow
-
-  it('関係が 1 つも無ければ何も描画しない', () => {
-    expect(renderSymbolRelationMap([mapRow({})], {}, [])).toBe('')
-  })
-
-  it('インバース対 / regime proxy / 退避先の 3 種エッジと未登録 proxy ノードを payload に積む', () => {
-    const rows = [
-      mapRow({ symbol: 'SOXL', role: 'leveraged_trend', budgetAllocPct: 0.2 }),
-      mapRow({ symbol: 'SOXS', role: 'inverse_hedge' }),
-      mapRow({ symbol: 'VUG', role: 'core_trend', cashFallbackSymbol: 'SGOV' }),
-      mapRow({ symbol: 'SGOV', role: 'cash_parking', active: false }),
-    ]
-    const html = renderSymbolRelationMap(
-      rows,
-      { SOXL: 'SOXS', SOXS: 'SOXL' },
-      [{ bullSymbol: 'SOXL', bearSymbol: 'SOXS', proxySymbol: 'SOXX', invalidConfig: null }],
-    )
-    expect(html).toContain('関係マップ')
-    expect(html).toContain('__symbolRelationMap')
-    // インバース対は片向きに dedup、proxy は bull/bear へ 2 本、退避先 1 本
-    const payload = JSON.parse(
-      html.match(/<script type="application\/json"[^>]*>([\s\S]*?)<\/script>/)?.[1] ??
-        html.match(/__symbolRelationMap\s*=\s*(\{[\s\S]*?\});?\s*<\/script>/)?.[1] ??
-        'null',
-    )
-    expect(payload).not.toBeNull()
-    const kinds = payload.edges.map((e: { kind: string }) => e.kind).sort()
-    expect(kinds).toEqual(['fallback', 'inverse', 'proxy', 'proxy'])
-    // SOXX は未登録 proxy としてノード化される
-    const soxx = payload.nodes.find((n: { name: string }) => n.name === 'SOXX')
-    expect(soxx?.registered).toBe(false)
-    // 無効銘柄 (SGOV) はグレー
-    const sgov = payload.nodes.find((n: { name: string }) => n.name === 'SGOV')
-    expect(sgov?.color).toBe('#9aa0a6')
-  })
-
-  it('misconfig な regime pair は proxy エッジを張らない (fail-safe)', () => {
-    const html = renderSymbolRelationMap(
-      [mapRow({ symbol: 'SOXL' }), mapRow({ symbol: 'SOXS' })],
-      { SOXL: 'SOXS', SOXS: 'SOXL' },
-      [{ bullSymbol: 'SOXL', bearSymbol: 'SOXS', proxySymbol: 'SOXL', invalidConfig: 'self-proxy' }],
-    )
-    expect(html).not.toContain('"kind":"proxy"')
-  })
-
-  it('inline script は構文エラーなく parse できる (#462 regression 防止)', () => {
-    const html = renderSymbolRelationMap(
-      [mapRow({ symbol: 'VUG', cashFallbackSymbol: 'SGOV' }), mapRow({ symbol: 'SGOV' })],
-      {},
-      [],
-    )
-    const blocks = [...html.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]!)
-    expect(blocks.length).toBeGreaterThan(0)
-    for (const code of blocks) {
-      expect(() => new Function(code)).not.toThrow()
-    }
-  })
-})
-
-describe('renderSymbolRelationMap 軸 (横=ロール / 縦=投入金額)', () => {
-  const mapRow2 = (over: Partial<SymbolConfigRow>): SymbolConfigRow =>
     ({
       symbol: 'X',
       active: true,
@@ -2808,35 +2739,78 @@ describe('renderSymbolRelationMap 軸 (横=ロール / 縦=投入金額)', () =>
       ...over,
     }) as SymbolConfigRow
 
-  it('列 = ロール、縦位置 = 投入額 (大きいほど上 = y が小さい)', () => {
+  const payloadOf = (html: string) =>
+    JSON.parse(html.match(/__symbolRelationMap = ([\s\S]*?);<\/script>/)?.[1] ?? 'null')
+
+  it('配分も関係も無ければ何も描画しない', () => {
+    expect(renderSymbolRelationMap([mapRow({})], {}, [])).toBe('')
+  })
+
+  it('予算 → ロール → 銘柄 → 退避先のリンクを配分% で積み、投入額をラベルに併記', () => {
     const rows = [
-      mapRow2({ symbol: 'SOXL', role: 'leveraged_trend' }),
-      mapRow2({ symbol: 'SOXS', role: 'inverse_hedge' }),
-      mapRow2({ symbol: 'SGOV', role: 'cash_parking' }),
-      mapRow2({ symbol: 'VUG', role: 'core_trend', cashFallbackSymbol: 'SGOV' }),
+      mapRow({ symbol: 'SOXL', role: 'leveraged_trend', budgetAllocPct: 0.2 }),
+      mapRow({ symbol: 'VUG', role: 'core_trend', budgetAllocPct: 0.3, cashFallbackSymbol: 'SGOV' }),
+      mapRow({ symbol: 'SGOV', role: 'cash_parking', budgetAllocPct: 0.1 }),
     ]
+    const html = renderSymbolRelationMap(rows, {}, [], {
+      SOXL: { native: '$300', jpy: 45000 },
+    })
+    const payload = payloadOf(html)
+    const link = (kind: string) => payload.links.filter((l: { kind: string }) => l.kind === kind)
+    // 予算 → ロール (3 role)、ロール → 銘柄 (3)、退避 (VUG → SGOV、量 = VUG の配分 30%)
+    expect(link('role')).toHaveLength(3)
+    expect(link('symbol')).toHaveLength(3)
+    expect(link('fallback')).toEqual([
+      { source: 'VUG', target: 'SGOV', value: 30, kind: 'fallback' },
+    ])
+    // 投入額がラベルに併記される
+    const soxl = payload.nodes.find((n: { name: string }) => n.name === 'SOXL')
+    expect(soxl.label).toBe('SOXL 20% ($300)')
+    // 予算ノードは合計%
+    const budget = payload.nodes.find((n: { name: string }) => n.name === '予算')
+    expect(budget.label).toBe('予算 60%')
+  })
+
+  it('配分 0% / 無効銘柄は Sankey に出さない', () => {
+    const rows = [
+      mapRow({ symbol: 'AAPL', role: 'core_trend', budgetAllocPct: 0.2 }),
+      mapRow({ symbol: 'ZERO', role: 'core_trend' }),
+      mapRow({ symbol: 'OFF', role: 'core_trend', budgetAllocPct: 0.5, active: false }),
+    ]
+    const payload = payloadOf(renderSymbolRelationMap(rows, {}, []))
+    const names = payload.nodes.map((n: { name: string }) => n.name)
+    expect(names).toContain('AAPL')
+    expect(names).not.toContain('ZERO')
+    expect(names).not.toContain('OFF')
+  })
+
+  it('インバース対 / regime proxy は Sankey ではなく脚注チップに出す (misconfig pair は出さない)', () => {
     const html = renderSymbolRelationMap(
-      rows,
+      [
+        mapRow({ symbol: 'SOXL', role: 'leveraged_trend', budgetAllocPct: 0.2 }),
+        mapRow({ symbol: 'SOXS', role: 'inverse_hedge' }),
+      ],
       { SOXL: 'SOXS', SOXS: 'SOXL' },
+      [
+        { bullSymbol: 'SOXL', bearSymbol: 'SOXS', proxySymbol: 'SOXX', invalidConfig: null },
+        { bullSymbol: 'TQQQ', bearSymbol: 'SQQQ', proxySymbol: 'TQQQ', invalidConfig: 'self-proxy' },
+      ],
+    )
+    expect(html).toContain('インバース対 SOXL ⇄ SOXS')
+    expect(html).toContain('regime proxy SOXX → SOXL/SOXS')
+    expect(html).not.toContain('TQQQ')
+  })
+
+  it('inline script は構文エラーなく parse できる (#462 regression 防止)', () => {
+    const html = renderSymbolRelationMap(
+      [mapRow({ symbol: 'VUG', role: 'core_trend', budgetAllocPct: 0.3, cashFallbackSymbol: 'SGOV' })],
+      {},
       [],
-      { SOXL: { native: '$300', jpy: 45000 }, SGOV: { native: '$100', jpy: 15000 } },
     )
-    const payload = JSON.parse(
-      html.match(/__symbolRelationMap = ([\s\S]*?);<\/script>/)?.[1] ?? 'null',
-    )
-    const byName = new Map(payload.nodes.map((n: { name: string }) => [n.name, n]))
-    // ロール列の割当
-    expect((byName.get('SOXL') as { col: string }).col).toBe('leveraged_trend')
-    expect((byName.get('SGOV') as { col: string }).col).toBe('cash_parking')
-    // 投入額が大きい SOXL (max) は最上段、未保有 VUG は SGOV より下
-    const y = (sym: string) => (byName.get(sym) as { y: number }).y
-    expect(y('SOXL')).toBeLessThan(y('SGOV'))
-    expect(y('SGOV')).toBeLessThan(y('VUG'))
-    // 列ヘッダ payload (使用中ロールのみ)
-    const headers = payload.headers.map((h: { label: string }) => h.label)
-    expect(headers).toContain('待機資金ETF')
-    expect(headers).toContain('レバETF・トレンド')
-    // 投入額ラベルがカード payload に乗る
-    expect((byName.get('SOXL') as { amountLabel: string }).amountLabel).toBe('$300')
+    const blocks = [...html.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]!)
+    expect(blocks.length).toBeGreaterThan(0)
+    for (const code of blocks) {
+      expect(() => new Function(code)).not.toThrow()
+    }
   })
 })

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -2728,7 +2728,7 @@ describe('renderSymbolRelationMap (#symbol-relation-map Sankey)', () => {
     expect(renderSymbolRelationMap([mapRow({})], {}, [])).toBe('')
   })
 
-  it('予算 → ロール → 銘柄 → 退避先のリンクを配分% で積み、投入額をラベルに併記', () => {
+  it('現在形フロー: 保有中は銘柄で止まり、未保有の条件連動 ON は退避先へ譲る', () => {
     const rows = [
       mapRow({ symbol: 'SOXL', role: 'leveraged_trend', budgetAllocPct: 0.2 }),
       mapRow({ symbol: 'VUG', role: 'core_trend', budgetAllocPct: 0.3, cashFallbackSymbol: 'SGOV', entryRequired: true }),
@@ -2736,34 +2736,41 @@ describe('renderSymbolRelationMap (#symbol-relation-map Sankey)', () => {
     ]
     const html = renderSymbolRelationMap(rows, {}, [], {
       SOXL: { native: '$300', jpy: 45000 },
+      SGOV: { native: '$100', jpy: 15000 },
     })
     const payload = payloadOf(html)
     const link = (kind: string) => payload.links.filter((l: { kind: string }) => l.kind === kind)
-    // 予算 → ロール (3 role)、ロール → 銘柄 (3)、退避 (VUG → SGOV、量 = VUG の配分 30%)
     expect(link('role')).toHaveLength(3)
     expect(link('symbol')).toHaveLength(3)
+    // 未保有 + 条件連動 ON の VUG だけが退避先へ譲る (保有中 SOXL/SGOV は流れない)
     expect(link('fallback')).toEqual([
       { source: 'VUG', target: 'SGOV', value: 30, kind: 'fallback' },
     ])
-    // 投入額がラベルに併記される
+    expect(link('idle')).toHaveLength(0)
+    // 状態がラベルに出る
     const soxl = payload.nodes.find((n: { name: string }) => n.name === 'SOXL')
-    expect(soxl.label).toBe('SOXL 20% ($300)')
-    // 予算ノードは合計%
+    expect(soxl.label).toBe('SOXL 20% ・ 使用中 $300')
+    const vug = payload.nodes.find((n: { name: string }) => n.name === 'VUG')
+    expect(vug.label).toBe('VUG 30% ・ 譲り中')
     const budget = payload.nodes.find((n: { name: string }) => n.name === '予算')
     expect(budget.label).toBe('予算 60%')
   })
 
-  it('退避フローは条件連動 ON のみ。退避先未設定の連動銘柄は現金待機ノードへ', () => {
+  it('未保有 + 条件連動 OFF は枠確保のまま現金待機 (idle、グレー)', () => {
     const rows = [
-      // 連動 OFF + 退避先あり → 流れない (設定だけでは退避は発生しない)
+      // 連動 OFF + 未保有 → idle で現金待機へ (退避先設定は無視 = 譲らない)
       mapRow({ symbol: 'AAPL', role: 'core_trend', budgetAllocPct: 0.2, cashFallbackSymbol: 'SGOV' }),
-      // 連動 ON + 退避先なし → 現金待機へ
+      // 連動 ON + 退避先なし + 未保有 → fallback で現金待機へ
       mapRow({ symbol: 'VUG', role: 'core_trend', budgetAllocPct: 0.3, entryRequired: true }),
     ]
     const payload = payloadOf(renderSymbolRelationMap(rows, {}, []))
-    const fallback = payload.links.filter((l: { kind: string }) => l.kind === 'fallback')
-    expect(fallback).toEqual([{ source: 'VUG', target: '現金待機', value: 30, kind: 'fallback' }])
-    expect(payload.nodes.some((n: { name: string }) => n.name === '現金待機')).toBe(true)
+    const links = payload.links.filter((l: { kind: string }) => l.kind === 'fallback' || l.kind === 'idle')
+    expect(links).toEqual([
+      { source: 'AAPL', target: '現金待機', value: 20, kind: 'idle' },
+      { source: 'VUG', target: '現金待機', value: 30, kind: 'fallback' },
+    ])
+    const aapl = payload.nodes.find((n: { name: string }) => n.name === 'AAPL')
+    expect(aapl.label).toBe('AAPL 20% ・ 待機')
   })
 
   it('配分 0% / 無効銘柄は Sankey に出さない', () => {

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -2822,7 +2822,7 @@ describe('renderSymbolRelationMap 軸 (横=ロール / 縦=投入金額)', () =>
       { SOXL: { native: '$300', jpy: 45000 }, SGOV: { native: '$100', jpy: 15000 } },
     )
     const payload = JSON.parse(
-      html.match(/<script type="application\/json"[^>]*>([\s\S]*?)<\/script>/)?.[1] ?? 'null',
+      html.match(/__symbolRelationMap = ([\s\S]*?);<\/script>/)?.[1] ?? 'null',
     )
     const byName = new Map(payload.nodes.map((n: { name: string }) => [n.name, n]))
     // ロール列の割当

--- a/test/routes/dashboardSymbolsCrud.test.ts
+++ b/test/routes/dashboardSymbolsCrud.test.ts
@@ -1707,3 +1707,53 @@ describe('銘柄フォームのセクション UI (#symbols-form-ui)', () => {
     expect(body).toMatch(/<details open[^>]*>\s*<summary[^>]*>配分の条件連動/)
   })
 })
+
+describe('POST /admin/symbol-config/:symbol/cash-fallback (#symbol-relation-map 編集)', () => {
+  const post = (app: ReturnType<typeof createApp>, symbol: string, body: unknown) =>
+    app.request(
+      `/admin/symbol-config/${symbol}/cash-fallback`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeader },
+        body: JSON.stringify(body),
+      },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+
+  it('set: 退避先を設定し entry_required も同時に ON、audit log を残す', async () => {
+    const db = fakeDb([
+      row({ symbol: 'SOXL', currency: 'USD', entryRequired: false }),
+      row({ symbol: 'SGOV', currency: 'USD' }),
+    ])
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const res = await post(createApp(), 'SOXL', { target: 'sgov' })
+    expect(res.status).toBe(200)
+    const updated = db.updates.find((u) => u.table === 'symbol_config')
+    expect(updated?.set).toMatchObject({ cashFallbackSymbol: 'SGOV', entryRequired: true })
+    expect(db.inserts.some((i) => i.table === 'config_audit_log')).toBe(true)
+  })
+
+  it('clear: target null で解除 (entry_required は触らない)', async () => {
+    const db = fakeDb([
+      row({ symbol: 'SOXL', currency: 'USD', cashFallbackSymbol: 'SGOV', entryRequired: true }),
+    ])
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const res = await post(createApp(), 'SOXL', { target: null })
+    expect(res.status).toBe(200)
+    const updated = db.updates.find((u) => u.table === 'symbol_config')
+    expect(updated?.set).toMatchObject({ cashFallbackSymbol: null })
+    expect(updated?.set).not.toHaveProperty('entryRequired')
+  })
+
+  it('検証: self 参照 / 未登録 target / 通貨不一致は 400', async () => {
+    const db = fakeDb([
+      row({ symbol: 'SOXL', currency: 'USD' }),
+      row({ symbol: '1357', currency: 'JPY' }),
+    ])
+    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
+    const app = createApp()
+    expect((await post(app, 'SOXL', { target: 'SOXL' })).status).toBe(400)
+    expect((await post(app, 'SOXL', { target: 'ZZZZ' })).status).toBe(400)
+    expect((await post(app, 'SOXL', { target: '1357' })).status).toBe(400)
+  })
+})

--- a/test/routes/dashboardSymbolsCrud.test.ts
+++ b/test/routes/dashboardSymbolsCrud.test.ts
@@ -176,7 +176,6 @@ function fakeDb(
               maxAtrRatioOverride: (v.maxAtrRatioOverride as number | null) ?? null,
               maxSma50DeviationPctOverride: (v.maxSma50DeviationPctOverride as number | null) ?? null,
               requireAboveSma50Override: (v.requireAboveSma50Override as boolean | null) ?? null,
-              alternatives: (v.alternatives as string | null) ?? null,
               entryRequired: v.entryRequired === true || v.entryRequired === 1,
               alwaysActive: v.alwaysActive === true || v.alwaysActive === 1,
               cashFallbackSymbol: (v.cashFallbackSymbol as string | null) ?? null,
@@ -246,7 +245,6 @@ function row(overrides: Partial<SymbolConfigRow> = {}): SymbolConfigRow {
     maxAtrRatioOverride: null,
     maxSma50DeviationPctOverride: null,
     requireAboveSma50Override: null,
-    alternatives: null,
     entryRequired: false,
     alwaysActive: false,
     cashFallbackSymbol: null,
@@ -1328,13 +1326,13 @@ describe('#315 inverse-pair list grouping', () => {
   })
 })
 
-describe('dashboard symbol_config role / entry override / alternatives (#452)', () => {
+describe('dashboard symbol_config role / entry override (#452)', () => {
   beforeEach(() => {
     vi.mocked(loadGlobalConfigFrom).mockResolvedValue(makeGlobalConfigSnapshot())
   })
   afterEach(() => vi.resetAllMocks())
 
-  it('POST persists role, entry overrides (% → fraction) and alternatives (JSON text)', async () => {
+  it('POST persists role and entry overrides (% → fraction)', async () => {
     const db = fakeDb([])
     vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
     const app = createApp()
@@ -1351,7 +1349,6 @@ describe('dashboard symbol_config role / entry override / alternatives (#452)', 
       max_atr_ratio_override: '1.8', // ratio 生値
       max_sma50_deviation_pct_override: '20', // +20% → 0.2
       require_above_sma50_override: 'false',
-      alternatives: 'voo, SPLG voo', // 区切り混在 + 重複
     })
     const res = await app.request(
       '/admin/symbol-config',
@@ -1371,7 +1368,6 @@ describe('dashboard symbol_config role / entry override / alternatives (#452)', 
     expect(inserted.values.maxAtrRatioOverride).toBeCloseTo(1.8, 6)
     expect(inserted.values.maxSma50DeviationPctOverride).toBeCloseTo(0.2, 6)
     expect(inserted.values.requireAboveSma50Override).toBe(false)
-    expect(inserted.values.alternatives).toBe('["VOO","SPLG"]')
   })
 
   it('POST with empty role / overrides persists NULLs (従来挙動)', async () => {
@@ -1386,7 +1382,6 @@ describe('dashboard symbol_config role / entry override / alternatives (#452)', 
       lot_size: '1',
       role: '',
       pullback_max_override: '',
-      alternatives: '',
     })
     const res = await app.request(
       '/admin/symbol-config',
@@ -1401,7 +1396,6 @@ describe('dashboard symbol_config role / entry override / alternatives (#452)', 
     const inserted = db.inserts.find((i) => i.table === 'symbol_config')!
     expect(inserted.values.role).toBeNull()
     expect(inserted.values.pullbackMaxOverride).toBeNull()
-    expect(inserted.values.alternatives).toBeNull()
   })
 
   it('rejects an out-of-enum role with 400 (typo を従来挙動に黙って倒さない)', async () => {
@@ -1451,28 +1445,6 @@ describe('dashboard symbol_config role / entry override / alternatives (#452)', 
     expect(res.status).toBe(400)
   })
 
-  it('rejects alternatives containing an invalid ticker with 400', async () => {
-    const db = fakeDb([])
-    vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
-    const app = createApp()
-    const res = await app.request(
-      '/admin/symbol-config',
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...authHeader },
-        body: new URLSearchParams({
-          symbol: 'SOXL',
-          market: 'US',
-          currency: 'USD',
-          active: 'true',
-          lot_size: '1',
-          alternatives: 'SOXX, BAD&SYM',
-        }).toString(),
-      },
-      { ...baseEnv, DB: {} as D1Database },
-    )
-    expect(res.status).toBe(400)
-  })
 
   it('edit form shows role select / entry override fields with current values', async () => {
     const db = fakeDb([
@@ -1482,7 +1454,6 @@ describe('dashboard symbol_config role / entry override / alternatives (#452)', 
         pullbackMaxOverride: -0.015,
         minReturn50dOverride: 0.03,
         requireAboveSma50Override: false,
-        alternatives: '["VOO","SPLG"]',
       }),
     ])
     vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
@@ -1499,7 +1470,6 @@ describe('dashboard symbol_config role / entry override / alternatives (#452)', 
     expect(body).toMatch(/name="pullback_max_override"[^>]*value="-1\.5"/)
     expect(body).toMatch(/name="min_return_50d_override"[^>]*value="3"/)
     expect(body).toMatch(/name="require_above_sma50_override"/)
-    expect(body).toMatch(/name="alternatives"[^>]*value="VOO, SPLG"/)
   })
 })
 


### PR DESCRIPTION
## 概要 (operator と反復して到達した最終形)

銘柄間の依存 (退避先・インバース対・regime proxy) と資金の流れを可視化し、さらに**キャンバス上で直接編集**できるようにする。force graph → Sankey → ノードツリーと反復し、「口座 → 銘柄 → 譲り先」の現在形ツリーに収束。

### 1. 配分マップ (銘柄管理ページ上部、読み取り専用)

- **口座 → 銘柄 → 譲り先のノードツリー (現在形)**。参加の基準 = 建玉保有 (DO position、ページ既取得でフェッチ追加ゼロ)
- カード: `Active ・ $300` (実線枠) / `Pending (様子見)` (破線枠)。塗り = 通貨 (濃グレー 口座 / 桜 JPY / 薄青 USD)
- 点線矢印 = 様子見銘柄の枠の行き先: 緑 = 退避先へ代替割当 ・ グレー = 現金待機 ・ **琥珀 ⚠ = 退避先設定済みなのに条件連動 OFF で不使用** (実際に踏んだ罠の可視化)
- 口座の予算合計はインバース対の枠共有 (#315) を反映 (対は max)
- インバース対 / regime proxy は量の流れではないので脚注チップ

### 2. 編集キャンバス `/dashboard/symbols/map` (Drawflow)

- **draft 編集モデル**: 線を引く/消すは即保存せず、緑破線 + 琥珀発光 + 変更サマリで可視化 → **「適用」で一括保存** → reload。リセットで破棄
- **配分 = 1/枝 (トポロジー導出)**: % 手入力を廃止。口座に繋がる枝数 N で均等割 (対は 1 枝)。**合計は構造的に常に 100%** — % 手管理のカオスを根絶。DB/cron は従来の budget_alloc_pct のまま (適用時にエディタが変換)
- **起点は通貨別口座カード** (日本/米国)。通貨違いの接続は理由付きで拒否。各口座に枝数・小計% 表示 (予算プールは単一 = JPY 換算ベースのまま)
- **銘柄 → 銘柄の線 = 退避先** (1 銘柄 1 本、設定時に条件連動も自動 ON — 眠った設定の罠を構造的に防止)
- 線の削除: Backspace 単体 / Delete / 専用ボタンの 3 通り

### 3. 専用 API + フォーム改善

- **`POST /admin/symbol-config/:symbol/cash-fallback`** (新規): set/clear、同一通貨・実在・self 禁止を検証、audit log、同値 no-op
- フォームの退避先欄に「条件連動 ON のときのみ有効」を明記

### 含まれるもの (マージ順の制約)

- **#484 (代替銘柄削除) のコミットを含む** — staging D1 に 0032 適用済みのため整合させた。**必ず #484 を先にマージ**してから本 PR をマージすること

## 検証

- 1511 tests pass (Sankey→ツリーの payload / fallback endpoint ×3 / inline script 構文 #462 ×2 ほか)
- staging で operator と反復検証済み (Version 3303a22a)

Refs #452 #472 #315

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ダッシュボードに配分マップを追加し、口座→銘柄→譲り先の関係をグラフィカルに表示・編集できるようになりました
  * 配分編集キャンバスで複数の変更を一括適用できるようになりました
  * 現金待機先を設定するAPIを追加しました

* **廃止**
  * 代替銘柄（alternatives）機能を完全に廃止しました

* **その他**
  * データベーススキーマを更新しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->