### PR TITLE
chore: production も Webull primary + Yahoo fallback に揃える

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -169,7 +169,12 @@
       "vars": {
         // #21: `WebullTradeClient` の trade gate を通すラベル。'production' のときだけ
         // placeOrder が実行可能。他の値 (staging / dev / 未設定) は強制 DRY_RUN。
-        "ENVIRONMENT": "production"
+        "ENVIRONMENT": "production",
+        // #475: staging canary 後に production へ昇格。Webull Market Data を
+        // primary、^VIX / JP / 障害時は Yahoo へ自動 fallback (FallbackBarClient /
+        // quoteScheduler)。quote と bars を揃える。
+        "QUOTE_SOURCE": "webull",
+        "BAR_SOURCE": "webull"
       },
       "routes": [
         { "pattern": "trading.chanu.co", "custom_domain": true }


### PR DESCRIPTION
## 変更

production の vars に `QUOTE_SOURCE=webull` / `BAR_SOURCE=webull` を追加。staging と同じ Webull primary + Yahoo fallback 構成にする。

- quote: US=Webull / JP・^VIX=Yahoo / Webull 障害時 Yahoo
- BAR: 同上
- 仕組みは既存 (`FallbackBarClient` / `quoteScheduler`)。env 2行のみ。

## デプロイ注意 (実マネー)

`pnpm deploy:production` は env だけでなく **(1) 未適用 D1 migration の適用** と **(2) main にマージ済みの全コード** (momentum 戦略 live 配線 / tradable allowlist #460 / 判定トレース UI 等) を本番へ出す。env 変更単体ではない点に注意。

> 補足: agent 環境の token は production D1 に未認可 (7403) のため、デプロイは operator が実行する必要あり。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 本番環境の設定を更新しました。環境設定と株価データ・チャートデータのソースを統一し、安定性を向上させています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->