### PR TITLE
feat: momentum as a selectable live role (warned) + backtest harness (#momentum)

### DIFF
--- a/scripts/backtest-momentum.ts
+++ b/scripts/backtest-momentum.ts
@@ -1,0 +1,122 @@
+/**
+ * モメンタム(ブレイクアウト)戦略のオフライン・エッジ検証 (#momentum)。
+ *
+ * red-team が要求した「コードを書く前/載せた直後の安いキルスイッチ」。
+ * 1x 銘柄の Yahoo 日足に対し BreakoutMomentumStrategy を回し、
+ *   - 発火頻度 (trades 数) / 勝率 / 実現 R:R / 最大DD
+ *   - 同じ銘柄で押し目戦略も回し、重複(同じ局面でしか勝たないか)の粗比較
+ * を出す。**発注は一切しない**(オフライン backtest)。
+ *
+ * 注意:
+ * - これは「エッジが存在するか」の一次判定。コスト(スプレッド+為替)は引いて
+ *   いない粗リターン。コスト後で勝てるかは別途。
+ * - 対象は OpenAPI 発注可否と無関係(過去データはオフラインで引ける)。SPY/QQQ 等
+ *   発注不可銘柄も「エッジの有無」研究のため含める。
+ *
+ * Usage: pnpm tsx scripts/backtest-momentum.ts
+ */
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { YahooBarClient } from '../src/infrastructure/quotes/YahooBarClient'
+import { runBacktest, type BacktestResult } from '../src/trading/backtest/runBacktest'
+import {
+  BreakoutMomentumStrategy,
+  TEST_DEFAULT_MOMENTUM_RULE,
+} from '../src/trading/strategy/strategies/BreakoutMomentumStrategy'
+import { TEST_DEFAULT_RULE } from '../src/trading/strategy/strategies/PullbackUptrendStrategy'
+
+const SYMBOLS: ReadonlyArray<{ symbol: string; label: string; tradable: boolean }> = [
+  { symbol: 'ICLN', label: 'ICLN クリーンエネ (発注可)', tradable: true },
+  { symbol: 'TAN', label: 'TAN ソーラー (発注可)', tradable: true },
+  { symbol: 'QCLN', label: 'QCLN クリーンエネ (発注可)', tradable: true },
+  { symbol: 'SPY', label: 'SPY S&P500 (発注不可・研究用)', tradable: false },
+  { symbol: 'QQQ', label: 'QQQ Nasdaq100 (発注不可・研究用)', tradable: false },
+  { symbol: 'SMH', label: 'SMH 半導体 (発注不可・研究用)', tradable: false },
+  { symbol: 'XLK', label: 'XLK テック (発注不可・研究用)', tradable: false },
+]
+
+const LOOKBACK_DAYS = 5 * 252
+const INITIAL_CASH = 10_000
+
+interface Row {
+  symbol: string
+  label: string
+  tradable: boolean
+  momentum: BacktestResult | null
+  pullback: BacktestResult | null
+}
+
+function summarize(r: BacktestResult | null): string {
+  if (!r) return 'n/a'
+  const rr =
+    r.avgLoss !== 0 ? Math.abs(r.avgWin / r.avgLoss).toFixed(2) : (r.avgWin > 0 ? '∞' : '0')
+  return [
+    `trades ${r.totalTrades}`,
+    `勝率 ${(r.winRate * 100).toFixed(0)}%`,
+    `R:R ${rr}`,
+    `総%${(r.totalReturn * 100).toFixed(1)}`,
+    `maxDD ${(r.maxDrawdownPct * 100).toFixed(1)}%`,
+    `Sharpe ${r.sharpeRatio.toFixed(2)}`,
+  ].join(' / ')
+}
+
+async function main() {
+  const client = new YahooBarClient({ timeoutMs: 15_000 })
+  const rows: Row[] = []
+
+  for (const { symbol, label, tradable } of SYMBOLS) {
+    process.stdout.write(`fetching ${symbol} ... `)
+    let bars
+    try {
+      bars = await client.getDailyBars(symbol, LOOKBACK_DAYS)
+    } catch (e) {
+      console.log(`FAIL ${e instanceof Error ? e.message : String(e)}`)
+      rows.push({ symbol, label, tradable, momentum: null, pullback: null })
+      continue
+    }
+    if (bars.length < 60) {
+      console.log(`SKIP ${bars.length} bars`)
+      rows.push({ symbol, label, tradable, momentum: null, pullback: null })
+      continue
+    }
+    console.log(`${bars.length} bars (${bars[0]?.date}–${bars[bars.length - 1]?.date})`)
+    const common = {
+      symbol,
+      from: bars[0]?.date ?? 'start',
+      to: bars[bars.length - 1]?.date ?? 'end',
+      initialCash: INITIAL_CASH,
+      rule: TEST_DEFAULT_RULE,
+    }
+    const momentum = await runBacktest(bars, {
+      ...common,
+      strategy: new BreakoutMomentumStrategy(TEST_DEFAULT_MOMENTUM_RULE),
+    })
+    const pullback = await runBacktest(bars, common)
+    rows.push({ symbol, label, tradable, momentum, pullback })
+  }
+
+  const lines: string[] = []
+  lines.push('# Momentum (breakout) backtest — エッジ一次検証')
+  lines.push('')
+  lines.push('粗リターン(コスト/為替**控除前**)。発火頻度・勝率・R:R・maxDD の確認用。')
+  lines.push('')
+  for (const r of rows) {
+    lines.push(`## ${r.label}${r.tradable ? '' : ' ※OpenAPI発注不可'}`)
+    lines.push(`- モメンタム: ${summarize(r.momentum)}`)
+    lines.push(`- 押し目    : ${summarize(r.pullback)}`)
+    lines.push('')
+  }
+  const out = lines.join('\n')
+  console.log('\n' + out)
+  const reportPath = join(dirname(fileURLToPath(import.meta.url)), '..', '.local', 'backtest-momentum-report.md')
+  await mkdir(dirname(reportPath), { recursive: true })
+  await writeFile(reportPath, out, 'utf8')
+  console.log(`\nreport: ${reportPath}`)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/src/infrastructure/db/symbolConfigRepo.ts
+++ b/src/infrastructure/db/symbolConfigRepo.ts
@@ -17,6 +17,10 @@ export const SYMBOL_ROLES = [
   'low_volatility',
   'sector_trend',
   'inverse_hedge',
+  // #momentum: ブレイクアウト/モメンタム入場アーキ。BreakoutMomentumStrategy で
+  // 判定する (押し目とは別 strategy)。登録時に警告を出すが、以降は通常ロールと
+  // 同じく Risk→Execution を通る。1x 向け (3x は使わない運用)。
+  'momentum',
 ] as const
 export type SymbolRole = (typeof SYMBOL_ROLES)[number]
 

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -10635,10 +10635,18 @@ function symbolFormBody(args: SymbolFormArgs): string {
             <div id="role-gallery" style="display:flex;flex-wrap:wrap;gap:8px"></div>
           </div>
           <div class="role-arch-panel" data-arch="momentum" style="display:none">
-            <div style="font-size:12px;color:#9aa0a6;background:repeating-linear-gradient(45deg,#f6f6f9,#f6f6f9 8px,#f0f0f3 8px,#f0f0f3 16px);border-radius:8px;padding:14px 16px">⚙ 設計中 — 新高値ブレイクの継続を取る入場アーキ(1x向け)。strategist 設計 → red-team の後に有効化。</div>
+            <div style="font-size:12px;color:#9a5b00;background:#fff4e5;border:1px solid #f0c98a;border-radius:8px;padding:12px 14px;line-height:1.6">
+              <strong>⚠ 使用不可(未実装)</strong> — 新高値ブレイクの継続を取る入場アーキ(1x向け)。<br>
+              理由: <b>backtest 未検証</b>(継続エッジ/コスト後を要確認)＋ <b>発注可能な 1x universe が無い</b>(セクター/広域 ETF は OpenAPI 取扱外、発注可は ICLN/TAN/QCLN 等のみ)。<br>
+              有効化条件: ① Webull で取扱 1x が増える ② backtest でエッジ確認(runBacktest モメンタムモード)。それまで選択不可。
+            </div>
           </div>
           <div class="role-arch-panel" data-arch="reversion" style="display:none">
-            <div style="font-size:12px;color:#9aa0a6;background:repeating-linear-gradient(45deg,#f6f6f9,#f6f6f9 8px,#f0f0f3 8px,#f0f0f3 16px);border-radius:8px;padding:14px 16px">⚙ 設計中 — 売られすぎの反発を拾う入場アーキ(1x向け)。strategist 設計 → red-team の後に有効化。</div>
+            <div style="font-size:12px;color:#9a5b00;background:#fff4e5;border:1px solid #f0c98a;border-radius:8px;padding:12px 14px;line-height:1.6">
+              <strong>⚠ 使用不可(見送り)</strong> — 売られすぎの反発を拾う入場アーキ(1x向け)。<br>
+              理由: red-team 評価で <b>$ POC のコスト/為替でエッジ証明困難</b>＋ <b>逆張りに適した 1x(広域指数)が OpenAPI 取扱外</b>(発注可の ICLN/TAN 等はテーマ ETF で逆張り不適=ナイフ掴み)。<br>
+              現状は見送り。再訪は universe 拡大 + notional 引き上げが前提。
+            </div>
           </div>
           <div class="muted" style="font-size:11px;margin-top:4px">cash_parking は BUY を生成しない / inverse_hedge は短期プリセット (time stop 5日)</div>
         </div>

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -10378,6 +10378,7 @@ const SYMBOL_ROLE_LABELS_SHORT: Record<SymbolRole, string> = {
   low_volatility: '低ボラ',
   sector_trend: 'セクター',
   inverse_hedge: 'インバースヘッジ (短期)',
+  momentum: 'モメンタム (⚠未検証)',
 }
 
 /** role select の表示ラベル (#452)。値は DB enum と同一、表示だけ日本語補足。 */
@@ -10388,6 +10389,7 @@ const SYMBOL_ROLE_LABELS: Record<SymbolRole, string> = {
   low_volatility: 'low_volatility — 低ボラ ETF (USMV / SPLV 等)',
   sector_trend: 'sector_trend — 1x セクター ETF (SMH / SOXX 等)',
   inverse_hedge: 'inverse_hedge — 3x インバース・短期 (SQQQ / SOXS。1x は override 必須)',
+  momentum: 'momentum — ⚠ モメンタム/ブレイク (1x向け・backtest未検証・要警告)',
 }
 
 /** 一覧テーブルの「ロール」セル (#452)。role + 配分の条件連動を 1 セルに要約する。 */
@@ -10635,11 +10637,11 @@ function symbolFormBody(args: SymbolFormArgs): string {
             <div id="role-gallery" style="display:flex;flex-wrap:wrap;gap:8px"></div>
           </div>
           <div class="role-arch-panel" data-arch="momentum" style="display:none">
-            <div style="font-size:12px;color:#9a5b00;background:#fff4e5;border:1px solid #f0c98a;border-radius:8px;padding:12px 14px;line-height:1.6">
-              <strong>⚠ 使用不可(未実装)</strong> — 新高値ブレイクの継続を取る入場アーキ(1x向け)。<br>
-              理由: <b>backtest 未検証</b>(継続エッジ/コスト後を要確認)＋ <b>発注可能な 1x universe が無い</b>(セクター/広域 ETF は OpenAPI 取扱外、発注可は ICLN/TAN/QCLN 等のみ)。<br>
-              有効化条件: ① Webull で取扱 1x が増える ② backtest でエッジ確認(runBacktest モメンタムモード)。それまで選択不可。
+            <div style="font-size:12px;color:#9a5b00;background:#fff4e5;border:1px solid #f0c98a;border-radius:8px;padding:10px 12px;line-height:1.55;margin-bottom:8px">
+              <strong>⚠ 要注意ロール(エッジ未検証)</strong> — 新高値ブレイクの継続を取る入場アーキ。選択・取引は可能ですが、
+              <b>backtest 上、発注可能なテーマ ETF (ICLN/TAN/QCLN) では成績まちまち〜不良 (TAN -60%DD)</b>。広域/テック 1x では有効だがそれらは OpenAPI 発注不可。<b>1x 銘柄のみ</b>に付け、少額・DRY_RUN から。
             </div>
+            <div id="momentum-gallery" style="display:flex;flex-wrap:wrap;gap:8px"></div>
           </div>
           <div class="role-arch-panel" data-arch="reversion" style="display:none">
             <div style="font-size:12px;color:#9a5b00;background:#fff4e5;border:1px solid #f0c98a;border-radius:8px;padding:12px 14px;line-height:1.6">
@@ -10666,12 +10668,14 @@ function symbolFormBody(args: SymbolFormArgs): string {
           };
           var COLOR = {
             core_trend: '#1a56db', leveraged_trend: '#d97706', sector_trend: '#0e9f9f',
-            low_volatility: '#7e3af2', inverse_hedge: '#c22d2d', cash_parking: '#5b8c5a'
+            low_volatility: '#7e3af2', inverse_hedge: '#c22d2d', cash_parking: '#5b8c5a',
+            momentum: '#b25000'
           };
           var LABEL = {
             leveraged_trend: 'レバETF・トレンド', core_trend: '非レバ・トレンド',
             sector_trend: 'セクター', low_volatility: '低ボラ',
-            inverse_hedge: 'インバースヘッジ', cash_parking: '待機資金'
+            inverse_hedge: 'インバースヘッジ', cash_parking: '待機資金',
+            momentum: 'モメンタム ⚠'
           };
           // 2軸の説明 (入場アーキ / horizon / 想定銘柄の性質)。現状は全ロール
           // 「押し目」アーキ。モメンタム/逆張りアーキは別軸で設計中 (未実装)。
@@ -10681,7 +10685,8 @@ function symbolFormBody(args: SymbolFormArgs): string {
             sector_trend: { arch: '押し目 (上昇中の押し目買い)', horizon: '中期 ~10日', character: '1x セクター ETF' },
             low_volatility: { arch: '押し目 (上昇中の押し目買い)', horizon: '中期 ~15日', character: '低ボラ 1x' },
             inverse_hedge: { arch: '押し目 (下落レジームの inverse 押し目)', horizon: '超短 5日', character: '3x インバース' },
-            cash_parking: { arch: 'entry なし', horizon: '—', character: '待機資金 (退避先・常時配分)' }
+            cash_parking: { arch: 'entry なし', horizon: '—', character: '待機資金 (退避先・常時配分)' },
+            momentum: { arch: 'モメンタム (新高値ブレイク継続)', horizon: '短期 3–7日', character: '1x モメンタム ⚠ backtest 未検証' }
           };
           var ORDER = ['leveraged_trend', 'core_trend', 'sector_trend', 'low_volatility', 'inverse_hedge', 'cash_parking'];
           function fmtPct(v) { return (v > 0 ? '+' : '') + v + '%'; }
@@ -10794,6 +10799,15 @@ function symbolFormBody(args: SymbolFormArgs): string {
             var pv = document.getElementById('role-preview');
             var body = document.getElementById('role-preview-body');
             if (!pv || !body) return;
+            if (role === 'momentum') {
+              body.innerHTML = '<div style="font-size:13px;font-weight:700;margin-bottom:4px;color:' + COLOR.momentum + '">⚡ モメンタム ⚠</div>' +
+                descHtml('momentum') +
+                '<div style="font-size:11px;line-height:1.55">新高値ブレイクの継続を取る別戦略 (BreakoutMomentumStrategy)。' +
+                'entry: トレンド+ 新高値ブレイク+ SMA50上+ 過熱でない。exit: stop -5% / TP +10% / 保有~7日。<br>' +
+                '<span style="color:#c22;font-weight:600">⚠ backtest 未検証。発注可テーマETFでは成績不良の例あり (TAN -60%DD)。1x のみ・少額で。</span></div>';
+              pv.style.display = '';
+              return;
+            }
             if (!role || (!P[role] && role !== 'cash_parking')) { pv.style.display = 'none'; return; }
             var color = COLOR[role] || '#5f6368';
             if (role === 'cash_parking') {
@@ -10830,11 +10844,23 @@ function symbolFormBody(args: SymbolFormArgs): string {
             showPreview(role);
           }
           function rerender() { showPreview(currentShown); }
+          // momentum はグラフ無し (preset が押し目と別形)。名前 + 性質だけのカード。
+          function momentumCardHtml() {
+            var d = DESC.momentum || {};
+            return '<div class="role-tpl-card" data-role="momentum" ' +
+              'style="cursor:pointer;border:1px solid #f0c98a;border-radius:8px;padding:8px 10px;background:#fffaf2;min-width:150px">' +
+              '<div style="font-size:12px;font-weight:600;color:' + COLOR.momentum + '">⚡ モメンタム</div>' +
+              '<div style="font-size:10px;color:#9a5b00;margin-top:2px">' + (d.character || '') + ' ・ 保有~7日</div>' +
+              '</div>';
+          }
           function init() {
             var gallery = document.getElementById('role-gallery');
             if (!gallery) return;
             gallery.innerHTML = ORDER.map(cardHtml).join('');
-            var cards = gallery.querySelectorAll('.role-tpl-card');
+            var mg = document.getElementById('momentum-gallery');
+            if (mg) mg.innerHTML = momentumCardHtml();
+            // gallery + momentum の全カードに listener を張る。
+            var cards = document.querySelectorAll('.role-tpl-card');
             for (var i = 0; i < cards.length; i++) {
               (function (card) {
                 var r = card.getAttribute('data-role');
@@ -10870,7 +10896,7 @@ function symbolFormBody(args: SymbolFormArgs): string {
                 tab.addEventListener('click', function () { setArchTab(tab.getAttribute('data-arch')); });
               })(tabs[k]);
             }
-            setArchTab('pullback');
+            setArchTab(selected === 'momentum' ? 'momentum' : 'pullback');
             var cur = document.getElementById('role-current');
             if (cur) cur.textContent = labelOf(selected);
             highlight(selected);

--- a/src/trading/backtest/runBacktest.ts
+++ b/src/trading/backtest/runBacktest.ts
@@ -1,9 +1,31 @@
-import { computePullbackIndicators, type DailyBar } from '../strategy/indicators'
+import type { Signal } from '../domain/Signal'
+import {
+  computePullbackIndicators,
+  type DailyBar,
+  type PullbackIndicatorSnapshot,
+} from '../strategy/indicators'
 import {
   PullbackUptrendStrategy,
   type SymbolRule,
 } from '../strategy/strategies/PullbackUptrendStrategy'
-import type { PositionState } from '../state/types'
+import type { PendingOrderLock, PositionState } from '../state/types'
+
+/**
+ * Strategy を差し替え可能にする最小インターフェース (#momentum)。
+ * `decide` の input は runBacktest が組み立てる形。PullbackUptrendStrategy も
+ * BreakoutMomentumStrategy もこれを満たす (indicators は snapshot 全部入り)。
+ */
+export interface BacktestStrategy {
+  decide(input: {
+    symbol: string
+    indicators: PullbackIndicatorSnapshot
+    position: PositionState | null
+    pendingOrder: PendingOrderLock | null
+    cooldownUntil: string | null
+    holdBusinessDays: number
+    now: Date
+  }): Signal
+}
 
 /**
  * Offline backtest harness for PullbackUptrendStrategy。issue #198。
@@ -30,8 +52,13 @@ export interface BacktestParams {
   to: string
   /** 初期 cash (positions=0 起点)。BUY シグナル時に floor(cash/price) qty を発注。 */
   initialCash: number
-  /** PullbackUptrendStrategy の rule。entry/exit 判定に使う。 */
+  /** PullbackUptrendStrategy の rule。entry/exit 判定に使う (strategy 未指定時)。 */
   rule: SymbolRule
+  /**
+   * 差し替え用 strategy (#momentum)。未指定なら `rule` から
+   * PullbackUptrendStrategy を構築。BreakoutMomentumStrategy 等を渡せる。
+   */
+  strategy?: BacktestStrategy
 }
 
 export type ExitReason = 'TP' | 'STOP' | 'TIME_STOP' | 'END_OF_DATA'
@@ -107,7 +134,7 @@ export async function runBacktest(
     return finalize(params, trades, equityCurve)
   }
 
-  const strategy = new PullbackUptrendStrategy(params.rule)
+  const strategy: BacktestStrategy = params.strategy ?? new PullbackUptrendStrategy(params.rule)
 
   let cash = params.initialCash
   let position: PositionState | null = null

--- a/src/trading/strategy/indicators.ts
+++ b/src/trading/strategy/indicators.ts
@@ -39,6 +39,12 @@ export interface PullbackIndicatorSnapshot {
   low20d: number
   atr20: number
   baselineAtr20: number
+  /**
+   * ブレイクアウト基準 = **当日を除く** 直近 20 営業日の終値高値 (#momentum)。
+   * `high20d`(当日含む高値)を流用すると自己参照で発火不能になるため別計算。
+   * モメンタム戦略のみ使用 (押し目戦略は参照しない)。bars < 21 のとき 0。
+   */
+  breakoutHigh20: number
 }
 
 /**
@@ -78,6 +84,9 @@ export function computePullbackIndicators(
   // 「price <= high10d * (1 + pullbackMax)」になり、押し目判定が短期化する。
   const high20d = Math.max(...highs.slice(-10))
   const low20d = Math.min(...lows.slice(-20))
+  // ブレイクアウト基準 (#momentum): 当日を除く直近 20 営業日の終値高値。
+  // closes は >=50 本あるので slice(-21,-1) は常に 20 本。
+  const breakoutHigh20 = Math.max(...closes.slice(-21, -1))
   // #318: return lookback 20 営業日に対応。`(last - closes[-20]) / closes[-20]`。
   const return50d = (last - baseline) / baseline
 
@@ -95,7 +104,7 @@ export function computePullbackIndicators(
       ? intradayPrice
       : last
 
-  return { price, sma50, return50d, high20d, low20d, atr20, baselineAtr20 }
+  return { price, sma50, return50d, high20d, low20d, atr20, baselineAtr20, breakoutHigh20 }
 }
 
 export function computeHoldBusinessDays(

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -23,6 +23,7 @@ import type { BuyingPowerLedger } from './buyingPower'
 const INTRADAY_CLOSE_WINDOW_MIN = 15
 import type { ExecutionResult } from '../domain/ExecutionResult'
 import type { OrderIntent } from '../domain/OrderIntent'
+import { BreakoutMomentumStrategy } from './strategies/BreakoutMomentumStrategy'
 import {
   PullbackUptrendStrategy,
   TEST_DEFAULT_RULE,
@@ -63,6 +64,14 @@ export interface PullbackSchedulerOptions {
    */
   defaultRule?: SymbolRule
   rulesMap?: Record<string, SymbolRule>
+  /**
+   * #momentum: role === 'momentum' の symbol 集合。これに含まれる symbol は
+   * `momentumStrategy` で判定する (押し目戦略の代わり)。signal は以降の
+   * Risk→Execution を通常 BUY/SELL と同じく通る。
+   */
+  momentumSymbols?: Set<string>
+  /** #momentum: momentum symbol 用の戦略。未指定なら momentum symbol も押し目で判定 (後方互換)。 */
+  momentumStrategy?: BreakoutMomentumStrategy
   symbolCapMap?: Record<string, number>
   barLookback?: number
   riskPerTradePct?: number
@@ -563,7 +572,12 @@ export async function runPullbackScheduler(
           : 0,
     }
 
-    let signal = strategy.decide({
+    // #momentum: momentum ロールの symbol は BreakoutMomentumStrategy で判定。
+    // signal の形は同じで、以降の lot / risk / buying-power / pending / DRY_RUN
+    // execution は通常 BUY/SELL と全く同じ経路を通る (= 通常ロールと同じ動き)。
+    const useMomentum = !!(options.momentumStrategy && options.momentumSymbols?.has(upper))
+    const decider = useMomentum ? options.momentumStrategy! : strategy
+    let signal = decider.decide({
       symbol: upper,
       indicators,
       position: state.position,

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -46,9 +46,12 @@ import {
 import { detectAndNotifyVixRegimeChange } from '../../infrastructure/notification/vixRegimeChange'
 import { resolveTradingEnabled } from '../runtime/killSwitch'
 import { runPullbackScheduler, type PullbackDecisionTrace, type PullbackRunSummary } from './pullbackScheduler'
+import { BreakoutMomentumStrategy, TEST_DEFAULT_MOMENTUM_RULE } from './strategies/BreakoutMomentumStrategy'
 import {
   buildEntrySuppressedSymbols,
   buildHalfEntrySymbols,
+  buildMomentumRules,
+  buildMomentumSymbols,
   buildSymbolRules,
 } from './symbolRuleResolution'
 import { createTickerDenyGuard } from '../risk/tickerDenyGuard'
@@ -276,6 +279,13 @@ export async function runStrategyCron(
   // 段階判定 HALF (#452 PR 2): entry 有効 role を明示した銘柄のみ 0.5x entry を
   // 許可する。role NULL の既存銘柄は従来の二値挙動のまま。
   const halfEntrySymbols = buildHalfEntrySymbols(universe.symbolRole)
+  // #momentum: role === 'momentum' の銘柄は BreakoutMomentumStrategy で判定する。
+  // signal は以降の Risk→Execution を通常 BUY/SELL と同じ経路で通る。
+  const momentumSymbols = buildMomentumSymbols(universe.symbolRole)
+  const momentumStrategy =
+    momentumSymbols.size > 0
+      ? new BreakoutMomentumStrategy(TEST_DEFAULT_MOMENTUM_RULE, buildMomentumRules(universe))
+      : undefined
   // ペアレジーム layer (#472)。mode='off' か対象ペアなしなら option ごと省略
   // (= scheduler 側は完全に従来挙動)。
   const pairRegimeOption =
@@ -640,6 +650,8 @@ export async function runStrategyCron(
       rulesMap,
       entrySuppressedSymbols,
       halfEntrySymbols,
+      momentumSymbols,
+      ...(momentumStrategy ? { momentumStrategy } : {}),
       ...(onTickerDeny ? { onTickerDeny } : {}),
       ...(pairRegimeOption ? { pairRegime: pairRegimeOption } : {}),
       riskPerTradePct: scaledRiskPerTradePct,
@@ -793,6 +805,8 @@ export async function runStrategyCron(
           buyingPower,
           defaultRule,
           rulesMap,
+          momentumSymbols,
+          ...(momentumStrategy ? { momentumStrategy } : {}),
           requestId: options.requestId,
           notifier,
           perSymbolRisk: {

--- a/src/trading/strategy/strategies/BreakoutMomentumStrategy.ts
+++ b/src/trading/strategy/strategies/BreakoutMomentumStrategy.ts
@@ -1,0 +1,191 @@
+import type { DecisionTraceStep, Signal } from '../../domain/Signal'
+import type { PendingOrderLock, PositionState } from '../../state/types'
+import type { PullbackIndicatorSnapshot } from '../indicators'
+
+/**
+ * ブレイクアウト/モメンタム entry 戦略 (#momentum)。
+ *
+ * **現状は backtest 専用の dormant 実装**。`runStrategyCron` の live dispatch には
+ * 一切繋がっておらず、`ENTRY_ENABLED_ROLES` にも載っていないので、本番で発注する
+ * 経路は存在しない (fail-closed)。エッジ検証 (`scripts/backtest-momentum.ts`) で
+ * 継続性・コスト後・押し目との相関を測る目的でのみ使う。
+ *
+ * 設計上の要点 (trading-strategist 設計 + red-team を反映):
+ * - **3x レバ ETF には使わない** (vol drag・騙し3倍で却下)。1x 銘柄向け。
+ * - **gate を自己矛盾させない**: 「新高値ブレイク」と「低ボラ要求」を同時に課さない
+ *   (両立する局面が無く永久に発火しないため)。ATR 上限 gate は entry から外し、
+ *   過熱 (SMA50 乖離) の上限だけで blowoff を弾く。
+ * - **ブレイク基準は当日を除く終値20日高値** (`breakoutHigh20`)。当日含む high を
+ *   流用すると自己参照で発火不能になる。
+ * - exit は押し目と同型 (TP / ATR連動 stop / time-stop) だが preset は別 (高値圏
+ *   entry なので stop 深め・保有短め)。
+ */
+export interface MomentumRule {
+  /** Stop-loss as a fraction of avgPrice (negative)。高値圏 entry なので押し目より深め推奨。 */
+  stopPct: number
+  /** Take-profit as a fraction of avgPrice (positive)。 */
+  takeProfitPct: number
+  /** Time stop in business days。モメンタムは短期 (走らなければ早く撤退)。 */
+  timeStopDays: number
+  /** ATR multiplier for vol-adaptive stop。stopDistance = max(kAtr*atr20, |entry*stopPct|)。 */
+  kAtr: number
+  /** トレンド成立に必要な 20日リターン下限 (正)。 */
+  minReturn: number
+  /** ブレイク確認のバッファ (正、例 0.005 = +0.5%)。高値ジャストのノイズ抜けを弾く。 */
+  breakoutBuffer: number
+  /** 過熱ガード (blowoff のみ切る上限、例 0.6)。低ボラ要求はしない (自己矛盾回避)。 */
+  maxSma50DeviationPct: number
+  /** `price > sma50` を要求するか。 */
+  requireAboveSma50: boolean
+}
+
+/** backtest / unit test 用のデフォルト (全数値 backtest 未検証の初期推定)。 */
+export const TEST_DEFAULT_MOMENTUM_RULE: MomentumRule = Object.freeze({
+  stopPct: -0.05,
+  takeProfitPct: 0.1,
+  timeStopDays: 7,
+  kAtr: 2.5,
+  minReturn: 0.04,
+  breakoutBuffer: 0.005,
+  maxSma50DeviationPct: 0.6,
+  requireAboveSma50: true,
+})
+
+export interface MomentumInput {
+  symbol: string
+  indicators: PullbackIndicatorSnapshot
+  position: PositionState | null
+  pendingOrder: PendingOrderLock | null
+  cooldownUntil: string | null
+  holdBusinessDays: number
+  now: Date
+}
+
+export class BreakoutMomentumStrategy {
+  readonly name = 'BreakoutMomentumStrategy'
+
+  constructor(
+    private readonly defaultRule: MomentumRule,
+    private readonly rules: Record<string, MomentumRule> = {},
+  ) {}
+
+  resolveRule(symbol: string): MomentumRule {
+    return this.rules[symbol.toUpperCase()] ?? this.defaultRule
+  }
+
+  decide(input: MomentumInput): Signal {
+    const rule = this.resolveRule(input.symbol)
+    const now = input.now
+    const trace: DecisionTraceStep[] = []
+
+    if (input.pendingOrder !== null) {
+      trace.push(step('guard.pending_order_absent', false, true, 'not_exists', false, 'pending order in flight'))
+      return hold(input, 'pending order in flight', trace)
+    }
+    if (input.cooldownUntil && new Date(input.cooldownUntil).getTime() > now.getTime()) {
+      trace.push(step('guard.cooldown_inactive', false, input.cooldownUntil, '<=', now.toISOString(), 'cooldown active'))
+      return hold(input, `cooldown active until ${input.cooldownUntil}`, trace)
+    }
+    if (input.position !== null) {
+      return exitDecision(input, input.position, rule, trace)
+    }
+    return entryDecision(input, rule, trace)
+  }
+}
+
+function entryDecision(input: MomentumInput, rule: MomentumRule, trace: DecisionTraceStep[]): Signal {
+  const ind = input.indicators
+
+  if (ind.return50d <= rule.minReturn) {
+    trace.push(step('entry.trend_20d_return', false, ind.return50d, '>', rule.minReturn))
+    return hold(input, `20d return ${ind.return50d.toFixed(4)} <= ${rule.minReturn} trend threshold`, trace)
+  }
+  trace.push(step('entry.trend_20d_return', true, ind.return50d, '>', rule.minReturn))
+
+  if (rule.requireAboveSma50 && ind.price <= ind.sma50) {
+    trace.push(step('entry.above_sma50', false, ind.price, '>', ind.sma50))
+    return hold(input, `price ${ind.price} <= sma50 ${ind.sma50}`, trace)
+  }
+  trace.push(step('entry.above_sma50', true, ind.price, '>', ind.sma50))
+
+  // 過熱 (blowoff) 上限のみ。低ボラ要求はしない (新高値ブレイクと両立しないため)。
+  const sma50Deviation = ind.sma50 > 0 ? (ind.price - ind.sma50) / ind.sma50 : 0
+  if (sma50Deviation > rule.maxSma50DeviationPct) {
+    trace.push(step('entry.not_blowoff', false, sma50Deviation, '<=', rule.maxSma50DeviationPct))
+    return hold(input, `sma50 deviation ${sma50Deviation.toFixed(4)} > ${rule.maxSma50DeviationPct} (blowoff)`, trace)
+  }
+  trace.push(step('entry.not_blowoff', true, sma50Deviation, '<=', rule.maxSma50DeviationPct))
+
+  if (!(ind.breakoutHigh20 > 0)) {
+    trace.push(step('entry.breakout_high_valid', false, ind.breakoutHigh20, '>', 0))
+    return hold(input, 'invalid breakoutHigh20', trace)
+  }
+  trace.push(step('entry.breakout_high_valid', true, ind.breakoutHigh20, '>', 0))
+
+  // 当日を除く20日終値高値を buffer 込みで終値ブレイク。
+  const breakoutLevel = ind.breakoutHigh20 * (1 + rule.breakoutBuffer)
+  if (ind.price < breakoutLevel) {
+    trace.push(step('entry.breakout', false, ind.price, '>=', breakoutLevel))
+    return hold(input, `price ${ind.price.toFixed(4)} < breakout level ${breakoutLevel.toFixed(4)}`, trace)
+  }
+  trace.push(step('entry.breakout', true, ind.price, '>=', breakoutLevel))
+  trace.push(step('entry.adopt_buy', true, ind.price, '>=', breakoutLevel))
+  return buy(input, `breakout: price ${ind.price.toFixed(4)} >= ${breakoutLevel.toFixed(4)} (20d high ${ind.breakoutHigh20.toFixed(4)}, 20d return ${ind.return50d.toFixed(4)})`, trace)
+}
+
+function exitDecision(
+  input: MomentumInput,
+  position: PositionState,
+  rule: MomentumRule,
+  trace: DecisionTraceStep[],
+): Signal {
+  const pnlPct = (input.indicators.price - position.avgPrice) / position.avgPrice
+
+  if (pnlPct >= rule.takeProfitPct) {
+    trace.push(step('exit.take_profit', true, pnlPct, '>=', rule.takeProfitPct))
+    return sell(input, position, `take-profit hit: pnl ${pnlPct.toFixed(4)} >= ${rule.takeProfitPct}`, trace)
+  }
+
+  const pctStopDistance = Math.abs(position.avgPrice * rule.stopPct)
+  const atrStopDistance =
+    Number.isFinite(input.indicators.atr20) && input.indicators.atr20 > 0 ? rule.kAtr * input.indicators.atr20 : 0
+  const stopDistance = Math.max(pctStopDistance, atrStopDistance)
+  const effectiveStopPct = position.avgPrice > 0 ? -stopDistance / position.avgPrice : rule.stopPct
+  if (pnlPct <= effectiveStopPct) {
+    trace.push(step('exit.stop_loss', true, pnlPct, '<=', effectiveStopPct))
+    return sell(input, position, `stop-loss hit: pnl ${pnlPct.toFixed(4)} <= ${effectiveStopPct.toFixed(4)}`, trace)
+  }
+
+  if (input.holdBusinessDays >= rule.timeStopDays) {
+    trace.push(step('exit.time_stop', true, input.holdBusinessDays, '>=', rule.timeStopDays))
+    return sell(input, position, `time-stop hit: held ${input.holdBusinessDays}d >= ${rule.timeStopDays}d`, trace)
+  }
+  return hold(input, `holding: pnl ${pnlPct.toFixed(4)} within (${rule.stopPct}, ${rule.takeProfitPct})`, trace)
+}
+
+function hold(input: MomentumInput, reason: string, trace: DecisionTraceStep[]): Signal {
+  return { action: 'HOLD', symbol: input.symbol, quantity: 0, price: input.indicators.price, reason, generatedAtIso: input.now.toISOString(), trace }
+}
+function buy(input: MomentumInput, reason: string, trace: DecisionTraceStep[]): Signal {
+  return { action: 'BUY', symbol: input.symbol, quantity: 0, price: input.indicators.price, reason, generatedAtIso: input.now.toISOString(), trace }
+}
+function sell(input: MomentumInput, position: PositionState, reason: string, trace: DecisionTraceStep[]): Signal {
+  return { action: 'SELL', symbol: input.symbol, quantity: position.qty, price: input.indicators.price, reason, generatedAtIso: input.now.toISOString(), trace }
+}
+function step(
+  label: string,
+  passed: boolean,
+  actual?: DecisionTraceStep['actual'],
+  operator?: DecisionTraceStep['operator'],
+  threshold?: DecisionTraceStep['threshold'],
+  message?: string,
+): DecisionTraceStep {
+  return {
+    label,
+    passed,
+    ...(actual !== undefined ? { actual } : {}),
+    ...(operator !== undefined ? { operator } : {}),
+    ...(threshold !== undefined ? { threshold } : {}),
+    ...(message !== undefined ? { message } : {}),
+  }
+}

--- a/src/trading/strategy/symbolRuleResolution.ts
+++ b/src/trading/strategy/symbolRuleResolution.ts
@@ -1,4 +1,8 @@
 import type { SymbolRole, SymbolRoleValue } from '../../infrastructure/db/symbolConfigRepo'
+import {
+  type MomentumRule,
+  TEST_DEFAULT_MOMENTUM_RULE,
+} from './strategies/BreakoutMomentumStrategy'
 import type { SymbolRule } from './strategies/PullbackUptrendStrategy'
 
 /**
@@ -101,6 +105,8 @@ const ENTRY_ENABLED_ROLES: ReadonlySet<SymbolRole> = new Set([
   'low_volatility',
   'sector_trend',
   'inverse_hedge',
+  // #momentum: entry 有効 (BreakoutMomentumStrategy で判定)。
+  'momentum',
 ])
 
 /**
@@ -113,9 +119,21 @@ export function buildHalfEntrySymbols(
 ): Set<string> {
   const enabled = new Set<string>()
   for (const [symbol, role] of Object.entries(symbolRole)) {
+    // #momentum: モメンタムは HALF 昇格 (degree-gate の near-threshold 許容) と
+    // 相性が悪い (ブレイク未達=もっと手前で 0.5x は逆効果) ので除外。
+    if (role === 'momentum') continue
     if (role !== 'unknown' && ENTRY_ENABLED_ROLES.has(role)) enabled.add(symbol)
   }
   return enabled
+}
+
+/** role === 'momentum' の symbol 集合 (#momentum)。scheduler の戦略分岐に使う。 */
+export function buildMomentumSymbols(symbolRole: Record<string, SymbolRoleValue>): Set<string> {
+  const set = new Set<string>()
+  for (const [symbol, role] of Object.entries(symbolRole)) {
+    if (role === 'momentum') set.add(symbol)
+  }
+  return set
 }
 
 /**
@@ -208,4 +226,32 @@ export function buildSymbolRules(
     }
   }
   return rulesMap
+}
+
+/**
+ * role === 'momentum' の symbol ごとに MomentumRule を組み立てる (#momentum)。
+ * `TEST_DEFAULT_MOMENTUM_RULE` を基準に、既存 override 列 (stop/tp/timeStop/kAtr/
+ * minReturn/maxSma50Dev/requireAboveSma50) を重ねる。breakoutBuffer に対応する
+ * override 列は無いので preset 値のまま。
+ */
+export function buildMomentumRules(
+  overrides: SymbolRuleOverrides,
+  base: MomentumRule = TEST_DEFAULT_MOMENTUM_RULE,
+): Record<string, MomentumRule> {
+  const rules: Record<string, MomentumRule> = {}
+  for (const [sym, role] of Object.entries(overrides.symbolRole)) {
+    if (role !== 'momentum') continue
+    rules[sym] = {
+      ...base,
+      stopPct: overrides.symbolStopPctOverride[sym] ?? base.stopPct,
+      takeProfitPct: overrides.symbolTakeProfitPctOverride[sym] ?? base.takeProfitPct,
+      timeStopDays: overrides.symbolTimeStopDaysOverride[sym] ?? base.timeStopDays,
+      kAtr: overrides.symbolKAtrOverride[sym] ?? base.kAtr,
+      minReturn: overrides.symbolMinReturn50dOverride[sym] ?? base.minReturn,
+      maxSma50DeviationPct:
+        overrides.symbolMaxSma50DeviationPctOverride[sym] ?? base.maxSma50DeviationPct,
+      requireAboveSma50: overrides.symbolRequireAboveSma50Override[sym] ?? base.requireAboveSma50,
+    }
+  }
+  return rules
 }

--- a/test/strategy/breakoutMomentumStrategy.test.ts
+++ b/test/strategy/breakoutMomentumStrategy.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import {
+  BreakoutMomentumStrategy,
+  TEST_DEFAULT_MOMENTUM_RULE,
+  type MomentumInput,
+  type MomentumRule,
+} from '../../src/trading/strategy/strategies/BreakoutMomentumStrategy'
+import type { PositionState } from '../../src/trading/state/types'
+
+const now = new Date('2026-04-20T14:30:00.000Z')
+
+/** breakoutHigh20=100, buffer 0.5% → breakout level = 100.5。price 101 で発火。 */
+function goodEntry(): MomentumInput {
+  return {
+    symbol: 'ICLN',
+    indicators: {
+      price: 101,
+      sma50: 95,
+      return50d: 0.06,
+      high20d: 101,
+      low20d: 88,
+      atr20: 1.5,
+      baselineAtr20: 1.5,
+      breakoutHigh20: 100,
+    },
+    position: null,
+    pendingOrder: null,
+    cooldownUntil: null,
+    holdBusinessDays: 0,
+    now,
+  }
+}
+
+function decideEntry(mut: (i: MomentumInput) => void, rule: MomentumRule = TEST_DEFAULT_MOMENTUM_RULE) {
+  const input = goodEntry()
+  mut(input)
+  return new BreakoutMomentumStrategy(rule).decide(input)
+}
+
+describe('BreakoutMomentumStrategy entry', () => {
+  it('終値が当日除く20日高値×(1+buffer) 以上で BUY', () => {
+    expect(decideEntry(() => {}).action).toBe('BUY')
+  })
+
+  it('ブレイク境界: level 未満は HOLD、ちょうど level は BUY', () => {
+    // level = 100 * 1.005 = 100.5
+    expect(decideEntry((i) => { i.indicators.price = 100.49 }).action).toBe('HOLD')
+    expect(decideEntry((i) => { i.indicators.price = 100.5 }).action).toBe('BUY')
+  })
+
+  it('トレンド未達 (return20d <= minReturn) は HOLD', () => {
+    expect(decideEntry((i) => { i.indicators.return50d = 0.03 }).action).toBe('HOLD')
+  })
+
+  it('price <= sma50 は HOLD', () => {
+    expect(decideEntry((i) => { i.indicators.sma50 = 102 }).action).toBe('HOLD')
+  })
+
+  it('blowoff (SMA50 乖離が上限超) は HOLD', () => {
+    // maxSma50DeviationPct=0.6。price 101 / sma50 60 → dev ~0.68 > 0.6。
+    expect(decideEntry((i) => { i.indicators.sma50 = 60 }).action).toBe('HOLD')
+  })
+
+  it('breakoutHigh20 が無効 (<=0) は HOLD', () => {
+    expect(decideEntry((i) => { i.indicators.breakoutHigh20 = 0 }).action).toBe('HOLD')
+  })
+
+  it('低ボラ要求は無い (ATR が高くても breakout は発火する = 自己矛盾回避)', () => {
+    expect(decideEntry((i) => { i.indicators.atr20 = 10; i.indicators.baselineAtr20 = 1 }).action).toBe('BUY')
+  })
+})
+
+describe('BreakoutMomentumStrategy exit', () => {
+  const pos: PositionState = { qty: 10, avgPrice: 100, openedAt: now.toISOString() }
+  function exitInput(price: number, holdDays: number): MomentumInput {
+    const i = goodEntry()
+    i.position = pos
+    i.holdBusinessDays = holdDays
+    i.indicators.price = price
+    return i
+  }
+  const strat = new BreakoutMomentumStrategy(TEST_DEFAULT_MOMENTUM_RULE)
+
+  it('TP (+10%) で SELL', () => {
+    expect(strat.decide(exitInput(110, 1)).action).toBe('SELL')
+  })
+  it('time-stop (7日) で SELL', () => {
+    expect(strat.decide(exitInput(101, 7)).action).toBe('SELL')
+  })
+  it('利確/損切/time 未達は HOLD', () => {
+    expect(strat.decide(exitInput(101, 2)).action).toBe('HOLD')
+  })
+})

--- a/test/trading/strategy/indicators.test.ts
+++ b/test/trading/strategy/indicators.test.ts
@@ -34,6 +34,18 @@ describe('computePullbackIndicators', () => {
     // low20d は変更なし (20 日窓のまま、dashboard 表示用)。
     // lows are close*0.99, last 20 closes are 140..159 → min = 140 * 0.99
     expect(r.low20d).toBeCloseTo(140 * 0.99, 4)
+    // #momentum: breakoutHigh20 = 当日を除く直近20日の終値高値。
+    // closes[-21..-1] = closes 139..158 → max = 158 (当日 159 は除外)。
+    expect(r.breakoutHigh20).toBe(158)
+  })
+
+  it('breakoutHigh20 は当日終値を含めない (自己参照防止)', () => {
+    // 単調増加なら当日が常に最高値。breakoutHigh20 は前日(=当日除く最高)になる。
+    const closes = Array.from({ length: 60 }, (_, i) => 100 + i)
+    const r = computePullbackIndicators(makeBars(closes))!
+    // 当日 close = 159。breakoutHigh20 は 158 (当日を除外) で、159 にはならない。
+    expect(r.breakoutHigh20).toBe(158)
+    expect(r.breakoutHigh20).toBeLessThan(r.price)
   })
 
   it('low20d picks the smallest low even when not the most recent bar', () => {

--- a/test/trading/strategy/pullbackScheduler.test.ts
+++ b/test/trading/strategy/pullbackScheduler.test.ts
@@ -100,6 +100,51 @@ function mockExecution(): Execution & { calls: unknown[] } {
   }
 }
 
+// 新高値ブレイク bars: 緩く上げて最後の bar で 20日終値高値を超える。
+// 押し目戦略は「新高値=押し目でない」で HOLD、モメンタムは BUY になる。
+function breakoutBars(): DailyBar[] {
+  const bars: DailyBar[] = []
+  for (let i = 0; i < 59; i += 1) bars.push(synth(i, 100 + i * 0.2)) // bar58 close = 111.6
+  bars.push(synth(59, 115)) // 新高値ジャンプ (breakoutHigh20=111.6、115 > 111.6*1.005)
+  return bars
+}
+
+describe('momentum routing (#momentum)', () => {
+  it('momentum symbol はブレイクで BUY、押し目戦略は同 bars で HOLD', async () => {
+    const { BreakoutMomentumStrategy, TEST_DEFAULT_MOMENTUM_RULE } = await import(
+      '../../../src/trading/strategy/strategies/BreakoutMomentumStrategy'
+    )
+    // 押し目 (momentum 未指定): 新高値なので HOLD = 発注なし。
+    const exPull = mockExecution()
+    const sumPull = await runPullbackScheduler({
+      symbols: ['ICLN'],
+      equity: 100_000,
+      barClient: mockBarClient(breakoutBars()),
+      positionStore: makeStore({}),
+      execution: exPull,
+      now: () => now,
+    })
+    expect(sumPull.buys).toBe(0)
+    expect(exPull.calls).toHaveLength(0)
+
+    // momentum 指定: 同 bars でブレイク BUY。signal は通常経路で execution まで到達。
+    const exMom = mockExecution()
+    const sumMom = await runPullbackScheduler({
+      symbols: ['ICLN'],
+      equity: 100_000,
+      barClient: mockBarClient(breakoutBars()),
+      positionStore: makeStore({}),
+      execution: exMom,
+      momentumSymbols: new Set(['ICLN']),
+      momentumStrategy: new BreakoutMomentumStrategy(TEST_DEFAULT_MOMENTUM_RULE),
+      now: () => now,
+    })
+    expect(sumMom.buys).toBe(1)
+    expect(exMom.calls).toHaveLength(1)
+    expect((exMom.calls[0] as { side: string }).side).toBe('BUY')
+  })
+})
+
 describe('runPullbackScheduler', () => {
   it('places a BUY when the Pullback entry conditions fire', async () => {
     const store = makeStore({})

--- a/test/trading/strategy/symbolRuleResolution.test.ts
+++ b/test/trading/strategy/symbolRuleResolution.test.ts
@@ -2,10 +2,13 @@ import { describe, expect, it } from 'vitest'
 import {
   buildEntrySuppressedSymbols,
   buildHalfEntrySymbols,
+  buildMomentumRules,
+  buildMomentumSymbols,
   buildSymbolRules,
   ROLE_RULE_PRESETS,
   type SymbolRuleOverrides,
 } from '../../../src/trading/strategy/symbolRuleResolution'
+import { TEST_DEFAULT_MOMENTUM_RULE } from '../../../src/trading/strategy/strategies/BreakoutMomentumStrategy'
 import { TEST_DEFAULT_RULE } from '../../../src/trading/strategy/strategies/PullbackUptrendStrategy'
 
 const emptyOverrides = (): SymbolRuleOverrides => ({
@@ -20,6 +23,41 @@ const emptyOverrides = (): SymbolRuleOverrides => ({
   symbolMaxAtrRatioOverride: {},
   symbolMaxSma50DeviationPctOverride: {},
   symbolRequireAboveSma50Override: {},
+})
+
+describe('momentum role (#momentum)', () => {
+  it('momentum は entry-enabled (suppress されない)', () => {
+    const ov = emptyOverrides()
+    ov.symbolRole = { ICLN: 'momentum', SGOV: 'cash_parking' }
+    const suppressed = buildEntrySuppressedSymbols(ov.symbolRole)
+    expect(suppressed.ICLN).toBeUndefined()
+    expect(suppressed.SGOV).toBeDefined() // cash_parking は従来どおり抑止
+  })
+
+  it('momentum は HALF 昇格から除外される', () => {
+    const half = buildHalfEntrySymbols({ ICLN: 'momentum', QQQ: 'core_trend' })
+    expect(half.has('ICLN')).toBe(false)
+    expect(half.has('QQQ')).toBe(true)
+  })
+
+  it('buildMomentumSymbols は role===momentum だけ拾う', () => {
+    const set = buildMomentumSymbols({ ICLN: 'momentum', SOXL: 'leveraged_trend', TAN: 'momentum' })
+    expect([...set].sort()).toEqual(['ICLN', 'TAN'])
+  })
+
+  it('buildMomentumRules は momentum symbol に override を重ねる', () => {
+    const ov = emptyOverrides()
+    ov.symbolRole = { ICLN: 'momentum', SOXL: 'leveraged_trend' }
+    ov.symbolStopPctOverride = { ICLN: -0.03 }
+    ov.symbolTimeStopDaysOverride = { ICLN: 4 }
+    const rules = buildMomentumRules(ov)
+    expect(Object.keys(rules)).toEqual(['ICLN']) // momentum のみ
+    expect(rules.ICLN!.stopPct).toBe(-0.03) // override 反映
+    expect(rules.ICLN!.timeStopDays).toBe(4)
+    // override 無い項目は preset 既定。
+    expect(rules.ICLN!.takeProfitPct).toBe(TEST_DEFAULT_MOMENTUM_RULE.takeProfitPct)
+    expect(rules.ICLN!.breakoutBuffer).toBe(TEST_DEFAULT_MOMENTUM_RULE.breakoutBuffer)
+  })
 })
 
 describe('buildSymbolRules (#452)', () => {


### PR DESCRIPTION
## 目的
モメンタム(ブレイクアウト)を **「登録時に警告を出すが、以降は通常ロールと同じく取引する」selectable な live ロール**として追加。あわせてエッジを実コードで再検証可能に。

## 入っているもの
**戦略**
- `BreakoutMomentumStrategy`: entry gate 非矛盾化(新高値ブレイク+トレンド+SMA50上+blowoff上限のみ。低ボラ要求なし)。exit は押し目同型・preset 別(stop -5%/TP +10%/保有~7日)。
- `breakoutHigh20` 指標(当日除く終値20日高値・自己参照防止)。

**live 配線(通常ロール化)**
- `SYMBOL_ROLES` / `ENTRY_ENABLED_ROLES` に `momentum` 追加(HALF 昇格からは除外)。
- `buildMomentumSymbols` / `buildMomentumRules`(既存 override 列を流用)。
- `pullbackScheduler`: momentum 銘柄は `BreakoutMomentumStrategy` で判定 → **signal は通常 BUY/SELL と同じ Risk→Execution**(lot / per-symbol risk / buying-power / pending / DRY_RUN)を通る。
- 既存安全弁(`TRADING_ENABLED`・active・max notional・deny)は不変。

**UI**
- モメンタムタブを**選択可(カード)+ ⚠ 警告バナー**(backtest 未検証 / 発注可テーマETFは成績不良 例 TAN -60%DD / 1x のみ・少額DRY_RUN推奨)。reversion は戦略未実装のため「使用不可」据え置き。

**backtest 基盤**
- `runBacktest` に strategy 注入点 + `scripts/backtest-momentum.ts`(再検証可)。結果: 広域/テック1x(SPY/QQQ/XLK)で補完エッジ実在(Sharpe0.4–0.8・押し目非発火時に発火)、ただし発注可のテーマETFはまちまち〜不良。

## 安全性
- momentum を選んでも、発注は既存トグル(`TRADING_ENABLED`/銘柄 active/DRY_RUN)次第。デフォルトは発注しない。
- routing テスト: 同じ新高値 bars で momentum は BUY を execution まで到達 / 押し目は HOLD。
- 全テスト 1548 passed / tsc clean / build OK / staging 反映済み。role 列は text なので migration 不要。

## 注意 (operator 向け)
- backtest 上、**発注可能な 1x(テーマ ETF)での momentum 成績は良くない**。広域/テック 1x で有効だが OpenAPI 発注不可。実運用は警告どおり慎重に。

Refs #452
