### PR TITLE
feat: role entry-style preview & 2-axis picker in symbol form

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -10619,7 +10619,7 @@ function symbolFormBody(args: SymbolFormArgs): string {
         <label>ロール${REQ}</label>
         <div style="display:flex;gap:18px;align-items:flex-start;flex-wrap:wrap">
           <div>
-            <select name="role" required id="symbol-form-role" style="padding:6px" onchange="window.renderRoleRadar(this.value)">
+            <select name="role" required id="symbol-form-role" style="padding:6px" onchange="window.renderRoleTemplate(this.value)">
               ${roleIsKnown ? '' : `<option value="${esc(roleValue)}" selected>⚠ 不正値: ${esc(roleValue)} (このままでは保存できません)</option>`}
               ${
                 mode === 'new'
@@ -10634,77 +10634,85 @@ function symbolFormBody(args: SymbolFormArgs): string {
             ${roleIsKnown ? '' : '<p class="err" style="margin:4px 0 0;font-size:11px">DB に enum 外の role 値が入っています。この銘柄の entry は抑止中 (fail-closed)。正しい role か「未設定」を明示的に選んで保存してください。</p>'}
             <div class="muted" style="font-size:11px;margin-top:2px">cash_parking は BUY を生成しない / inverse_hedge は短期プリセット (time stop 5日)</div>
           </div>
-          <!-- #role-stats: 装備画面風に、選択ロールの入場/退場スタイルを六角形レーダーで表示。 -->
-          <div id="role-radar-wrap" style="display:none;text-align:center;background:#fafafd;border:1px solid #ececf2;border-radius:8px;padding:6px 8px 8px">
-            <div style="font-size:10px;color:#86868b;margin-bottom:-4px">入場↑ / 退場↓ スタイル</div>
-            <svg id="role-radar" viewBox="0 0 200 212" width="190" height="201" style="overflow:visible"></svg>
-            <div id="role-radar-summary" style="font-size:11px;color:#444;max-width:200px;margin:2px auto 0;line-height:1.4"></div>
+          <!-- #role-stats: ロールの入場ゲート閾値と押し目/stop/TP を、ライブ銘柄
+               ではなく role preset から作った「虚のチャート + ゲート」で表示
+               (個別銘柄チャートタブの視覚言語を流用)。 -->
+          <div id="role-tpl-wrap" style="display:none;background:#fafafd;border:1px solid #ececf2;border-radius:8px;padding:8px 10px;max-width:360px">
+            <div style="font-size:10px;color:#86868b;margin-bottom:2px">ロード・テンプレート <span style="color:#aaa">(直近高値=0% 基準・preset 値の模式)</span></div>
+            <div style="display:flex;gap:10px;align-items:flex-start">
+              <svg id="role-tpl-chart" viewBox="0 0 150 178" width="150" height="178" style="overflow:visible;flex:0 0 auto"></svg>
+              <div id="role-tpl-gate" style="font-size:11px;line-height:1.55;flex:1 1 auto"></div>
+            </div>
           </div>
         </div>
         <script>
         (function () {
-          var AXES = ['勢い要求', '押し目待ち', '高値追い', '保有の長さ', '損切りの粘り', '利確待ち'];
-          var STATS = {
-            leveraged_trend: [5, 10, 10, 7, 8, 9],
-            core_trend: [2, 8, 3, 7, 8, 9],
-            low_volatility: [1, 5, 2, 10, 3, 3],
-            sector_trend: [3, 8, 5, 7, 8, 9],
-            inverse_hedge: [10, 10, 7, 3, 5, 9]
-          };
-          var SUMMARY = {
-            leveraged_trend: '深い押し目で乗り高値追いも許容。保有~10日、利確+7%まで引っ張る (global default)',
-            core_trend: '緩い勢いで早めにエントリー、過熱は回避。保有~10日',
-            low_volatility: '浅い押しで乗り、損切り・利確とも早い。保有は最長15日',
-            sector_trend: '中程度の勢い・押し目で入る。exit は global 据え置き',
-            inverse_hedge: '強い下落勢いを要求、保有5日で即退出 (ボラ drag 回避)',
-            cash_parking: '戦略 entry なし。条件未達時の退避先・常時配分'
+          // ROLE_RULE_PRESETS を global default に重ねた解決値 (%・日・倍)。
+          var P = {
+            leveraged_trend: { tr: 8, heat: 60, atr: 1.5, pbMax: -3, pbMin: -6, stop: -4, tp: 7, tstop: 10, katr: 2.0 },
+            core_trend: { tr: 3, heat: 20, atr: 1.5, pbMax: -1.5, pbMin: -5, stop: -4, tp: 7, tstop: 10, katr: 2.0 },
+            low_volatility: { tr: 1.5, heat: 10, atr: 1.3, pbMax: -1, pbMin: -3, stop: -1.5, tp: 2.5, tstop: 15, katr: 2.0 },
+            sector_trend: { tr: 4, heat: 30, atr: 1.5, pbMax: -2, pbMin: -5, stop: -4, tp: 7, tstop: 10, katr: 2.0 },
+            inverse_hedge: { tr: 15, heat: 40, atr: 1.5, pbMax: -3, pbMin: -6, stop: -4, tp: 7, tstop: 5, katr: 1.5 }
           };
           var COLOR = {
-            cash_parking: '#5b8c5a', core_trend: '#1a56db', leveraged_trend: '#d97706',
+            core_trend: '#1a56db', leveraged_trend: '#d97706',
             low_volatility: '#7e3af2', sector_trend: '#0e9f9f', inverse_hedge: '#c22d2d'
           };
-          var CX = 100, CY = 100, R = 60;
-          function pt(i, scale) {
-            var ang = (-90 + i * 60) * Math.PI / 180;
-            return [CX + R * scale * Math.cos(ang), CY + R * scale * Math.sin(ang)];
-          }
-          function ring(scale) {
-            var s = '';
-            for (var i = 0; i < 6; i++) { var p = pt(i, scale); s += p[0].toFixed(1) + ',' + p[1].toFixed(1) + ' '; }
-            return s.trim();
-          }
-          window.renderRoleRadar = function (role) {
-            var wrap = document.getElementById('role-radar-wrap');
+          // 価格軸: +4%(上) 〜 -11%(下) 固定。% あたり 10px。
+          function yOf(pct) { return 16 + (4 - pct) * 10; }
+          function fmtPct(v) { return (v > 0 ? '+' : '') + v + '%'; }
+          window.renderRoleTemplate = function (role) {
+            var wrap = document.getElementById('role-tpl-wrap');
             if (!wrap) return;
-            var svg = document.getElementById('role-radar');
-            var sum = document.getElementById('role-radar-summary');
-            var vals = STATS[role];
-            if (!vals && role !== 'cash_parking') { wrap.style.display = 'none'; return; }
+            var svg = document.getElementById('role-tpl-chart');
+            var gate = document.getElementById('role-tpl-gate');
+            if (role === 'cash_parking') {
+              wrap.style.display = '';
+              svg.innerHTML = '<text x="75" y="80" font-size="11" fill="#5b8c5a" text-anchor="middle">entry なし</text>';
+              gate.innerHTML = '<strong>cash_parking</strong><br>戦略 entry なし。条件連動の<b>退避先</b>・<b>常時配分</b>枠 (pullback 判定を行わない)。';
+              return;
+            }
+            var p = P[role];
+            if (!p) { wrap.style.display = 'none'; return; }
             wrap.style.display = '';
             var color = COLOR[role] || '#5f6368';
+            var entryMid = (p.pbMax + p.pbMin) / 2;
+            var tpLv = entryMid + p.tp;
+            var stopLv = entryMid + p.stop;
+            var X0 = 40, X1 = 110; // price bar の左右
             var parts = [];
-            for (var g = 1; g <= 4; g++) {
-              parts.push('<polygon points="' + ring(g / 4) + '" fill="none" stroke="#e6e6ec" stroke-width="1"/>');
-            }
-            for (var i = 0; i < 6; i++) {
-              var pe = pt(i, 1);
-              parts.push('<line x1="' + CX + '" y1="' + CY + '" x2="' + pe[0].toFixed(1) + '" y2="' + pe[1].toFixed(1) + '" stroke="#e6e6ec" stroke-width="1"/>');
-              var pl = pt(i, 1.2);
-              var anchor = pl[0] > CX + 2 ? 'start' : (pl[0] < CX - 2 ? 'end' : 'middle');
-              parts.push('<text x="' + pl[0].toFixed(1) + '" y="' + pl[1].toFixed(1) + '" font-size="9" fill="#6e6e73" text-anchor="' + anchor + '" dominant-baseline="middle">' + AXES[i] + '</text>');
-            }
-            if (vals) {
-              var poly = '';
-              for (var k = 0; k < 6; k++) { var pv = pt(k, vals[k] / 10); poly += pv[0].toFixed(1) + ',' + pv[1].toFixed(1) + ' '; }
-              parts.push('<polygon points="' + poly.trim() + '" fill="' + color + '33" stroke="' + color + '" stroke-width="2"/>');
-              for (var m = 0; m < 6; m++) { var pd = pt(m, vals[m] / 10); parts.push('<circle cx="' + pd[0].toFixed(1) + '" cy="' + pd[1].toFixed(1) + '" r="2.5" fill="' + color + '"/>'); }
-            } else {
-              parts.push('<text x="' + CX + '" y="' + CY + '" font-size="11" fill="#9a5b00" text-anchor="middle" dominant-baseline="middle">entry なし</text>');
-            }
+            // 直近高値 基準線 (0%)
+            parts.push('<line x1="' + X0 + '" y1="' + yOf(0) + '" x2="' + X1 + '" y2="' + yOf(0) + '" stroke="#9aa0a6" stroke-width="1"/>');
+            parts.push('<text x="' + (X0 - 3) + '" y="' + yOf(0) + '" font-size="8" fill="#80868b" text-anchor="end" dominant-baseline="middle">高値</text>');
+            // 押し目ゾーン (entry 帯)
+            var zy = yOf(p.pbMax), zh = yOf(p.pbMin) - yOf(p.pbMax);
+            parts.push('<rect x="' + X0 + '" y="' + zy.toFixed(1) + '" width="' + (X1 - X0) + '" height="' + zh.toFixed(1) + '" fill="#f59e0b33" stroke="#f59e0b" stroke-width="0.8"/>');
+            parts.push('<text x="' + (X1 + 3) + '" y="' + (zy + zh / 2).toFixed(1) + '" font-size="8" fill="#b25000" text-anchor="start" dominant-baseline="middle">押し目 ' + p.pbMax + '〜' + p.pbMin + '%</text>');
+            // entry marker
+            parts.push('<circle cx="' + ((X0 + X1) / 2) + '" cy="' + yOf(entryMid).toFixed(1) + '" r="3" fill="' + color + '"/>');
+            parts.push('<text x="' + ((X0 + X1) / 2) + '" y="' + (yOf(entryMid) - 5).toFixed(1) + '" font-size="8" fill="' + color + '" text-anchor="middle">entry</text>');
+            // stop (赤破線)
+            parts.push('<line x1="' + X0 + '" y1="' + yOf(stopLv).toFixed(1) + '" x2="' + X1 + '" y2="' + yOf(stopLv).toFixed(1) + '" stroke="#c22d2d" stroke-width="1" stroke-dasharray="3,2"/>');
+            parts.push('<text x="' + (X1 + 3) + '" y="' + yOf(stopLv).toFixed(1) + '" font-size="8" fill="#c22d2d" text-anchor="start" dominant-baseline="middle">stop ' + fmtPct(p.stop) + '</text>');
+            // TP (緑破線)
+            parts.push('<line x1="' + X0 + '" y1="' + yOf(tpLv).toFixed(1) + '" x2="' + X1 + '" y2="' + yOf(tpLv).toFixed(1) + '" stroke="#0e9f6e" stroke-width="1" stroke-dasharray="3,2"/>');
+            parts.push('<text x="' + (X1 + 3) + '" y="' + yOf(tpLv).toFixed(1) + '" font-size="8" fill="#0e9f6e" text-anchor="start" dominant-baseline="middle">TP ' + fmtPct(p.tp) + '</text>');
             svg.innerHTML = parts.join('');
-            if (sum) sum.textContent = SUMMARY[role] || '';
+            // 入場ゲート(閾値) + 退場
+            var g = [];
+            g.push('<div style="font-weight:600;margin-bottom:2px">入場ゲート(閾値)</div>');
+            g.push('<div>トレンド &gt; ' + fmtPct(p.tr) + '</div>');
+            g.push('<div>SMA50 上抜け必須</div>');
+            g.push('<div>過熱(SMA50乖離) ≤ ' + fmtPct(p.heat) + '</div>');
+            g.push('<div>ボラ(ATR比) ≤ ' + p.atr + '×</div>');
+            g.push('<div>押し目 ' + p.pbMax + '% 〜 ' + p.pbMin + '%</div>');
+            g.push('<div style="font-weight:600;margin:4px 0 2px">退場</div>');
+            g.push('<div>損切 ' + fmtPct(p.stop) + ' / 利確 ' + fmtPct(p.tp) + '</div>');
+            g.push('<div>保有上限 ' + p.tstop + '日 (損切ATR ' + p.katr + '×)</div>');
+            gate.innerHTML = g.join('');
           };
-          window.renderRoleRadar(${JSON.stringify(roleValue)});
+          window.renderRoleTemplate(${JSON.stringify(roleValue)});
         })();
         </script>
         <label>状態</label>

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -10655,15 +10655,53 @@ function symbolFormBody(args: SymbolFormArgs): string {
           };
           var ORDER = ['leveraged_trend', 'core_trend', 'sector_trend', 'low_volatility', 'inverse_hedge', 'cash_parking'];
           function fmtPct(v) { return (v > 0 ? '+' : '') + v + '%'; }
-          // 共通の価格ラダー SVG。big=true で軸ラベル付きの大版。
-          function ladder(role, w, h, big) {
+          // 銘柄別 override 入力 (任意セクション) を読む。空 → null。
+          var OV_NAMES = {
+            tr: 'min_return_50d_override', heat: 'max_sma50_deviation_pct_override',
+            atr: 'max_atr_ratio_override', pbMax: 'pullback_max_override',
+            pbMin: 'pullback_min_override', stop: 'stop_pct_override',
+            tp: 'take_profit_pct_override', tstop: 'time_stop_days_override', katr: 'k_atr_override'
+          };
+          function ovNum(name) {
+            var el = document.getElementsByName(name)[0];
+            if (!el) return null;
+            var v = (el.value || '').trim();
+            if (v === '') return null;
+            var n = Number(v);
+            return isFinite(n) ? n : null;
+          }
+          function ovSel(name) {
+            var el = document.getElementsByName(name)[0];
+            return el ? (el.value || '') : '';
+          }
+          // 実効値 = override ?? preset ?? (sma50 は global 既定 true)。
+          function eff(role) {
+            var b = P[role], r = {}, ov = {}, any = false;
+            var keys = ['tr', 'heat', 'atr', 'pbMax', 'pbMin', 'stop', 'tp', 'tstop', 'katr'];
+            for (var i = 0; i < keys.length; i++) {
+              var k = keys[i], o = ovNum(OV_NAMES[k]);
+              r[k] = (o == null) ? b[k] : o;
+              ov[k] = o != null;
+              if (o != null) any = true;
+            }
+            var sma = ovSel('require_above_sma50_override');
+            r.sma50 = sma === '' ? true : (sma === 'true');
+            ov.sma50 = sma !== '';
+            if (sma !== '') any = true;
+            ov.any = any;
+            r.ov = ov;
+            return r;
+          }
+          function omark(b) { return b ? ' <span style="color:#d97706;font-weight:700" title="この銘柄の override">*</span>' : ''; }
+          // 価格ラダー SVG。p = 実効パラメータ。big=true で軸ラベル付き。
+          function ladder(role, p, w, h, big) {
             function y(pct) { return 12 + (4 - pct) * ((h - 24) / 15); } // +4%..-11% 固定
             if (role === 'cash_parking') {
               return '<svg viewBox="0 0 ' + w + ' ' + h + '" width="' + w + '" height="' + h + '"><text x="' + (w / 2) + '" y="' + (h / 2) + '" font-size="' + (big ? 12 : 10) + '" fill="#5b8c5a" text-anchor="middle">entry なし</text></svg>';
             }
-            var p = P[role], color = COLOR[role];
+            var color = COLOR[role], ov = p.ov || {};
             var em = (p.pbMax + p.pbMin) / 2, tp = em + p.tp, st = em + p.stop;
-            var X0 = 14, X1 = big ? w - 64 : w - 12, a = [];
+            var X0 = 14, X1 = big ? w - 70 : w - 12, a = [];
             a.push('<line x1="' + X0 + '" y1="' + y(0).toFixed(1) + '" x2="' + X1 + '" y2="' + y(0).toFixed(1) + '" stroke="#c4c8cd" stroke-width="1"/>');
             var zy = y(p.pbMax), zh = y(p.pbMin) - y(p.pbMax);
             a.push('<rect x="' + X0 + '" y="' + zy.toFixed(1) + '" width="' + (X1 - X0) + '" height="' + zh.toFixed(1) + '" fill="#f59e0b33" stroke="#f59e0b" stroke-width="0.8"/>');
@@ -10672,51 +10710,62 @@ function symbolFormBody(args: SymbolFormArgs): string {
             a.push('<line x1="' + X0 + '" y1="' + y(tp).toFixed(1) + '" x2="' + X1 + '" y2="' + y(tp).toFixed(1) + '" stroke="#0e9f6e" stroke-width="1" stroke-dasharray="3,2"/>');
             if (big) {
               var lx = X1 + 4;
+              var mz = (ov.pbMax || ov.pbMin) ? ' *' : '', ms = ov.stop ? ' *' : '', mt = ov.tp ? ' *' : '';
               a.push('<text x="' + lx + '" y="' + y(0).toFixed(1) + '" font-size="8" fill="#80868b" dominant-baseline="middle">高値 0%</text>');
-              a.push('<text x="' + lx + '" y="' + (zy + zh / 2).toFixed(1) + '" font-size="8" fill="#b25000" dominant-baseline="middle">押し目 ' + p.pbMax + '〜' + p.pbMin + '%</text>');
-              a.push('<text x="' + lx + '" y="' + y(st).toFixed(1) + '" font-size="8" fill="#c22d2d" dominant-baseline="middle">stop ' + fmtPct(p.stop) + '</text>');
-              a.push('<text x="' + lx + '" y="' + y(tp).toFixed(1) + '" font-size="8" fill="#0e9f6e" dominant-baseline="middle">TP ' + fmtPct(p.tp) + '</text>');
+              a.push('<text x="' + lx + '" y="' + (zy + zh / 2).toFixed(1) + '" font-size="8" fill="#b25000" dominant-baseline="middle">押し目 ' + p.pbMax + '〜' + p.pbMin + '%' + mz + '</text>');
+              a.push('<text x="' + lx + '" y="' + y(st).toFixed(1) + '" font-size="8" fill="#c22d2d" dominant-baseline="middle">stop ' + fmtPct(p.stop) + ms + '</text>');
+              a.push('<text x="' + lx + '" y="' + y(tp).toFixed(1) + '" font-size="8" fill="#0e9f6e" dominant-baseline="middle">TP ' + fmtPct(p.tp) + mt + '</text>');
             } else {
               a.push('<text x="' + X0 + '" y="' + (y(0) - 2).toFixed(1) + '" font-size="7" fill="#9aa0a6">高値0%</text>');
             }
             return '<svg viewBox="0 0 ' + w + ' ' + h + '" width="' + w + '" height="' + h + '" style="overflow:visible">' + a.join('') + '</svg>';
           }
-          function gateHtml(role) {
+          function gateHtml(role, p) {
             if (role === 'cash_parking') return '<div style="color:#5b8c5a;font-size:11px">戦略 entry なし。条件未達時の<b>退避先</b>・<b>常時配分</b>枠 (pullback 判定なし)。</div>';
-            var p = P[role], g = [];
+            var ov = p.ov || {}, g = [];
             g.push('<div style="font-weight:600;font-size:11px;margin-bottom:2px">入場ゲート(閾値)</div>');
-            g.push('<div>トレンド &gt; ' + fmtPct(p.tr) + '</div>');
-            g.push('<div>SMA50 上抜け必須</div>');
-            g.push('<div>過熱(SMA50乖離) ≤ ' + fmtPct(p.heat) + '</div>');
-            g.push('<div>ボラ(ATR比) ≤ ' + p.atr + '×</div>');
-            g.push('<div>押し目 ' + p.pbMax + '% 〜 ' + p.pbMin + '%</div>');
+            g.push('<div>トレンド &gt; ' + fmtPct(p.tr) + omark(ov.tr) + '</div>');
+            g.push('<div>SMA50 ' + (p.sma50 ? '上抜け必須' : '上抜け不問') + omark(ov.sma50) + '</div>');
+            g.push('<div>過熱(SMA50乖離) ≤ ' + fmtPct(p.heat) + omark(ov.heat) + '</div>');
+            g.push('<div>ボラ(ATR比) ≤ ' + p.atr + '×' + omark(ov.atr) + '</div>');
+            g.push('<div>押し目 ' + p.pbMax + '% 〜 ' + p.pbMin + '%' + omark(ov.pbMax || ov.pbMin) + '</div>');
             g.push('<div style="font-weight:600;margin:4px 0 2px">退場</div>');
-            g.push('<div>損切 ' + fmtPct(p.stop) + ' / 利確 ' + fmtPct(p.tp) + '</div>');
-            g.push('<div>保有上限 ' + p.tstop + '日 (損切ATR ' + p.katr + '×)</div>');
+            g.push('<div>損切 ' + fmtPct(p.stop) + ' / 利確 ' + fmtPct(p.tp) + omark(ov.stop || ov.tp) + '</div>');
+            g.push('<div>保有上限 ' + p.tstop + '日 (損切ATR ' + p.katr + '×)' + omark(ov.tstop || ov.katr) + '</div>');
             return '<div style="font-size:11px;line-height:1.55">' + g.join('') + '</div>';
           }
           function cardHtml(role) {
             var color = COLOR[role] || '#5f6368';
+            // カードは preset (ロールの素性) を固定表示。override 反映は右プレビューだけ。
             return '<div class="role-tpl-card" data-role="' + role + '" ' +
               'style="cursor:pointer;border:1px solid #e3e3e8;border-radius:8px;padding:6px 8px;background:#fff;width:150px">' +
               '<div style="font-size:11px;font-weight:600;margin-bottom:2px"><span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:' + color + ';margin-right:5px"></span>' + LABEL[role] + '</div>' +
-              ladder(role, 134, 96, false) +
+              ladder(role, P[role] || {}, 134, 96, false) +
               '<div style="font-size:10px;color:#86868b;margin-top:1px">保有 ' + (role === 'cash_parking' ? '—' : P[role].tstop + '日') + '</div>' +
               '</div>';
           }
           var selected = ${JSON.stringify(roleValue)};
+          var currentShown = selected;
           function labelOf(role) { return LABEL[role] || (role ? ('⚠ ' + role) : '未選択'); }
           function showPreview(role) {
+            currentShown = role;
             var pv = document.getElementById('role-preview');
             var body = document.getElementById('role-preview-body');
             if (!pv || !body) return;
             if (!role || (!P[role] && role !== 'cash_parking')) { pv.style.display = 'none'; return; }
             var color = COLOR[role] || '#5f6368';
+            if (role === 'cash_parking') {
+              body.innerHTML = '<div style="font-size:13px;font-weight:700;margin-bottom:4px;color:' + color + '">待機資金</div>' + ladder(role, {}, 280, 120, true) + '<div style="margin-top:6px">' + gateHtml(role, {}) + '</div>';
+              pv.style.display = '';
+              return;
+            }
+            var p = eff(role);
+            var note = p.ov.any ? 'preset + この銘柄の override (* 印) を反映' : 'preset の姿 (override 未設定)';
             body.innerHTML =
               '<div style="font-size:13px;font-weight:700;margin-bottom:4px;color:' + color + '">' + LABEL[role] + '</div>' +
-              ladder(role, 280, 150, true) +
-              '<div style="margin-top:6px">' + gateHtml(role) + '</div>' +
-              '<div style="font-size:10px;color:#aaa;margin-top:6px">直近高値=0% 基準・preset 値の模式</div>';
+              ladder(role, p, 280, 150, true) +
+              '<div style="margin-top:6px">' + gateHtml(role, p) + '</div>' +
+              '<div style="font-size:10px;color:#aaa;margin-top:6px">直近高値=0% 基準・実効値の模式<br>' + note + '</div>';
             pv.style.display = '';
           }
           function highlight(role) {
@@ -10737,8 +10786,10 @@ function symbolFormBody(args: SymbolFormArgs): string {
             highlight(role);
             showPreview(role);
           }
-          var gallery = document.getElementById('role-gallery');
-          if (gallery) {
+          function rerender() { showPreview(currentShown); }
+          function init() {
+            var gallery = document.getElementById('role-gallery');
+            if (!gallery) return;
             gallery.innerHTML = ORDER.map(cardHtml).join('');
             var cards = gallery.querySelectorAll('.role-tpl-card');
             for (var i = 0; i < cards.length; i++) {
@@ -10748,13 +10799,21 @@ function symbolFormBody(args: SymbolFormArgs): string {
                 card.addEventListener('mouseenter', function () { showPreview(r); });
               })(cards[i]);
             }
-            // ホバーが外れたら選択中ロールのプレビューに戻す (無ければ消す)。
+            // ホバーが外れたら選択中ロールのプレビューに戻す。
             gallery.addEventListener('mouseleave', function () { showPreview(selected); });
+            // 銘柄別 override を編集したら実効プレビューを即更新。
+            var names = ['min_return_50d_override', 'max_sma50_deviation_pct_override', 'max_atr_ratio_override', 'pullback_max_override', 'pullback_min_override', 'stop_pct_override', 'take_profit_pct_override', 'time_stop_days_override', 'k_atr_override', 'require_above_sma50_override'];
+            for (var j = 0; j < names.length; j++) {
+              var el = document.getElementsByName(names[j])[0];
+              if (el) { el.addEventListener('input', rerender); el.addEventListener('change', rerender); }
+            }
             var cur = document.getElementById('role-current');
             if (cur) cur.textContent = labelOf(selected);
             highlight(selected);
             showPreview(selected);
           }
+          if (document.readyState !== 'loading') init();
+          else document.addEventListener('DOMContentLoaded', init);
         })();
         </script>
         <label>状態</label>

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -10617,22 +10617,96 @@ function symbolFormBody(args: SymbolFormArgs): string {
           <div class="muted" style="font-size:11px;margin-top:2px">未設定の銘柄は発注されません (fail-closed)</div>
         </div>
         <label>ロール${REQ}</label>
-        <div>
-          <select name="role" required style="padding:6px">
-            ${roleIsKnown ? '' : `<option value="${esc(roleValue)}" selected>⚠ 不正値: ${esc(roleValue)} (このままでは保存できません)</option>`}
-            ${
-              mode === 'new'
-                ? `<option value="" disabled${roleValue === '' ? ' selected' : ''}>選択してください</option>`
-                : `<option value=""${roleValue === '' ? ' selected' : ''}>未設定 (旧銘柄のみ — 従来挙動)</option>`
-            }
-            ${SYMBOL_ROLES.map(
-              (r) =>
-                `<option value="${r}"${roleValue === r ? ' selected' : ''}>${esc(SYMBOL_ROLE_LABELS[r])}</option>`,
-            ).join('')}
-          </select>
-          ${roleIsKnown ? '' : '<p class="err" style="margin:4px 0 0;font-size:11px">DB に enum 外の role 値が入っています。この銘柄の entry は抑止中 (fail-closed)。正しい role か「未設定」を明示的に選んで保存してください。</p>'}
-          <div class="muted" style="font-size:11px;margin-top:2px">cash_parking は BUY を生成しない / inverse_hedge は短期プリセット (time stop 5日)</div>
+        <div style="display:flex;gap:18px;align-items:flex-start;flex-wrap:wrap">
+          <div>
+            <select name="role" required id="symbol-form-role" style="padding:6px" onchange="window.renderRoleRadar(this.value)">
+              ${roleIsKnown ? '' : `<option value="${esc(roleValue)}" selected>⚠ 不正値: ${esc(roleValue)} (このままでは保存できません)</option>`}
+              ${
+                mode === 'new'
+                  ? `<option value="" disabled${roleValue === '' ? ' selected' : ''}>選択してください</option>`
+                  : `<option value=""${roleValue === '' ? ' selected' : ''}>未設定 (旧銘柄のみ — 従来挙動)</option>`
+              }
+              ${SYMBOL_ROLES.map(
+                (r) =>
+                  `<option value="${r}"${roleValue === r ? ' selected' : ''}>${esc(SYMBOL_ROLE_LABELS[r])}</option>`,
+              ).join('')}
+            </select>
+            ${roleIsKnown ? '' : '<p class="err" style="margin:4px 0 0;font-size:11px">DB に enum 外の role 値が入っています。この銘柄の entry は抑止中 (fail-closed)。正しい role か「未設定」を明示的に選んで保存してください。</p>'}
+            <div class="muted" style="font-size:11px;margin-top:2px">cash_parking は BUY を生成しない / inverse_hedge は短期プリセット (time stop 5日)</div>
+          </div>
+          <!-- #role-stats: 装備画面風に、選択ロールの入場/退場スタイルを六角形レーダーで表示。 -->
+          <div id="role-radar-wrap" style="display:none;text-align:center;background:#fafafd;border:1px solid #ececf2;border-radius:8px;padding:6px 8px 8px">
+            <div style="font-size:10px;color:#86868b;margin-bottom:-4px">入場↑ / 退場↓ スタイル</div>
+            <svg id="role-radar" viewBox="0 0 200 212" width="190" height="201" style="overflow:visible"></svg>
+            <div id="role-radar-summary" style="font-size:11px;color:#444;max-width:200px;margin:2px auto 0;line-height:1.4"></div>
+          </div>
         </div>
+        <script>
+        (function () {
+          var AXES = ['勢い要求', '押し目待ち', '高値追い', '保有の長さ', '損切りの粘り', '利確待ち'];
+          var STATS = {
+            leveraged_trend: [5, 10, 10, 7, 8, 9],
+            core_trend: [2, 8, 3, 7, 8, 9],
+            low_volatility: [1, 5, 2, 10, 3, 3],
+            sector_trend: [3, 8, 5, 7, 8, 9],
+            inverse_hedge: [10, 10, 7, 3, 5, 9]
+          };
+          var SUMMARY = {
+            leveraged_trend: '深い押し目で乗り高値追いも許容。保有~10日、利確+7%まで引っ張る (global default)',
+            core_trend: '緩い勢いで早めにエントリー、過熱は回避。保有~10日',
+            low_volatility: '浅い押しで乗り、損切り・利確とも早い。保有は最長15日',
+            sector_trend: '中程度の勢い・押し目で入る。exit は global 据え置き',
+            inverse_hedge: '強い下落勢いを要求、保有5日で即退出 (ボラ drag 回避)',
+            cash_parking: '戦略 entry なし。条件未達時の退避先・常時配分'
+          };
+          var COLOR = {
+            cash_parking: '#5b8c5a', core_trend: '#1a56db', leveraged_trend: '#d97706',
+            low_volatility: '#7e3af2', sector_trend: '#0e9f9f', inverse_hedge: '#c22d2d'
+          };
+          var CX = 100, CY = 100, R = 60;
+          function pt(i, scale) {
+            var ang = (-90 + i * 60) * Math.PI / 180;
+            return [CX + R * scale * Math.cos(ang), CY + R * scale * Math.sin(ang)];
+          }
+          function ring(scale) {
+            var s = '';
+            for (var i = 0; i < 6; i++) { var p = pt(i, scale); s += p[0].toFixed(1) + ',' + p[1].toFixed(1) + ' '; }
+            return s.trim();
+          }
+          window.renderRoleRadar = function (role) {
+            var wrap = document.getElementById('role-radar-wrap');
+            if (!wrap) return;
+            var svg = document.getElementById('role-radar');
+            var sum = document.getElementById('role-radar-summary');
+            var vals = STATS[role];
+            if (!vals && role !== 'cash_parking') { wrap.style.display = 'none'; return; }
+            wrap.style.display = '';
+            var color = COLOR[role] || '#5f6368';
+            var parts = [];
+            for (var g = 1; g <= 4; g++) {
+              parts.push('<polygon points="' + ring(g / 4) + '" fill="none" stroke="#e6e6ec" stroke-width="1"/>');
+            }
+            for (var i = 0; i < 6; i++) {
+              var pe = pt(i, 1);
+              parts.push('<line x1="' + CX + '" y1="' + CY + '" x2="' + pe[0].toFixed(1) + '" y2="' + pe[1].toFixed(1) + '" stroke="#e6e6ec" stroke-width="1"/>');
+              var pl = pt(i, 1.2);
+              var anchor = pl[0] > CX + 2 ? 'start' : (pl[0] < CX - 2 ? 'end' : 'middle');
+              parts.push('<text x="' + pl[0].toFixed(1) + '" y="' + pl[1].toFixed(1) + '" font-size="9" fill="#6e6e73" text-anchor="' + anchor + '" dominant-baseline="middle">' + AXES[i] + '</text>');
+            }
+            if (vals) {
+              var poly = '';
+              for (var k = 0; k < 6; k++) { var pv = pt(k, vals[k] / 10); poly += pv[0].toFixed(1) + ',' + pv[1].toFixed(1) + ' '; }
+              parts.push('<polygon points="' + poly.trim() + '" fill="' + color + '33" stroke="' + color + '" stroke-width="2"/>');
+              for (var m = 0; m < 6; m++) { var pd = pt(m, vals[m] / 10); parts.push('<circle cx="' + pd[0].toFixed(1) + '" cy="' + pd[1].toFixed(1) + '" r="2.5" fill="' + color + '"/>'); }
+            } else {
+              parts.push('<text x="' + CX + '" y="' + CY + '" font-size="11" fill="#9a5b00" text-anchor="middle" dominant-baseline="middle">entry なし</text>');
+            }
+            svg.innerHTML = parts.join('');
+            if (sum) sum.textContent = SUMMARY[role] || '';
+          };
+          window.renderRoleRadar(${JSON.stringify(roleValue)});
+        })();
+        </script>
         <label>状態</label>
         <label style="display:flex;align-items:center;gap:6px;font-size:13px">
           <input type="hidden" name="active" value="false">

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -10619,7 +10619,7 @@ function symbolFormBody(args: SymbolFormArgs): string {
         <label>ロール${REQ}</label>
         <div style="display:flex;gap:18px;align-items:flex-start;flex-wrap:wrap">
           <div>
-            <select name="role" required id="symbol-form-role" style="padding:6px" onchange="window.renderRoleTemplate(this.value)">
+            <select name="role" required id="symbol-form-role" style="padding:6px" onchange="window.syncRolePick(this.value)">
               ${roleIsKnown ? '' : `<option value="${esc(roleValue)}" selected>⚠ 不正値: ${esc(roleValue)} (このままでは保存できません)</option>`}
               ${
                 mode === 'new'
@@ -10634,15 +10634,12 @@ function symbolFormBody(args: SymbolFormArgs): string {
             ${roleIsKnown ? '' : '<p class="err" style="margin:4px 0 0;font-size:11px">DB に enum 外の role 値が入っています。この銘柄の entry は抑止中 (fail-closed)。正しい role か「未設定」を明示的に選んで保存してください。</p>'}
             <div class="muted" style="font-size:11px;margin-top:2px">cash_parking は BUY を生成しない / inverse_hedge は短期プリセット (time stop 5日)</div>
           </div>
-          <!-- #role-stats: ロールの入場ゲート閾値と押し目/stop/TP を、ライブ銘柄
-               ではなく role preset から作った「虚のチャート + ゲート」で表示
-               (個別銘柄チャートタブの視覚言語を流用)。 -->
-          <div id="role-tpl-wrap" style="display:none;background:#fafafd;border:1px solid #ececf2;border-radius:8px;padding:8px 10px;max-width:360px">
-            <div style="font-size:10px;color:#86868b;margin-bottom:2px">ロード・テンプレート <span style="color:#aaa">(直近高値=0% 基準・preset 値の模式)</span></div>
-            <div style="display:flex;gap:10px;align-items:flex-start">
-              <svg id="role-tpl-chart" viewBox="0 0 150 178" width="150" height="178" style="overflow:visible;flex:0 0 auto"></svg>
-              <div id="role-tpl-gate" style="font-size:11px;line-height:1.55;flex:1 1 auto"></div>
-            </div>
+          <!-- #role-stats: 6 ロールの「虚のチャート + 入場ゲート」を横並びカードで
+               比較。クリックで select と同期・選択をハイライト (個別銘柄チャート
+               タブの視覚言語を流用)。 -->
+          <div id="role-tpl-wrap" style="display:none;flex:1 1 100%;margin-top:4px">
+            <div style="font-size:10px;color:#86868b;margin-bottom:4px">ロール比較 — 押し目ゾーン / stop / TP と入場ゲート閾値 (直近高値=0% 基準・preset 模式 / クリックで選択)</div>
+            <div id="role-gallery" style="display:flex;flex-wrap:wrap;gap:8px"></div>
           </div>
         </div>
         <script>
@@ -10651,68 +10648,78 @@ function symbolFormBody(args: SymbolFormArgs): string {
           var P = {
             leveraged_trend: { tr: 8, heat: 60, atr: 1.5, pbMax: -3, pbMin: -6, stop: -4, tp: 7, tstop: 10, katr: 2.0 },
             core_trend: { tr: 3, heat: 20, atr: 1.5, pbMax: -1.5, pbMin: -5, stop: -4, tp: 7, tstop: 10, katr: 2.0 },
-            low_volatility: { tr: 1.5, heat: 10, atr: 1.3, pbMax: -1, pbMin: -3, stop: -1.5, tp: 2.5, tstop: 15, katr: 2.0 },
             sector_trend: { tr: 4, heat: 30, atr: 1.5, pbMax: -2, pbMin: -5, stop: -4, tp: 7, tstop: 10, katr: 2.0 },
+            low_volatility: { tr: 1.5, heat: 10, atr: 1.3, pbMax: -1, pbMin: -3, stop: -1.5, tp: 2.5, tstop: 15, katr: 2.0 },
             inverse_hedge: { tr: 15, heat: 40, atr: 1.5, pbMax: -3, pbMin: -6, stop: -4, tp: 7, tstop: 5, katr: 1.5 }
           };
           var COLOR = {
-            core_trend: '#1a56db', leveraged_trend: '#d97706',
-            low_volatility: '#7e3af2', sector_trend: '#0e9f9f', inverse_hedge: '#c22d2d'
+            core_trend: '#1a56db', leveraged_trend: '#d97706', sector_trend: '#0e9f9f',
+            low_volatility: '#7e3af2', inverse_hedge: '#c22d2d', cash_parking: '#5b8c5a'
           };
-          // 価格軸: +4%(上) 〜 -11%(下) 固定。% あたり 10px。
-          function yOf(pct) { return 16 + (4 - pct) * 10; }
+          var LABEL = {
+            leveraged_trend: 'レバETF・トレンド', core_trend: '非レバ・トレンド',
+            sector_trend: 'セクター', low_volatility: '低ボラ',
+            inverse_hedge: 'インバースヘッジ', cash_parking: '待機資金'
+          };
+          var ORDER = ['leveraged_trend', 'core_trend', 'sector_trend', 'low_volatility', 'inverse_hedge', 'cash_parking'];
+          // 価格軸: +4%(上) 〜 -11%(下) 固定。% あたり 7px。
+          function yOf(pct) { return 10 + (4 - pct) * 7; }
           function fmtPct(v) { return (v > 0 ? '+' : '') + v + '%'; }
-          window.renderRoleTemplate = function (role) {
-            var wrap = document.getElementById('role-tpl-wrap');
-            if (!wrap) return;
-            var svg = document.getElementById('role-tpl-chart');
-            var gate = document.getElementById('role-tpl-gate');
+          function miniSvg(role) {
             if (role === 'cash_parking') {
-              wrap.style.display = '';
-              svg.innerHTML = '<text x="75" y="80" font-size="11" fill="#5b8c5a" text-anchor="middle">entry なし</text>';
-              gate.innerHTML = '<strong>cash_parking</strong><br>戦略 entry なし。条件連動の<b>退避先</b>・<b>常時配分</b>枠 (pullback 判定を行わない)。';
-              return;
+              return '<svg viewBox="0 0 140 116" width="140" height="116"><text x="70" y="54" font-size="10" fill="#5b8c5a" text-anchor="middle">entry なし</text><text x="70" y="70" font-size="8" fill="#80868b" text-anchor="middle">(常時配分・退避先)</text></svg>';
             }
-            var p = P[role];
-            if (!p) { wrap.style.display = 'none'; return; }
-            wrap.style.display = '';
-            var color = COLOR[role] || '#5f6368';
-            var entryMid = (p.pbMax + p.pbMin) / 2;
-            var tpLv = entryMid + p.tp;
-            var stopLv = entryMid + p.stop;
-            var X0 = 40, X1 = 110; // price bar の左右
-            var parts = [];
-            // 直近高値 基準線 (0%)
-            parts.push('<line x1="' + X0 + '" y1="' + yOf(0) + '" x2="' + X1 + '" y2="' + yOf(0) + '" stroke="#9aa0a6" stroke-width="1"/>');
-            parts.push('<text x="' + (X0 - 3) + '" y="' + yOf(0) + '" font-size="8" fill="#80868b" text-anchor="end" dominant-baseline="middle">高値</text>');
-            // 押し目ゾーン (entry 帯)
+            var p = P[role], color = COLOR[role];
+            var entryMid = (p.pbMax + p.pbMin) / 2, tpLv = entryMid + p.tp, stopLv = entryMid + p.stop;
+            var X0 = 16, X1 = 124, a = [];
+            a.push('<line x1="' + X0 + '" y1="' + yOf(0) + '" x2="' + X1 + '" y2="' + yOf(0) + '" stroke="#c4c8cd" stroke-width="1"/>');
+            a.push('<text x="' + X0 + '" y="' + (yOf(0) - 2) + '" font-size="7" fill="#9aa0a6">高値0%</text>');
             var zy = yOf(p.pbMax), zh = yOf(p.pbMin) - yOf(p.pbMax);
-            parts.push('<rect x="' + X0 + '" y="' + zy.toFixed(1) + '" width="' + (X1 - X0) + '" height="' + zh.toFixed(1) + '" fill="#f59e0b33" stroke="#f59e0b" stroke-width="0.8"/>');
-            parts.push('<text x="' + (X1 + 3) + '" y="' + (zy + zh / 2).toFixed(1) + '" font-size="8" fill="#b25000" text-anchor="start" dominant-baseline="middle">押し目 ' + p.pbMax + '〜' + p.pbMin + '%</text>');
-            // entry marker
-            parts.push('<circle cx="' + ((X0 + X1) / 2) + '" cy="' + yOf(entryMid).toFixed(1) + '" r="3" fill="' + color + '"/>');
-            parts.push('<text x="' + ((X0 + X1) / 2) + '" y="' + (yOf(entryMid) - 5).toFixed(1) + '" font-size="8" fill="' + color + '" text-anchor="middle">entry</text>');
-            // stop (赤破線)
-            parts.push('<line x1="' + X0 + '" y1="' + yOf(stopLv).toFixed(1) + '" x2="' + X1 + '" y2="' + yOf(stopLv).toFixed(1) + '" stroke="#c22d2d" stroke-width="1" stroke-dasharray="3,2"/>');
-            parts.push('<text x="' + (X1 + 3) + '" y="' + yOf(stopLv).toFixed(1) + '" font-size="8" fill="#c22d2d" text-anchor="start" dominant-baseline="middle">stop ' + fmtPct(p.stop) + '</text>');
-            // TP (緑破線)
-            parts.push('<line x1="' + X0 + '" y1="' + yOf(tpLv).toFixed(1) + '" x2="' + X1 + '" y2="' + yOf(tpLv).toFixed(1) + '" stroke="#0e9f6e" stroke-width="1" stroke-dasharray="3,2"/>');
-            parts.push('<text x="' + (X1 + 3) + '" y="' + yOf(tpLv).toFixed(1) + '" font-size="8" fill="#0e9f6e" text-anchor="start" dominant-baseline="middle">TP ' + fmtPct(p.tp) + '</text>');
-            svg.innerHTML = parts.join('');
-            // 入場ゲート(閾値) + 退場
-            var g = [];
-            g.push('<div style="font-weight:600;margin-bottom:2px">入場ゲート(閾値)</div>');
-            g.push('<div>トレンド &gt; ' + fmtPct(p.tr) + '</div>');
-            g.push('<div>SMA50 上抜け必須</div>');
-            g.push('<div>過熱(SMA50乖離) ≤ ' + fmtPct(p.heat) + '</div>');
-            g.push('<div>ボラ(ATR比) ≤ ' + p.atr + '×</div>');
-            g.push('<div>押し目 ' + p.pbMax + '% 〜 ' + p.pbMin + '%</div>');
-            g.push('<div style="font-weight:600;margin:4px 0 2px">退場</div>');
-            g.push('<div>損切 ' + fmtPct(p.stop) + ' / 利確 ' + fmtPct(p.tp) + '</div>');
-            g.push('<div>保有上限 ' + p.tstop + '日 (損切ATR ' + p.katr + '×)</div>');
-            gate.innerHTML = g.join('');
+            a.push('<rect x="' + X0 + '" y="' + zy.toFixed(1) + '" width="' + (X1 - X0) + '" height="' + zh.toFixed(1) + '" fill="#f59e0b33" stroke="#f59e0b" stroke-width="0.8"/>');
+            a.push('<circle cx="70" cy="' + yOf(entryMid).toFixed(1) + '" r="2.6" fill="' + color + '"/>');
+            a.push('<line x1="' + X0 + '" y1="' + yOf(stopLv).toFixed(1) + '" x2="' + X1 + '" y2="' + yOf(stopLv).toFixed(1) + '" stroke="#c22d2d" stroke-width="1" stroke-dasharray="3,2"/>');
+            a.push('<line x1="' + X0 + '" y1="' + yOf(tpLv).toFixed(1) + '" x2="' + X1 + '" y2="' + yOf(tpLv).toFixed(1) + '" stroke="#0e9f6e" stroke-width="1" stroke-dasharray="3,2"/>');
+            return '<svg viewBox="0 0 140 116" width="140" height="116" style="overflow:visible">' + a.join('') + '</svg>';
+          }
+          function statLines(role) {
+            if (role === 'cash_parking') return '<div style="color:#5b8c5a">pullback 判定なし</div>';
+            var p = P[role];
+            return '<div>押し目 ' + p.pbMax + '〜' + p.pbMin + '%</div>' +
+              '<div><span style="color:#c22d2d">stop ' + fmtPct(p.stop) + '</span> / <span style="color:#0e9f6e">TP ' + fmtPct(p.tp) + '</span></div>' +
+              '<div>保有 ' + p.tstop + '日 ・ 勢い &gt;' + fmtPct(p.tr) + '</div>' +
+              '<div style="color:#86868b">過熱≤' + fmtPct(p.heat) + ' ・ ATR≤' + p.atr + '×</div>';
+          }
+          function cardHtml(role) {
+            var color = COLOR[role] || '#5f6368';
+            return '<div class="role-tpl-card" data-role="' + role + '" onclick="window.pickRoleTpl(\\'' + role + '\\')" ' +
+              'style="cursor:pointer;border:1px solid #e3e3e8;border-radius:8px;padding:6px 8px;background:#fff;width:158px">' +
+              '<div style="font-size:11px;font-weight:600;margin-bottom:2px"><span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:' + color + ';margin-right:5px"></span>' + LABEL[role] + '</div>' +
+              miniSvg(role) +
+              '<div style="font-size:10px;line-height:1.5;margin-top:2px">' + statLines(role) + '</div>' +
+              '</div>';
+          }
+          window.pickRoleTpl = function (role) {
+            var sel = document.getElementById('symbol-form-role');
+            if (sel) sel.value = role;
+            window.syncRolePick(role);
           };
-          window.renderRoleTemplate(${JSON.stringify(roleValue)});
+          window.syncRolePick = function (role) {
+            var cards = document.querySelectorAll('.role-tpl-card');
+            for (var i = 0; i < cards.length; i++) {
+              var r = cards[i].getAttribute('data-role');
+              var on = r === role;
+              cards[i].style.border = on ? ('2px solid ' + (COLOR[r] || '#06c')) : '1px solid #e3e3e8';
+              cards[i].style.background = on ? '#fcfbf7' : '#fff';
+              cards[i].style.boxShadow = on ? '0 1px 4px rgba(0,0,0,0.08)' : 'none';
+            }
+          };
+          var wrap = document.getElementById('role-tpl-wrap');
+          var gallery = document.getElementById('role-gallery');
+          if (wrap && gallery) {
+            wrap.style.display = '';
+            gallery.innerHTML = ORDER.map(cardHtml).join('');
+            window.syncRolePick(${JSON.stringify(roleValue)});
+          }
         })();
         </script>
         <label>状態</label>

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -10617,30 +10617,22 @@ function symbolFormBody(args: SymbolFormArgs): string {
           <div class="muted" style="font-size:11px;margin-top:2px">未設定の銘柄は発注されません (fail-closed)</div>
         </div>
         <label>ロール${REQ}</label>
-        <div style="display:flex;gap:18px;align-items:flex-start;flex-wrap:wrap">
-          <div>
-            <select name="role" required id="symbol-form-role" style="padding:6px" onchange="window.syncRolePick(this.value)">
-              ${roleIsKnown ? '' : `<option value="${esc(roleValue)}" selected>⚠ 不正値: ${esc(roleValue)} (このままでは保存できません)</option>`}
-              ${
-                mode === 'new'
-                  ? `<option value="" disabled${roleValue === '' ? ' selected' : ''}>選択してください</option>`
-                  : `<option value=""${roleValue === '' ? ' selected' : ''}>未設定 (旧銘柄のみ — 従来挙動)</option>`
-              }
-              ${SYMBOL_ROLES.map(
-                (r) =>
-                  `<option value="${r}"${roleValue === r ? ' selected' : ''}>${esc(SYMBOL_ROLE_LABELS[r])}</option>`,
-              ).join('')}
-            </select>
-            ${roleIsKnown ? '' : '<p class="err" style="margin:4px 0 0;font-size:11px">DB に enum 外の role 値が入っています。この銘柄の entry は抑止中 (fail-closed)。正しい role か「未設定」を明示的に選んで保存してください。</p>'}
-            <div class="muted" style="font-size:11px;margin-top:2px">cash_parking は BUY を生成しない / inverse_hedge は短期プリセット (time stop 5日)</div>
+        <div style="flex:1 1 100%">
+          <!-- #role-stats: select を廃止し、カードのギャラリー = ロール選択。クリックで
+               選択 (hidden input に同期)、ホバーで画面右に大きいプレビュー (虚のチャート
+               + 入場ゲート閾値、個別銘柄チャートタブの視覚言語を流用)。 -->
+          <input type="hidden" name="role" id="symbol-form-role" value="${esc(roleValue)}">
+          <div style="font-size:12px;margin-bottom:5px">
+            選択中: <strong id="role-current" style="font-size:13px">—</strong>
+            <span class="muted" style="font-size:11px;margin-left:6px">カードをクリックで選択 / ホバーで右に詳細</span>
           </div>
-          <!-- #role-stats: 6 ロールの「虚のチャート + 入場ゲート」を横並びカードで
-               比較。クリックで select と同期・選択をハイライト (個別銘柄チャート
-               タブの視覚言語を流用)。 -->
-          <div id="role-tpl-wrap" style="display:none;flex:1 1 100%;margin-top:4px">
-            <div style="font-size:10px;color:#86868b;margin-bottom:4px">ロール比較 — 押し目ゾーン / stop / TP と入場ゲート閾値 (直近高値=0% 基準・preset 模式 / クリックで選択)</div>
-            <div id="role-gallery" style="display:flex;flex-wrap:wrap;gap:8px"></div>
-          </div>
+          ${roleIsKnown ? '' : '<p class="err" style="margin:0 0 4px;font-size:11px">DB に enum 外の role 値が入っています。この銘柄の entry は抑止中 (fail-closed)。正しい role を選んで保存してください。</p>'}
+          <div id="role-gallery" style="display:flex;flex-wrap:wrap;gap:8px"></div>
+          <div class="muted" style="font-size:11px;margin-top:3px">cash_parking は BUY を生成しない / inverse_hedge は短期プリセット (time stop 5日)</div>
+        </div>
+        <!-- ホバー時に画面右へ出る大プレビュー (fixed)。 -->
+        <div id="role-preview" style="display:none;position:fixed;right:16px;top:96px;width:300px;z-index:60;background:#fff;border:1px solid #d0d0d5;border-radius:10px;box-shadow:0 6px 22px rgba(0,0,0,0.14);padding:10px 12px">
+          <div id="role-preview-body"></div>
         </div>
         <script>
         (function () {
@@ -10662,63 +10654,106 @@ function symbolFormBody(args: SymbolFormArgs): string {
             inverse_hedge: 'インバースヘッジ', cash_parking: '待機資金'
           };
           var ORDER = ['leveraged_trend', 'core_trend', 'sector_trend', 'low_volatility', 'inverse_hedge', 'cash_parking'];
-          // 価格軸: +4%(上) 〜 -11%(下) 固定。% あたり 7px。
-          function yOf(pct) { return 10 + (4 - pct) * 7; }
           function fmtPct(v) { return (v > 0 ? '+' : '') + v + '%'; }
-          function miniSvg(role) {
+          // 共通の価格ラダー SVG。big=true で軸ラベル付きの大版。
+          function ladder(role, w, h, big) {
+            function y(pct) { return 12 + (4 - pct) * ((h - 24) / 15); } // +4%..-11% 固定
             if (role === 'cash_parking') {
-              return '<svg viewBox="0 0 140 116" width="140" height="116"><text x="70" y="54" font-size="10" fill="#5b8c5a" text-anchor="middle">entry なし</text><text x="70" y="70" font-size="8" fill="#80868b" text-anchor="middle">(常時配分・退避先)</text></svg>';
+              return '<svg viewBox="0 0 ' + w + ' ' + h + '" width="' + w + '" height="' + h + '"><text x="' + (w / 2) + '" y="' + (h / 2) + '" font-size="' + (big ? 12 : 10) + '" fill="#5b8c5a" text-anchor="middle">entry なし</text></svg>';
             }
             var p = P[role], color = COLOR[role];
-            var entryMid = (p.pbMax + p.pbMin) / 2, tpLv = entryMid + p.tp, stopLv = entryMid + p.stop;
-            var X0 = 16, X1 = 124, a = [];
-            a.push('<line x1="' + X0 + '" y1="' + yOf(0) + '" x2="' + X1 + '" y2="' + yOf(0) + '" stroke="#c4c8cd" stroke-width="1"/>');
-            a.push('<text x="' + X0 + '" y="' + (yOf(0) - 2) + '" font-size="7" fill="#9aa0a6">高値0%</text>');
-            var zy = yOf(p.pbMax), zh = yOf(p.pbMin) - yOf(p.pbMax);
+            var em = (p.pbMax + p.pbMin) / 2, tp = em + p.tp, st = em + p.stop;
+            var X0 = 14, X1 = big ? w - 64 : w - 12, a = [];
+            a.push('<line x1="' + X0 + '" y1="' + y(0).toFixed(1) + '" x2="' + X1 + '" y2="' + y(0).toFixed(1) + '" stroke="#c4c8cd" stroke-width="1"/>');
+            var zy = y(p.pbMax), zh = y(p.pbMin) - y(p.pbMax);
             a.push('<rect x="' + X0 + '" y="' + zy.toFixed(1) + '" width="' + (X1 - X0) + '" height="' + zh.toFixed(1) + '" fill="#f59e0b33" stroke="#f59e0b" stroke-width="0.8"/>');
-            a.push('<circle cx="70" cy="' + yOf(entryMid).toFixed(1) + '" r="2.6" fill="' + color + '"/>');
-            a.push('<line x1="' + X0 + '" y1="' + yOf(stopLv).toFixed(1) + '" x2="' + X1 + '" y2="' + yOf(stopLv).toFixed(1) + '" stroke="#c22d2d" stroke-width="1" stroke-dasharray="3,2"/>');
-            a.push('<line x1="' + X0 + '" y1="' + yOf(tpLv).toFixed(1) + '" x2="' + X1 + '" y2="' + yOf(tpLv).toFixed(1) + '" stroke="#0e9f6e" stroke-width="1" stroke-dasharray="3,2"/>');
-            return '<svg viewBox="0 0 140 116" width="140" height="116" style="overflow:visible">' + a.join('') + '</svg>';
+            a.push('<circle cx="' + ((X0 + X1) / 2).toFixed(1) + '" cy="' + y(em).toFixed(1) + '" r="' + (big ? 3.2 : 2.6) + '" fill="' + color + '"/>');
+            a.push('<line x1="' + X0 + '" y1="' + y(st).toFixed(1) + '" x2="' + X1 + '" y2="' + y(st).toFixed(1) + '" stroke="#c22d2d" stroke-width="1" stroke-dasharray="3,2"/>');
+            a.push('<line x1="' + X0 + '" y1="' + y(tp).toFixed(1) + '" x2="' + X1 + '" y2="' + y(tp).toFixed(1) + '" stroke="#0e9f6e" stroke-width="1" stroke-dasharray="3,2"/>');
+            if (big) {
+              var lx = X1 + 4;
+              a.push('<text x="' + lx + '" y="' + y(0).toFixed(1) + '" font-size="8" fill="#80868b" dominant-baseline="middle">高値 0%</text>');
+              a.push('<text x="' + lx + '" y="' + (zy + zh / 2).toFixed(1) + '" font-size="8" fill="#b25000" dominant-baseline="middle">押し目 ' + p.pbMax + '〜' + p.pbMin + '%</text>');
+              a.push('<text x="' + lx + '" y="' + y(st).toFixed(1) + '" font-size="8" fill="#c22d2d" dominant-baseline="middle">stop ' + fmtPct(p.stop) + '</text>');
+              a.push('<text x="' + lx + '" y="' + y(tp).toFixed(1) + '" font-size="8" fill="#0e9f6e" dominant-baseline="middle">TP ' + fmtPct(p.tp) + '</text>');
+            } else {
+              a.push('<text x="' + X0 + '" y="' + (y(0) - 2).toFixed(1) + '" font-size="7" fill="#9aa0a6">高値0%</text>');
+            }
+            return '<svg viewBox="0 0 ' + w + ' ' + h + '" width="' + w + '" height="' + h + '" style="overflow:visible">' + a.join('') + '</svg>';
           }
-          function statLines(role) {
-            if (role === 'cash_parking') return '<div style="color:#5b8c5a">pullback 判定なし</div>';
-            var p = P[role];
-            return '<div>押し目 ' + p.pbMax + '〜' + p.pbMin + '%</div>' +
-              '<div><span style="color:#c22d2d">stop ' + fmtPct(p.stop) + '</span> / <span style="color:#0e9f6e">TP ' + fmtPct(p.tp) + '</span></div>' +
-              '<div>保有 ' + p.tstop + '日 ・ 勢い &gt;' + fmtPct(p.tr) + '</div>' +
-              '<div style="color:#86868b">過熱≤' + fmtPct(p.heat) + ' ・ ATR≤' + p.atr + '×</div>';
+          function gateHtml(role) {
+            if (role === 'cash_parking') return '<div style="color:#5b8c5a;font-size:11px">戦略 entry なし。条件未達時の<b>退避先</b>・<b>常時配分</b>枠 (pullback 判定なし)。</div>';
+            var p = P[role], g = [];
+            g.push('<div style="font-weight:600;font-size:11px;margin-bottom:2px">入場ゲート(閾値)</div>');
+            g.push('<div>トレンド &gt; ' + fmtPct(p.tr) + '</div>');
+            g.push('<div>SMA50 上抜け必須</div>');
+            g.push('<div>過熱(SMA50乖離) ≤ ' + fmtPct(p.heat) + '</div>');
+            g.push('<div>ボラ(ATR比) ≤ ' + p.atr + '×</div>');
+            g.push('<div>押し目 ' + p.pbMax + '% 〜 ' + p.pbMin + '%</div>');
+            g.push('<div style="font-weight:600;margin:4px 0 2px">退場</div>');
+            g.push('<div>損切 ' + fmtPct(p.stop) + ' / 利確 ' + fmtPct(p.tp) + '</div>');
+            g.push('<div>保有上限 ' + p.tstop + '日 (損切ATR ' + p.katr + '×)</div>');
+            return '<div style="font-size:11px;line-height:1.55">' + g.join('') + '</div>';
           }
           function cardHtml(role) {
             var color = COLOR[role] || '#5f6368';
-            return '<div class="role-tpl-card" data-role="' + role + '" onclick="window.pickRoleTpl(\\'' + role + '\\')" ' +
-              'style="cursor:pointer;border:1px solid #e3e3e8;border-radius:8px;padding:6px 8px;background:#fff;width:158px">' +
+            return '<div class="role-tpl-card" data-role="' + role + '" ' +
+              'style="cursor:pointer;border:1px solid #e3e3e8;border-radius:8px;padding:6px 8px;background:#fff;width:150px">' +
               '<div style="font-size:11px;font-weight:600;margin-bottom:2px"><span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:' + color + ';margin-right:5px"></span>' + LABEL[role] + '</div>' +
-              miniSvg(role) +
-              '<div style="font-size:10px;line-height:1.5;margin-top:2px">' + statLines(role) + '</div>' +
+              ladder(role, 134, 96, false) +
+              '<div style="font-size:10px;color:#86868b;margin-top:1px">保有 ' + (role === 'cash_parking' ? '—' : P[role].tstop + '日') + '</div>' +
               '</div>';
           }
-          window.pickRoleTpl = function (role) {
-            var sel = document.getElementById('symbol-form-role');
-            if (sel) sel.value = role;
-            window.syncRolePick(role);
-          };
-          window.syncRolePick = function (role) {
+          var selected = ${JSON.stringify(roleValue)};
+          function labelOf(role) { return LABEL[role] || (role ? ('⚠ ' + role) : '未選択'); }
+          function showPreview(role) {
+            var pv = document.getElementById('role-preview');
+            var body = document.getElementById('role-preview-body');
+            if (!pv || !body) return;
+            if (!role || (!P[role] && role !== 'cash_parking')) { pv.style.display = 'none'; return; }
+            var color = COLOR[role] || '#5f6368';
+            body.innerHTML =
+              '<div style="font-size:13px;font-weight:700;margin-bottom:4px;color:' + color + '">' + LABEL[role] + '</div>' +
+              ladder(role, 280, 150, true) +
+              '<div style="margin-top:6px">' + gateHtml(role) + '</div>' +
+              '<div style="font-size:10px;color:#aaa;margin-top:6px">直近高値=0% 基準・preset 値の模式</div>';
+            pv.style.display = '';
+          }
+          function highlight(role) {
             var cards = document.querySelectorAll('.role-tpl-card');
             for (var i = 0; i < cards.length; i++) {
-              var r = cards[i].getAttribute('data-role');
-              var on = r === role;
+              var r = cards[i].getAttribute('data-role'), on = r === role;
               cards[i].style.border = on ? ('2px solid ' + (COLOR[r] || '#06c')) : '1px solid #e3e3e8';
               cards[i].style.background = on ? '#fcfbf7' : '#fff';
               cards[i].style.boxShadow = on ? '0 1px 4px rgba(0,0,0,0.08)' : 'none';
             }
-          };
-          var wrap = document.getElementById('role-tpl-wrap');
+          }
+          function pick(role) {
+            selected = role;
+            var inp = document.getElementById('symbol-form-role');
+            if (inp) inp.value = role;
+            var cur = document.getElementById('role-current');
+            if (cur) cur.textContent = labelOf(role);
+            highlight(role);
+            showPreview(role);
+          }
           var gallery = document.getElementById('role-gallery');
-          if (wrap && gallery) {
-            wrap.style.display = '';
+          if (gallery) {
             gallery.innerHTML = ORDER.map(cardHtml).join('');
-            window.syncRolePick(${JSON.stringify(roleValue)});
+            var cards = gallery.querySelectorAll('.role-tpl-card');
+            for (var i = 0; i < cards.length; i++) {
+              (function (card) {
+                var r = card.getAttribute('data-role');
+                card.addEventListener('click', function () { pick(r); });
+                card.addEventListener('mouseenter', function () { showPreview(r); });
+              })(cards[i]);
+            }
+            // ホバーが外れたら選択中ロールのプレビューに戻す (無ければ消す)。
+            gallery.addEventListener('mouseleave', function () { showPreview(selected); });
+            var cur = document.getElementById('role-current');
+            if (cur) cur.textContent = labelOf(selected);
+            highlight(selected);
+            showPreview(selected);
           }
         })();
         </script>

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -10622,23 +10622,25 @@ function symbolFormBody(args: SymbolFormArgs): string {
                選択 (hidden input に同期)、ホバーで画面右に大きいプレビュー (虚のチャート
                + 入場ゲート閾値、個別銘柄チャートタブの視覚言語を流用)。 -->
           <input type="hidden" name="role" id="symbol-form-role" value="${esc(roleValue)}">
-          <div style="font-size:12px;margin-bottom:5px">
-            選択中: <strong id="role-current" style="font-size:13px">—</strong>
-            <span class="muted" style="font-size:11px;margin-left:6px">カードをクリックで選択 / ホバーで右に詳細</span>
-          </div>
-          <!-- 2軸の案内: 入場アーキ(横) × 銘柄プロファイル(縦のカード)。現状は
-               全ロールが「押し目」アーキ。モメンタム/逆張りは別軸で設計中。 -->
-          <div style="font-size:11px;color:#5f6368;background:#f6f6f9;border-radius:6px;padding:6px 8px;margin-bottom:6px">
-            <strong>2軸</strong>: 入場アーキ × 銘柄プロファイル。
-            入場アーキ =
-            <span style="background:#e7f1ff;color:#06c;border-radius:4px;padding:0 5px">押し目 (有効)</span>
-            <span style="background:#eee;color:#999;border-radius:4px;padding:0 5px" title="設計中・未実装">モメンタム (設計中)</span>
-            <span style="background:#eee;color:#999;border-radius:4px;padding:0 5px" title="設計中・未実装">逆張り (設計中)</span>
-            <span class="muted">／ 下のカード = 銘柄プロファイル(現状すべて押し目アーキ)。ホバーで「入場アーキ/horizon/想定銘柄」の説明。</span>
-          </div>
+          <div style="font-size:12px;margin-bottom:6px">選択中: <strong id="role-current" style="font-size:13px">—</strong></div>
           ${roleIsKnown ? '' : '<p class="err" style="margin:0 0 4px;font-size:11px">DB に enum 外の role 値が入っています。この銘柄の entry は抑止中 (fail-closed)。正しい role を選んで保存してください。</p>'}
-          <div id="role-gallery" style="display:flex;flex-wrap:wrap;gap:8px"></div>
-          <div class="muted" style="font-size:11px;margin-top:3px">cash_parking は BUY を生成しない / inverse_hedge は短期プリセット (time stop 5日)</div>
+          <!-- 2軸を構造で表現: 行 = 入場アーキ、各行のカード = 銘柄プロファイル。
+               現状は「押し目」行のみ有効。モメンタム/逆張り行は設計中 (グレー)。 -->
+          <div id="role-grid" style="display:flex;flex-direction:column;gap:6px">
+            <div style="display:flex;gap:8px;align-items:stretch">
+              <div style="flex:0 0 70px;font-size:12px;font-weight:600;color:#06c;display:flex;align-items:center;border-right:3px solid #06c;padding-right:8px">押し目</div>
+              <div id="role-gallery" style="display:flex;flex-wrap:wrap;gap:8px;flex:1 1 auto"></div>
+            </div>
+            <div style="display:flex;gap:8px;align-items:center;opacity:0.55">
+              <div style="flex:0 0 70px;font-size:12px;font-weight:600;color:#9aa0a6;border-right:3px solid #d8dadd;padding-right:8px">モメンタム</div>
+              <div style="flex:1 1 auto;font-size:11px;color:#9aa0a6;background:repeating-linear-gradient(45deg,#f6f6f9,#f6f6f9 8px,#f0f0f3 8px,#f0f0f3 16px);border-radius:8px;padding:10px 12px">設計中 — 新高値ブレイクの継続を取る入場アーキ(1x向け)</div>
+            </div>
+            <div style="display:flex;gap:8px;align-items:center;opacity:0.55">
+              <div style="flex:0 0 70px;font-size:12px;font-weight:600;color:#9aa0a6;border-right:3px solid #d8dadd;padding-right:8px">逆張り</div>
+              <div style="flex:1 1 auto;font-size:11px;color:#9aa0a6;background:repeating-linear-gradient(45deg,#f6f6f9,#f6f6f9 8px,#f0f0f3 8px,#f0f0f3 16px);border-radius:8px;padding:10px 12px">設計中 — 売られすぎの反発を拾う入場アーキ(1x向け)</div>
+            </div>
+          </div>
+          <div class="muted" style="font-size:11px;margin-top:4px">cash_parking は BUY を生成しない / inverse_hedge は短期プリセット (time stop 5日)</div>
         </div>
         <!-- ホバー時に画面右へ出る大プレビュー (fixed)。 -->
         <div id="role-preview" style="display:none;position:fixed;right:16px;top:96px;width:300px;z-index:60;background:#fff;border:1px solid #d0d0d5;border-radius:10px;box-shadow:0 6px 22px rgba(0,0,0,0.14);padding:10px 12px">

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -10626,6 +10626,16 @@ function symbolFormBody(args: SymbolFormArgs): string {
             選択中: <strong id="role-current" style="font-size:13px">—</strong>
             <span class="muted" style="font-size:11px;margin-left:6px">カードをクリックで選択 / ホバーで右に詳細</span>
           </div>
+          <!-- 2軸の案内: 入場アーキ(横) × 銘柄プロファイル(縦のカード)。現状は
+               全ロールが「押し目」アーキ。モメンタム/逆張りは別軸で設計中。 -->
+          <div style="font-size:11px;color:#5f6368;background:#f6f6f9;border-radius:6px;padding:6px 8px;margin-bottom:6px">
+            <strong>2軸</strong>: 入場アーキ × 銘柄プロファイル。
+            入場アーキ =
+            <span style="background:#e7f1ff;color:#06c;border-radius:4px;padding:0 5px">押し目 (有効)</span>
+            <span style="background:#eee;color:#999;border-radius:4px;padding:0 5px" title="設計中・未実装">モメンタム (設計中)</span>
+            <span style="background:#eee;color:#999;border-radius:4px;padding:0 5px" title="設計中・未実装">逆張り (設計中)</span>
+            <span class="muted">／ 下のカード = 銘柄プロファイル(現状すべて押し目アーキ)。ホバーで「入場アーキ/horizon/想定銘柄」の説明。</span>
+          </div>
           ${roleIsKnown ? '' : '<p class="err" style="margin:0 0 4px;font-size:11px">DB に enum 外の role 値が入っています。この銘柄の entry は抑止中 (fail-closed)。正しい role を選んで保存してください。</p>'}
           <div id="role-gallery" style="display:flex;flex-wrap:wrap;gap:8px"></div>
           <div class="muted" style="font-size:11px;margin-top:3px">cash_parking は BUY を生成しない / inverse_hedge は短期プリセット (time stop 5日)</div>
@@ -10652,6 +10662,16 @@ function symbolFormBody(args: SymbolFormArgs): string {
             leveraged_trend: 'レバETF・トレンド', core_trend: '非レバ・トレンド',
             sector_trend: 'セクター', low_volatility: '低ボラ',
             inverse_hedge: 'インバースヘッジ', cash_parking: '待機資金'
+          };
+          // 2軸の説明 (入場アーキ / horizon / 想定銘柄の性質)。現状は全ロール
+          // 「押し目」アーキ。モメンタム/逆張りアーキは別軸で設計中 (未実装)。
+          var DESC = {
+            leveraged_trend: { arch: '押し目 (上昇中の押し目買い)', horizon: '中期 ~10日', character: '3x レバ ETF' },
+            core_trend: { arch: '押し目 (上昇中の押し目買い)', horizon: '中期 ~10日', character: '1x トレンド' },
+            sector_trend: { arch: '押し目 (上昇中の押し目買い)', horizon: '中期 ~10日', character: '1x セクター ETF' },
+            low_volatility: { arch: '押し目 (上昇中の押し目買い)', horizon: '中期 ~15日', character: '低ボラ 1x' },
+            inverse_hedge: { arch: '押し目 (下落レジームの inverse 押し目)', horizon: '超短 5日', character: '3x インバース' },
+            cash_parking: { arch: 'entry なし', horizon: '—', character: '待機資金 (退避先・常時配分)' }
           };
           var ORDER = ['leveraged_trend', 'core_trend', 'sector_trend', 'low_volatility', 'inverse_hedge', 'cash_parking'];
           function fmtPct(v) { return (v > 0 ? '+' : '') + v + '%'; }
@@ -10747,6 +10767,14 @@ function symbolFormBody(args: SymbolFormArgs): string {
           var selected = ${JSON.stringify(roleValue)};
           var currentShown = selected;
           function labelOf(role) { return LABEL[role] || (role ? ('⚠ ' + role) : '未選択'); }
+          // 4 つの説明 (ロール / 入場アーキ / horizon / 想定銘柄の性質)。
+          function descHtml(role) {
+            var d = DESC[role];
+            if (!d) return '';
+            function row(k, v) { return '<div style="display:flex;gap:6px"><span style="color:#86868b;min-width:62px">' + k + '</span><span>' + v + '</span></div>'; }
+            return '<div style="font-size:11px;line-height:1.5;background:#f6f6f9;border-radius:6px;padding:5px 7px;margin-bottom:6px">' +
+              row('入場アーキ', d.arch) + row('horizon', d.horizon) + row('想定銘柄', d.character) + '</div>';
+          }
           function showPreview(role) {
             currentShown = role;
             var pv = document.getElementById('role-preview');
@@ -10755,7 +10783,7 @@ function symbolFormBody(args: SymbolFormArgs): string {
             if (!role || (!P[role] && role !== 'cash_parking')) { pv.style.display = 'none'; return; }
             var color = COLOR[role] || '#5f6368';
             if (role === 'cash_parking') {
-              body.innerHTML = '<div style="font-size:13px;font-weight:700;margin-bottom:4px;color:' + color + '">待機資金</div>' + ladder(role, {}, 280, 120, true) + '<div style="margin-top:6px">' + gateHtml(role, {}) + '</div>';
+              body.innerHTML = '<div style="font-size:13px;font-weight:700;margin-bottom:4px;color:' + color + '">待機資金</div>' + descHtml(role) + ladder(role, {}, 280, 120, true) + '<div style="margin-top:6px">' + gateHtml(role, {}) + '</div>';
               pv.style.display = '';
               return;
             }
@@ -10763,6 +10791,7 @@ function symbolFormBody(args: SymbolFormArgs): string {
             var note = p.ov.any ? 'preset + この銘柄の override (* 印) を反映' : 'preset の姿 (override 未設定)';
             body.innerHTML =
               '<div style="font-size:13px;font-weight:700;margin-bottom:4px;color:' + color + '">' + LABEL[role] + '</div>' +
+              descHtml(role) +
               ladder(role, p, 280, 150, true) +
               '<div style="margin-top:6px">' + gateHtml(role, p) + '</div>' +
               '<div style="font-size:10px;color:#aaa;margin-top:6px">直近高値=0% 基準・実効値の模式<br>' + note + '</div>';

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -10624,21 +10624,21 @@ function symbolFormBody(args: SymbolFormArgs): string {
           <input type="hidden" name="role" id="symbol-form-role" value="${esc(roleValue)}">
           <div style="font-size:12px;margin-bottom:6px">選択中: <strong id="role-current" style="font-size:13px">—</strong></div>
           ${roleIsKnown ? '' : '<p class="err" style="margin:0 0 4px;font-size:11px">DB に enum 外の role 値が入っています。この銘柄の entry は抑止中 (fail-closed)。正しい role を選んで保存してください。</p>'}
-          <!-- 2軸を構造で表現: 行 = 入場アーキ、各行のカード = 銘柄プロファイル。
-               現状は「押し目」行のみ有効。モメンタム/逆張り行は設計中 (グレー)。 -->
-          <div id="role-grid" style="display:flex;flex-direction:column;gap:6px">
-            <div style="display:flex;gap:8px;align-items:stretch">
-              <div style="flex:0 0 70px;font-size:12px;font-weight:600;color:#06c;display:flex;align-items:center;border-right:3px solid #06c;padding-right:8px">押し目</div>
-              <div id="role-gallery" style="display:flex;flex-wrap:wrap;gap:8px;flex:1 1 auto"></div>
-            </div>
-            <div style="display:flex;gap:8px;align-items:center;opacity:0.55">
-              <div style="flex:0 0 70px;font-size:12px;font-weight:600;color:#9aa0a6;border-right:3px solid #d8dadd;padding-right:8px">モメンタム</div>
-              <div style="flex:1 1 auto;font-size:11px;color:#9aa0a6;background:repeating-linear-gradient(45deg,#f6f6f9,#f6f6f9 8px,#f0f0f3 8px,#f0f0f3 16px);border-radius:8px;padding:10px 12px">設計中 — 新高値ブレイクの継続を取る入場アーキ(1x向け)</div>
-            </div>
-            <div style="display:flex;gap:8px;align-items:center;opacity:0.55">
-              <div style="flex:0 0 70px;font-size:12px;font-weight:600;color:#9aa0a6;border-right:3px solid #d8dadd;padding-right:8px">逆張り</div>
-              <div style="flex:1 1 auto;font-size:11px;color:#9aa0a6;background:repeating-linear-gradient(45deg,#f6f6f9,#f6f6f9 8px,#f0f0f3 8px,#f0f0f3 16px);border-radius:8px;padding:10px 12px">設計中 — 売られすぎの反発を拾う入場アーキ(1x向け)</div>
-            </div>
+          <!-- 2軸を構造で表現: タブ = 入場アーキ、タブ内のカード = 銘柄プロファイル。
+               現状は「押し目」タブのみ有効。モメンタム/逆張りは設計中。 -->
+          <div style="display:flex;gap:2px;border-bottom:1px solid #e3e3e8;margin-bottom:8px">
+            <button type="button" class="role-arch-tab" data-arch="pullback" style="background:none;border:none;border-bottom:2px solid transparent;padding:6px 16px;font-size:13px;cursor:pointer">押し目</button>
+            <button type="button" class="role-arch-tab" data-arch="momentum" style="background:none;border:none;border-bottom:2px solid transparent;padding:6px 16px;font-size:13px;cursor:pointer">モメンタム <span style="font-size:10px;color:#bbb">設計中</span></button>
+            <button type="button" class="role-arch-tab" data-arch="reversion" style="background:none;border:none;border-bottom:2px solid transparent;padding:6px 16px;font-size:13px;cursor:pointer">逆張り <span style="font-size:10px;color:#bbb">設計中</span></button>
+          </div>
+          <div class="role-arch-panel" data-arch="pullback">
+            <div id="role-gallery" style="display:flex;flex-wrap:wrap;gap:8px"></div>
+          </div>
+          <div class="role-arch-panel" data-arch="momentum" style="display:none">
+            <div style="font-size:12px;color:#9aa0a6;background:repeating-linear-gradient(45deg,#f6f6f9,#f6f6f9 8px,#f0f0f3 8px,#f0f0f3 16px);border-radius:8px;padding:14px 16px">⚙ 設計中 — 新高値ブレイクの継続を取る入場アーキ(1x向け)。strategist 設計 → red-team の後に有効化。</div>
+          </div>
+          <div class="role-arch-panel" data-arch="reversion" style="display:none">
+            <div style="font-size:12px;color:#9aa0a6;background:repeating-linear-gradient(45deg,#f6f6f9,#f6f6f9 8px,#f0f0f3 8px,#f0f0f3 16px);border-radius:8px;padding:14px 16px">⚙ 設計中 — 売られすぎの反発を拾う入場アーキ(1x向け)。strategist 設計 → red-team の後に有効化。</div>
           </div>
           <div class="muted" style="font-size:11px;margin-top:4px">cash_parking は BUY を生成しない / inverse_hedge は短期プリセット (time stop 5日)</div>
         </div>
@@ -10758,12 +10758,16 @@ function symbolFormBody(args: SymbolFormArgs): string {
           }
           function cardHtml(role) {
             var color = COLOR[role] || '#5f6368';
-            // カードは preset (ロールの素性) を固定表示。override 反映は右プレビューだけ。
+            var d = DESC[role] || {};
+            // カードはグラフ無し (ホバー右プレビューに虚チャートがある)。名前 +
+            // 銘柄プロファイル + 保有 だけのコンパクト表示。
+            var sub = role === 'cash_parking'
+              ? (d.character || '')
+              : (d.character || '') + ' ・ 保有' + P[role].tstop + '日';
             return '<div class="role-tpl-card" data-role="' + role + '" ' +
-              'style="cursor:pointer;border:1px solid #e3e3e8;border-radius:8px;padding:6px 8px;background:#fff;width:150px">' +
-              '<div style="font-size:11px;font-weight:600;margin-bottom:2px"><span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:' + color + ';margin-right:5px"></span>' + LABEL[role] + '</div>' +
-              ladder(role, P[role] || {}, 134, 96, false) +
-              '<div style="font-size:10px;color:#86868b;margin-top:1px">保有 ' + (role === 'cash_parking' ? '—' : P[role].tstop + '日') + '</div>' +
+              'style="cursor:pointer;border:1px solid #e3e3e8;border-radius:8px;padding:8px 10px;background:#fff;min-width:150px">' +
+              '<div style="font-size:12px;font-weight:600"><span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:' + color + ';margin-right:5px"></span>' + LABEL[role] + '</div>' +
+              '<div style="font-size:10px;color:#86868b;margin-top:2px">' + sub + '</div>' +
               '</div>';
           }
           var selected = ${JSON.stringify(roleValue)};
@@ -10838,6 +10842,27 @@ function symbolFormBody(args: SymbolFormArgs): string {
               var el = document.getElementsByName(names[j])[0];
               if (el) { el.addEventListener('input', rerender); el.addEventListener('change', rerender); }
             }
+            // 入場アーキのタブ切替 (押し目=有効、モメンタム/逆張り=設計中パネル)。
+            function setArchTab(arch) {
+              var tabs = document.querySelectorAll('.role-arch-tab');
+              for (var t = 0; t < tabs.length; t++) {
+                var a = tabs[t].getAttribute('data-arch'), on = a === arch;
+                tabs[t].style.borderBottom = on ? '2px solid #06c' : '2px solid transparent';
+                tabs[t].style.color = on ? '#06c' : '#5f6368';
+                tabs[t].style.fontWeight = on ? '600' : 'normal';
+              }
+              var panels = document.querySelectorAll('.role-arch-panel');
+              for (var q = 0; q < panels.length; q++) {
+                panels[q].style.display = panels[q].getAttribute('data-arch') === arch ? '' : 'none';
+              }
+            }
+            var tabs = document.querySelectorAll('.role-arch-tab');
+            for (var k = 0; k < tabs.length; k++) {
+              (function (tab) {
+                tab.addEventListener('click', function () { setArchTab(tab.getAttribute('data-arch')); });
+              })(tabs[k]);
+            }
+            setArchTab('pullback');
             var cur = document.getElementById('role-current');
             if (cur) cur.textContent = labelOf(selected);
             highlight(selected);

--- a/test/routes/dashboardSymbolsCrud.test.ts
+++ b/test/routes/dashboardSymbolsCrud.test.ts
@@ -1678,12 +1678,13 @@ describe('銘柄フォームのセクション UI (#symbols-form-ui)', () => {
     expect(body).not.toMatch(/<details open[^>]*>\s*<summary[^>]*>発注サイズ/)
     // 売買単位の fail-closed 注意は 1 行だけ残す
     expect(body).toContain('未設定の銘柄は発注されません (fail-closed)')
-    // #role-stats: ロール選択横に入場/退場スタイルの六角形レーダーが ship される。
-    expect(body).toContain('id="role-radar"')
-    expect(body).toContain('window.renderRoleRadar(')
-    // role 別ステータスデータ (preset 由来) が含まれる。
-    expect(body).toContain('leveraged_trend: [5, 10, 10, 7, 8, 9]')
-    expect(body).toContain('inverse_hedge: [10, 10, 7, 3, 5, 9]')
+    // #role-stats: ロール選択横に「虚のチャート + 入場ゲート」テンプレートが ship される。
+    expect(body).toContain('id="role-tpl-chart"')
+    expect(body).toContain('window.renderRoleTemplate(')
+    // role 別 preset 解決値 (入場ゲート閾値・stop/TP) が含まれる。
+    expect(body).toContain('leveraged_trend: { tr: 8, heat: 60')
+    expect(body).toContain('inverse_hedge: { tr: 15, heat: 40')
+    expect(body).toContain('入場ゲート(閾値)')
   })
 
   it('edit フォーム: 値が入っているセクションは開いた状態で表示', async () => {

--- a/test/routes/dashboardSymbolsCrud.test.ts
+++ b/test/routes/dashboardSymbolsCrud.test.ts
@@ -1678,6 +1678,12 @@ describe('銘柄フォームのセクション UI (#symbols-form-ui)', () => {
     expect(body).not.toMatch(/<details open[^>]*>\s*<summary[^>]*>発注サイズ/)
     // 売買単位の fail-closed 注意は 1 行だけ残す
     expect(body).toContain('未設定の銘柄は発注されません (fail-closed)')
+    // #role-stats: ロール選択横に入場/退場スタイルの六角形レーダーが ship される。
+    expect(body).toContain('id="role-radar"')
+    expect(body).toContain('window.renderRoleRadar(')
+    // role 別ステータスデータ (preset 由来) が含まれる。
+    expect(body).toContain('leveraged_trend: [5, 10, 10, 7, 8, 9]')
+    expect(body).toContain('inverse_hedge: [10, 10, 7, 3, 5, 9]')
   })
 
   it('edit フォーム: 値が入っているセクションは開いた状態で表示', async () => {

--- a/test/routes/dashboardSymbolsCrud.test.ts
+++ b/test/routes/dashboardSymbolsCrud.test.ts
@@ -1678,13 +1678,13 @@ describe('銘柄フォームのセクション UI (#symbols-form-ui)', () => {
     expect(body).not.toMatch(/<details open[^>]*>\s*<summary[^>]*>発注サイズ/)
     // 売買単位の fail-closed 注意は 1 行だけ残す
     expect(body).toContain('未設定の銘柄は発注されません (fail-closed)')
-    // #role-stats: ロール選択横に「虚のチャート + 入場ゲート」テンプレートが ship される。
-    expect(body).toContain('id="role-tpl-chart"')
-    expect(body).toContain('window.renderRoleTemplate(')
+    // #role-stats: ロール比較ギャラリー (6 ロールの虚チャート + ゲート閾値) が ship される。
+    expect(body).toContain('id="role-gallery"')
+    expect(body).toContain('window.pickRoleTpl(')
+    expect(body).toContain('ロール比較')
     // role 別 preset 解決値 (入場ゲート閾値・stop/TP) が含まれる。
     expect(body).toContain('leveraged_trend: { tr: 8, heat: 60')
     expect(body).toContain('inverse_hedge: { tr: 15, heat: 40')
-    expect(body).toContain('入場ゲート(閾値)')
   })
 
   it('edit フォーム: 値が入っているセクションは開いた状態で表示', async () => {

--- a/test/routes/dashboardSymbolsCrud.test.ts
+++ b/test/routes/dashboardSymbolsCrud.test.ts
@@ -1465,7 +1465,8 @@ describe('dashboard symbol_config role / entry override (#452)', () => {
     )
     const body = await res.text()
     expect(body).toContain('name="role"')
-    expect(body).toMatch(/<option value="core_trend" selected>/)
+    // select 廃止 → hidden input に現在の role が入る (#role-stats)
+    expect(body).toMatch(/<input type="hidden" name="role" id="symbol-form-role" value="core_trend">/)
     // fraction → % 表示
     expect(body).toMatch(/name="pullback_max_override"[^>]*value="-1\.5"/)
     expect(body).toMatch(/name="min_return_50d_override"[^>]*value="3"/)
@@ -1602,7 +1603,7 @@ describe('CodeRabbit #453 対応 (不正 role のフォーム防御)', () => {
   })
   afterEach(() => vi.resetAllMocks())
 
-  it('不正 role はフォームで selected のまま警告表示 (silent に未設定へ戻さない)', async () => {
+  it('不正 role は hidden input に保持され警告表示 (silent に未設定へ戻さない)', async () => {
     const db = fakeDb([row({ symbol: 'OOPS', role: 'cash_praking' })])
     vi.mocked(createDb).mockReturnValue(db.drizzleLike as never)
     const app = createApp()
@@ -1612,10 +1613,9 @@ describe('CodeRabbit #453 対応 (不正 role のフォーム防御)', () => {
       { ...baseEnv, DB: {} as D1Database },
     )
     const body = await res.text()
-    expect(body).toMatch(/<option value="cash_praking" selected>⚠ 不正値/)
+    // select 廃止 → 不正値は hidden input に保持され、警告を出す (#role-stats)
+    expect(body).toMatch(/<input type="hidden" name="role" id="symbol-form-role" value="cash_praking">/)
     expect(body).toContain('entry は抑止中')
-    // role select の「未設定」が selected になっていない (他 select の '' とは区別)
-    expect(body).not.toMatch(/<option value="" selected>未設定/)
   })
 })
 
@@ -1667,9 +1667,9 @@ describe('銘柄フォームのセクション UI (#symbols-form-ui)', () => {
     const body = await res.text()
     // 必須バッジ: 凡例 1 + 銘柄 / 市場 / 通貨 / 売買単位 / ロール の計 6 箇所
     expect((body.match(/>必須<\/span>/g) ?? []).length).toBe(6)
-    // ロールは基本カードで必須 select (新規はプレースホルダのみ、未設定は選べない)
-    expect(body).toMatch(/<select name="role" required/)
-    expect(body).toContain('<option value="" disabled selected>選択してください</option>')
+    // ロールは select を廃止し hidden input + カードギャラリーで選択 (#role-stats)
+    expect(body).toMatch(/<input type="hidden" name="role" id="symbol-form-role"/)
+    expect(body).toContain('選択中:')
     // 任意セクションは details で、新規時は閉じている (open なし)
     expect(body).toContain('発注サイズ')
     expect(body).toContain('戦略ロール・entry 条件')
@@ -1678,10 +1678,10 @@ describe('銘柄フォームのセクション UI (#symbols-form-ui)', () => {
     expect(body).not.toMatch(/<details open[^>]*>\s*<summary[^>]*>発注サイズ/)
     // 売買単位の fail-closed 注意は 1 行だけ残す
     expect(body).toContain('未設定の銘柄は発注されません (fail-closed)')
-    // #role-stats: ロール比較ギャラリー (6 ロールの虚チャート + ゲート閾値) が ship される。
+    // #role-stats: ロール比較ギャラリー + ホバー右プレビューが ship される。
     expect(body).toContain('id="role-gallery"')
-    expect(body).toContain('window.pickRoleTpl(')
-    expect(body).toContain('ロール比較')
+    expect(body).toContain('id="role-preview"')
+    expect(body).toContain('ホバーで右に詳細')
     // role 別 preset 解決値 (入場ゲート閾値・stop/TP) が含まれる。
     expect(body).toContain('leveraged_trend: { tr: 8, heat: 60')
     expect(body).toContain('inverse_hedge: { tr: 15, heat: 40')

--- a/test/routes/dashboardSymbolsCrud.test.ts
+++ b/test/routes/dashboardSymbolsCrud.test.ts
@@ -1681,7 +1681,10 @@ describe('銘柄フォームのセクション UI (#symbols-form-ui)', () => {
     // #role-stats: ロール比較ギャラリー + ホバー右プレビューが ship される。
     expect(body).toContain('id="role-gallery"')
     expect(body).toContain('id="role-preview"')
-    expect(body).toContain('ホバーで右に詳細')
+    // 2軸を構造で表現: 入場アーキ行 (押し目 + 設計中の モメンタム/逆張り)
+    expect(body).toContain('id="role-grid"')
+    expect(body).toContain('モメンタム')
+    expect(body).toContain('逆張り')
     // role 別 preset 解決値 (入場ゲート閾値・stop/TP) が含まれる。
     expect(body).toContain('leveraged_trend: { tr: 8, heat: 60')
     expect(body).toContain('inverse_hedge: { tr: 15, heat: 40')

--- a/test/routes/dashboardSymbolsCrud.test.ts
+++ b/test/routes/dashboardSymbolsCrud.test.ts
@@ -1681,8 +1681,9 @@ describe('銘柄フォームのセクション UI (#symbols-form-ui)', () => {
     // #role-stats: ロール比較ギャラリー + ホバー右プレビューが ship される。
     expect(body).toContain('id="role-gallery"')
     expect(body).toContain('id="role-preview"')
-    // 2軸を構造で表現: 入場アーキ行 (押し目 + 設計中の モメンタム/逆張り)
-    expect(body).toContain('id="role-grid"')
+    // 2軸を構造で表現: 入場アーキのタブ (押し目 + 設計中の モメンタム/逆張り)
+    expect(body).toContain('class="role-arch-tab"')
+    expect(body).toMatch(/data-arch="pullback"/)
     expect(body).toContain('モメンタム')
     expect(body).toContain('逆張り')
     // role 別 preset 解決値 (入場ゲート閾値・stop/TP) が含まれる。


### PR DESCRIPTION
## 目的

銘柄管理フォームで「このロールを選ぶと entry/exit がどうなるか」を、ライブ銘柄ではなく role preset から作った**虚のチャート + 入場ゲート**で見えるようにする。装備画面のように選びながら比較・確認できる UI。**戦略ロジックは未変更**(表示・選択 UI のみ)。

## 入っているもの

- **ロール選択を select → カードピッカー化**: `name="role"` は hidden input、カードのクリックで選択(同期・ハイライト)。
- **ホバーで画面右に大プレビュー**: 直近高値=0% 基準の押し目ゾーン / stop / TP 模式チャート + 入場ゲート閾値(トレンド/SMA50/過熱/ATR/押し目)+ 退場(損切/利確/保有/kAtr)。数値は `ROLE_RULE_PRESETS` の解決値。
- **実効値プレビュー**: 銘柄別 override 欄(`*_override`)を編集すると、プレビューが **preset + override の実効値**に即更新し、上書きした値に `*` マーク。`require_above_sma50` も反映。
- **2軸を構造で表現**: 入場アーキ = **タブ**(押し目=有効 / モメンタム・逆張り=設計中パネル)、タブ内のカード = 銘柄プロファイル(レバ/1x/セクター/低ボラ/インバース/待機)。
- **説明(4 descriptor)**: 入場アーキ / horizon / 想定銘柄 をホバープレビューに構造化表示(説明文は置かず UI 構造で表現、dashboard-ui-preferences 準拠)。
- カードはグラフ無し(プレビューに集約)、名前 + プロファイル + 保有日数のみ。

## 非対象(後続フェーズ)

- モメンタム(breakout)/ 逆張り(reversion)の **strategy 実体は未実装**(タブは「設計中」表示・選択不可、fail-closed)。設計 → red-team → 実装は別 PR。
- データモデルの 2軸カラム化(`entry_archetype` 等)も後続。本 PR は既存 `role` のまま挙動不変。

## 検証

- 全テスト **1532 passed**、`tsc --noEmit` clean、`wrangler deploy --dry-run` OK、staging 反映済み。
- inline-script 構文テスト・XSS テスト・symbols CRUD テストでフォーム回帰を担保。

Refs #452
