### PR TITLE
fix: 対→対の側別退避を正式サポート (1対1本ルールの撤回)

### DIFF
--- a/src/infrastructure/db/symbolConfigRepo.ts
+++ b/src/infrastructure/db/symbolConfigRepo.ts
@@ -609,36 +609,18 @@ export async function updateCashFallback(
   symbol: string,
   target: string | null,
   nowIso: string,
-): Promise<{
-  before: SymbolConfigRow
-  after: SymbolConfigRow
-  /** 対の相方から外した退避先 (1 対 1 本ルール)。無ければ null。 */
-  clearedPartner: { symbol: string; previousFallback: string } | null
-} | null> {
+): Promise<{ before: SymbolConfigRow; after: SymbolConfigRow } | null> {
   const before = await findSymbolConfig(db, symbol)
   if (before === null) return null
   const beforeSnapshot: SymbolConfigRow = { ...before }
-  // 1 対 1 本 (キャンバスと同じ規則): 対の両側に退避先があると、対で 1 枠の
-  // 配分が銘柄単位の reroute で二重退避されるため、set 時は相方の退避先を外す。
-  let clearedPartner: { symbol: string; previousFallback: string } | null = null
-  if (target !== null) {
-    const pairs = await loadInversePairs(db).catch(() => ({}) as Record<string, string>)
-    const partner = pairs[symbol.toUpperCase()]
-    if (partner !== undefined) {
-      const partnerRow = await findSymbolConfig(db, partner)
-      if (partnerRow?.cashFallbackSymbol) {
-        await db
-          .update(symbolConfig)
-          .set({ cashFallbackSymbol: null, updatedAt: nowIso })
-          .where(eq(symbolConfig.symbol, partnerRow.symbol))
-        clearedPartner = { symbol: partnerRow.symbol, previousFallback: partnerRow.cashFallbackSymbol }
-      }
-    }
-  }
+  // NOTE: 対の両側がそれぞれ退避先を持つ「側別の対→対退避」(SOXL→TQQQ /
+  // SOXS→SQQQ) は正当な構成 — 二重買いはインバース対ガード (建玉は片側のみ)
+  // が退避先側でも防ぐ。以前あった「相方の退避先を自動クリア」はこの構成を
+  // 壊す誤実装だったため撤回 (operator 指摘)。
   const sameTarget = (before.cashFallbackSymbol ?? null) === (target ?? null)
   const needsEntryRequired = target !== null && before.entryRequired !== true
   if (sameTarget && !needsEntryRequired) {
-    return { before: beforeSnapshot, after: beforeSnapshot, clearedPartner }
+    return { before: beforeSnapshot, after: beforeSnapshot }
   }
   await db
     .update(symbolConfig)
@@ -650,7 +632,7 @@ export async function updateCashFallback(
     .where(eq(symbolConfig.symbol, symbol))
   const after = await findSymbolConfig(db, symbol)
   if (after === null) return null
-  return { before: beforeSnapshot, after, clearedPartner }
+  return { before: beforeSnapshot, after }
 }
 
 export async function updateBudgetAllocPct(

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1923,20 +1923,10 @@ export const admin = new Hono<AppBindings>()
       { cashFallbackSymbol: result.before.cashFallbackSymbol, entryRequired: result.before.entryRequired },
       { cashFallbackSymbol: result.after.cashFallbackSymbol, entryRequired: result.after.entryRequired },
     )
-    if (result.clearedPartner !== null) {
-      await writeAuditLog(
-        c,
-        '/admin/symbol-config/cash-fallback',
-        `symbol=${result.clearedPartner.symbol}`,
-        { cashFallbackSymbol: result.clearedPartner.previousFallback },
-        { cashFallbackSymbol: null, reason: 'pair-single-fallback rule' },
-      )
-    }
     return c.json({
       symbol,
       cashFallbackSymbol: result.after.cashFallbackSymbol,
       entryRequired: result.after.entryRequired,
-      clearedPartner: result.clearedPartner,
     })
   })
   /**

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -9482,6 +9482,11 @@ export function symbolMapEditorBody(
         }
         delete removedOnCanvas[pItem.sym];
         data.inactive = data.inactive.filter(function (x) { return x.sym !== pItem.sym; });
+        // 対メンバーから対を召喚した場合は側別ミラー退避を自動配線する
+        // (src の相方 → 召喚した対の相方)。
+        if (spawnedPairFromSymbol) {
+          mirrorPairFallback(src, item.sym);
+        }
       }
       // 接続の意味づけは通常ハンドラと同じ規則で draft に反映する。
       var src = symOf[srcNodeId];
@@ -9490,6 +9495,7 @@ export function symbolMapEditorBody(
       } else {
         draft[src].fallback = item.sym;
       }
+      var spawnedPairFromSymbol = !accountSymOf[src] && item.partner;
       // 払い出した銘柄はピッカー在庫から除外。
       data.inactive = data.inactive.filter(function (x) { return x.sym !== item.sym; });
       renderChanges();
@@ -9502,10 +9508,13 @@ export function symbolMapEditorBody(
         return { sym: sym, role: n.role, color: n.color, currency: n.currency, inverse: n.inverse };
       });
       var candidates = data.inactive.concat(removedItems).filter(function (x) { return x.currency === ccy; });
-      // 口座から引いた場合、対 (両方在庫) は 1 エントリに畳んで 2 枚セットで出す
-      // (対 = 1 枝なので個別に出すのは意味論として誤り)。退避先 (銘柄から引いた
-      // 場合) は対象を 1 銘柄に決める必要があるため個別のまま。
-      if (accountSymOf[src]) {
+      // 対 (両方在庫) を 1 エントリに畳むケース:
+      //   - 口座から引いた場合 (対 = 1 枝)
+      //   - **対メンバーから引いた場合** (側別ミラー退避: SOXL→TQQQ / SOXS→SQQQ を
+      //     1 ジェスチャで張る — operator の設計)
+      // 単独銘柄からの退避は対象を 1 銘柄に決める必要があるため個別のまま。
+      var srcIsPairMember = !accountSymOf[src] && nodeBySym[src] && nodeBySym[src].inverse && draft[nodeBySym[src].inverse];
+      if (accountSymOf[src] || srcIsPairMember) {
         var bySym2 = {};
         candidates.forEach(function (x) { bySym2[x.sym] = x; });
         var merged = [];
@@ -9610,10 +9619,11 @@ export function symbolMapEditorBody(
         alert(src + ' は ' + nodeBySym[src].currency + '、' + dst + ' は ' + nodeBySym[dst].currency + ' です。異通貨の退避先は設定できません (同一通貨のみ)。');
         return;
       }
-      // 退避先は 1 対 (単独銘柄は 1 銘柄) 1 本 — 自分と相方の既存退避を外して張る。
-      clearPairFallbacks(src);
+      // 自分の既存退避を外して張り、対 → 対なら側別ミラーも張る。
+      clearFallbackOf(src);
       draft[src].fallback = dst;
       markConnectionPending(info.output_id, info.input_id);
+      mirrorPairFallback(src, dst);
       renderChanges();
     });
 
@@ -9627,7 +9637,11 @@ export function symbolMapEditorBody(
         renderChanges();
         return;
       }
-      if (draft[src].fallback === dst) draft[src].fallback = null;
+      if (draft[src].fallback === dst) {
+        draft[src].fallback = null;
+        // 対 → 対のミラー退避も連動して外す (張るときと対称)。
+        clearPairFallbackMirror(src);
+      }
       renderChanges();
     });
 
@@ -9660,9 +9674,9 @@ export function symbolMapEditorBody(
     function hideGuide() {
       if (guide) { guide.remove(); guide = null; }
     }
-    // 退避線は「1 対 1 本」: 対の両側に設定すると、対で 1 枠のはずの配分が
-    // 2 回退避されて二重計上になる (computeConditionalAllocation は銘柄単位で
-    // reroute する) ため、相方の既存退避を自動で外してから張る。
+    // 退避は銘柄ごと 1 本。**対 → 対は側別ミラー** (operator の設計: SOXL→TQQQ
+    // を引くと SOXS→SQQQ も連動) — 二重買いはインバース対ガード (建玉は片側
+    // のみ) が退避先側でも防ぐため、両側の退避は正当な構成。
     function clearFallbackOf(sym) {
       var fb = draft[sym] && draft[sym].fallback;
       if (!fb) return;
@@ -9673,10 +9687,28 @@ export function symbolMapEditorBody(
       }
       draft[sym].fallback = null;
     }
-    function clearPairFallbacks(srcSym) {
+    function setFallbackEdge(srcSym, dstSym) {
       clearFallbackOf(srcSym);
-      var inv = nodeBySym[srcSym] && nodeBySym[srcSym].inverse;
-      if (inv && draft[inv]) clearFallbackOf(inv);
+      if (idOf[srcSym] && idOf[dstSym]) {
+        programmatic = true;
+        editor.addConnection(idOf[srcSym], idOf[dstSym], 'output_1', 'input_1');
+        programmatic = false;
+        markConnectionPending(idOf[srcSym], idOf[dstSym]);
+      }
+      draft[srcSym].fallback = dstSym;
+    }
+    // src→dst の退避に対し、双方が対なら相方同士 (側別) もミラーで張る。
+    function mirrorPairFallback(srcSym, dstSym) {
+      var srcInv = nodeBySym[srcSym] && nodeBySym[srcSym].inverse;
+      var dstInv = nodeBySym[dstSym] && nodeBySym[dstSym].inverse;
+      if (!srcInv || !dstInv || !draft[srcInv] || !draft[dstInv]) return null;
+      setFallbackEdge(srcInv, dstInv);
+      return { src: srcInv, dst: dstInv };
+    }
+    function clearPairFallbackMirror(srcSym) {
+      var srcInv = nodeBySym[srcSym] && nodeBySym[srcSym].inverse;
+      if (!srcInv || !draft[srcInv]) return;
+      clearFallbackOf(srcInv);
     }
     function srcNodeIdOf(srcSym) {
       return accountSymOf[srcSym] ? accountIds[accountSymOf[srcSym]] : idOf[srcSym];
@@ -9706,12 +9738,8 @@ export function symbolMapEditorBody(
         alert(srcSym + ' は ' + nodeBySym[srcSym].currency + '、' + dstSym + ' は ' + nodeBySym[dstSym].currency + ' です。異通貨の退避先は設定できません。');
         return false;
       }
-      clearPairFallbacks(srcSym)
-      programmatic = true;
-      editor.addConnection(idOf[srcSym], idOf[dstSym], 'output_1', 'input_1');
-      programmatic = false;
-      draft[srcSym].fallback = dstSym;
-      markConnectionPending(idOf[srcSym], idOf[dstSym]);
+      setFallbackEdge(srcSym, dstSym);
+      mirrorPairFallback(srcSym, dstSym);
       return true;
     }
     el.addEventListener('mousedown', function (ev) {


### PR DESCRIPTION
## 背景 (operator 指摘)

実運用の退避設計は「**対 → 対の側別退避**」(SOXL→TQQQ / SOXS→SQQQ — bull は bull へ、bear は bear へ)。#487 で入れた「1 対 1 本」ルールは「両側退避 = 1 枠の二重 reroute」という誤った前提で、この正当な構成を壊していた (server 側は相方の退避先を自動クリア)。

二重買いにならない根拠: 退避先の対にも**インバース対ガード (建玉は常に片側のみ)** が効くため、cash rebalance の BUY は片側しか通らない。

## 変更

- **server**: `updateCashFallback` の相方自動クリアを撤回 (退避は銘柄ごと独立に戻す)
- **canvas**: 対 → 対の退避は**側別ミラー** — SOXL→TQQQ を引くと SOXS→SQQQ も自動で張られ、削除・付け替えも連動
- **ピッカー**: 対メンバーから出した場合も対は 1 エントリ (`TQQQ ⇄ SQQQ`) に畳み、選ぶと 2 枚出現 + 側別 2 本を自動配線

## 検証

- 1507 tests pass、staging デプロイ済み
- production の既存設定 (SOXL→TQQQ / SOXS→SQQQ) はこの構成のまま正となる

Refs #487 #452 #315