### PR TITLE
fix: sizing/VIX qty=0 の decision を REJECT → HOLD に変更

### DIFF
--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -895,10 +895,10 @@ export async function runPullbackScheduler(
           lotSize: resolvedLotSize,
           entryPrice: indicators.price,
         })
-        summary.rejected.push({ symbol: upper, reason })
+        summary.holds += 1
         await emitDecision({
           symbol: upper,
-          decision: 'REJECT',
+          decision: 'HOLD',
           reason,
           price: indicators.price,
           indicatorsJson: JSON.stringify(indicators),
@@ -916,10 +916,10 @@ export async function runPullbackScheduler(
         scaledQuantity = lot > 1 ? Math.floor(rawScaled / lot) * lot : Math.floor(rawScaled)
         if (scaledQuantity <= 0) {
           const reason = `sizing rejected: half-entry qty rounded to 0 (raw ${sizing.quantity} × ${positionMultiplier}, lot=${lot})`
-          summary.rejected.push({ symbol: upper, reason })
+          summary.holds += 1
           await emitDecision({
             symbol: upper,
-            decision: 'REJECT',
+            decision: 'HOLD',
             reason,
             price: indicators.price,
             indicatorsJson: JSON.stringify(indicators),
@@ -938,13 +938,11 @@ export async function runPullbackScheduler(
       // SELL は VIX 関係なく通すため、ここで scaling しても OK (BUY 経路だけ)。
       if (options.vixDecision) {
         if (options.vixDecision.sizeScale === 0) {
-          // critical: BUY 全 reject。decision.reason をそのまま乗せて操作者に
-          // 「VIX で止めた」を明示する (localizeReason が日本語化)。
           const reason = `risk: ${options.vixDecision.reason}`
-          summary.rejected.push({ symbol: upper, reason })
+          summary.holds += 1
           await emitDecision({
             symbol: upper,
-            decision: 'REJECT',
+            decision: 'HOLD',
             reason,
             price: indicators.price,
             indicatorsJson: JSON.stringify(indicators),
@@ -967,10 +965,10 @@ export async function runPullbackScheduler(
             : Math.floor(rawScaled)
           if (scaledQuantity <= 0) {
             const reason = `risk: ${options.vixDecision.reason} (qty rounded to 0, lot=${lot})`
-            summary.rejected.push({ symbol: upper, reason })
+            summary.holds += 1
             await emitDecision({
               symbol: upper,
-              decision: 'REJECT',
+              decision: 'HOLD',
               reason,
               price: indicators.price,
               indicatorsJson: JSON.stringify(indicators),

--- a/test/trading/strategy/pullbackScheduler.test.ts
+++ b/test/trading/strategy/pullbackScheduler.test.ts
@@ -843,8 +843,8 @@ describe('runPullbackScheduler VIX regime filter (#196 3/3)', () => {
     })
     expect(summary.buys).toBe(0)
     expect(execution.calls).toHaveLength(0)
-    const reject = summary.decisions.find((d) => d.decision === 'REJECT')
-    expect(reject?.reason).toContain('risk: vix_critical')
+    const held = summary.decisions.find((d) => d.decision === 'HOLD' && (d.reason ?? '').includes('vix_critical'))
+    expect(held?.reason).toContain('risk: vix_critical')
     expect(summary.vix?.regime).toBe('critical')
   })
 
@@ -898,9 +898,9 @@ describe('runPullbackScheduler VIX regime filter (#196 3/3)', () => {
     })
     expect(summary.buys).toBe(0)
     expect(execution.calls).toHaveLength(0)
-    const reject = summary.decisions.find((d) => d.decision === 'REJECT')
-    expect(reject?.reason).toContain('vix_warning')
-    expect(reject?.reason).toContain('qty rounded to 0')
+    const held = summary.decisions.find((d) => d.decision === 'HOLD' && (d.reason ?? '').includes('vix_warning'))
+    expect(held?.reason).toContain('vix_warning')
+    expect(held?.reason).toContain('qty rounded to 0')
   })
 
   it('does not modify BUY in normal regime (sizeScale = 1)', async () => {
@@ -1001,11 +1001,11 @@ describe('runPullbackScheduler VIX regime filter (#196 3/3)', () => {
     const sellDecision = summary.decisions.find((d) => d.decision === 'SELL')
     expect(sellDecision).toBeDefined()
     expect(sellDecision?.order?.side).toBe('SELL')
-    // vix_critical 起因の REJECT が混ざっていないこと。
-    const vixReject = summary.decisions.find(
-      (d) => d.decision === 'REJECT' && (d.reason ?? '').includes('vix_critical'),
+    // vix_critical 起因の HOLD が混ざっていないこと (SELL 銘柄は VIX 無関係で通る)。
+    const vixHold = summary.decisions.find(
+      (d) => d.decision === 'HOLD' && (d.reason ?? '').includes('vix_critical'),
     )
-    expect(vixReject).toBeUndefined()
+    expect(vixHold).toBeUndefined()
   })
 })
 
@@ -1613,7 +1613,7 @@ describe('runPullbackScheduler per-symbol lot_size (#symbol-lot-size)', () => {
 
     expect(summary.buys).toBe(0)
     const aapl = summary.decisions.find((d) => d.symbol === 'AAPL')
-    expect(aapl?.decision).toBe('REJECT')
+    expect(aapl?.decision).toBe('HOLD')
     expect(aapl?.reason).toMatch(/lot-size-round/)
   })
 })
@@ -1638,7 +1638,7 @@ describe('runPullbackScheduler budget-alloc basis fail-closed (#417 buying-power
     expect(summary.buys).toBe(0)
     expect(execution.calls).toHaveLength(0)
     const aapl = summary.decisions.find((d) => d.symbol === 'AAPL')
-    expect(aapl?.decision).toBe('REJECT')
+    expect(aapl?.decision).toBe('HOLD')
   })
 
   it('places a BUY for a budget symbol once budgetBasisJpy is a real account total', async () => {


### PR DESCRIPTION
## Summary

- sizing qty=0 / half-entry 丸め→0 / VIX critical (sizeScale=0) / VIX warning+lot 丸め→0 の 4 経路で `decision: 'REJECT'` → `'HOLD'` に変更
- broker API に到達していない = 発注を試みていないので REJECT は意味的に不正確。HOLD (= 行動しない) が正しい
- reason / trace は据え置き。ダッシュボードの localizeReason は reason 文字列ベースなので影響なし

## Test plan

- [x] 全 1548 テスト pass (既存の REJECT 期待値 4 箇所を HOLD に更新)
- [x] tsc --noEmit pass
- [x] staging deploy 済 (次の cron cycle で HOLD 表示を確認可)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* 取引戦略の数量判定ロジックを改善しました。設定値や市場条件により購入数量がゼロになるケースにおいて、これまでの「拒否」判定から「保留」判定に変更されました。リスク管理に関連する複数の条件下での判定が該当します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->