### PR TITLE
fix: 対の共有枠は退避を 1 回分に抑止 (#452 follow-up)

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1839,6 +1839,7 @@ export const admin = new Hono<AppBindings>()
       entryStatuses,
       heldSymbols,
       symbolCurrency: universe.symbolCurrency,
+    inversePairs: universe.inversePairs,
     })
 
     // 退避の実発注プラン。total_capital_jpy 未設定なら金額換算不可 (fail-closed

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -424,6 +424,7 @@ export const dashboard = new Hono<DashboardBindings>()
           entryStatuses,
           heldSymbols,
           symbolCurrency: universe.symbolCurrency,
+    inversePairs: universe.inversePairs,
         })
         const sortedCharts = sortGridChartsByEntryPriority(charts, entryStatuses, universe)
         // grid の zoom 基準: 全 panel 共通の dataZoom 同期があるため、最初に

--- a/src/trading/strategy/conditionalAllocation.ts
+++ b/src/trading/strategy/conditionalAllocation.ts
@@ -39,6 +39,13 @@ export interface AllocationComputeInput {
   heldSymbols: ReadonlySet<string>
   /** symbol → 通貨。退避の同一通貨チェックに使う (不在は 'USD' 扱い)。 */
   symbolCurrency: Record<string, SymbolCurrency>
+  /**
+   * インバース対 (両方向 map)。対は **1 枠を共有**する (#315) ため、退避の
+   * 二重流出を抑止するのに使う (#452 follow-up): 両側が同時に未通過のとき
+   * 退避できるのは片側分のみ、相方が枠を使用中 (保有 or 判定通過) のときは
+   * 退避自体しない。未指定は従来挙動 (対を知らない)。
+   */
+  inversePairs?: Record<string, string>
 }
 
 export interface SymbolAllocation {
@@ -111,6 +118,23 @@ export function computeConditionalAllocation(input: AllocationComputeInput): All
     if (ownCurrency !== fallbackCurrency) {
       alloc.reason = `entry 判定 ${statusLabel}: 実配分 0 (退避先 ${fallback} と通貨不一致 → 現金のまま)`
       continue
+    }
+    // 対の枠は 1 つ (#315): 相方が枠を使用中 (保有 or 判定通過) なら退避しない。
+    // 両側とも未通過なら退避できるのは片側分のみ — 先頭 (Object.entries の
+    // 反復順で先に処理された側) が退避済みなら、こちらは枠なしとして止める。
+    const partner = input.inversePairs?.[symbol]
+    if (partner !== undefined) {
+      const partnerHeld = input.heldSymbols.has(partner)
+      const partnerEligible = isEntryEligible(input.entryStatuses[partner])
+      if (partnerHeld || partnerEligible) {
+        alloc.reason = `entry 判定 ${statusLabel}: 実配分 0 (対の枠は ${partner} が使用中 → 退避なし)`
+        continue
+      }
+      const partnerAlloc = bySymbol[partner]
+      if (partnerAlloc !== undefined && partnerAlloc.rerouteTo !== undefined) {
+        alloc.reason = `entry 判定 ${statusLabel}: 実配分 0 (対の枠は ${partner} 側から退避済み → 二重退避なし)`
+        continue
+      }
     }
     alloc.rerouteTo = fallback
     alloc.reason = `entry 判定 ${statusLabel}: 実配分 0 → ${fallback} へ退避`

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -750,6 +750,7 @@ export async function runStrategyCron(
         .map(([sym]) => sym),
     ),
     symbolCurrency: universe.symbolCurrency,
+    inversePairs: universe.inversePairs,
   })
   analysis.allocation = { view: allocationView, ordersEnabled: global.cashFallbackOrdersEnabled }
 

--- a/test/trading/strategy/conditionalAllocation.test.ts
+++ b/test/trading/strategy/conditionalAllocation.test.ts
@@ -94,6 +94,57 @@ describe('computeConditionalAllocation (#452 Layer 3)', () => {
   })
 })
 
