### PR TITLE
fix: sizing 系の表示を買付余力不足/発注見送りに改善

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -3941,23 +3941,22 @@ export function localizeReason(en: string | null | undefined): string {
       `買い: 上昇トレンド中の押し目買い (下落率 ${fmtPct(p)}、騰落率 ${fmtPct(r)})`,
   )
 
-  // === Sizing 系 reject (発注スキップ) ===
-  // 「建玉可」= risk 予算で保有可能な建玉数 (信用取引等での "許容建玉" 用法)
+  // === Sizing 系 (買付余力不足で発注見送り) ===
   s = s.replace(
     /^sizing rejected: lot-size-round \(raw qty (\S+) < lot (\S+), stop (\S+), entry (\S+)\)$/,
-    '発注スキップ: 売買単位未満 (建玉可 $1 株 < 1単元 $2 株、損切り幅 $3/株、株価 $4)',
+    '買付余力不足: 売買単位未満 ($1 株 < 1単元 $2 株、株価 $4)',
   )
   s = s.replace(
     /^sizing rejected: insufficient-risk-budget \(budget (\S+)\)$/,
-    '発注スキップ: リスク予算枯渇 (残 $1)',
+    '買付余力不足: リスク予算残 $1',
   )
-  s = s.replace(/^sizing rejected: atr-floor$/, '発注スキップ: ボラティリティ低下 (ATR 下限割れ)')
-  s = s.replace(/^sizing rejected: symbol-cap$/, '発注スキップ: 銘柄別投資上限超過')
+  s = s.replace(/^sizing rejected: atr-floor$/, '発注見送り: ボラティリティ低下 (ATR 下限割れ)')
+  s = s.replace(/^sizing rejected: symbol-cap$/, '発注見送り: 銘柄別投資上限超過')
   s = s.replace(
     /^sizing rejected: invalid-stop \(stopDistance (\S+)\)$/,
-    '発注スキップ: 損切り幅が算出不能 ($1)',
+    '発注見送り: 損切り幅が算出不能 ($1)',
   )
-  s = s.replace(/^sizing rejected: zero qty$/, '発注スキップ: 発注株数が 0')
+  s = s.replace(/^sizing rejected: zero qty$/, '買付余力不足: 1株分の余力なし')
 
   // === Scheduler inline ===
   s = s.replace(/^SELL without position$/, '発注スキップ: 手仕舞い対象の建玉なし')

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -1617,7 +1617,7 @@ function labelJa(label: string): string {
 }
 
 const TRACE_LABEL_JA: Record<string, string> = {
-  'sizing.quantity_positive': '発注数量が1株/1単元以上ある',
+  'sizing.quantity_positive': '買付余力が1株/1単元以上ある',
   'sizing.lot_size_configured': '売買単位 (lot_size) が設定済み',
   'exit.intraday_close': 'intraday-only 引け前強制クローズ',
   'scheduler.price_valid': '株価が有効',

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -441,7 +441,7 @@ describe('dashboard', () => {
     const body = await res.text()
 
     expect(body).toContain('<details class="reason-details">')
-    expect(body).toContain('発注スキップ: 売買単位未満')
+    expect(body).toContain('買付余力不足: 売買単位未満')
     expect(body).toContain('計算上は 79 株まで建てられるが、必要な売買単位 100 株に届かないため発注しません。')
     expect(body).toContain('<strong>RUNID</strong>')
     expect(body).toContain('<code>req-1</code>')

--- a/test/routes/localizeReason.test.ts
+++ b/test/routes/localizeReason.test.ts
@@ -108,37 +108,37 @@ describe('localizeReason (日本株・信用取引の伝統的語彙)', () => {
   })
 
   describe('発注スキップ / 発注中', () => {
-    it('lot-size-round with diagnostics → 建玉可 / 1単元', () => {
+    it('lot-size-round with diagnostics', () => {
       expect(
         localizeReason(
           'sizing rejected: lot-size-round (raw qty 98 < lot 100, stop 203.00, entry 2876)',
         ),
       ).toBe(
-        '発注スキップ: 売買単位未満 (建玉可 98 株 < 1単元 100 株、損切り幅 203.00/株、株価 2876)',
+        '買付余力不足: 売買単位未満 (98 株 < 1単元 100 株、株価 2876)',
       )
     })
 
-    it('insufficient-risk-budget → リスク予算枯渇', () => {
+    it('insufficient-risk-budget', () => {
       expect(
         localizeReason('sizing rejected: insufficient-risk-budget (budget 0.00)'),
-      ).toBe('発注スキップ: リスク予算枯渇 (残 0.00)')
+      ).toBe('買付余力不足: リスク予算残 0.00')
     })
 
     it('invalid-stop', () => {
       expect(localizeReason('sizing rejected: invalid-stop (stopDistance 0)')).toBe(
-        '発注スキップ: 損切り幅が算出不能 (0)',
+        '発注見送り: 損切り幅が算出不能 (0)',
       )
     })
 
     it('atr-floor', () => {
       expect(localizeReason('sizing rejected: atr-floor')).toBe(
-        '発注スキップ: ボラティリティ低下 (ATR 下限割れ)',
+        '発注見送り: ボラティリティ低下 (ATR 下限割れ)',
       )
     })
 
     it('symbol-cap', () => {
       expect(localizeReason('sizing rejected: symbol-cap')).toBe(
-        '発注スキップ: 銘柄別投資上限超過',
+        '発注見送り: 銘柄別投資上限超過',
       )
     })
 


### PR DESCRIPTION
## Summary

- `localizeReason` の sizing 系表現を改善
  - `発注スキップ: 発注株数が 0` → `買付余力不足: 1株分の余力なし`
  - `発注スキップ: リスク予算枯渇` → `買付余力不足: リスク予算残 X`
  - `発注スキップ: 売買単位未満` → `買付余力不足: 売買単位未満`
  - `発注スキップ: ボラティリティ低下` → `発注見送り: ボラティリティ低下`
  - `発注スキップ: 銘柄別投資上限超過` → `発注見送り: 銘柄別投資上限超過`
- trace label_ja: `発注数量が1株/1単元以上ある` → `買付余力が1株/1単元以上ある`

## Test plan

- [x] 全 1548 テスト pass
- [x] staging deploy 済

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 注文判定時のエラーメッセージ表示を改善しました。各エラーパターンのラベル表記を「発注スキップ」から「買付余力不足」または「発注見送り」に整理し、ユーザーの判断がしやすくなるよう調整しました。

* **Tests**
  * 上記の表示改善に対応したテストケースを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->