### PR TITLE
feat: 退避の多分岐 — 複数退避先を等分割で流す (issue #496)

### DIFF
--- a/drizzle/0033_multi_cash_fallback.sql
+++ b/drizzle/0033_multi_cash_fallback.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `symbol_config` ADD `cash_fallback_symbols` text;--> statement-breakpoint
+UPDATE `symbol_config` SET `cash_fallback_symbols` = json_array(`cash_fallback_symbol`) WHERE `cash_fallback_symbol` IS NOT NULL;

--- a/drizzle/0034_drop_single_cash_fallback.sql
+++ b/drizzle/0034_drop_single_cash_fallback.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `symbol_config` DROP COLUMN `cash_fallback_symbol`;

--- a/drizzle/meta/0033_snapshot.json
+++ b/drizzle/meta/0033_snapshot.json
@@ -1,0 +1,1506 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "f5474854-3bb6-4bdd-bb02-8c7267c273e6",
+  "prevId": "9aebeb71-514e-46ee-99be-0e79c84ab1a2",
+  "tables": {
+    "config_audit_log": {
+      "name": "config_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before_json": {
+          "name": "before_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "after_json": {
+          "name": "after_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "config_audit_log_timestamp_id_idx": {
+          "name": "config_audit_log_timestamp_id_idx",
+          "columns": [
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "config_audit_log_actor_timestamp_id_idx": {
+          "name": "config_audit_log_actor_timestamp_id_idx",
+          "columns": [
+            "actor",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "config_audit_log_endpoint_timestamp_id_idx": {
+          "name": "config_audit_log_endpoint_timestamp_id_idx",
+          "columns": [
+            "endpoint",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "config_state_snapshot": {
+      "name": "config_state_snapshot",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "earnings_calendar": {
+      "name": "earnings_calendar",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "earnings_date": {
+          "name": "earnings_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "earnings_calendar_symbol_date_unique": {
+          "name": "earnings_calendar_symbol_date_unique",
+          "columns": [
+            "symbol",
+            "earnings_date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "global_config": {
+      "name": "global_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "trading_enabled": {
+          "name": "trading_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "market_hours_check": {
+          "name": "market_hours_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "max_order_notional": {
+          "name": "max_order_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "max_order_notional_usd": {
+          "name": "max_order_notional_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2000
+        },
+        "max_order_notional_jpy": {
+          "name": "max_order_notional_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100000
+        },
+        "total_capital_usd": {
+          "name": "total_capital_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_capital_jpy": {
+          "name": "total_capital_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_portfolio_exposure_pct": {
+          "name": "max_portfolio_exposure_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.6
+        },
+        "drawdown_kill_threshold": {
+          "name": "drawdown_kill_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.02
+        },
+        "stale_quote_ms": {
+          "name": "stale_quote_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 900000
+        },
+        "gap_reject_pct": {
+          "name": "gap_reject_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.03
+        },
+        "spread_limit_pct_us": {
+          "name": "spread_limit_pct_us",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.0025
+        },
+        "spread_limit_pct_jp": {
+          "name": "spread_limit_pct_jp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.006
+        },
+        "pullback_default_stop_pct": {
+          "name": "pullback_default_stop_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.04
+        },
+        "pullback_default_take_profit_pct": {
+          "name": "pullback_default_take_profit_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.07
+        },
+        "pullback_default_time_stop_days": {
+          "name": "pullback_default_time_stop_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "pullback_default_pullback_max": {
+          "name": "pullback_default_pullback_max",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.03
+        },
+        "pullback_default_pullback_min": {
+          "name": "pullback_default_pullback_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.06
+        },
+        "pullback_default_min_return_50d": {
+          "name": "pullback_default_min_return_50d",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.08
+        },
+        "pullback_default_require_above_sma50": {
+          "name": "pullback_default_require_above_sma50",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "pullback_default_k_atr": {
+          "name": "pullback_default_k_atr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "pullback_default_max_sma50_deviation_pct": {
+          "name": "pullback_default_max_sma50_deviation_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.6
+        },
+        "pullback_default_max_atr_ratio": {
+          "name": "pullback_default_max_atr_ratio",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1.5
+        },
+        "risk_base_per_trade_pct": {
+          "name": "risk_base_per_trade_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.004
+        },
+        "risk_dd_half_threshold": {
+          "name": "risk_dd_half_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.05
+        },
+        "risk_dd_halt_threshold": {
+          "name": "risk_dd_halt_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.1
+        },
+        "vix_warning_threshold": {
+          "name": "vix_warning_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 25
+        },
+        "vix_critical_threshold": {
+          "name": "vix_critical_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "vix_warning_size_scale": {
+          "name": "vix_warning_size_scale",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.5
+        },
+        "pair_regime_mode": {
+          "name": "pair_regime_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'off'"
+        },
+        "pair_regime_theta_bull_enter": {
+          "name": "pair_regime_theta_bull_enter",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.03
+        },
+        "pair_regime_theta_bull_exit": {
+          "name": "pair_regime_theta_bull_exit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.01
+        },
+        "pair_regime_theta_bear_enter": {
+          "name": "pair_regime_theta_bear_enter",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.04
+        },
+        "pair_regime_theta_bear_exit": {
+          "name": "pair_regime_theta_bear_exit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.015
+        },
+        "overview_panels": {
+          "name": "overview_panels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'kpi,equity,composition,recent'"
+        },
+        "cash_fallback_orders_enabled": {
+          "name": "cash_fallback_orders_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "global_config_max_order_notional_range": {
+          "name": "global_config_max_order_notional_range",
+          "value": "\"global_config\".\"max_order_notional\" > 0 AND \"global_config\".\"max_order_notional\" <= 10000000"
+        },
+        "global_config_max_order_notional_usd_range": {
+          "name": "global_config_max_order_notional_usd_range",
+          "value": "\"global_config\".\"max_order_notional_usd\" > 0 AND \"global_config\".\"max_order_notional_usd\" <= 1000000"
+        },
+        "global_config_max_order_notional_jpy_range": {
+          "name": "global_config_max_order_notional_jpy_range",
+          "value": "\"global_config\".\"max_order_notional_jpy\" > 0 AND \"global_config\".\"max_order_notional_jpy\" <= 100000000"
+        },
+        "global_config_total_capital_usd_range": {
+          "name": "global_config_total_capital_usd_range",
+          "value": "\"global_config\".\"total_capital_usd\" IS NULL OR \"global_config\".\"total_capital_usd\" > 0"
+        },
+        "global_config_total_capital_jpy_range": {
+          "name": "global_config_total_capital_jpy_range",
+          "value": "\"global_config\".\"total_capital_jpy\" IS NULL OR \"global_config\".\"total_capital_jpy\" > 0"
+        },
+        "global_config_max_portfolio_exposure_pct_range": {
+          "name": "global_config_max_portfolio_exposure_pct_range",
+          "value": "\"global_config\".\"max_portfolio_exposure_pct\" > 0 AND \"global_config\".\"max_portfolio_exposure_pct\" <= 1"
+        },
+        "global_config_drawdown_kill_threshold_range": {
+          "name": "global_config_drawdown_kill_threshold_range",
+          "value": "\"global_config\".\"drawdown_kill_threshold\" >= -1 AND \"global_config\".\"drawdown_kill_threshold\" <= 0"
+        },
+        "global_config_stale_quote_ms_range": {
+          "name": "global_config_stale_quote_ms_range",
+          "value": "\"global_config\".\"stale_quote_ms\" >= 0"
+        },
+        "global_config_gap_reject_pct_range": {
+          "name": "global_config_gap_reject_pct_range",
+          "value": "\"global_config\".\"gap_reject_pct\" >= 0 AND \"global_config\".\"gap_reject_pct\" <= 1"
+        },
+        "global_config_spread_limit_pct_us_range": {
+          "name": "global_config_spread_limit_pct_us_range",
+          "value": "\"global_config\".\"spread_limit_pct_us\" >= 0 AND \"global_config\".\"spread_limit_pct_us\" <= 1"
+        },
+        "global_config_spread_limit_pct_jp_range": {
+          "name": "global_config_spread_limit_pct_jp_range",
+          "value": "\"global_config\".\"spread_limit_pct_jp\" >= 0 AND \"global_config\".\"spread_limit_pct_jp\" <= 1"
+        },
+        "global_config_pullback_default_stop_pct_range": {
+          "name": "global_config_pullback_default_stop_pct_range",
+          "value": "\"global_config\".\"pullback_default_stop_pct\" < 0 AND \"global_config\".\"pullback_default_stop_pct\" >= -1"
+        },
+        "global_config_pullback_default_take_profit_pct_range": {
+          "name": "global_config_pullback_default_take_profit_pct_range",
+          "value": "\"global_config\".\"pullback_default_take_profit_pct\" > 0 AND \"global_config\".\"pullback_default_take_profit_pct\" <= 1"
+        },
+        "global_config_pullback_default_time_stop_days_range": {
+          "name": "global_config_pullback_default_time_stop_days_range",
+          "value": "\"global_config\".\"pullback_default_time_stop_days\" > 0 AND \"global_config\".\"pullback_default_time_stop_days\" <= ?"
+        },
+        "global_config_pullback_default_pullback_max_range": {
+          "name": "global_config_pullback_default_pullback_max_range",
+          "value": "\"global_config\".\"pullback_default_pullback_max\" <= 0 AND \"global_config\".\"pullback_default_pullback_max\" >= -1"
+        },
+        "global_config_pullback_default_pullback_min_range": {
+          "name": "global_config_pullback_default_pullback_min_range",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= 0 AND \"global_config\".\"pullback_default_pullback_min\" >= -1"
+        },
+        "global_config_pullback_default_min_return_50d_range": {
+          "name": "global_config_pullback_default_min_return_50d_range",
+          "value": "\"global_config\".\"pullback_default_min_return_50d\" >= -1 AND \"global_config\".\"pullback_default_min_return_50d\" <= 10"
+        },
+        "global_config_pullback_default_k_atr_range": {
+          "name": "global_config_pullback_default_k_atr_range",
+          "value": "\"global_config\".\"pullback_default_k_atr\" > 0 AND \"global_config\".\"pullback_default_k_atr\" <= 10"
+        },
+        "global_config_pullback_default_pullback_window_order": {
+          "name": "global_config_pullback_default_pullback_window_order",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= \"global_config\".\"pullback_default_pullback_max\""
+        },
+        "global_config_risk_base_per_trade_pct_range": {
+          "name": "global_config_risk_base_per_trade_pct_range",
+          "value": "\"global_config\".\"risk_base_per_trade_pct\" > 0 AND \"global_config\".\"risk_base_per_trade_pct\" <= 1"
+        },
+        "global_config_risk_dd_half_threshold_range": {
+          "name": "global_config_risk_dd_half_threshold_range",
+          "value": "\"global_config\".\"risk_dd_half_threshold\" < 0 AND \"global_config\".\"risk_dd_half_threshold\" >= -1"
+        },
+        "global_config_risk_dd_halt_threshold_range": {
+          "name": "global_config_risk_dd_halt_threshold_range",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" < 0 AND \"global_config\".\"risk_dd_halt_threshold\" >= -1"
+        },
+        "global_config_risk_dd_threshold_order": {
+          "name": "global_config_risk_dd_threshold_order",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" <= \"global_config\".\"risk_dd_half_threshold\""
+        },
+        "global_config_vix_warning_threshold_range": {
+          "name": "global_config_vix_warning_threshold_range",
+          "value": "\"global_config\".\"vix_warning_threshold\" > 0 AND \"global_config\".\"vix_warning_threshold\" <= 200"
+        },
+        "global_config_vix_critical_threshold_range": {
+          "name": "global_config_vix_critical_threshold_range",
+          "value": "\"global_config\".\"vix_critical_threshold\" > 0 AND \"global_config\".\"vix_critical_threshold\" <= 200"
+        },
+        "global_config_vix_threshold_order": {
+          "name": "global_config_vix_threshold_order",
+          "value": "\"global_config\".\"vix_warning_threshold\" <= \"global_config\".\"vix_critical_threshold\""
+        },
+        "global_config_vix_warning_size_scale_range": {
+          "name": "global_config_vix_warning_size_scale_range",
+          "value": "\"global_config\".\"vix_warning_size_scale\" >= 0 AND \"global_config\".\"vix_warning_size_scale\" <= 1"
+        }
+      }
+    },
+    "inverse_pairs": {
+      "name": "inverse_pairs",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inverse": {
+          "name": "inverse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "regime_enabled": {
+          "name": "regime_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "regime_proxy_symbol": {
+          "name": "regime_proxy_symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "regime_bull_symbol": {
+          "name": "regime_bull_symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "macro_event_calendar": {
+      "name": "macro_event_calendar",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_time": {
+          "name": "event_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "macro_event_calendar_type_date_unique": {
+          "name": "macro_event_calendar_type_date_unique",
+          "columns": [
+            "event_type",
+            "event_date"
+          ],
+          "isUnique": true
+        },
+        "macro_event_calendar_date_idx": {
+          "name": "macro_event_calendar_date_idx",
+          "columns": [
+            "event_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_emit_log": {
+      "name": "notification_emit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cause": {
+          "name": "cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notification_emit_log_timestamp_id_idx": {
+          "name": "notification_emit_log_timestamp_id_idx",
+          "columns": [
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "notification_emit_log_severity_timestamp_id_idx": {
+          "name": "notification_emit_log_severity_timestamp_id_idx",
+          "columns": [
+            "severity",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "notification_emit_log_event_type_timestamp_id_idx": {
+          "name": "notification_emit_log_event_type_timestamp_id_idx",
+          "columns": [
+            "event_type",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "portfolio_equity_snapshot": {
+      "name": "portfolio_equity_snapshot",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "daily_start_equity_usd": {
+          "name": "daily_start_equity_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_start_equity_jpy": {
+          "name": "daily_start_equity_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_realized_pnl_usd": {
+          "name": "daily_realized_pnl_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_realized_pnl_jpy": {
+          "name": "daily_realized_pnl_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "drawdown_pct": {
+          "name": "drawdown_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "portfolio_equity_snapshot_at_idx": {
+          "name": "portfolio_equity_snapshot_at_idx",
+          "columns": [
+            "snapshot_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "strategy_decision_log": {
+      "name": "strategy_decision_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indicators_json": {
+          "name": "indicators_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trace_json": {
+          "name": "trace_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "strategy_decision_log_symbol_id_idx": {
+          "name": "strategy_decision_log_symbol_id_idx",
+          "columns": [
+            "symbol",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "strategy_decision_log_coid_idx": {
+          "name": "strategy_decision_log_coid_idx",
+          "columns": [
+            "client_order_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "symbol_config": {
+      "name": "symbol_config",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "market": {
+          "name": "market",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_notional": {
+          "name": "max_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_stop_days_override": {
+          "name": "time_stop_days_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "k_atr_override": {
+          "name": "k_atr_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "budget_alloc_pct": {
+          "name": "budget_alloc_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lot_size": {
+          "name": "lot_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stop_pct_override": {
+          "name": "stop_pct_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "take_profit_pct_override": {
+          "name": "take_profit_pct_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "intraday_only": {
+          "name": "intraday_only",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pullback_max_override": {
+          "name": "pullback_max_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pullback_min_override": {
+          "name": "pullback_min_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "min_return_50d_override": {
+          "name": "min_return_50d_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_atr_ratio_override": {
+          "name": "max_atr_ratio_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_sma50_deviation_pct_override": {
+          "name": "max_sma50_deviation_pct_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "require_above_sma50_override": {
+          "name": "require_above_sma50_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_required": {
+          "name": "entry_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "always_active": {
+          "name": "always_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cash_fallback_symbols": {
+          "name": "cash_fallback_symbols",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cash_fallback_symbol": {
+          "name": "cash_fallback_symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "symbol_config_currency_enum": {
+          "name": "symbol_config_currency_enum",
+          "value": "\"symbol_config\".\"currency\" IN ('USD', 'JPY')"
+        },
+        "symbol_config_time_stop_days_override_range": {
+          "name": "symbol_config_time_stop_days_override_range",
+          "value": "\"symbol_config\".\"time_stop_days_override\" IS NULL OR (\"symbol_config\".\"time_stop_days_override\" >= 1 AND \"symbol_config\".\"time_stop_days_override\" <= ?)"
+        },
+        "symbol_config_k_atr_override_range": {
+          "name": "symbol_config_k_atr_override_range",
+          "value": "\"symbol_config\".\"k_atr_override\" IS NULL OR (\"symbol_config\".\"k_atr_override\" >= 0.5 AND \"symbol_config\".\"k_atr_override\" <= 5.0)"
+        }
+      }
+    },
+    "trade_journal": {
+      "name": "trade_journal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trade_event_type": {
+          "name": "trade_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "strategy_name": {
+          "name": "strategy_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_action": {
+          "name": "signal_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_reason": {
+          "name": "signal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_allowed": {
+          "name": "risk_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_reasons": {
+          "name": "risk_reasons",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "limit_price": {
+          "name": "limit_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notional": {
+          "name": "notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "broker_status": {
+          "name": "broker_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "submitted": {
+          "name": "submitted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_qty": {
+          "name": "filled_qty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_price": {
+          "name": "filled_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "realized_pnl": {
+          "name": "realized_pnl",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hold_days": {
+          "name": "hold_days",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_reason": {
+          "name": "exit_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_applied_at": {
+          "name": "state_applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_error": {
+          "name": "state_apply_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_attempts": {
+          "name": "state_apply_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trading_toggle_history": {
+      "name": "trading_toggle_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before": {
+          "name": "before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "after": {
+          "name": "after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0034_snapshot.json
+++ b/drizzle/meta/0034_snapshot.json
@@ -1,0 +1,1499 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "62341df9-c8e4-4d04-a93a-d712349a5075",
+  "prevId": "f5474854-3bb6-4bdd-bb02-8c7267c273e6",
+  "tables": {
+    "config_audit_log": {
+      "name": "config_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before_json": {
+          "name": "before_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "after_json": {
+          "name": "after_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "config_audit_log_timestamp_id_idx": {
+          "name": "config_audit_log_timestamp_id_idx",
+          "columns": [
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "config_audit_log_actor_timestamp_id_idx": {
+          "name": "config_audit_log_actor_timestamp_id_idx",
+          "columns": [
+            "actor",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "config_audit_log_endpoint_timestamp_id_idx": {
+          "name": "config_audit_log_endpoint_timestamp_id_idx",
+          "columns": [
+            "endpoint",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "config_state_snapshot": {
+      "name": "config_state_snapshot",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "earnings_calendar": {
+      "name": "earnings_calendar",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "earnings_date": {
+          "name": "earnings_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "earnings_calendar_symbol_date_unique": {
+          "name": "earnings_calendar_symbol_date_unique",
+          "columns": [
+            "symbol",
+            "earnings_date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "global_config": {
+      "name": "global_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "trading_enabled": {
+          "name": "trading_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "market_hours_check": {
+          "name": "market_hours_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "max_order_notional": {
+          "name": "max_order_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "max_order_notional_usd": {
+          "name": "max_order_notional_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2000
+        },
+        "max_order_notional_jpy": {
+          "name": "max_order_notional_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100000
+        },
+        "total_capital_usd": {
+          "name": "total_capital_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_capital_jpy": {
+          "name": "total_capital_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_portfolio_exposure_pct": {
+          "name": "max_portfolio_exposure_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.6
+        },
+        "drawdown_kill_threshold": {
+          "name": "drawdown_kill_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.02
+        },
+        "stale_quote_ms": {
+          "name": "stale_quote_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 900000
+        },
+        "gap_reject_pct": {
+          "name": "gap_reject_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.03
+        },
+        "spread_limit_pct_us": {
+          "name": "spread_limit_pct_us",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.0025
+        },
+        "spread_limit_pct_jp": {
+          "name": "spread_limit_pct_jp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.006
+        },
+        "pullback_default_stop_pct": {
+          "name": "pullback_default_stop_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.04
+        },
+        "pullback_default_take_profit_pct": {
+          "name": "pullback_default_take_profit_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.07
+        },
+        "pullback_default_time_stop_days": {
+          "name": "pullback_default_time_stop_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "pullback_default_pullback_max": {
+          "name": "pullback_default_pullback_max",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.03
+        },
+        "pullback_default_pullback_min": {
+          "name": "pullback_default_pullback_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.06
+        },
+        "pullback_default_min_return_50d": {
+          "name": "pullback_default_min_return_50d",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.08
+        },
+        "pullback_default_require_above_sma50": {
+          "name": "pullback_default_require_above_sma50",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "pullback_default_k_atr": {
+          "name": "pullback_default_k_atr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "pullback_default_max_sma50_deviation_pct": {
+          "name": "pullback_default_max_sma50_deviation_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.6
+        },
+        "pullback_default_max_atr_ratio": {
+          "name": "pullback_default_max_atr_ratio",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1.5
+        },
+        "risk_base_per_trade_pct": {
+          "name": "risk_base_per_trade_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.004
+        },
+        "risk_dd_half_threshold": {
+          "name": "risk_dd_half_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.05
+        },
+        "risk_dd_halt_threshold": {
+          "name": "risk_dd_halt_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.1
+        },
+        "vix_warning_threshold": {
+          "name": "vix_warning_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 25
+        },
+        "vix_critical_threshold": {
+          "name": "vix_critical_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "vix_warning_size_scale": {
+          "name": "vix_warning_size_scale",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.5
+        },
+        "pair_regime_mode": {
+          "name": "pair_regime_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'off'"
+        },
+        "pair_regime_theta_bull_enter": {
+          "name": "pair_regime_theta_bull_enter",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.03
+        },
+        "pair_regime_theta_bull_exit": {
+          "name": "pair_regime_theta_bull_exit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.01
+        },
+        "pair_regime_theta_bear_enter": {
+          "name": "pair_regime_theta_bear_enter",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.04
+        },
+        "pair_regime_theta_bear_exit": {
+          "name": "pair_regime_theta_bear_exit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.015
+        },
+        "overview_panels": {
+          "name": "overview_panels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'kpi,equity,composition,recent'"
+        },
+        "cash_fallback_orders_enabled": {
+          "name": "cash_fallback_orders_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "global_config_max_order_notional_range": {
+          "name": "global_config_max_order_notional_range",
+          "value": "\"global_config\".\"max_order_notional\" > 0 AND \"global_config\".\"max_order_notional\" <= 10000000"
+        },
+        "global_config_max_order_notional_usd_range": {
+          "name": "global_config_max_order_notional_usd_range",
+          "value": "\"global_config\".\"max_order_notional_usd\" > 0 AND \"global_config\".\"max_order_notional_usd\" <= 1000000"
+        },
+        "global_config_max_order_notional_jpy_range": {
+          "name": "global_config_max_order_notional_jpy_range",
+          "value": "\"global_config\".\"max_order_notional_jpy\" > 0 AND \"global_config\".\"max_order_notional_jpy\" <= 100000000"
+        },
+        "global_config_total_capital_usd_range": {
+          "name": "global_config_total_capital_usd_range",
+          "value": "\"global_config\".\"total_capital_usd\" IS NULL OR \"global_config\".\"total_capital_usd\" > 0"
+        },
+        "global_config_total_capital_jpy_range": {
+          "name": "global_config_total_capital_jpy_range",
+          "value": "\"global_config\".\"total_capital_jpy\" IS NULL OR \"global_config\".\"total_capital_jpy\" > 0"
+        },
+        "global_config_max_portfolio_exposure_pct_range": {
+          "name": "global_config_max_portfolio_exposure_pct_range",
+          "value": "\"global_config\".\"max_portfolio_exposure_pct\" > 0 AND \"global_config\".\"max_portfolio_exposure_pct\" <= 1"
+        },
+        "global_config_drawdown_kill_threshold_range": {
+          "name": "global_config_drawdown_kill_threshold_range",
+          "value": "\"global_config\".\"drawdown_kill_threshold\" >= -1 AND \"global_config\".\"drawdown_kill_threshold\" <= 0"
+        },
+        "global_config_stale_quote_ms_range": {
+          "name": "global_config_stale_quote_ms_range",
+          "value": "\"global_config\".\"stale_quote_ms\" >= 0"
+        },
+        "global_config_gap_reject_pct_range": {
+          "name": "global_config_gap_reject_pct_range",
+          "value": "\"global_config\".\"gap_reject_pct\" >= 0 AND \"global_config\".\"gap_reject_pct\" <= 1"
+        },
+        "global_config_spread_limit_pct_us_range": {
+          "name": "global_config_spread_limit_pct_us_range",
+          "value": "\"global_config\".\"spread_limit_pct_us\" >= 0 AND \"global_config\".\"spread_limit_pct_us\" <= 1"
+        },
+        "global_config_spread_limit_pct_jp_range": {
+          "name": "global_config_spread_limit_pct_jp_range",
+          "value": "\"global_config\".\"spread_limit_pct_jp\" >= 0 AND \"global_config\".\"spread_limit_pct_jp\" <= 1"
+        },
+        "global_config_pullback_default_stop_pct_range": {
+          "name": "global_config_pullback_default_stop_pct_range",
+          "value": "\"global_config\".\"pullback_default_stop_pct\" < 0 AND \"global_config\".\"pullback_default_stop_pct\" >= -1"
+        },
+        "global_config_pullback_default_take_profit_pct_range": {
+          "name": "global_config_pullback_default_take_profit_pct_range",
+          "value": "\"global_config\".\"pullback_default_take_profit_pct\" > 0 AND \"global_config\".\"pullback_default_take_profit_pct\" <= 1"
+        },
+        "global_config_pullback_default_time_stop_days_range": {
+          "name": "global_config_pullback_default_time_stop_days_range",
+          "value": "\"global_config\".\"pullback_default_time_stop_days\" > 0 AND \"global_config\".\"pullback_default_time_stop_days\" <= ?"
+        },
+        "global_config_pullback_default_pullback_max_range": {
+          "name": "global_config_pullback_default_pullback_max_range",
+          "value": "\"global_config\".\"pullback_default_pullback_max\" <= 0 AND \"global_config\".\"pullback_default_pullback_max\" >= -1"
+        },
+        "global_config_pullback_default_pullback_min_range": {
+          "name": "global_config_pullback_default_pullback_min_range",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= 0 AND \"global_config\".\"pullback_default_pullback_min\" >= -1"
+        },
+        "global_config_pullback_default_min_return_50d_range": {
+          "name": "global_config_pullback_default_min_return_50d_range",
+          "value": "\"global_config\".\"pullback_default_min_return_50d\" >= -1 AND \"global_config\".\"pullback_default_min_return_50d\" <= 10"
+        },
+        "global_config_pullback_default_k_atr_range": {
+          "name": "global_config_pullback_default_k_atr_range",
+          "value": "\"global_config\".\"pullback_default_k_atr\" > 0 AND \"global_config\".\"pullback_default_k_atr\" <= 10"
+        },
+        "global_config_pullback_default_pullback_window_order": {
+          "name": "global_config_pullback_default_pullback_window_order",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= \"global_config\".\"pullback_default_pullback_max\""
+        },
+        "global_config_risk_base_per_trade_pct_range": {
+          "name": "global_config_risk_base_per_trade_pct_range",
+          "value": "\"global_config\".\"risk_base_per_trade_pct\" > 0 AND \"global_config\".\"risk_base_per_trade_pct\" <= 1"
+        },
+        "global_config_risk_dd_half_threshold_range": {
+          "name": "global_config_risk_dd_half_threshold_range",
+          "value": "\"global_config\".\"risk_dd_half_threshold\" < 0 AND \"global_config\".\"risk_dd_half_threshold\" >= -1"
+        },
+        "global_config_risk_dd_halt_threshold_range": {
+          "name": "global_config_risk_dd_halt_threshold_range",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" < 0 AND \"global_config\".\"risk_dd_halt_threshold\" >= -1"
+        },
+        "global_config_risk_dd_threshold_order": {
+          "name": "global_config_risk_dd_threshold_order",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" <= \"global_config\".\"risk_dd_half_threshold\""
+        },
+        "global_config_vix_warning_threshold_range": {
+          "name": "global_config_vix_warning_threshold_range",
+          "value": "\"global_config\".\"vix_warning_threshold\" > 0 AND \"global_config\".\"vix_warning_threshold\" <= 200"
+        },
+        "global_config_vix_critical_threshold_range": {
+          "name": "global_config_vix_critical_threshold_range",
+          "value": "\"global_config\".\"vix_critical_threshold\" > 0 AND \"global_config\".\"vix_critical_threshold\" <= 200"
+        },
+        "global_config_vix_threshold_order": {
+          "name": "global_config_vix_threshold_order",
+          "value": "\"global_config\".\"vix_warning_threshold\" <= \"global_config\".\"vix_critical_threshold\""
+        },
+        "global_config_vix_warning_size_scale_range": {
+          "name": "global_config_vix_warning_size_scale_range",
+          "value": "\"global_config\".\"vix_warning_size_scale\" >= 0 AND \"global_config\".\"vix_warning_size_scale\" <= 1"
+        }
+      }
+    },
+    "inverse_pairs": {
+      "name": "inverse_pairs",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inverse": {
+          "name": "inverse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "regime_enabled": {
+          "name": "regime_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "regime_proxy_symbol": {
+          "name": "regime_proxy_symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "regime_bull_symbol": {
+          "name": "regime_bull_symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "macro_event_calendar": {
+      "name": "macro_event_calendar",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_time": {
+          "name": "event_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "macro_event_calendar_type_date_unique": {
+          "name": "macro_event_calendar_type_date_unique",
+          "columns": [
+            "event_type",
+            "event_date"
+          ],
+          "isUnique": true
+        },
+        "macro_event_calendar_date_idx": {
+          "name": "macro_event_calendar_date_idx",
+          "columns": [
+            "event_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_emit_log": {
+      "name": "notification_emit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cause": {
+          "name": "cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notification_emit_log_timestamp_id_idx": {
+          "name": "notification_emit_log_timestamp_id_idx",
+          "columns": [
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "notification_emit_log_severity_timestamp_id_idx": {
+          "name": "notification_emit_log_severity_timestamp_id_idx",
+          "columns": [
+            "severity",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "notification_emit_log_event_type_timestamp_id_idx": {
+          "name": "notification_emit_log_event_type_timestamp_id_idx",
+          "columns": [
+            "event_type",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "portfolio_equity_snapshot": {
+      "name": "portfolio_equity_snapshot",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "daily_start_equity_usd": {
+          "name": "daily_start_equity_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_start_equity_jpy": {
+          "name": "daily_start_equity_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_realized_pnl_usd": {
+          "name": "daily_realized_pnl_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_realized_pnl_jpy": {
+          "name": "daily_realized_pnl_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "drawdown_pct": {
+          "name": "drawdown_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "portfolio_equity_snapshot_at_idx": {
+          "name": "portfolio_equity_snapshot_at_idx",
+          "columns": [
+            "snapshot_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "strategy_decision_log": {
+      "name": "strategy_decision_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indicators_json": {
+          "name": "indicators_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trace_json": {
+          "name": "trace_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "strategy_decision_log_symbol_id_idx": {
+          "name": "strategy_decision_log_symbol_id_idx",
+          "columns": [
+            "symbol",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "strategy_decision_log_coid_idx": {
+          "name": "strategy_decision_log_coid_idx",
+          "columns": [
+            "client_order_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "symbol_config": {
+      "name": "symbol_config",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "market": {
+          "name": "market",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_notional": {
+          "name": "max_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_stop_days_override": {
+          "name": "time_stop_days_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "k_atr_override": {
+          "name": "k_atr_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "budget_alloc_pct": {
+          "name": "budget_alloc_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lot_size": {
+          "name": "lot_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stop_pct_override": {
+          "name": "stop_pct_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "take_profit_pct_override": {
+          "name": "take_profit_pct_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "intraday_only": {
+          "name": "intraday_only",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pullback_max_override": {
+          "name": "pullback_max_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pullback_min_override": {
+          "name": "pullback_min_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "min_return_50d_override": {
+          "name": "min_return_50d_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_atr_ratio_override": {
+          "name": "max_atr_ratio_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_sma50_deviation_pct_override": {
+          "name": "max_sma50_deviation_pct_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "require_above_sma50_override": {
+          "name": "require_above_sma50_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_required": {
+          "name": "entry_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "always_active": {
+          "name": "always_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cash_fallback_symbols": {
+          "name": "cash_fallback_symbols",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "symbol_config_currency_enum": {
+          "name": "symbol_config_currency_enum",
+          "value": "\"symbol_config\".\"currency\" IN ('USD', 'JPY')"
+        },
+        "symbol_config_time_stop_days_override_range": {
+          "name": "symbol_config_time_stop_days_override_range",
+          "value": "\"symbol_config\".\"time_stop_days_override\" IS NULL OR (\"symbol_config\".\"time_stop_days_override\" >= 1 AND \"symbol_config\".\"time_stop_days_override\" <= ?)"
+        },
+        "symbol_config_k_atr_override_range": {
+          "name": "symbol_config_k_atr_override_range",
+          "value": "\"symbol_config\".\"k_atr_override\" IS NULL OR (\"symbol_config\".\"k_atr_override\" >= 0.5 AND \"symbol_config\".\"k_atr_override\" <= 5.0)"
+        }
+      }
+    },
+    "trade_journal": {
+      "name": "trade_journal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trade_event_type": {
+          "name": "trade_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "strategy_name": {
+          "name": "strategy_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_action": {
+          "name": "signal_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_reason": {
+          "name": "signal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_allowed": {
+          "name": "risk_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_reasons": {
+          "name": "risk_reasons",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "limit_price": {
+          "name": "limit_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notional": {
+          "name": "notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "broker_status": {
+          "name": "broker_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "submitted": {
+          "name": "submitted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_qty": {
+          "name": "filled_qty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_price": {
+          "name": "filled_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "realized_pnl": {
+          "name": "realized_pnl",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hold_days": {
+          "name": "hold_days",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_reason": {
+          "name": "exit_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_applied_at": {
+          "name": "state_applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_error": {
+          "name": "state_apply_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_attempts": {
+          "name": "state_apply_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trading_toggle_history": {
+      "name": "trading_toggle_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before": {
+          "name": "before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "after": {
+          "name": "after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -232,6 +232,20 @@
       "when": 1781193221867,
       "tag": "0032_drop_alternatives",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "6",
+      "when": 1781262893984,
+      "tag": "0033_multi_cash_fallback",
+      "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "6",
+      "when": 1781262918382,
+      "tag": "0034_drop_single_cash_fallback",
+      "breakpoints": true
     }
   ]
 }

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -187,13 +187,14 @@ export const symbolConfig = sqliteTable(
      */
     alwaysActive: integer('always_active', { mode: 'boolean' }).notNull().default(false),
     /**
-     * entry_required 銘柄が条件未通過のときの退避先 symbol (例 'SGOV')。
-     * NULL = 退避しない (浮いた分は現金のまま)。同一通貨の銘柄のみ有効 —
-     * 通貨が異なる場合は配分計算時に退避を skip する (fail-closed、現金待機)。
+     * entry_required 銘柄が条件未通過のときの退避先 symbol 群 (#496 多分岐)。
+     * JSON 配列 text (例 '["SGOV","USMV"]')。複数なら**等分割**で流す。
+     * NULL / 空配列 = 退避しない (浮いた分は現金のまま)。同一通貨の銘柄のみ
+     * 有効 — 通貨が異なる先の取り分は配分計算時に skip (fail-closed、現金待機)。
      * 退避先への**自動発注は global_config.cash_fallback_orders_enabled (default
      * false) を on にするまで行わない** (判定・表示のみ)。
      */
-    cashFallbackSymbol: text('cash_fallback_symbol'),
+    cashFallbackSymbols: text('cash_fallback_symbols'),
     updatedAt: text('updated_at').notNull(),
   },
   (t) => ({

--- a/src/infrastructure/db/symbolConfigRepo.ts
+++ b/src/infrastructure/db/symbolConfigRepo.ts
@@ -136,7 +136,7 @@ export interface SymbolConfigSnapshot {
    * symbol → cash_fallback_symbol (#452)。NULL / 不正 ticker / self 参照は不在
    * (= 退避しない、現金のまま)。
    */
-  symbolCashFallback: Record<string, string>
+  symbolCashFallback: Record<string, string[]>
 }
 
 /**
@@ -176,7 +176,7 @@ export async function loadSymbolConfig(
   const symbolRequireAboveSma50Override: Record<string, boolean> = {}
   const symbolEntryRequired: Record<string, boolean> = {}
   const symbolAlwaysActive: Record<string, boolean> = {}
-  const symbolCashFallback: Record<string, string> = {}
+  const symbolCashFallback: Record<string, string[]> = {}
   for (const row of rows) {
     const symbol = row.symbol.toUpperCase()
     if (row.active) {
@@ -330,13 +330,12 @@ export async function loadSymbolConfig(
     if (row.alwaysActive === true) {
       symbolAlwaysActive[symbol] = true
     }
-    // 退避先は ticker 文法 + self 参照禁止まで検証。無効値は不在 (= 退避なし、
-    // 現金のまま) — 誤った退避先に積み増すより安全側。
-    if (row.cashFallbackSymbol !== null && row.cashFallbackSymbol !== undefined) {
-      const fallback = row.cashFallbackSymbol.trim().toUpperCase()
-      if (/^[A-Z0-9]{1,10}$/.test(fallback) && fallback !== symbol) {
-        symbolCashFallback[symbol] = fallback
-      }
+    // 退避先 (#496 多分岐: JSON 配列)。要素ごとに ticker 文法 + self 参照禁止
+    // まで検証し、無効要素は捨てる (= その取り分は現金のまま) — 誤った退避先に
+    // 積み増すより安全側。不正 JSON / 空配列は不在。
+    const fallbacks = parseCashFallbacksJson(row.cashFallbackSymbols, symbol)
+    if (fallbacks.length > 0) {
+      symbolCashFallback[symbol] = fallbacks
     }
   }
   return {
@@ -428,7 +427,7 @@ export interface SymbolConfigWriteInput {
   /** 常時 target = active (cash_parking 用、#452)。default false。 */
   alwaysActive: boolean
   /** 条件未通過時の退避先 symbol (NULL = 退避しない、#452)。 */
-  cashFallbackSymbol: string | null
+  cashFallbackSymbols: string[] | null
 }
 
 /**
@@ -469,7 +468,7 @@ export async function insertSymbolConfig(
       requireAboveSma50Override: input.requireAboveSma50Override,
       entryRequired: input.entryRequired,
       alwaysActive: input.alwaysActive,
-      cashFallbackSymbol: input.cashFallbackSymbol,
+      cashFallbackSymbols: cashFallbacksToJson(input.cashFallbackSymbols),
       updatedAt: nowIso,
     })
   } catch (err) {
@@ -527,7 +526,7 @@ export async function updateSymbolConfig(
       requireAboveSma50Override: input.requireAboveSma50Override,
       entryRequired: input.entryRequired,
       alwaysActive: input.alwaysActive,
-      cashFallbackSymbol: input.cashFallbackSymbol,
+      cashFallbackSymbols: cashFallbacksToJson(input.cashFallbackSymbols),
       updatedAt: nowIso,
     })
     .where(eq(symbolConfig.symbol, input.symbol))
@@ -604,29 +603,58 @@ export async function toggleSymbolActive(
  * clear は entry_required を触らない (条件連動自体の意図は別设定)。
  * 同値なら UPDATE しない (updatedAt だけ無監査で進むのを防ぐ)。
  */
+/** 退避先 JSON 配列の検証付き parse (#496)。不正は空配列 (= 退避なし)。 */
+export function parseCashFallbacksJson(raw: string | null | undefined, selfSymbol: string): string[] {
+  if (raw === null || raw === undefined) return []
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return []
+  }
+  if (!Array.isArray(parsed)) return []
+  const out: string[] = []
+  for (const item of parsed) {
+    if (typeof item !== 'string') continue
+    const sym = item.trim().toUpperCase()
+    if (!/^[A-Z0-9]{1,10}$/.test(sym)) continue
+    if (sym === selfSymbol.toUpperCase()) continue
+    if (!out.includes(sym)) out.push(sym)
+    if (out.length >= MAX_CASH_FALLBACKS) break
+  }
+  return out
+}
+
+/** 退避先の上限 (等分割の最小取り分が薄くなりすぎない防御値)。 */
+export const MAX_CASH_FALLBACKS = 4
+
+function cashFallbacksToJson(targets: string[] | null): string | null {
+  if (targets === null || targets.length === 0) return null
+  return JSON.stringify(targets)
+}
+
 export async function updateCashFallback(
   db: DrizzleD1Database,
   symbol: string,
-  target: string | null,
+  targets: string[] | null,
   nowIso: string,
 ): Promise<{ before: SymbolConfigRow; after: SymbolConfigRow } | null> {
   const before = await findSymbolConfig(db, symbol)
   if (before === null) return null
   const beforeSnapshot: SymbolConfigRow = { ...before }
-  // NOTE: 対の両側がそれぞれ退避先を持つ「側別の対→対退避」(SOXL→TQQQ /
-  // SOXS→SQQQ) は正当な構成 — 二重買いはインバース対ガード (建玉は片側のみ)
-  // が退避先側でも防ぐ。以前あった「相方の退避先を自動クリア」はこの構成を
-  // 壊す誤実装だったため撤回 (operator 指摘)。
-  const sameTarget = (before.cashFallbackSymbol ?? null) === (target ?? null)
-  const needsEntryRequired = target !== null && before.entryRequired !== true
+  // NOTE: 対の両側がそれぞれ退避先を持つ「側別の対→対退避」は正当な構成。
+  // 複数先 (#496) は配分計算側で等分割される。
+  const normalized = cashFallbacksToJson(targets)
+  const sameTarget = (before.cashFallbackSymbols ?? null) === normalized
+  const needsEntryRequired = normalized !== null && before.entryRequired !== true
   if (sameTarget && !needsEntryRequired) {
     return { before: beforeSnapshot, after: beforeSnapshot }
   }
   await db
     .update(symbolConfig)
     .set({
-      cashFallbackSymbol: target,
-      ...(target !== null ? { entryRequired: true } : {}),
+      cashFallbackSymbols: normalized,
+      ...(normalized !== null ? { entryRequired: true } : {}),
       updatedAt: nowIso,
     })
     .where(eq(symbolConfig.symbol, symbol))
@@ -892,7 +920,7 @@ export async function createSymbolPair(
       // できない。default (false / NULL) = 従来挙動で開始。
       entryRequired: false,
       alwaysActive: false,
-      cashFallbackSymbol: null,
+      cashFallbackSymbols: null,
       updatedAt: nowIso,
     })
     await db.batch([delLink, insCounterpart, insLink])

--- a/src/infrastructure/db/symbolUniverse.ts
+++ b/src/infrastructure/db/symbolUniverse.ts
@@ -72,7 +72,7 @@ export interface SymbolUniverse {
   /** always_active=true の集合 (#452、cash_parking 用)。false は不在。 */
   symbolAlwaysActive: Record<string, boolean>
   /** symbol → 退避先 symbol (#452)。不在 = 退避しない。 */
-  symbolCashFallback: Record<string, string>
+  symbolCashFallback: Record<string, string[]>
   inversePairs: Record<string, string>
   /** regime 有効化済みペア (#472)。misconfig は invalidConfig 付き (= unknown 扱い)。 */
   pairRegimes: PairRegimeEntry[]

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -52,6 +52,8 @@ import {
   toggleSymbolActive,
   updateBudgetAllocPct,
   updateCashFallback,
+  MAX_CASH_FALLBACKS,
+  parseCashFallbacksJson,
   updateSymbolConfig,
   isSymbolRole,
   SYMBOL_ROLES,
@@ -1768,7 +1770,7 @@ export const admin = new Hono<AppBindings>()
       if (pct <= 0) delete targetWeights[sym]
       else targetWeights[sym] = pct / 100
     }
-    const cashFallback: Record<string, string> = { ...universe.symbolCashFallback }
+    const cashFallback: Record<string, string[]> = { ...universe.symbolCashFallback }
     const entryRequired = new Set(Object.keys(universe.symbolEntryRequired))
     for (const [symRaw, v] of Object.entries(body.fallbacks ?? {})) {
       const sym = normalizeSymbol(symRaw)
@@ -1776,10 +1778,20 @@ export const admin = new Hono<AppBindings>()
         delete cashFallback[sym]
         continue
       }
-      if (typeof v !== 'string' || !/^[A-Za-z0-9]{1,10}$/.test(v.trim())) {
-        throw new ValidationError(`fallbacks.${sym} must be a ticker or null`, { field: 'fallbacks' })
+      const list = Array.isArray(v) ? v : [v]
+      const out: string[] = []
+      for (const item of list) {
+        if (typeof item !== 'string' || !/^[A-Za-z0-9]{1,10}$/.test(item.trim())) {
+          throw new ValidationError(`fallbacks.${sym} must be tickers or null`, { field: 'fallbacks' })
+        }
+        const t = normalizeSymbol(item)
+        if (!out.includes(t)) out.push(t)
       }
-      cashFallback[sym] = normalizeSymbol(v)
+      if (out.length === 0) {
+        delete cashFallback[sym]
+        continue
+      }
+      cashFallback[sym] = out
       // canvas 同様、退避先の設定は条件連動 ON を含意する。
       entryRequired.add(sym)
     }
@@ -1839,7 +1851,7 @@ export const admin = new Hono<AppBindings>()
       entryStatuses,
       heldSymbols,
       symbolCurrency: universe.symbolCurrency,
-    inversePairs: universe.inversePairs,
+      inversePairs: universe.inversePairs,
     })
 
     // 退避の実発注プラン。total_capital_jpy 未設定なら金額換算不可 (fail-closed
@@ -1873,9 +1885,10 @@ export const admin = new Hono<AppBindings>()
     })
   })
   /**
-   * 退避先の set / clear (#symbol-relation-map 編集キャンバス)。
-   * body: { target: 'SGOV' } で設定 (entry_required も同時に ON)、
-   * { target: null } で解除。検証: 両銘柄が登録済み・同一通貨・self 禁止。
+   * 退避先の set / clear (#symbol-relation-map 編集キャンバス、#496 多分岐)。
+   * body: { targets: ['SGOV','USMV'] } で設定 (entry_required も同時に ON、
+   * 複数は配分計算で等分割)、{ targets: null } で解除。旧 { target } も受ける。
+   * 検証: 全銘柄が登録済み・同一通貨・self 禁止・上限 MAX_CASH_FALLBACKS。
    */
   .post('/symbol-config/:symbol/cash-fallback', rateLimit('ADMIN_WRITE'), async (c) => {
     if (!c.env.DB) {
@@ -1883,50 +1896,58 @@ export const admin = new Hono<AppBindings>()
     }
     const symbol = normalizeSymbol(c.req.param('symbol'))
     const body = (await c.req.json().catch(() => null)) as unknown
-    // primitive / 配列 JSON で `'target' in body` が TypeError → 500 になるのを防ぐ
-    // (CodeRabbit #485): 先に object 判定して 400 に落とす。
-    if (body === null || typeof body !== 'object' || Array.isArray(body) || !('target' in body)) {
-      throw new ValidationError("body must be JSON { target: string | null }", { field: 'target' })
+    if (body === null || typeof body !== 'object' || Array.isArray(body) || !('targets' in body || 'target' in body)) {
+      throw new ValidationError("body must be JSON { targets: string[] | null }", { field: 'targets' })
     }
-    const payload = body as { target?: unknown }
-    let target: string | null = null
-    if (payload.target !== null) {
-      if (typeof payload.target !== 'string' || !/^[A-Za-z0-9]{1,10}$/.test(payload.target.trim())) {
-        throw new ValidationError('target must be a ticker or null', { field: 'target' })
+    const payload = body as { targets?: unknown; target?: unknown }
+    const rawTargets = 'targets' in payload ? payload.targets : payload.target
+    let targets: string[] | null = null
+    if (rawTargets !== null) {
+      const list = Array.isArray(rawTargets) ? rawTargets : [rawTargets]
+      const out: string[] = []
+      for (const item of list) {
+        if (typeof item !== 'string' || !/^[A-Za-z0-9]{1,10}$/.test(item.trim())) {
+          throw new ValidationError('targets must be tickers or null', { field: 'targets' })
+        }
+        const sym = normalizeSymbol(item)
+        if (sym === symbol) {
+          throw new ValidationError('targets must differ from the symbol itself', { field: 'targets' })
+        }
+        if (!out.includes(sym)) out.push(sym)
       }
-      target = normalizeSymbol(payload.target)
-      if (target === symbol) {
-        throw new ValidationError('target must differ from the symbol itself', { field: 'target' })
+      if (out.length > MAX_CASH_FALLBACKS) {
+        throw new ValidationError(`targets must have at most ${MAX_CASH_FALLBACKS} symbols`, { field: 'targets' })
       }
+      targets = out.length > 0 ? out : null
     }
     const db = createDb(c.env.DB)
     const source = await findSymbolConfig(db, symbol)
     if (source === null) return c.json({ error: 'symbol not found' }, 404)
-    if (target !== null) {
+    for (const target of targets ?? []) {
       const targetRow = await findSymbolConfig(db, target)
       if (targetRow === null) {
-        throw new ValidationError(`target ${target} is not a registered symbol`, { field: 'target' })
+        throw new ValidationError(`target ${target} is not a registered symbol`, { field: 'targets' })
       }
       // 通貨跨ぎの退避は配分計算側で skip される (fail-closed) ため、入力時点で拒否する。
       if (targetRow.currency !== source.currency) {
         throw new ValidationError(
-          `target currency ${targetRow.currency} must match ${source.currency}`,
-          { field: 'target' },
+          `target ${target} currency ${targetRow.currency} must match ${source.currency}`,
+          { field: 'targets' },
         )
       }
     }
-    const result = await updateCashFallback(db, symbol, target, new Date().toISOString())
+    const result = await updateCashFallback(db, symbol, targets, new Date().toISOString())
     if (result === null) return c.json({ error: 'symbol not found' }, 404)
     await writeAuditLog(
       c,
       '/admin/symbol-config/cash-fallback',
       `symbol=${symbol}`,
-      { cashFallbackSymbol: result.before.cashFallbackSymbol, entryRequired: result.before.entryRequired },
-      { cashFallbackSymbol: result.after.cashFallbackSymbol, entryRequired: result.after.entryRequired },
+      { cashFallbackSymbols: result.before.cashFallbackSymbols, entryRequired: result.before.entryRequired },
+      { cashFallbackSymbols: result.after.cashFallbackSymbols, entryRequired: result.after.entryRequired },
     )
     return c.json({
       symbol,
-      cashFallbackSymbol: result.after.cashFallbackSymbol,
+      cashFallbackSymbols: result.after.cashFallbackSymbols,
       entryRequired: result.after.entryRequired,
     })
   })
@@ -2728,7 +2749,7 @@ function parseSymbolConfigBody(body: unknown): SymbolConfigWriteInput {
   // ticker 文法 + self 参照禁止。空 → NULL (= 退避しない)。
   const entryRequired = parseFormBool(raw.entry_required ?? raw.entryRequired, false)
   const alwaysActive = parseFormBool(raw.always_active ?? raw.alwaysActive, false)
-  const cashFallbackSymbol = parseCashFallbackSymbol(
+  const cashFallbackSymbols = parseCashFallbackSymbols(
     raw.cash_fallback_symbol ?? raw.cashFallbackSymbol,
     symbol,
   )
@@ -2756,34 +2777,54 @@ function parseSymbolConfigBody(body: unknown): SymbolConfigWriteInput {
     requireAboveSma50Override,
     entryRequired,
     alwaysActive,
-    cashFallbackSymbol,
+    cashFallbackSymbols,
   }
 }
 
 /**
- * cash_fallback_symbol (#452): 空 / undefined → NULL。ticker 文法外・self 参照は
- * 400 (誤った退避先へ積み増す事故の入口防御)。
+ * cash_fallback_symbol(s) (#452 / #496 多分岐): form はカンマ/空白区切り text。
+ * 空 / undefined → NULL。ticker 文法外・self 参照・上限超過は 400
+ * (誤った退避先へ積み増す事故の入口防御)。
  */
-function parseCashFallbackSymbol(value: unknown, selfSymbol: string): string | null {
+function parseCashFallbackSymbols(value: unknown, selfSymbol: string): string[] | null {
   if (value === undefined || value === null) return null
-  if (typeof value !== 'string') {
-    throw new ValidationError('cashFallbackSymbol must be a symbol string', {
-      field: 'cashFallbackSymbol',
+  let tokens: string[]
+  if (Array.isArray(value)) {
+    tokens = value.map((v) => {
+      if (typeof v !== 'string') {
+        throw new ValidationError('cashFallbackSymbols must be symbols', { field: 'cashFallbackSymbols' })
+      }
+      return v
+    })
+  } else if (typeof value === 'string') {
+    tokens = value.split(/[\s,]+/)
+  } else {
+    throw new ValidationError('cashFallbackSymbols must be a string or array', {
+      field: 'cashFallbackSymbols',
     })
   }
-  const sym = value.trim().toUpperCase()
-  if (sym === '') return null
-  if (!/^[A-Z0-9]{1,10}$/.test(sym)) {
-    throw new ValidationError(`cashFallbackSymbol is not a valid symbol: ${sym}`, {
-      field: 'cashFallbackSymbol',
+  const out: string[] = []
+  for (const token of tokens) {
+    const sym = token.trim().toUpperCase()
+    if (sym === '') continue
+    if (!/^[A-Z0-9]{1,10}$/.test(sym)) {
+      throw new ValidationError(`cashFallbackSymbols contains an invalid symbol: ${sym}`, {
+        field: 'cashFallbackSymbols',
+      })
+    }
+    if (sym === selfSymbol.toUpperCase()) {
+      throw new ValidationError('cashFallbackSymbols cannot reference itself', {
+        field: 'cashFallbackSymbols',
+      })
+    }
+    if (!out.includes(sym)) out.push(sym)
+  }
+  if (out.length > MAX_CASH_FALLBACKS) {
+    throw new ValidationError(`cashFallbackSymbols must have at most ${MAX_CASH_FALLBACKS} symbols`, {
+      field: 'cashFallbackSymbols',
     })
   }
-  if (sym === selfSymbol.toUpperCase()) {
-    throw new ValidationError('cashFallbackSymbol cannot reference itself', {
-      field: 'cashFallbackSymbol',
-    })
-  }
-  return sym
+  return out.length > 0 ? out : null
 }
 
 /**

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -19,7 +19,7 @@ import { loadOverviewPanelsCsv, setOverviewPanels } from '../infrastructure/db/g
 import { resolveTradingEnabled } from '../trading/runtime/killSwitch'
 import { loadSymbolUniverse, type SymbolUniverse } from '../infrastructure/db/symbolUniverse'
 import type { SymbolCurrency, SymbolRole } from '../infrastructure/db/symbolConfigRepo'
-import { loadInversePairs, loadPairRegimeConfigs, SYMBOL_ROLES } from '../infrastructure/db/symbolConfigRepo'
+import { loadInversePairs, loadPairRegimeConfigs, parseCashFallbacksJson, SYMBOL_ROLES } from '../infrastructure/db/symbolConfigRepo'
 import { escapeHtml, formatSymbolDisplay } from '../shared/format'
 import { createDb } from '../infrastructure/db/tradeJournalRepo'
 import {
@@ -583,7 +583,7 @@ export const dashboard = new Hono<DashboardBindings>()
                   targetWeight: universe.symbolBudgetAllocPct[focusSymbol] ?? null,
                   entryRequired: universe.symbolEntryRequired[focusSymbol] === true,
                   alwaysActive: universe.symbolAlwaysActive[focusSymbol] === true,
-                  cashFallbackSymbol: universe.symbolCashFallback[focusSymbol] ?? null,
+                  cashFallbackSymbols: universe.symbolCashFallback[focusSymbol] ?? null,
                 }
               : null,
           }),
@@ -5903,7 +5903,7 @@ export interface SymbolPolicySummary {
   targetWeight: number | null
   entryRequired: boolean
   alwaysActive: boolean
-  cashFallbackSymbol: string | null
+  cashFallbackSymbols: string[] | null
 }
 
 /**
@@ -7388,7 +7388,7 @@ export function renderSymbolPolicyLine(
     policy.targetWeight !== null ||
     policy.entryRequired ||
     policy.alwaysActive ||
-    policy.cashFallbackSymbol !== null
+    policy.cashFallbackSymbols !== null
   if (!hasAny) return ''
   const parts: string[] = []
   if (policy.role !== null) {
@@ -7404,9 +7404,9 @@ export function renderSymbolPolicyLine(
   }
   if (policy.alwaysActive) parts.push('<span title="判定に関わらず常時 target = active">常時配分</span>')
   if (policy.entryRequired) parts.push('<span title="entry 判定 (ENTRY/HALF) 通過時のみ実配分有効">条件連動</span>')
-  if (policy.cashFallbackSymbol !== null) {
+  if (policy.cashFallbackSymbols !== null) {
     parts.push(
-      `退避先 <a href="/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(policy.cashFallbackSymbol)}">${esc(policy.cashFallbackSymbol)}</a>`,
+      `退避先 ${policy.cashFallbackSymbols.map((fb) => `<a href="/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(fb)}">${esc(fb)}</a>`).join(' / ')}`,
     )
   }
   return `<div style="margin-top:8px;font-size:13px;color:#3a3a3c;display:flex;gap:12px;flex-wrap:wrap;align-items:center">
@@ -8798,7 +8798,7 @@ export function symbolMapEditorBody(
     active: boolean
     held: Record<string, string>
     entryRequired: boolean
-    fallbackSyms: Record<string, string | null>
+    fallbackSyms: Record<string, string[]>
     y: number
   }
   const units: Unit[] = []
@@ -8835,7 +8835,9 @@ export function symbolMapEditorBody(
         syms.filter((x) => amounts[x] !== undefined).map((x) => [x, amounts[x]!.native]),
       ),
       entryRequired: members.some((m) => m.entryRequired === true),
-      fallbackSyms: Object.fromEntries(syms.map((x) => [x, bySym.get(x)?.cashFallbackSymbol?.toUpperCase() ?? null])),
+      fallbackSyms: Object.fromEntries(
+        syms.map((x) => [x, parseCashFallbacksJson(bySym.get(x)?.cashFallbackSymbols, x)]),
+      ),
       y: 0,
     }
     for (const x of syms) unitOfSym[x] = unit.id
@@ -8845,17 +8847,15 @@ export function symbolMapEditorBody(
   if (onCanvas.length === 0) {
     return `<p class="muted">有効な銘柄がありません。</p>`
   }
-  // unit の退避先 (unit 単位): 各側の fallback が指す unit。混在は先頭優先 +
-  // 警告 (旧データの片側欠け等は適用で側別に正規化される)。
-  const fallbackUnitOf = (u: Unit): { id: string | null; mixed: boolean } => {
+  // unit の退避先 (unit 単位、#496 多分岐): 各側の fallback リストが指す unit
+  // 群の和集合。側ごとの食い違い (旧データの片側欠け等) は適用で側別に正規化
+  // される。
+  const fallbackUnitsOf = (u: Unit): string[] => {
     const targets = u.syms
-      .map((x) => u.fallbackSyms[x])
-      .filter((x): x is string => x !== null)
+      .flatMap((x) => u.fallbackSyms[x] ?? [])
       .map((x) => unitOfSym[x] ?? null)
       .filter((x): x is string => x !== null)
-    if (targets.length === 0) return { id: null, mixed: false }
-    const uniq = [...new Set(targets)]
-    return { id: uniq[0]!, mixed: uniq.length > 1 }
+    return [...new Set(targets)]
   }
   // JPY 群 → USD 群で縦に並べる。
   let yCursor = 30
@@ -8877,7 +8877,7 @@ export function symbolMapEditorBody(
       pct: u.pct,
       held: u.held,
       entryRequired: u.entryRequired,
-      fallback: fallbackUnitOf(u),
+      fallbacks: fallbackUnitsOf(u),
       y: u.y,
     })),
     // スポーン在庫: 盤面に無い (= 全側 inactive) unit。
@@ -9047,8 +9047,8 @@ export function symbolMapEditorBody(
     function addUnitNode(u, x, y, opts2) {
       var spawned = !!(opts2 && opts2.spawned);
       unitBy[u.id] = u;
-      baseline[u.id] = baseline[u.id] || { pct: u.pct || 0, fallback: (u.fallback && u.fallback.id) || null, active: !spawned };
-      draft[u.id] = { connected: (u.pct || 0) > 0, fallback: (u.fallback && u.fallback.id) || null };
+      baseline[u.id] = baseline[u.id] || { pct: u.pct || 0, fallbacks: (u.fallbacks || []).slice().sort(), active: !spawned };
+      draft[u.id] = { connected: (u.pct || 0) > 0, fallbacks: (u.fallbacks || []).slice() };
       var id = editor.addNode(u.id, 1, 1, x, y, 'sm-node ' + (u.currency === 'JPY' ? 'sm-jpy' : 'sm-usd'), { unit: u.id }, unitCardHtml(u, spawned));
       idOf[u.id] = id;
       unitOf[id] = u.id;
@@ -9065,11 +9065,11 @@ export function symbolMapEditorBody(
     programmatic = true;
     data.units.forEach(function (u) {
       if (u.pct > 0) editor.addConnection(accountIds[u.currency], idOf[u.id], 'output_1', 'input_1');
-      var fb = u.fallback && u.fallback.id;
-      if (fb && idOf[fb]) {
+      (u.fallbacks || []).forEach(function (fb) {
+        if (!idOf[fb]) return;
         editor.addConnection(idOf[u.id], idOf[fb], 'output_1', 'input_1');
         tagConnectionClass(idOf[u.id], idOf[fb], 'sm-fallback');
-      }
+      });
     });
     programmatic = false;
 
@@ -9123,28 +9123,35 @@ export function symbolMapEditorBody(
       div.innerHTML = html;
       card.appendChild(div);
     }
-    // 適用/シミュレートで使う「unit → 銘柄ごとの fallback 展開」。
+    // 適用/シミュレートで使う「unit → 銘柄ごとの fallback 展開」(#496 多分岐)。
+    // 各 src 側は dst unit ごとに 1 銘柄ずつ受け取る:
     //   対→対: 役割で側合わせ (leveraged↔leveraged)、なければ並び順。
     //   対→単独: 両側 → 同一先。単独→単独: そのまま。
-    function expandFallback(srcUid, dstUid) {
+    function expandFallbacks(srcUid, dstUids) {
       var src = unitBy[srcUid];
       var out = {};
-      if (dstUid === null) {
-        src.syms.forEach(function (x) { out[x] = null; });
-        return out;
-      }
-      var dst = unitBy[dstUid];
-      src.syms.forEach(function (x, i) {
-        if (dst.syms.length === 1) {
-          out[x] = dst.syms[0];
-          return;
-        }
-        var role = src.roles[x];
-        var match = null;
-        dst.syms.forEach(function (y) { if (dst.roles[y] === role && role) match = y; });
-        out[x] = match || dst.syms[Math.min(i, dst.syms.length - 1)];
+      src.syms.forEach(function (x) { out[x] = (dstUids && dstUids.length > 0) ? [] : null; });
+      (dstUids || []).forEach(function (dstUid) {
+        var dst = unitBy[dstUid];
+        src.syms.forEach(function (x, i) {
+          var pick;
+          if (dst.syms.length === 1) {
+            pick = dst.syms[0];
+          } else {
+            var role = src.roles[x];
+            var match = null;
+            dst.syms.forEach(function (y) { if (dst.roles[y] === role && role) match = y; });
+            pick = match || dst.syms[Math.min(i, dst.syms.length - 1)];
+          }
+          out[x].push(pick);
+        });
       });
       return out;
+    }
+    function fallbacksChanged(uid) {
+      var a = (draft[uid].fallbacks || []).slice().sort().join(',');
+      var b = (baseline[uid].fallbacks || []).slice().sort().join(',');
+      return a !== b;
     }
     if (simBtn) simBtn.addEventListener('click', function () {
       simBtn.disabled = true;
@@ -9159,8 +9166,8 @@ export function symbolMapEditorBody(
           if (d.shares[uid] !== baseline[uid].pct) {
             u.syms.forEach(function (x) { pcts[x] = d.shares[uid] > 0 ? d.shares[uid] : null; });
           }
-          if ((draft[uid].fallback || null) !== (baseline[uid].fallback || null)) {
-            var exp = expandFallback(uid, draft[uid].fallback || null);
+          if (fallbacksChanged(uid)) {
+            var exp = expandFallbacks(uid, draft[uid].fallbacks);
             Object.keys(exp).forEach(function (x) { fallbacks[x] = exp[x]; });
           }
         });
@@ -9180,8 +9187,9 @@ export function symbolMapEditorBody(
           clearSim();
           var pctTxt = function (w) { return Math.round(w * 1000) / 10 + '%'; };
           Object.keys(draft).forEach(function (uid) {
-            var fb = draft[uid].fallback;
-            if (fb && idOf[fb]) tagConnectionClass(idOf[uid], idOf[fb], 'sm-sim-dim');
+            (draft[uid].fallbacks || []).forEach(function (fb) {
+              if (idOf[fb]) tagConnectionClass(idOf[uid], idOf[fb], 'sm-sim-dim');
+            });
           });
           var planBySym = {};
           if (res.plan) res.plan.orders.forEach(function (o) { planBySym[o.symbol] = o; });
@@ -9193,12 +9201,16 @@ export function symbolMapEditorBody(
             var held = res.heldSymbols.indexOf(sym) !== -1;
             var prefix = unitBy[uid].syms.length > 1 ? sym + ': ' : '';
             if (a.rerouteTo) {
-              simBadge(uid, 'sm-sim-reroute', prefix + '判定 ' + status + ' → <strong>' + pctTxt(a.targetWeight) + ' を ' + a.rerouteTo + ' へ退避</strong>');
-              var dstUid = data.unitOfSym[a.rerouteTo];
-              if (dstUid && idOf[dstUid]) {
-                var conn = el.querySelector('svg.connection.node_in_node-' + idOf[dstUid] + '.node_out_node-' + idOf[uid]);
-                if (conn) { conn.classList.remove('sm-sim-dim'); conn.classList.add('sm-sim-flow'); }
-              }
+              var targets = Array.isArray(a.rerouteTo) ? a.rerouteTo : [a.rerouteTo];
+              var per = targets.length > 1 ? ' (各 ' + pctTxt(a.targetWeight / targets.length) + ')' : '';
+              simBadge(uid, 'sm-sim-reroute', prefix + '判定 ' + status + ' → <strong>' + pctTxt(a.targetWeight) + ' を ' + targets.join('/') + ' へ退避' + per + '</strong>');
+              targets.forEach(function (t) {
+                var dstUid = data.unitOfSym[t];
+                if (dstUid && idOf[dstUid]) {
+                  var conn = el.querySelector('svg.connection.node_in_node-' + idOf[dstUid] + '.node_out_node-' + idOf[uid]);
+                  if (conn) { conn.classList.remove('sm-sim-dim'); conn.classList.add('sm-sim-flow'); }
+                }
+              });
             } else {
               simBadge(uid, 'sm-sim-active', prefix + (held ? '保有中' : '判定 ' + status) + ' ・ <strong>active ' + pctTxt(a.activeWeight) + '</strong>');
             }
@@ -9254,8 +9266,9 @@ export function symbolMapEditorBody(
         var uid = queue.pop();
         if (seen[uid]) continue;
         seen[uid] = true;
-        var fb = draft[uid].fallback;
-        if (fb && draft[fb] && !seen[fb]) queue.push(fb);
+        (draft[uid].fallbacks || []).forEach(function (fb) {
+          if (draft[fb] && !seen[fb]) queue.push(fb);
+        });
       }
       return seen;
     }
@@ -9285,15 +9298,17 @@ export function symbolMapEditorBody(
         var u = unitBy[uid];
         var newPct = d.shares[uid];
         var pctChanged = newPct !== b.pct;
-        var fbChanged = (draft[uid].fallback || null) !== (b.fallback || null);
+        var fbChanged = fallbacksChanged(uid);
         if (pctChanged) {
           items.push(u.label + ': 配分 ' + (b.pct ? b.pct + '%' : 'なし') + ' → ' + (newPct ? '1/' + d.branches + ' = ' + newPct + '%' : '解除 (risk-%)'));
         }
         if (fbChanged) {
-          if (draft[uid].fallback) {
-            var exp = expandFallback(uid, draft[uid].fallback);
-            var detail = u.syms.map(function (x) { return x + '→' + exp[x]; }).join(' / ');
-            items.push(u.label + ': 退避先 → ' + unitBy[draft[uid].fallback].label + ' (' + detail + '、条件連動 ON)');
+          var fbs = draft[uid].fallbacks || [];
+          if (fbs.length > 0) {
+            var exp = expandFallbacks(uid, fbs);
+            var detail = u.syms.map(function (x) { return x + '→' + exp[x].join('+'); }).join(' / ');
+            var split = fbs.length > 1 ? '、各 1/' + fbs.length + ' に等分割' : '';
+            items.push(u.label + ': 退避先 → ' + fbs.map(function (f) { return unitBy[f].label; }).join(' + ') + ' (' + detail + split + '、条件連動 ON)');
           } else {
             items.push(u.label + ': 退避先を解除');
           }
@@ -9327,8 +9342,10 @@ export function symbolMapEditorBody(
       delete idOf[uid];
       removedOnCanvas[uid] = true;
       draft[uid].connected = false;
-      draft[uid].fallback = null;
-      Object.keys(draft).forEach(function (x) { if (draft[x].fallback === uid) draft[x].fallback = null; });
+      draft[uid].fallbacks = [];
+      Object.keys(draft).forEach(function (x) {
+        draft[x].fallbacks = (draft[x].fallbacks || []).filter(function (f) { return f !== uid; });
+      });
       renderChanges();
     });
 
@@ -9371,13 +9388,16 @@ export function symbolMapEditorBody(
         alert('異通貨の退避先は設定できません (同一通貨のみ)。');
         return;
       }
-      // 退避は unit 1 本 — 既存の退避線を外して張る。
-      if (draft[src].fallback && idOf[draft[src].fallback]) {
+      // 退避は多分岐可 (#496): 追加で**等分割**される。重複と上限 (4) のみ防ぐ。
+      var cur = draft[src].fallbacks || [];
+      if (cur.indexOf(dst) !== -1 || cur.length >= 4) {
         programmatic = true;
-        editor.removeSingleConnection(idOf[src], idOf[draft[src].fallback], 'output_1', 'input_1');
+        editor.removeSingleConnection(info.output_id, info.input_id, info.output_class, info.input_class);
         programmatic = false;
+        if (cur.length >= 4) alert('退避先は最大 4 つまでです。');
+        return;
       }
-      draft[src].fallback = dst;
+      draft[src].fallbacks = cur.concat([dst]);
       tagConnectionClass(info.output_id, info.input_id, 'sm-fallback');
       markConnectionPending(info.output_id, info.input_id);
       renderChanges();
@@ -9393,7 +9413,7 @@ export function symbolMapEditorBody(
         renderChanges();
         return;
       }
-      if (draft[src].fallback === dst) draft[src].fallback = null;
+      draft[src].fallbacks = (draft[src].fallbacks || []).filter(function (f) { return f !== dst; });
       renderChanges();
     });
 
@@ -9439,7 +9459,7 @@ export function symbolMapEditorBody(
       if (accountCcyOf[src]) {
         draft[u.id].connected = true;
       } else {
-        draft[src].fallback = u.id;
+        draft[src].fallbacks = (draft[src].fallbacks || []).concat([u.id]);
         tagConnectionClass(srcNodeId, newId, 'sm-fallback');
       }
       markConnectionPending(srcNodeId, newId);
@@ -9586,22 +9606,24 @@ export function symbolMapEditorBody(
         draft[newDst].connected = true;
         markConnectionPending(state.srcId, idOf[newDst]);
       } else {
-        if (draft[src].fallback === oldDst) draft[src].fallback = null;
-        var invalid = (unitBy[src].syms.length === 1 && unitBy[newDst].syms.length > 1) || unitBy[src].currency !== unitBy[newDst].currency;
+        draft[src].fallbacks = (draft[src].fallbacks || []).filter(function (f) { return f !== oldDst; });
+        var invalid = (unitBy[src].syms.length === 1 && unitBy[newDst].syms.length > 1) ||
+          unitBy[src].currency !== unitBy[newDst].currency ||
+          (draft[src].fallbacks || []).indexOf(newDst) !== -1;
         if (invalid) {
-          alert('その付け替えはできません (単独→対 or 異通貨)。元に戻します。');
+          alert('その付け替えはできません (単独→対 / 異通貨 / 重複)。元に戻します。');
           programmatic = true;
           editor.addConnection(state.srcId, state.oldDstId, 'output_1', 'input_1');
           programmatic = false;
           tagConnectionClass(state.srcId, state.oldDstId, 'sm-fallback');
-          draft[src].fallback = oldDst;
+          draft[src].fallbacks = (draft[src].fallbacks || []).concat([oldDst]);
           renderChanges();
           return;
         }
         programmatic = true;
         editor.addConnection(state.srcId, idOf[newDst], 'output_1', 'input_1');
         programmatic = false;
-        draft[src].fallback = newDst;
+        draft[src].fallbacks = (draft[src].fallbacks || []).concat([newDst]);
         tagConnectionClass(state.srcId, idOf[newDst], 'sm-fallback');
         markConnectionPending(state.srcId, idOf[newDst]);
       }
@@ -9638,7 +9660,7 @@ export function symbolMapEditorBody(
       var d = deriveShares();
       var ad = activeDiffs();
       var pctUnits = Object.keys(draft).filter(function (uid) { return d.shares[uid] !== baseline[uid].pct; });
-      var fbUnits = Object.keys(draft).filter(function (uid) { return (draft[uid].fallback || null) !== (baseline[uid].fallback || null); });
+      var fbUnits = Object.keys(draft).filter(function (uid) { return fallbacksChanged(uid); });
       if (pctUnits.length === 0 && fbUnits.length === 0 && ad.activate.length === 0 && ad.deactivate.length === 0) return;
       var confirmMsg = '表示中の変更をまとめて適用します (' + d.branches + ' 枝 ・ 1 枝 = ' + d.share + '%';
       if (ad.activate.length > 0) confirmMsg += ' ・ 有効化 ' + ad.activate.map(function (x) { return unitBy[x].label; }).join('/');
@@ -9673,14 +9695,14 @@ export function symbolMapEditorBody(
         });
       }
       fbUnits.forEach(function (uid) {
-        var exp = expandFallback(uid, draft[uid].fallback || null);
+        var exp = expandFallbacks(uid, draft[uid].fallbacks || []);
         Object.keys(exp).forEach(function (sym) {
           steps = steps.then(function () {
             return fetch('/admin/symbol-config/' + encodeURIComponent(sym) + '/cash-fallback', {
               method: 'POST',
               credentials: 'same-origin',
               headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ target: exp[sym] }),
+              body: JSON.stringify({ targets: exp[sym] }),
             }).then(function (r) {
               if (!r.ok) return r.json().then(function (b) { throw new Error(sym + ' の退避先の保存に失敗: ' + (b.error || 'HTTP ' + r.status)); });
             });
@@ -10163,9 +10185,12 @@ export function renderSymbolRoleCell(row: SymbolConfigRow): string {
   const notes: string[] = []
   if (row.alwaysActive) notes.push('<span title="判定に関わらず常時 target = active">常時配分</span>')
   if (row.entryRequired) notes.push('<span title="entry 判定 (ENTRY/HALF) 通過時のみ実配分有効">条件連動</span>')
-  if (row.cashFallbackSymbol) {
+  const fallbackList = parseCashFallbacksJson(row.cashFallbackSymbols, row.symbol)
+  if (fallbackList.length > 0) {
     notes.push(
-      `<a href="/dashboard/symbols/${encodeURIComponent(row.cashFallbackSymbol)}/edit" title="条件未通過時の退避先">→${esc(row.cashFallbackSymbol)}</a>`,
+      `<span title="条件未通過時の退避先${fallbackList.length > 1 ? ' (等分割)' : ''}">→${fallbackList
+        .map((fb) => `<a href="/dashboard/symbols/${encodeURIComponent(fb)}/edit">${esc(fb)}</a>`)
+        .join('/')}</span>`,
     )
   }
   const noteHtml = notes.length
@@ -10242,7 +10267,7 @@ function symbolFormBody(args: SymbolFormArgs): string {
   // 条件連動配分 (#452 Layer 3)。
   const entryRequiredChecked = row?.entryRequired ? ' checked' : ''
   const alwaysActiveChecked = row?.alwaysActive ? ' checked' : ''
-  const cashFallbackValue = row?.cashFallbackSymbol ?? ''
+  const cashFallbackValue = row ? parseCashFallbacksJson(row.cashFallbackSymbols, row.symbol).join(', ') : ''
   const timeStopPlaceholder = globalDefaults
     ? `空欄で global default (${globalDefaults.timeStopDays}日) を使用`
     : '空欄で global default を使用'
@@ -10487,7 +10512,7 @@ function symbolFormBody(args: SymbolFormArgs): string {
         </label>
         <label>退避先</label>
         <div>
-          <input type="text" name="cash_fallback_symbol" value="${esc(cashFallbackValue)}" maxlength="10" pattern="[A-Za-z0-9]{0,10}" placeholder="例: SGOV" style="padding:6px;width:160px;text-transform:uppercase">
+          <input type="text" name="cash_fallback_symbol" value="${esc(cashFallbackValue)}" maxlength="60" placeholder="例: SGOV, USMV (複数は等分割)" style="padding:6px;width:240px;text-transform:uppercase">
           <span class="muted" style="font-size:12px;margin-left:6px"><strong>条件連動 ON のときのみ有効</strong>。同一通貨のみ。自動発注は flag (default off) を on にするまで無し</span>
         </div>`,
       hasAllocValues,

--- a/src/trading/strategy/conditionalAllocation.ts
+++ b/src/trading/strategy/conditionalAllocation.ts
@@ -26,7 +26,8 @@ export interface ConditionalAllocationPolicy {
   /** always_active=true の集合。 */
   alwaysActive: ReadonlySet<string>
   /** symbol → 退避先 symbol。 */
-  cashFallback: Record<string, string>
+  /** symbol → 退避先リスト (#496 多分岐)。複数なら等分割で流す。 */
+  cashFallback: Record<string, string[]>
 }
 
 export interface AllocationComputeInput {
@@ -54,8 +55,8 @@ export interface SymbolAllocation {
   targetWeight: number
   /** 判定連動後の実配分。退避受入分を含む。 */
   activeWeight: number
-  /** 自銘柄の枠が退避された先 (退避なしは undefined)。 */
-  rerouteTo?: string
+  /** 自銘柄の枠が退避された先 (#496 で複数化。退避なしは undefined)。 */
+  rerouteTo?: string[]
   /** 退避 / 据え置きの理由 (操作者向け)。 */
   reason: string
   /** 他銘柄から退避で受け入れた weight 合計 (退避先のみ > 0)。 */
@@ -106,17 +107,21 @@ export function computeConditionalAllocation(input: AllocationComputeInput): All
       continue
     }
     // 未通過 (WATCH / NG / 評価不能) → 実配分 0。退避先があり同一通貨なら積み増す。
+    // 複数先 (#496) は**設定数で等分割** — 無効な先 (通貨不一致等) の取り分は
+    // 再正規化せず現金のまま (fail-closed)。
     alloc.activeWeight = 0
     const statusLabel = status ?? '評価データ無し'
-    const fallback = input.policy.cashFallback[symbol]
-    if (fallback === undefined) {
+    const fallbacks = input.policy.cashFallback[symbol]
+    if (fallbacks === undefined || fallbacks.length === 0) {
       alloc.reason = `entry 判定 ${statusLabel}: 実配分 0 (退避先未設定 → 現金のまま)`
       continue
     }
     const ownCurrency = input.symbolCurrency[symbol] ?? 'USD'
-    const fallbackCurrency = input.symbolCurrency[fallback] ?? 'USD'
-    if (ownCurrency !== fallbackCurrency) {
-      alloc.reason = `entry 判定 ${statusLabel}: 実配分 0 (退避先 ${fallback} と通貨不一致 → 現金のまま)`
+    const validFallbacks = fallbacks.filter(
+      (fb) => (input.symbolCurrency[fb] ?? 'USD') === ownCurrency,
+    )
+    if (validFallbacks.length === 0) {
+      alloc.reason = `entry 判定 ${statusLabel}: 実配分 0 (退避先 ${fallbacks.join('/')} と通貨不一致 → 現金のまま)`
       continue
     }
     // 対の枠は 1 つ (#315): 相方が枠を使用中 (保有 or 判定通過) なら退避しない。
@@ -136,13 +141,19 @@ export function computeConditionalAllocation(input: AllocationComputeInput): All
         continue
       }
     }
-    alloc.rerouteTo = fallback
-    alloc.reason = `entry 判定 ${statusLabel}: 実配分 0 → ${fallback} へ退避`
-    const fallbackAlloc = ensure(fallback, input.targetWeights[fallback] ?? 0)
-    fallbackAlloc.activeWeight += target
-    fallbackAlloc.reroutedInWeight += target
-    if (fallbackAlloc.reason === '') {
-      fallbackAlloc.reason = '退避受入のみ (自身の target なし)'
+    alloc.rerouteTo = validFallbacks
+    const slice = target / fallbacks.length
+    alloc.reason =
+      fallbacks.length === 1
+        ? `entry 判定 ${statusLabel}: 実配分 0 → ${validFallbacks[0]} へ退避`
+        : `entry 判定 ${statusLabel}: 実配分 0 → ${validFallbacks.join('/')} へ等分割で退避 (各 1/${fallbacks.length})`
+    for (const fb of validFallbacks) {
+      const fallbackAlloc = ensure(fb, input.targetWeights[fb] ?? 0)
+      fallbackAlloc.activeWeight += slice
+      fallbackAlloc.reroutedInWeight += slice
+      if (fallbackAlloc.reason === '') {
+        fallbackAlloc.reason = '退避受入のみ (自身の target なし)'
+      }
     }
   }
   return { bySymbol }

--- a/test/infrastructure/db/symbolConfigRepo.test.ts
+++ b/test/infrastructure/db/symbolConfigRepo.test.ts
@@ -262,7 +262,7 @@ const writeInput = (symbol: string): SymbolConfigWriteInput => ({
   requireAboveSma50Override: null,
   entryRequired: false,
   alwaysActive: false,
-  cashFallbackSymbol: null,
+  cashFallbackSymbols: null,
 })
 
 describe('setInversePair', () => {

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -2638,7 +2638,7 @@ describe('renderAllocationLine (#452 Layer 3 target/active 並記)', () => {
     policy: {
       entryRequired: new Set(['TQQQ']),
       alwaysActive: new Set(['SGOV']),
-      cashFallback: { TQQQ: 'SGOV' },
+      cashFallback: { TQQQ: ['SGOV'] },
     },
     entryStatuses: { TQQQ: 'NG' },
     heldSymbols: new Set(),
@@ -2673,7 +2673,7 @@ describe('renderSymbolPolicyLine (#452 個別銘柄タブのロール表示)', (
       targetWeight: 0.05,
       entryRequired: true,
       alwaysActive: false,
-      cashFallbackSymbol: 'SGOV',
+      cashFallbackSymbols: ['SGOV'],
     })
     expect(html).toContain('leveraged_trend')
     expect(html).toContain('レバETF・トレンド')
@@ -2690,7 +2690,7 @@ describe('renderSymbolPolicyLine (#452 個別銘柄タブのロール表示)', (
         targetWeight: null,
         entryRequired: false,
         alwaysActive: false,
-        cashFallbackSymbol: null,
+        cashFallbackSymbols: null,
       }),
     ).toBe('')
   })
@@ -2701,7 +2701,7 @@ describe('renderSymbolPolicyLine (#452 個別銘柄タブのロール表示)', (
       targetWeight: null,
       entryRequired: false,
       alwaysActive: false,
-      cashFallbackSymbol: null,
+      cashFallbackSymbols: null,
     })
     expect(html).toContain('⚠ unknown')
   })
@@ -2718,7 +2718,7 @@ describe('symbolMapEditorBody (#symbol-relation-map 編集キャンバス・unit
       role: null,
       currency: 'USD',
       budgetAllocPct: null,
-      cashFallbackSymbol: null,
+      cashFallbackSymbols: null,
       entryRequired: false,
       ...over,
     }) as SymbolConfigRow
@@ -2729,8 +2729,8 @@ describe('symbolMapEditorBody (#symbol-relation-map 編集キャンバス・unit
   it('対は 1 unit (leveraged 側が先頭)、配分は対で 1 枠、退避は unit 解決', () => {
     const html = symbolMapEditorBody(
       [
-        edRow({ symbol: 'SOXS', role: 'inverse_hedge', budgetAllocPct: 0.5, cashFallbackSymbol: 'SQQQ', entryRequired: true }),
-        edRow({ symbol: 'SOXL', role: 'leveraged_trend', budgetAllocPct: 0.5, cashFallbackSymbol: 'TQQQ', entryRequired: true }),
+        edRow({ symbol: 'SOXS', role: 'inverse_hedge', budgetAllocPct: 0.5, cashFallbackSymbols: '["SQQQ"]', entryRequired: true }),
+        edRow({ symbol: 'SOXL', role: 'leveraged_trend', budgetAllocPct: 0.5, cashFallbackSymbols: '["TQQQ"]', entryRequired: true }),
         edRow({ symbol: 'TQQQ', role: 'leveraged_trend' }),
         edRow({ symbol: 'SQQQ', role: 'inverse_hedge' }),
       ],
@@ -2742,7 +2742,7 @@ describe('symbolMapEditorBody (#symbol-relation-map 編集キャンバス・unit
     expect(sox).toMatchObject({
       label: 'SOXL ⇄ SOXS',
       pct: 50,
-      fallback: { id: 'TQQQ/SQQQ', mixed: false },
+      fallbacks: ['TQQQ/SQQQ'],
     })
     // 保有は side 単位で持つ (SQQQ $44)
     const qqq = payload.units.find((u: { id: string }) => u.id === 'TQQQ/SQQQ')
@@ -2751,11 +2751,11 @@ describe('symbolMapEditorBody (#symbol-relation-map 編集キャンバス・unit
     expect(payload.unitOfSym.SOXS).toBe('SOXL/SOXS')
   })
 
-  it('片側だけ退避が欠けた旧データは mixed=false で先頭 unit に解決 (適用で側別に正規化される)', () => {
+  it('片側だけ退避が欠けた旧データも unit の退避として解決 (適用で側別に正規化される)', () => {
     const html = symbolMapEditorBody(
       [
         edRow({ symbol: 'SOXL', role: 'leveraged_trend', budgetAllocPct: 0.5 }),
-        edRow({ symbol: 'SOXS', role: 'inverse_hedge', budgetAllocPct: 0.5, cashFallbackSymbol: 'SQQQ', entryRequired: true }),
+        edRow({ symbol: 'SOXS', role: 'inverse_hedge', budgetAllocPct: 0.5, cashFallbackSymbols: '["SQQQ"]', entryRequired: true }),
         edRow({ symbol: 'TQQQ', role: 'leveraged_trend' }),
         edRow({ symbol: 'SQQQ', role: 'inverse_hedge' }),
       ],
@@ -2764,7 +2764,22 @@ describe('symbolMapEditorBody (#symbol-relation-map 編集キャンバス・unit
     )
     const payload = payloadOf(html)
     const sox = payload.units.find((u: { id: string }) => u.id === 'SOXL/SOXS')
-    expect(sox.fallback).toEqual({ id: 'TQQQ/SQQQ', mixed: false })
+    expect(sox.fallbacks).toEqual(['TQQQ/SQQQ'])
+  })
+
+  it('多分岐退避 (#496): 複数先は unit の fallbacks に並ぶ', () => {
+    const html = symbolMapEditorBody(
+      [
+        edRow({ symbol: 'AAPL', role: 'core_trend', budgetAllocPct: 0.5, cashFallbackSymbols: '["SGOV","USMV"]', entryRequired: true }),
+        edRow({ symbol: 'SGOV', role: 'cash_parking' }),
+        edRow({ symbol: 'USMV', role: 'low_volatility' }),
+      ],
+      {},
+      {},
+    )
+    const payload = payloadOf(html)
+    const aapl = payload.units.find((u: { id: string }) => u.id === 'AAPL')
+    expect(aapl.fallbacks.sort()).toEqual(['SGOV', 'USMV'])
   })
 
   it('全側 inactive の unit はスポーン在庫に入る', () => {
@@ -2810,7 +2825,7 @@ describe('symbolMapEditorBody (#symbol-relation-map 編集キャンバス・unit
   it('inline script は構文エラーなく parse できる (#462 regression 防止)', () => {
     const html = symbolMapEditorBody(
       [
-        edRow({ symbol: 'VUG', role: 'core_trend', budgetAllocPct: 0.3, cashFallbackSymbol: 'SGOV', entryRequired: true }),
+        edRow({ symbol: 'VUG', role: 'core_trend', budgetAllocPct: 0.3, cashFallbackSymbols: '["SGOV"]', entryRequired: true }),
         edRow({ symbol: 'SGOV', role: 'cash_parking' }),
       ],
       {},

--- a/test/routes/dashboardSymbolsCrud.test.ts
+++ b/test/routes/dashboardSymbolsCrud.test.ts
@@ -178,7 +178,7 @@ function fakeDb(
               requireAboveSma50Override: (v.requireAboveSma50Override as boolean | null) ?? null,
               entryRequired: v.entryRequired === true || v.entryRequired === 1,
               alwaysActive: v.alwaysActive === true || v.alwaysActive === 1,
-              cashFallbackSymbol: (v.cashFallbackSymbol as string | null) ?? null,
+              cashFallbackSymbols: (v.cashFallbackSymbols as string | null) ?? null,
               updatedAt: String(v.updatedAt ?? ''),
             })
           }
@@ -247,7 +247,7 @@ function row(overrides: Partial<SymbolConfigRow> = {}): SymbolConfigRow {
     requireAboveSma50Override: null,
     entryRequired: false,
     alwaysActive: false,
-    cashFallbackSymbol: null,
+    cashFallbackSymbols: null,
     updatedAt: '2026-04-23T00:00:00.000Z',
     ...overrides,
   }
@@ -1506,7 +1506,7 @@ describe('dashboard symbol_config 条件連動配分 (#452 Layer 3)', () => {
     const inserted = db.inserts.find((i) => i.table === 'symbol_config')!
     expect(inserted.values.entryRequired).toBe(true)
     expect(inserted.values.alwaysActive).toBe(false)
-    expect(inserted.values.cashFallbackSymbol).toBe('SGOV')
+    expect(inserted.values.cashFallbackSymbols).toBe('["SGOV"]')
   })
 
   it('rejects a self-referential cash_fallback_symbol with 400', async () => {
@@ -1534,7 +1534,7 @@ describe('dashboard symbol_config 条件連動配分 (#452 Layer 3)', () => {
 
   it('edit form shows 条件連動配分 fields with current values', async () => {
     const db = fakeDb([
-      row({ symbol: 'QQQ', entryRequired: true, cashFallbackSymbol: 'SGOV' }),
+      row({ symbol: 'QQQ', entryRequired: true, cashFallbackSymbols: '["SGOV"]' }),
     ])
     vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
     const app = createApp()
@@ -1562,7 +1562,7 @@ describe('symbols list ロール列 (#452)', () => {
         symbol: 'QQQ',
         role: 'core_trend',
         entryRequired: true,
-        cashFallbackSymbol: 'SGOV',
+        cashFallbackSymbols: '["SGOV"]',
       }),
       row({ symbol: 'SOXL' }), // role NULL = 従来挙動
     ])
@@ -1579,7 +1579,7 @@ describe('symbols list ロール列 (#452)', () => {
     expect(body).toContain('常時配分')
     expect(body).toContain('core_trend')
     expect(body).toContain('条件連動')
-    expect(body).toContain('→SGOV')
+    expect(body).toMatch(/→<a [^>]*>SGOV<\/a>/)
   })
 
   it('不正な role 値は警告表示 (entry 抑止の旨)', async () => {
@@ -1689,7 +1689,7 @@ describe('銘柄フォームのセクション UI (#symbols-form-ui)', () => {
         stopPctOverride: -0.03,
         minReturn50dOverride: 0.03,
         entryRequired: true,
-        cashFallbackSymbol: 'SGOV',
+        cashFallbackSymbols: '["SGOV"]',
       }),
     ])
     vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
@@ -1729,19 +1729,19 @@ describe('POST /admin/symbol-config/:symbol/cash-fallback (#symbol-relation-map 
     const res = await post(createApp(), 'SOXL', { target: 'sgov' })
     expect(res.status).toBe(200)
     const updated = db.updates.find((u) => u.table === 'symbol_config')
-    expect(updated?.set).toMatchObject({ cashFallbackSymbol: 'SGOV', entryRequired: true })
+    expect(updated?.set).toMatchObject({ cashFallbackSymbols: '["SGOV"]', entryRequired: true })
     expect(db.inserts.some((i) => i.table === 'config_audit_log')).toBe(true)
   })
 
   it('clear: target null で解除 (entry_required は触らない)', async () => {
     const db = fakeDb([
-      row({ symbol: 'SOXL', currency: 'USD', cashFallbackSymbol: 'SGOV', entryRequired: true }),
+      row({ symbol: 'SOXL', currency: 'USD', cashFallbackSymbols: '["SGOV"]', entryRequired: true }),
     ])
     vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
     const res = await post(createApp(), 'SOXL', { target: null })
     expect(res.status).toBe(200)
     const updated = db.updates.find((u) => u.table === 'symbol_config')
-    expect(updated?.set).toMatchObject({ cashFallbackSymbol: null })
+    expect(updated?.set).toMatchObject({ cashFallbackSymbols: null })
     expect(updated?.set).not.toHaveProperty('entryRequired')
   })
 

--- a/test/trading/strategy/conditionalAllocation.test.ts
+++ b/test/trading/strategy/conditionalAllocation.test.ts
@@ -10,7 +10,7 @@ const baseInput = (): AllocationComputeInput => ({
   policy: {
     entryRequired: new Set(['QQQ', 'TQQQ', 'SOXL']),
     alwaysActive: new Set(['SGOV']),
-    cashFallback: { QQQ: 'SGOV', TQQQ: 'SGOV', SOXL: 'SGOV' },
+    cashFallback: { QQQ: ['SGOV'], TQQQ: ['SGOV'], SOXL: ['SGOV'] },
   },
   entryStatuses: { SGOV: 'NG', QQQ: 'ENTRY', TQQQ: 'WATCH', SOXL: 'NG' },
   heldSymbols: new Set(),
@@ -23,7 +23,7 @@ describe('computeConditionalAllocation (#452 Layer 3)', () => {
     // QQQ は ENTRY → target 維持。TQQQ/SOXL は未通過 → 0、SGOV へ +10%。
     expect(view.bySymbol.QQQ!.activeWeight).toBeCloseTo(0.2, 9)
     expect(view.bySymbol.TQQQ!.activeWeight).toBe(0)
-    expect(view.bySymbol.TQQQ!.rerouteTo).toBe('SGOV')
+    expect(view.bySymbol.TQQQ!.rerouteTo).toEqual(['SGOV'])
     expect(view.bySymbol.SOXL!.activeWeight).toBe(0)
     expect(view.bySymbol.SGOV!.activeWeight).toBeCloseTo(0.8, 9)
     expect(view.bySymbol.SGOV!.reroutedInWeight).toBeCloseTo(0.1, 9)
@@ -94,13 +94,35 @@ describe('computeConditionalAllocation (#452 Layer 3)', () => {
   })
 })
 
+describe('computeConditionalAllocation × 多分岐退避 (#496 等分割)', () => {
+  it('複数先は設定数で等分割し、無効な先の取り分は現金のまま (再正規化しない)', () => {
+    const view = computeConditionalAllocation({
+      targetWeights: { AAPL: 0.6 },
+      policy: {
+        entryRequired: new Set(['AAPL']),
+        alwaysActive: new Set(),
+        cashFallback: { AAPL: ['SGOV', 'USMV', '1357'] }, // 1357 は JPY = 無効
+      },
+      entryStatuses: { AAPL: 'WATCH' },
+      heldSymbols: new Set(),
+      symbolCurrency: { AAPL: 'USD', SGOV: 'USD', USMV: 'USD', '1357': 'JPY' },
+    })
+    // 設定 3 件で等分割 (各 0.2)。無効な 1357 の取り分は流れない = 合計 0.4 のみ退避
+    expect(view.bySymbol.SGOV!.reroutedInWeight).toBeCloseTo(0.2)
+    expect(view.bySymbol.USMV!.reroutedInWeight).toBeCloseTo(0.2)
+    expect(view.bySymbol['1357']).toBeUndefined()
+    expect(view.bySymbol.AAPL!.rerouteTo).toEqual(['SGOV', 'USMV'])
+    expect(view.bySymbol.AAPL!.reason).toContain('等分割')
+  })
+})
+
 describe('computeConditionalAllocation × インバース対 (枠共有の退避抑止)', () => {
   const pairInput = (): AllocationComputeInput => ({
     targetWeights: { SOXL: 0.5, SOXS: 0.5 },
     policy: {
       entryRequired: new Set(['SOXL', 'SOXS']),
       alwaysActive: new Set(),
-      cashFallback: { SOXL: 'VUG', SOXS: 'VUG' },
+      cashFallback: { SOXL: ['VUG'], SOXS: ['VUG'] },
     },
     entryStatuses: { SOXL: 'WATCH', SOXS: 'WATCH' },
     heldSymbols: new Set(),


### PR DESCRIPTION
## 概要 (#496、operator 要望「AAPL に来ていた配分を更に分割して配分」)

退避先を複数化し、entry 未通過時の枠を**設定数で等分割**して流す (1/枝 の再帰)。

### DB (migration 0033/0034、staging 適用済み)

- `cash_fallback_symbols TEXT` (JSON 配列) 追加 → 既存 1 列から backfill → 旧列 drop (additive → destructive の 2 段)

### ランタイム

- `computeConditionalAllocation`: 退避を等分割 (`AAPL 50% → SGOV 25% / USMV 25%`)。**無効な先 (通貨不一致等) の取り分は再正規化せず現金のまま** (fail-closed)。`rerouteTo: string[]` 化。対の 1 枠ルール (#495) は維持
- 上限 `MAX_CASH_FALLBACKS = 4` (等分割の最小取り分の防御)

### API / UI

- `cash-fallback` endpoint: `{ targets: string[] | null }` (旧 `target` 後方互換)
- キャンバス: unit からの退避線を複数本可 (引くたび追加・重複/上限は拒否)、サマリに `各 1/N に等分割`、シミュレーション overlay も複数先表示
- フォーム: カンマ区切り (`SGOV, USMV`)、一覧の注記も複数リンク化

## 検証

- 1514 tests pass (+等分割/無効先据え置き、endpoint targets[]、unit fallbacks)
- staging: migration 適用 + デプロイ済み — AAPL から 2 本目の退避線が引けます

base は #495 (対の 1 枠ルール)。**#495 を先にマージ**してから本 PR を main に retarget してください。

Refs #496 #495 #452