### PR TITLE
fix: 口座区分を一般→特定に変更

### DIFF
--- a/src/infrastructure/webull/dto.ts
+++ b/src/infrastructure/webull/dto.ts
@@ -75,7 +75,7 @@ export interface WebullV2OrderEntry {
   side: 'BUY' | 'SELL'
   time_in_force: 'DAY'
   entrust_type: 'QTY'
-  account_tax_type: 'GENERAL'
+  account_tax_type: 'GENERAL' | 'SPECIFIC'
   /** v2 のみ。combo / multi-leg 未対応 POC では常に 'NORMAL'。 */
   combo_type?: 'NORMAL'
 }

--- a/src/infrastructure/webull/mapper.ts
+++ b/src/infrastructure/webull/mapper.ts
@@ -31,7 +31,7 @@ export function toWebullPlaceOrderRequest(
     side: intent.side,
     time_in_force: 'DAY' as const,
     entrust_type: 'QTY' as const,
-    account_tax_type: 'GENERAL' as const,
+    account_tax_type: 'SPECIFIC' as const,
   }
   if (schema === 'v2') {
     return {

--- a/src/infrastructure/webull/tradabilityCheck.ts
+++ b/src/infrastructure/webull/tradabilityCheck.ts
@@ -106,7 +106,7 @@ export function buildPreviewOrderVariants(
     quantity: '1',
     time_in_force: 'DAY',
     entrust_type: 'QTY',
-    account_tax_type: 'GENERAL',
+    account_tax_type: 'SPECIFIC',
   }
   return [
     {

--- a/test/infrastructure/webull/webullHttpClient.test.ts
+++ b/test/infrastructure/webull/webullHttpClient.test.ts
@@ -96,7 +96,7 @@ describe('WebullHttpClient', () => {
           side: 'BUY',
           time_in_force: 'DAY',
           entrust_type: 'QTY',
-          account_tax_type: 'GENERAL',
+          account_tax_type: 'SPECIFIC',
         },
       ],
     })


### PR DESCRIPTION
## Summary

- 発注 (mapper) と tradability check の `account_tax_type` を `GENERAL` → `SPECIFIC` に変更
- dto の型を `'GENERAL' | 'SPECIFIC'` に拡張
- 特定口座 (源泉徴収あり) で買付するのが正しい運用

## Test plan

- [x] 全 1548 テスト pass
- [x] tsc --noEmit pass
- [x] staging deploy 済

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * 注文の税務分類オプションを拡張し、より柔軟な対応が可能になりました
  * 注文プレビュー処理における税務分類ロジックを更新しました

* **Tests**
  * 税務分類関連のテストケースを更新しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->