### PR TITLE
fix: シミュレーションバッジをカード外オーバーレイに (点と線のズレ解消)

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -9007,7 +9007,7 @@ export function symbolMapEditorBody(
     if (isView) el.classList.add('sm-view');
 
     // 盤面レイアウトの記憶 (#496 follow-up): ノード位置とパン/ズームを
-    // localStorage に保存する (origin 単位・管理画面のみなので銘柄名と座標が
+    // localStorage に保存する (origin 単位・管理画面のみなのでティッカーと座標が
     // 残る程度は許容、operator 合意)。view/edit でキーを共有して同じ配置に。
     var LAYOUT_KEY = 'webull-sm-map-layout-v1';
     var savedLayout = {};

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -9006,6 +9006,35 @@ export function symbolMapEditorBody(
     editor.start();
     if (isView) el.classList.add('sm-view');
 
+    // 盤面レイアウトの記憶 (#496 follow-up): ノード位置とパン/ズームを
+    // localStorage に保存する (origin 単位・管理画面のみなので銘柄名と座標が
+    // 残る程度は許容、operator 合意)。view/edit でキーを共有して同じ配置に。
+    var LAYOUT_KEY = 'webull-sm-map-layout-v1';
+    var savedLayout = {};
+    try {
+      savedLayout = JSON.parse(localStorage.getItem(LAYOUT_KEY) || '{}') || {};
+    } catch (e) { savedLayout = {}; }
+    var savedPos = savedLayout.pos || {};
+    function persistLayout() {
+      try {
+        var pos = {};
+        Object.keys(idOf).forEach(function (uid) {
+          var d2 = editor.drawflow.drawflow[editor.module].data[idOf[uid]];
+          if (d2) pos[uid] = { x: d2.pos_x, y: d2.pos_y };
+        });
+        Object.keys(accountIds).forEach(function (ccy) {
+          var d2 = editor.drawflow.drawflow[editor.module].data[accountIds[ccy]];
+          if (d2) pos['__account_' + ccy + '__'] = { x: d2.pos_x, y: d2.pos_y };
+        });
+        localStorage.setItem(LAYOUT_KEY, JSON.stringify({
+          pos: pos,
+          zoom: editor.zoom,
+          canvasX: editor.canvas_x,
+          canvasY: editor.canvas_y,
+        }));
+      } catch (e) { /* private mode 等は黙って諦める (表示専用機能) */ }
+    }
+
     var idOf = {};      // unitId -> drawflow node id
     var unitOf = {};    // drawflow node id -> unitId
     var unitBy = {};    // unitId -> unit payload
@@ -9022,7 +9051,8 @@ export function symbolMapEditorBody(
     currencies.forEach(function (ccy) {
       var label = ccy === 'JPY' ? '日本口座 (JPY)' : '米国口座 (USD)';
       var y = ccy === 'JPY' ? 30 + ((Math.max(nJpy, 1) - 1) * 130) / 2 : 30 + nJpy * 130 + ((Math.max(data.units.length - nJpy, 1) - 1) * 130) / 2;
-      var id = editor.addNode('口座' + ccy, 0, 1, 40, y, 'sm-node sm-account',
+      var saved = savedPos['__account_' + ccy + '__'];
+      var id = editor.addNode('口座' + ccy, 0, 1, saved ? saved.x : 40, saved ? saved.y : y, 'sm-node sm-account',
         { unit: '口座' + ccy },
         '<div class="sm-card"><div class="sm-title" style="color:#fff">' + label + '</div>' +
         '<div class="sm-meta" style="color:#e8eaed">—</div></div>');
@@ -9060,7 +9090,8 @@ export function symbolMapEditorBody(
       return id;
     }
     data.units.forEach(function (u) {
-      addUnitNode(u, u.pct > 0 ? 360 : 760, u.y);
+      var saved = savedPos[u.id];
+      addUnitNode(u, saved ? saved.x : (u.pct > 0 ? 360 : 760), saved ? saved.y : u.y);
     });
 
     function tagConnectionClass(srcId, dstId, cls) {
@@ -9077,6 +9108,17 @@ export function symbolMapEditorBody(
       });
     });
     programmatic = false;
+
+    // パン/ズームの復元と、移動・ズームのたびの保存。
+    if (typeof savedLayout.zoom === 'number' && savedLayout.zoom > 0.2 && savedLayout.zoom <= 2) {
+      editor.zoom = savedLayout.zoom;
+      editor.canvas_x = savedLayout.canvasX || 0;
+      editor.canvas_y = savedLayout.canvasY || 0;
+      editor.zoom_refresh();
+    }
+    editor.on('nodeMoved', function () { persistLayout(); });
+    editor.on('zoom', function () { persistLayout(); });
+    editor.on('translate', function () { persistLayout(); });
 
     function deriveShares() {
       var branches = 0;

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -8978,10 +8978,15 @@ export function symbolMapEditorBody(
   .sm-card .sm-status-pending{color:#b25000;font-size:11px}
   .sm-card .sm-meta{color:#6e6e73;font-size:10px;margin-top:2px}
   .sm-card .sm-share{font-weight:600}
-  .sm-card .sm-sim{margin-top:4px;padding:3px 6px;border-radius:6px;font-size:10px;line-height:1.5}
-  .sm-card .sm-sim.sm-sim-active{background:#eafaf1;color:#0b6e4f}
-  .sm-card .sm-sim.sm-sim-reroute{background:#fff4e5;color:#9a5b00}
-  .sm-card .sm-sim.sm-sim-recv{background:#eafaf1;color:#0b6e4f;border:1px dashed #0e9f6e}
+  /* シミュレーション結果はカードの「外」に浮かせる (#496 follow-up): フロー内に
+     置くとカードが伸び、Drawflow が線の端点を再計算しないため点と線がズレる。
+     absolute overlay なら几何が一切変わらない。 */
+  #symbol-map-editor .drawflow .drawflow-node{overflow:visible}
+  .sm-sim-wrap{position:absolute;top:calc(100% + 4px);left:2px;right:2px;z-index:6;display:flex;flex-direction:column;gap:3px;pointer-events:none}
+  .sm-sim{padding:3px 6px;border-radius:6px;font-size:10px;line-height:1.5;box-shadow:0 1px 4px rgba(0,0,0,0.18)}
+  .sm-sim.sm-sim-active{background:#eafaf1;color:#0b6e4f}
+  .sm-sim.sm-sim-reroute{background:#fff4e5;color:#9a5b00}
+  .sm-sim.sm-sim-recv{background:#eafaf1;color:#0b6e4f;border:1px dashed #0e9f6e}
   #symbol-map-editor svg.connection.sm-sim-flow path{stroke:#0e9f6e !important;stroke-width:4px;stroke-dasharray:10 6;animation:smflow 1.2s linear infinite}
   #symbol-map-editor svg.connection.sm-sim-dim path{opacity:0.25}
   @keyframes smflow{to{stroke-dashoffset:-32}}
@@ -9106,7 +9111,7 @@ export function symbolMapEditorBody(
     // ---- シミュレーション (両モード共通)。結果は銘柄 → unit カードに重ねる。
     var simBtn = document.getElementById('sm-simulate');
     function clearSim() {
-      el.querySelectorAll('.sm-sim').forEach(function (n) { n.remove(); });
+      el.querySelectorAll('.sm-sim-wrap').forEach(function (n) { n.remove(); });
       el.querySelectorAll('svg.connection.sm-sim-flow').forEach(function (n) { n.classList.remove('sm-sim-flow'); });
       el.querySelectorAll('svg.connection.sm-sim-dim').forEach(function (n) { n.classList.remove('sm-sim-dim'); });
       document.getElementById('sm-sim-meta').hidden = true;
@@ -9116,12 +9121,16 @@ export function symbolMapEditorBody(
     function simBadge(uid, cls, html) {
       var nodeEl = document.getElementById('node-' + idOf[uid]);
       if (!nodeEl) return;
-      var card = nodeEl.querySelector('.sm-card');
-      if (!card) return;
+      var wrap = nodeEl.querySelector('.sm-sim-wrap');
+      if (!wrap) {
+        wrap = document.createElement('div');
+        wrap.className = 'sm-sim-wrap';
+        nodeEl.appendChild(wrap);
+      }
       var div = document.createElement('div');
       div.className = 'sm-sim ' + cls;
       div.innerHTML = html;
-      card.appendChild(div);
+      wrap.appendChild(div);
     }
     // 適用/シミュレートで使う「unit → 銘柄ごとの fallback 展開」(#496 多分岐)。
     // 各 src 側は dst unit ごとに 1 銘柄ずつ受け取る:


### PR DESCRIPTION
## 問題 (operator 指摘)

シミュレート結果のバッジをカードの文書フロー内に追加していたため、①カードが縦に伸びて見切れる、②Drawflow は線の端点を再計算しないので**ポートの点と線がズレる**。

## 変更

バッジを **absolute オーバーレイ** (カード下端に浮く、`pointer-events: none`) に変更 — ノードの几何が一切変わらないので、点も線も動かない。クリアでオーバーレイごと撤去。

## 検証

1514 tests pass、staging デプロイ済み (Version e1f274fd)。

Refs #496 #497