+describe('computeConditionalAllocation × インバース対 (枠共有の退避抑止)', () => {
+  const pairInput = (): AllocationComputeInput => ({
+    targetWeights: { SOXL: 0.5, SOXS: 0.5 },
+    policy: {
+      entryRequired: new Set(['SOXL', 'SOXS']),
+      alwaysActive: new Set(),
+      cashFallback: { SOXL: 'VUG', SOXS: 'VUG' },
+    },
+    entryStatuses: { SOXL: 'WATCH', SOXS: 'WATCH' },
+    heldSymbols: new Set(),
+    symbolCurrency: { SOXL: 'USD', SOXS: 'USD', VUG: 'USD' },
+    inversePairs: { SOXL: 'SOXS', SOXS: 'SOXL' },
+  })
+
+  it('両側未通過でも退避は片側分のみ (対の 1 枠が二重に流れない)', () => {
+    const view = computeConditionalAllocation(pairInput())
+    const vug = view.bySymbol.VUG!
+    expect(vug.reroutedInWeight).toBeCloseTo(0.5) // 1.0 (二重) ではなく 0.5
+    const rerouted = [view.bySymbol.SOXL!, view.bySymbol.SOXS!].filter((a) => a.rerouteTo !== undefined)
+    expect(rerouted).toHaveLength(1)
+    const suppressed = [view.bySymbol.SOXL!, view.bySymbol.SOXS!].find((a) => a.rerouteTo === undefined)!
+    expect(suppressed.activeWeight).toBe(0)
+    expect(suppressed.reason).toContain('二重退避なし')
+  })
+
+  it('相方が保有中なら退避しない (枠は使用中)', () => {
+    const input = pairInput()
+    input.heldSymbols = new Set(['SOXL'])
+    const view = computeConditionalAllocation(input)
+    expect(view.bySymbol.SOXS!.rerouteTo).toBeUndefined()
+    expect(view.bySymbol.SOXS!.reason).toContain('使用中')
+    expect(view.bySymbol.VUG).toBeUndefined() // 退避ゼロなので VUG に枠は流れない
+  })
+
+  it('相方が判定通過 (ENTRY) なら退避しない', () => {
+    const input = pairInput()
+    input.entryStatuses = { SOXL: 'ENTRY', SOXS: 'WATCH' }
+    const view = computeConditionalAllocation(input)
+    expect(view.bySymbol.SOXL!.activeWeight).toBeCloseTo(0.5)
+    expect(view.bySymbol.SOXS!.rerouteTo).toBeUndefined()
+    expect(view.bySymbol.SOXS!.reason).toContain('使用中')
+  })
+
+  it('inversePairs 未指定は従来挙動 (互換)', () => {
+    const input = pairInput()
+    delete (input as { inversePairs?: unknown }).inversePairs
+    const view = computeConditionalAllocation(input)
+    expect(view.bySymbol.VUG!.reroutedInWeight).toBeCloseTo(1.0)
+  })
+})
+
 describe('buildCashRebalancePlan (#452 Layer 3)', () => {
   const view = computeConditionalAllocation(baseInput()) // SGOV active 0.8
 


### PR DESCRIPTION
## 背景 (シミュレーションが暴いた runtime バグ)

対 (SOXL ⇄ SOXS) の両側が未通過で退避先が単独銘柄 (VUG) のとき、`computeConditionalAllocation` は銘柄単位で reroute するため **1 枠 (100%) が二重に流れ、VUG 受入 +200% ・ 14 単位の買付プラン**になっていた (キャンバスのシミュレートで operator が発見)。対→対は受け側のインバースガードが実害を抑えるが、対→単独には抑止が無かった。

## 変更

`computeConditionalAllocation` に `inversePairs` (省略可・省略時は従来挙動) を追加し、対の枠を 1 つとして扱う:

- 相方が**枠を使用中** (保有 or 判定通過) → 自分は退避しない (`対の枠は X が使用中`)
- 両側未通過 → **退避できるのは片側分のみ** (`二重退避なし`)

呼び出し側 (cron / simulate / grid タブ) はすべて `universe.inversePairs` を渡す。

## 検証

- 18 tests (conditionalAllocation) +4: 二重抑止 / 保有中 / 判定通過 / 互換
- 全体 1512 pass、staging デプロイ済み — 同じ図でシミュレートすると VUG 受入が +100% ・ 7 単位に半減します

Refs #452 #493