### PR TITLE
fix: ロールプレビューのグラフと説明文の重なりを解消

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -10809,12 +10809,17 @@ function symbolFormBody(args: SymbolFormArgs): string {
           function omark(b) { return b ? ' <span style="color:#d97706;font-weight:700" title="この銘柄の override">*</span>' : ''; }
           // 価格ラダー SVG。p = 実効パラメータ。big=true で軸ラベル付き。
           function ladder(role, p, w, h, big) {
-            function y(pct) { return 12 + (4 - pct) * ((h - 24) / 15); } // +4%..-11% 固定
             if (role === 'cash_parking') {
               return '<svg viewBox="0 0 ' + w + ' ' + h + '" width="' + w + '" height="' + h + '"><text x="' + (w / 2) + '" y="' + (h / 2) + '" font-size="' + (big ? 12 : 10) + '" fill="#5b8c5a" text-anchor="middle">entry なし</text></svg>';
             }
             var color = COLOR[role], ov = p.ov || {};
             var em = (p.pbMax + p.pbMin) / 2, tp = em + p.tp, st = em + p.stop;
+            // 縦軸は描画する全水準 (0% / TP / stop / 押し目バンド) に合わせて動的スケール。
+            // 固定レンジ (+4%..-11%) だと override で押し目や stop を広げた時に SVG 枠外へ
+            // はみ出し、下の入場ゲート文字に重なっていた (operator 指摘) ため。
+            var hi = Math.max(0, tp, p.pbMax) + 2, lo = Math.min(st, p.pbMin) - 2;
+            if (hi - lo < 6) { hi += 1; lo -= 1; }
+            function y(pct) { return 12 + (hi - pct) * ((h - 24) / (hi - lo)); }
             var X0 = 14, X1 = big ? w - 70 : w - 12, a = [];
             a.push('<line x1="' + X0 + '" y1="' + y(0).toFixed(1) + '" x2="' + X1 + '" y2="' + y(0).toFixed(1) + '" stroke="#c4c8cd" stroke-width="1"/>');
             var zy = y(p.pbMax), zh = y(p.pbMin) - y(p.pbMax);


### PR DESCRIPTION
## 背景

パラメータ (override) で押し目バンドや stop を広げると、ロールプレビューのグラフ (SVG) が枠外へはみ出し、下の入場ゲート説明文に重なっていた ([Image] operator 指摘)。

## 原因

`ladder()` の縦軸が `+4%..-11%` 固定。押し目 -24% / stop など固定レンジ外の値が `overflow:visible` の SVG 枠 (高さ 150px) を超えて描画され、直後の説明 div に被さっていた。

## 修正

縦軸を描画する全水準 (`0% / TP / stop / 押し目バンド`) に合わせて動的スケール化。常に枠内に収まり、説明文と分離する。

## テスト

`pnpm typecheck` ✅ / dashboard tests 326 passed ✅ / staging デプロイ済 (031995ea)