### PR TITLE
判定トレース / 入場ゲートで「現在値 vs 閾値」を明示

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1669,7 +1669,9 @@ const STYLE = `
   .tl-step.tl-decisive{border-left-color:#06c;font-weight:600;box-shadow:0 0 0 1px #cfe0ff inset}
   .tl-mark{flex:0 0 auto}
   .tl-label{flex:1 1 auto;min-width:140px}
-  .tl-cmp{color:#555;font-variant-numeric:tabular-nums}
+  .tl-cmp{color:#222;font-variant-numeric:tabular-nums}
+  .tl-cmp b{color:#06c}
+  .tl-thresh{color:#9aa0a6}
   .tl-msg{color:#86868b;font-style:italic}
   .tl-pick{color:#06c;font-weight:700;font-size:11px}
   .tl-arrow{text-align:center;color:#86868b;line-height:1.1;margin:2px 0}
@@ -4478,15 +4480,47 @@ function renderDecisionLadder(
     if (typeof v === 'number') return String(Math.round(v * 10000) / 10000)
     return String(v)
   }
+  // 演算子 → 閾値の意味する向き (どちらが「現在値」でどちらが「基準」か明示)。
+  const opSymbol: Record<string, string> = {
+    '>': '>', '>=': '≥', '<': '<', '<=': '≤', '==': '=', '!=': '≠',
+    between: '∈', exists: '', not_exists: '',
+  }
+  const thresholdWord = (op?: string): string => {
+    switch (op) {
+      case '>':
+      case '>=':
+        return '必要' // threshold は下限 (これ以上ないと不成立)
+      case '<':
+      case '<=':
+        return '上限' // threshold は上限 (これを超えると不成立)
+      case '==':
+        return '期待'
+      case '!=':
+        return '不可'
+      case 'between':
+        return '範囲'
+      default:
+        return '基準'
+    }
+  }
   const lastIdx = steps.length - 1
   const rows = steps
     .map((s, i) => {
       const ok = s.passed === true
       const mark = ok ? '✅' : '❌'
       const label = esc(s.label_ja || s.label || '?')
+      // 「現在 <実測>(太字)/ <方向語> <記号> <閾値>(muted)」で、どちらが変数で
+      // どちらが基準値かを一目で分かるようにする (#trace-readability)。
+      const aStr = fmt(s.actual)
+      const tStr = fmt(s.threshold)
+      const sym = s.operator ? (opSymbol[s.operator] ?? s.operator) : ''
       const cmp =
         s.actual !== undefined || s.threshold !== undefined
-          ? `<span class="tl-cmp">${esc(fmt(s.actual))}${s.operator ? ' ' + esc(s.operator) + ' ' : ' '}${esc(fmt(s.threshold))}</span>`
+          ? `<span class="tl-cmp">${aStr !== '' ? `現在 <b>${esc(aStr)}</b>` : ''}${
+              tStr !== ''
+                ? `<span class="tl-thresh"> / ${esc(thresholdWord(s.operator))}${sym ? ' ' + esc(sym) : ''} ${esc(tStr)}</span>`
+                : ''
+            }</span>`
           : ''
       const msg = s.message ? `<span class="tl-msg">${esc(s.message)}</span>` : ''
       const decisive = i === lastIdx ? ' tl-decisive' : ''
@@ -8462,22 +8496,31 @@ function fmtPctSigned(v: number): string {
   return `${v >= 0 ? '+' : ''}${(v * 100).toFixed(1)}%`
 }
 
-/** 入場ゲートの「現在値 op 閾値」を人間可読に整形 (#entry-distance)。 */
+/**
+ * 入場ゲートを「現在 <実測> ／ <方向語> <記号> <閾値>」で整形 (#entry-distance /
+ * #trace-readability)。どちらが現在値 (変数) でどちらが基準 (設定) かを語で明示する。
+ * 方向語: 演算子が >/≥ なら閾値は「必要」(下限)、</≤ なら「上限」。
+ */
 function fmtGateValue(g: EntryGateStatus): string {
-  const op = ` ${g.operator} `
-  switch (g.key) {
-    case 'trend':
-    case 'overextension':
-    case 'pullback_shallow':
-    case 'pullback_deep':
-      return `${fmtPctSigned(g.actual)}${op}${fmtPctSigned(g.threshold)}`
-    case 'above_sma50':
-      return `$${g.actual.toFixed(2)}${op}$${g.threshold.toFixed(2)} (SMA50)`
-    case 'volatility':
-      return `${g.actual.toFixed(2)}×${op}${g.threshold.toFixed(2)}×`
-    case 'high20d_valid':
-      return `$${g.actual.toFixed(2)}${op}0`
-  }
+  const sym = ({ '>': '>', '>=': '≥', '<': '<', '<=': '≤' } as Record<string, string>)[g.operator] ?? g.operator
+  const word =
+    g.operator === '<' || g.operator === '<=' ? '上限' : g.operator === '>' || g.operator === '>=' ? '必要' : '基準'
+  const [a, t] = ((): [string, string] => {
+    switch (g.key) {
+      case 'trend':
+      case 'overextension':
+      case 'pullback_shallow':
+      case 'pullback_deep':
+        return [fmtPctSigned(g.actual), fmtPctSigned(g.threshold)]
+      case 'above_sma50':
+        return [`$${g.actual.toFixed(2)}`, `$${g.threshold.toFixed(2)} (SMA50)`]
+      case 'volatility':
+        return [`${g.actual.toFixed(2)}×`, `${g.threshold.toFixed(2)}×`]
+      case 'high20d_valid':
+        return [`$${g.actual.toFixed(2)}`, '0']
+    }
+  })()
+  return `現在 ${a} ／ ${word} ${sym} ${t}`
 }
 
 /**
@@ -8521,7 +8564,7 @@ export function renderBuyabilityPanel(
         : 'この指標が条件を満たすまでは、価格がどこでも入場しません。'
       : ''
     headline = g
-      ? `価格を動かすだけでは入場不可 — ボトルネック: <strong>${esc(g.labelJa)}</strong>（現在 ${esc(fmtGateValue(g))} 不成立）。${why}`
+      ? `価格を動かすだけでは入場不可 — ボトルネック: <strong>${esc(g.labelJa)}</strong>（${esc(fmtGateValue(g))} 不成立）。${why}`
       : '入場条件 評価不可'
     headColor = '#c22'
   }

--- a/src/trading/strategy/strategies/BreakoutMomentumStrategy.ts
+++ b/src/trading/strategy/strategies/BreakoutMomentumStrategy.ts
@@ -182,10 +182,31 @@ function step(
 ): DecisionTraceStep {
   return {
     label,
+    label_ja: labelJa(label),
     passed,
     ...(actual !== undefined ? { actual } : {}),
     ...(operator !== undefined ? { operator } : {}),
     ...(threshold !== undefined ? { threshold } : {}),
     ...(message !== undefined ? { message } : {}),
   }
+}
+
+function labelJa(label: string): string {
+  return TRACE_LABEL_JA[label] ?? label
+}
+
+// momentum 固有の trace 識別子 → 日本語ラベル。識別子 (`entry.breakout` 等) は
+// decision_log 互換のため英語据え置きで、表示文字列のみ日本語化する (#trace-readability)。
+const TRACE_LABEL_JA: Record<string, string> = {
+  'guard.pending_order_absent': '未約定注文がない',
+  'guard.cooldown_inactive': 'クールダウン中ではない',
+  'entry.trend_20d_return': '20日騰落率が上昇トレンド条件を満たす',
+  'entry.above_sma50': '株価が50日移動平均線を上回る',
+  'entry.not_blowoff': '移動平均からの上方乖離が過大でない (吹き上げでない)',
+  'entry.breakout_high_valid': '当日除く直近20日高値が有効',
+  'entry.breakout': '株価が直近20日高値をブレイク',
+  'entry.adopt_buy': '買い採用',
+  'exit.take_profit': '利確条件を満たす',
+  'exit.stop_loss': '損切り条件を満たす',
+  'exit.time_stop': '時間切れ手仕舞い条件を満たす',
 }


### PR DESCRIPTION
## 背景

判定や設定値の表示で、どちらが現在値 (live な変数) でどちらが比較対象の閾値 (設定) なのか語が無く、混同しやすかった (`+84.7% > +8.0%` のような並びだけでは向きが読み取れない)。

## 変更

判定トレースと入場ゲートの両方で、変数と基準を語で明示:

- **実測値** → `現在 <値>` (太字 / 強調)
- **閾値** → 方向語 + 比較記号 + 値。演算子から向きを導出:
  - `>` / `≥` → **必要** (下限、これ以上ないと不成立)
  - `<` / `≤` → **上限** (これを超えると不成立)
  - `==`→期待 / `!=`→不可 / `between`→範囲

例: `トレンド +84.7% > +8.0%` → `トレンド 現在 +84.7% ／ 必要 ≥ +8.0%`

### 対象

- `renderDecisionLadder` (server-rendered 判定トレースのラダー)
- `fmtGateValue` (チャートタブの入場ゲートチェックリスト / ボトルネック要約)

## テスト

- `pnpm typecheck` ✅
- dashboard tests 326 passed ✅