### PR TITLE
fix: edit symbol form layout (stray grid cells)

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -10511,10 +10511,13 @@ function symbolFormBody(args: SymbolFormArgs): string {
       : ''
   const symbolField =
     mode === 'edit'
-      ? `<input type="text" name="symbol" value="${esc(symbolValue)}" readonly style="padding:6px;background:#eee">
-         <span></span>
-         ${editAllowlistBadge}
-         <p class="muted" style="margin:0;font-size:11px">symbol は immutable です。変更したい場合は一度削除して再追加してください。</p>`
+      ? // 値セルは必ず 1 要素 (div) に包む。複数の裸要素を出すと 2 列グリッドが
+        // 1 セルずれて以降のラベル/値が全部崩れる (#layout)。
+        `<div>
+           <input type="text" name="symbol" value="${esc(symbolValue)}" readonly style="padding:6px;background:#eee">
+           ${editAllowlistBadge}
+           <p class="muted" style="margin:4px 0 0;font-size:11px">symbol は immutable です。変更したい場合は一度削除して再追加してください。</p>
+         </div>`
       : `<div>
            <div style="position:relative;display:inline-block">
              <input type="text" name="symbol" id="symbol-form-symbol" value="${esc(symbolValue)}" required maxlength="10" pattern="[A-Za-z0-9]{1,10}" placeholder="SOXL / 7974 / 1570" autocomplete="off" data-1p-ignore="true" data-lpignore="true" data-form-type="other" oninput="window.searchSymbolSuggest(this.value)" onfocus="window.searchSymbolSuggest(this.value)" onblur="setTimeout(window.hideSymbolSuggest, 200)" style="padding:6px;width:200px;text-transform:uppercase">

--- a/test/routes/dashboardSymbolsCrud.test.ts
+++ b/test/routes/dashboardSymbolsCrud.test.ts
@@ -1467,6 +1467,10 @@ describe('dashboard symbol_config role / entry override (#452)', () => {
     expect(body).toContain('name="role"')
     // select 廃止 → hidden input に現在の role が入る (#role-stats)
     expect(body).toMatch(/<input type="hidden" name="role" id="symbol-form-role" value="core_trend">/)
+    // #layout 回帰: 編集モードの「銘柄」値セルは 1 div に包む (裸の <span></span> を
+    // グリッドに直接出すと 2 列レイアウトが 1 セルずれて全崩れする)。
+    expect(body).not.toMatch(/readonly style="padding:6px;background:#eee">\s*<span><\/span>/)
+    expect(body).toContain('symbol は immutable です')
     // fraction → % 表示
     expect(body).toMatch(/name="pullback_max_override"[^>]*value="-1\.5"/)
     expect(body).toMatch(/name="min_return_50d_override"[^>]*value="3"/)


### PR DESCRIPTION
編集フォームのラベル/入力が1列ずれて全崩れする不具合を修正。

**原因**: 編集モードの「銘柄」値が `input` / 空 `span` / 取扱バッジ / immutable注記 の**裸4要素**を 150px+1fr の2列グリッドに直接出していた。#460 の取扱 allowlist バッジを足したことで要素数が偶数→奇数になり、以降の label/value 対が1セルずつズレた(ラベルが値の列に落ちる)。

**修正**: 編集モードの銘柄値を**1つの div に内包**し、各フィールド=label + 値1セルにする。

全テスト 1548 passed / staging 反映済み。回帰テスト追加。