### PR TITLE
feat: session window gate — 休場中の戦略 cron 評価スキップ

### DIFF
--- a/drizzle/0036_add_session_window_gate.sql
+++ b/drizzle/0036_add_session_window_gate.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `global_config` ADD `session_window_gate_enabled` integer DEFAULT false NOT NULL;

--- a/drizzle/meta/0036_snapshot.json
+++ b/drizzle/meta/0036_snapshot.json
@@ -1,0 +1,1589 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "d4e0629e-0c13-4962-97bd-84b87308bd76",
+  "prevId": "74145a77-6a44-45ae-ab8f-755a41abb7b7",
+  "tables": {
+    "config_audit_log": {
+      "name": "config_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before_json": {
+          "name": "before_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "after_json": {
+          "name": "after_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "config_audit_log_timestamp_id_idx": {
+          "name": "config_audit_log_timestamp_id_idx",
+          "columns": [
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "config_audit_log_actor_timestamp_id_idx": {
+          "name": "config_audit_log_actor_timestamp_id_idx",
+          "columns": [
+            "actor",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "config_audit_log_endpoint_timestamp_id_idx": {
+          "name": "config_audit_log_endpoint_timestamp_id_idx",
+          "columns": [
+            "endpoint",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "config_state_snapshot": {
+      "name": "config_state_snapshot",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "earnings_calendar": {
+      "name": "earnings_calendar",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "earnings_date": {
+          "name": "earnings_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "earnings_calendar_symbol_date_unique": {
+          "name": "earnings_calendar_symbol_date_unique",
+          "columns": [
+            "symbol",
+            "earnings_date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "global_config": {
+      "name": "global_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "trading_enabled": {
+          "name": "trading_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "market_hours_check": {
+          "name": "market_hours_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "session_window_gate_enabled": {
+          "name": "session_window_gate_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "max_order_notional": {
+          "name": "max_order_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "max_order_notional_usd": {
+          "name": "max_order_notional_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2000
+        },
+        "max_order_notional_jpy": {
+          "name": "max_order_notional_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100000
+        },
+        "total_capital_usd": {
+          "name": "total_capital_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_capital_jpy": {
+          "name": "total_capital_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_portfolio_exposure_pct": {
+          "name": "max_portfolio_exposure_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.6
+        },
+        "drawdown_kill_threshold": {
+          "name": "drawdown_kill_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.02
+        },
+        "stale_quote_ms": {
+          "name": "stale_quote_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 900000
+        },
+        "gap_reject_pct": {
+          "name": "gap_reject_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.03
+        },
+        "spread_limit_pct_us": {
+          "name": "spread_limit_pct_us",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.0025
+        },
+        "spread_limit_pct_jp": {
+          "name": "spread_limit_pct_jp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.006
+        },
+        "pullback_default_stop_pct": {
+          "name": "pullback_default_stop_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.04
+        },
+        "pullback_default_take_profit_pct": {
+          "name": "pullback_default_take_profit_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.07
+        },
+        "pullback_default_time_stop_days": {
+          "name": "pullback_default_time_stop_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "pullback_default_pullback_max": {
+          "name": "pullback_default_pullback_max",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.03
+        },
+        "pullback_default_pullback_min": {
+          "name": "pullback_default_pullback_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.06
+        },
+        "pullback_default_min_return_50d": {
+          "name": "pullback_default_min_return_50d",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.08
+        },
+        "pullback_default_require_above_sma50": {
+          "name": "pullback_default_require_above_sma50",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "pullback_default_k_atr": {
+          "name": "pullback_default_k_atr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "pullback_default_max_sma50_deviation_pct": {
+          "name": "pullback_default_max_sma50_deviation_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.6
+        },
+        "pullback_default_max_atr_ratio": {
+          "name": "pullback_default_max_atr_ratio",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1.5
+        },
+        "risk_base_per_trade_pct": {
+          "name": "risk_base_per_trade_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.004
+        },
+        "risk_dd_half_threshold": {
+          "name": "risk_dd_half_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.05
+        },
+        "risk_dd_halt_threshold": {
+          "name": "risk_dd_halt_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.1
+        },
+        "vix_warning_threshold": {
+          "name": "vix_warning_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 25
+        },
+        "vix_critical_threshold": {
+          "name": "vix_critical_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "vix_warning_size_scale": {
+          "name": "vix_warning_size_scale",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.5
+        },
+        "pair_regime_mode": {
+          "name": "pair_regime_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'off'"
+        },
+        "pair_regime_theta_bull_enter": {
+          "name": "pair_regime_theta_bull_enter",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.03
+        },
+        "pair_regime_theta_bull_exit": {
+          "name": "pair_regime_theta_bull_exit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.01
+        },
+        "pair_regime_theta_bear_enter": {
+          "name": "pair_regime_theta_bear_enter",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.04
+        },
+        "pair_regime_theta_bear_exit": {
+          "name": "pair_regime_theta_bear_exit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.015
+        },
+        "overview_panels": {
+          "name": "overview_panels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'kpi,equity,composition,recent'"
+        },
+        "cash_fallback_orders_enabled": {
+          "name": "cash_fallback_orders_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "global_config_max_order_notional_range": {
+          "name": "global_config_max_order_notional_range",
+          "value": "\"global_config\".\"max_order_notional\" > 0 AND \"global_config\".\"max_order_notional\" <= 10000000"
+        },
+        "global_config_max_order_notional_usd_range": {
+          "name": "global_config_max_order_notional_usd_range",
+          "value": "\"global_config\".\"max_order_notional_usd\" > 0 AND \"global_config\".\"max_order_notional_usd\" <= 1000000"
+        },
+        "global_config_max_order_notional_jpy_range": {
+          "name": "global_config_max_order_notional_jpy_range",
+          "value": "\"global_config\".\"max_order_notional_jpy\" > 0 AND \"global_config\".\"max_order_notional_jpy\" <= 100000000"
+        },
+        "global_config_total_capital_usd_range": {
+          "name": "global_config_total_capital_usd_range",
+          "value": "\"global_config\".\"total_capital_usd\" IS NULL OR \"global_config\".\"total_capital_usd\" > 0"
+        },
+        "global_config_total_capital_jpy_range": {
+          "name": "global_config_total_capital_jpy_range",
+          "value": "\"global_config\".\"total_capital_jpy\" IS NULL OR \"global_config\".\"total_capital_jpy\" > 0"
+        },
+        "global_config_max_portfolio_exposure_pct_range": {
+          "name": "global_config_max_portfolio_exposure_pct_range",
+          "value": "\"global_config\".\"max_portfolio_exposure_pct\" > 0 AND \"global_config\".\"max_portfolio_exposure_pct\" <= 1"
+        },
+        "global_config_drawdown_kill_threshold_range": {
+          "name": "global_config_drawdown_kill_threshold_range",
+          "value": "\"global_config\".\"drawdown_kill_threshold\" >= -1 AND \"global_config\".\"drawdown_kill_threshold\" <= 0"
+        },
+        "global_config_stale_quote_ms_range": {
+          "name": "global_config_stale_quote_ms_range",
+          "value": "\"global_config\".\"stale_quote_ms\" >= 0"
+        },
+        "global_config_gap_reject_pct_range": {
+          "name": "global_config_gap_reject_pct_range",
+          "value": "\"global_config\".\"gap_reject_pct\" >= 0 AND \"global_config\".\"gap_reject_pct\" <= 1"
+        },
+        "global_config_spread_limit_pct_us_range": {
+          "name": "global_config_spread_limit_pct_us_range",
+          "value": "\"global_config\".\"spread_limit_pct_us\" >= 0 AND \"global_config\".\"spread_limit_pct_us\" <= 1"
+        },
+        "global_config_spread_limit_pct_jp_range": {
+          "name": "global_config_spread_limit_pct_jp_range",
+          "value": "\"global_config\".\"spread_limit_pct_jp\" >= 0 AND \"global_config\".\"spread_limit_pct_jp\" <= 1"
+        },
+        "global_config_pullback_default_stop_pct_range": {
+          "name": "global_config_pullback_default_stop_pct_range",
+          "value": "\"global_config\".\"pullback_default_stop_pct\" < 0 AND \"global_config\".\"pullback_default_stop_pct\" >= -1"
+        },
+        "global_config_pullback_default_take_profit_pct_range": {
+          "name": "global_config_pullback_default_take_profit_pct_range",
+          "value": "\"global_config\".\"pullback_default_take_profit_pct\" > 0 AND \"global_config\".\"pullback_default_take_profit_pct\" <= 1"
+        },
+        "global_config_pullback_default_time_stop_days_range": {
+          "name": "global_config_pullback_default_time_stop_days_range",
+          "value": "\"global_config\".\"pullback_default_time_stop_days\" > 0 AND \"global_config\".\"pullback_default_time_stop_days\" <= ?"
+        },
+        "global_config_pullback_default_pullback_max_range": {
+          "name": "global_config_pullback_default_pullback_max_range",
+          "value": "\"global_config\".\"pullback_default_pullback_max\" <= 0 AND \"global_config\".\"pullback_default_pullback_max\" >= -1"
+        },
+        "global_config_pullback_default_pullback_min_range": {
+          "name": "global_config_pullback_default_pullback_min_range",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= 0 AND \"global_config\".\"pullback_default_pullback_min\" >= -1"
+        },
+        "global_config_pullback_default_min_return_50d_range": {
+          "name": "global_config_pullback_default_min_return_50d_range",
+          "value": "\"global_config\".\"pullback_default_min_return_50d\" >= -1 AND \"global_config\".\"pullback_default_min_return_50d\" <= 10"
+        },
+        "global_config_pullback_default_k_atr_range": {
+          "name": "global_config_pullback_default_k_atr_range",
+          "value": "\"global_config\".\"pullback_default_k_atr\" > 0 AND \"global_config\".\"pullback_default_k_atr\" <= 10"
+        },
+        "global_config_pullback_default_pullback_window_order": {
+          "name": "global_config_pullback_default_pullback_window_order",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= \"global_config\".\"pullback_default_pullback_max\""
+        },
+        "global_config_risk_base_per_trade_pct_range": {
+          "name": "global_config_risk_base_per_trade_pct_range",
+          "value": "\"global_config\".\"risk_base_per_trade_pct\" > 0 AND \"global_config\".\"risk_base_per_trade_pct\" <= 1"
+        },
+        "global_config_risk_dd_half_threshold_range": {
+          "name": "global_config_risk_dd_half_threshold_range",
+          "value": "\"global_config\".\"risk_dd_half_threshold\" < 0 AND \"global_config\".\"risk_dd_half_threshold\" >= -1"
+        },
+        "global_config_risk_dd_halt_threshold_range": {
+          "name": "global_config_risk_dd_halt_threshold_range",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" < 0 AND \"global_config\".\"risk_dd_halt_threshold\" >= -1"
+        },
+        "global_config_risk_dd_threshold_order": {
+          "name": "global_config_risk_dd_threshold_order",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" <= \"global_config\".\"risk_dd_half_threshold\""
+        },
+        "global_config_vix_warning_threshold_range": {
+          "name": "global_config_vix_warning_threshold_range",
+          "value": "\"global_config\".\"vix_warning_threshold\" > 0 AND \"global_config\".\"vix_warning_threshold\" <= 200"
+        },
+        "global_config_vix_critical_threshold_range": {
+          "name": "global_config_vix_critical_threshold_range",
+          "value": "\"global_config\".\"vix_critical_threshold\" > 0 AND \"global_config\".\"vix_critical_threshold\" <= 200"
+        },
+        "global_config_vix_threshold_order": {
+          "name": "global_config_vix_threshold_order",
+          "value": "\"global_config\".\"vix_warning_threshold\" <= \"global_config\".\"vix_critical_threshold\""
+        },
+        "global_config_vix_warning_size_scale_range": {
+          "name": "global_config_vix_warning_size_scale_range",
+          "value": "\"global_config\".\"vix_warning_size_scale\" >= 0 AND \"global_config\".\"vix_warning_size_scale\" <= 1"
+        }
+      }
+    },
+    "inverse_pairs": {
+      "name": "inverse_pairs",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inverse": {
+          "name": "inverse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "regime_enabled": {
+          "name": "regime_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "regime_proxy_symbol": {
+          "name": "regime_proxy_symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "regime_bull_symbol": {
+          "name": "regime_bull_symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "macro_event_calendar": {
+      "name": "macro_event_calendar",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_time": {
+          "name": "event_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "macro_event_calendar_type_date_unique": {
+          "name": "macro_event_calendar_type_date_unique",
+          "columns": [
+            "event_type",
+            "event_date"
+          ],
+          "isUnique": true
+        },
+        "macro_event_calendar_date_idx": {
+          "name": "macro_event_calendar_date_idx",
+          "columns": [
+            "event_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_emit_log": {
+      "name": "notification_emit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cause": {
+          "name": "cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notification_emit_log_timestamp_id_idx": {
+          "name": "notification_emit_log_timestamp_id_idx",
+          "columns": [
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "notification_emit_log_severity_timestamp_id_idx": {
+          "name": "notification_emit_log_severity_timestamp_id_idx",
+          "columns": [
+            "severity",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "notification_emit_log_event_type_timestamp_id_idx": {
+          "name": "notification_emit_log_event_type_timestamp_id_idx",
+          "columns": [
+            "event_type",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "portfolio_equity_snapshot": {
+      "name": "portfolio_equity_snapshot",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "daily_start_equity_usd": {
+          "name": "daily_start_equity_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_start_equity_jpy": {
+          "name": "daily_start_equity_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_realized_pnl_usd": {
+          "name": "daily_realized_pnl_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_realized_pnl_jpy": {
+          "name": "daily_realized_pnl_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "drawdown_pct": {
+          "name": "drawdown_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "portfolio_equity_snapshot_at_idx": {
+          "name": "portfolio_equity_snapshot_at_idx",
+          "columns": [
+            "snapshot_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "strategy_decision_log": {
+      "name": "strategy_decision_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indicators_json": {
+          "name": "indicators_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trace_json": {
+          "name": "trace_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "strategy_decision_log_symbol_id_idx": {
+          "name": "strategy_decision_log_symbol_id_idx",
+          "columns": [
+            "symbol",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "strategy_decision_log_coid_idx": {
+          "name": "strategy_decision_log_coid_idx",
+          "columns": [
+            "client_order_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "symbol_config": {
+      "name": "symbol_config",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "market": {
+          "name": "market",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_notional": {
+          "name": "max_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_stop_days_override": {
+          "name": "time_stop_days_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "k_atr_override": {
+          "name": "k_atr_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "budget_alloc_pct": {
+          "name": "budget_alloc_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lot_size": {
+          "name": "lot_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stop_pct_override": {
+          "name": "stop_pct_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "take_profit_pct_override": {
+          "name": "take_profit_pct_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "intraday_only": {
+          "name": "intraday_only",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pullback_max_override": {
+          "name": "pullback_max_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pullback_min_override": {
+          "name": "pullback_min_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "min_return_50d_override": {
+          "name": "min_return_50d_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_atr_ratio_override": {
+          "name": "max_atr_ratio_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_sma50_deviation_pct_override": {
+          "name": "max_sma50_deviation_pct_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "require_above_sma50_override": {
+          "name": "require_above_sma50_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_required": {
+          "name": "entry_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "always_active": {
+          "name": "always_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cash_fallback_symbols": {
+          "name": "cash_fallback_symbols",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "symbol_config_currency_enum": {
+          "name": "symbol_config_currency_enum",
+          "value": "\"symbol_config\".\"currency\" IN ('USD', 'JPY')"
+        },
+        "symbol_config_time_stop_days_override_range": {
+          "name": "symbol_config_time_stop_days_override_range",
+          "value": "\"symbol_config\".\"time_stop_days_override\" IS NULL OR (\"symbol_config\".\"time_stop_days_override\" >= 1 AND \"symbol_config\".\"time_stop_days_override\" <= ?)"
+        },
+        "symbol_config_k_atr_override_range": {
+          "name": "symbol_config_k_atr_override_range",
+          "value": "\"symbol_config\".\"k_atr_override\" IS NULL OR (\"symbol_config\".\"k_atr_override\" >= 0.5 AND \"symbol_config\".\"k_atr_override\" <= 5.0)"
+        }
+      }
+    },
+    "tradable_instrument": {
+      "name": "tradable_instrument",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exchange_code": {
+          "name": "exchange_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currently_tradable": {
+          "name": "currently_tradable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tradable_instrument_currently_idx": {
+          "name": "tradable_instrument_currently_idx",
+          "columns": [
+            "currently_tradable"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trade_journal": {
+      "name": "trade_journal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trade_event_type": {
+          "name": "trade_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "strategy_name": {
+          "name": "strategy_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_action": {
+          "name": "signal_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_reason": {
+          "name": "signal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_allowed": {
+          "name": "risk_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_reasons": {
+          "name": "risk_reasons",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "limit_price": {
+          "name": "limit_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notional": {
+          "name": "notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "broker_status": {
+          "name": "broker_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "submitted": {
+          "name": "submitted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_qty": {
+          "name": "filled_qty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_price": {
+          "name": "filled_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "realized_pnl": {
+          "name": "realized_pnl",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hold_days": {
+          "name": "hold_days",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_reason": {
+          "name": "exit_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_applied_at": {
+          "name": "state_applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_error": {
+          "name": "state_apply_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_attempts": {
+          "name": "state_apply_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trading_toggle_history": {
+      "name": "trading_toggle_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before": {
+          "name": "before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "after": {
+          "name": "after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1781268003149,
       "tag": "0035_add_tradable_instruments",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "6",
+      "when": 1782209104396,
+      "tag": "0036_add_session_window_gate",
+      "breakpoints": true
     }
   ]
 }

--- a/src/infrastructure/db/globalConfigRepo.ts
+++ b/src/infrastructure/db/globalConfigRepo.ts
@@ -7,6 +7,11 @@ export interface GlobalConfigSnapshot {
   tradingEnabled: boolean
   marketHoursCheck: boolean
   /**
+   * #session-window-gate: true で開場 30 分前〜引けの窓外は戦略 cron を skip
+   * (市場ごと判定)。default false = 従来通り常時評価。
+   */
+  sessionWindowGateEnabled: boolean
+  /**
    * @deprecated Phase E で通貨別 `maxOrderNotionalUsd` / `maxOrderNotionalJpy`
    * に移行。互換目的でロード時も読み出しているが Risk gate は通貨別値を使う。
    */
@@ -77,6 +82,7 @@ export const GLOBAL_CONFIG_DEFAULTS: GlobalConfigSnapshot = Object.freeze({
   dryRun: true,
   tradingEnabled: false,
   marketHoursCheck: false,
+  sessionWindowGateEnabled: false,
   maxOrderNotional: 100,
   maxOrderNotionalUsd: 2000,
   maxOrderNotionalJpy: 100000,
@@ -340,6 +346,8 @@ export async function loadGlobalConfig(
             vixWarningThreshold: GLOBAL_CONFIG_DEFAULTS.vixWarningThreshold,
             vixCriticalThreshold: GLOBAL_CONFIG_DEFAULTS.vixCriticalThreshold,
             vixWarningSizeScale: GLOBAL_CONFIG_DEFAULTS.vixWarningSizeScale,
+            // 0036 追加列 (#session-window-gate)。legacy path は default (false = 常時評価)。
+            sessionWindowGateEnabled: GLOBAL_CONFIG_DEFAULTS.sessionWindowGateEnabled,
             // 0030 追加列 (#452)。legacy path は default (false = 自動発注しない)。
             cashFallbackOrdersEnabled: GLOBAL_CONFIG_DEFAULTS.cashFallbackOrdersEnabled,
             // 0031 追加列 (#472)。legacy path は default ('off' = gate 無効)。
@@ -405,6 +413,10 @@ export async function loadGlobalConfig(
       row.vixCriticalThreshold ?? GLOBAL_CONFIG_DEFAULTS.vixCriticalThreshold,
     vixWarningSizeScale:
       row.vixWarningSizeScale ?? GLOBAL_CONFIG_DEFAULTS.vixWarningSizeScale,
+    // 0036 で追加 (#session-window-gate)。古い D1 では undefined になり得るため
+    // default (false = 常時評価) へ畳む — 従来挙動側なので安全。
+    sessionWindowGateEnabled:
+      row.sessionWindowGateEnabled ?? GLOBAL_CONFIG_DEFAULTS.sessionWindowGateEnabled,
     // 0030 で追加 (#452)。古い D1 では undefined になり得るため default (false =
     // 自動発注しない) へ畳む — fail-closed 側なので安全。
     cashFallbackOrdersEnabled:

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -271,6 +271,14 @@ export const globalConfig = sqliteTable(
     dryRun: integer('dry_run', { mode: 'boolean' }).notNull().default(true),
     tradingEnabled: integer('trading_enabled', { mode: 'boolean' }).notNull().default(false),
     marketHoursCheck: integer('market_hours_check', { mode: 'boolean' }).notNull().default(false),
+    /**
+     * #session-window-gate: true で開場 (US 09:30 ET / JP 08:30 → 09:00 JST) の
+     * 30 分前〜引けの窓外は戦略 cron の評価そのものを skip。false (default) は
+     * 従来通り常時評価。
+     */
+    sessionWindowGateEnabled: integer('session_window_gate_enabled', { mode: 'boolean' })
+      .notNull()
+      .default(false),
     /** @deprecated Phase E で通貨別 cap に移行。互換のため残置、参照はしない。 */
     maxOrderNotional: real('max_order_notional').notNull().default(100),
     /** USD 銘柄 (currency='USD') の 1 注文上限。 */

--- a/src/infrastructure/notification/configStateChange.ts
+++ b/src/infrastructure/notification/configStateChange.ts
@@ -7,10 +7,11 @@ import type { Notifier, NotificationSeverity } from './Notifier'
  * `global_config` の重要 field の前回値を D1 `config_state_snapshot` に
  * 保存し、cron tick ごとに diff を取って STATE_CHANGE 通知する (#141)。
  *
- * 検知対象は **trading の安全性に直結する** 4 つに絞る:
+ * 検知対象は **trading の安全性に直結する** field に絞る:
  *   - `dry_run`            (true → false: 実発注 ON、危険)
  *   - `trading_enabled`    (false → true: 実発注 ON、危険)
  *   - `market_hours_check` (false → true: 取引時間外 reject、運用変更)
+ *   - `session_window_gate_enabled` (true → false: 開場前 fence が外れる)
  *   - `drawdown_kill_threshold` (絶対値が緩む方向は危険)
  *
  * 「実発注に近づく方向」の遷移は `severity: critical`、逆方向は `info`。
@@ -24,6 +25,7 @@ export interface WatchedConfig {
   dryRun: boolean
   tradingEnabled: boolean
   marketHoursCheck: boolean
+  sessionWindowGateEnabled: boolean
   drawdownKillThreshold: number
 }
 
@@ -31,6 +33,7 @@ export const WATCHED_KEYS: ReadonlyArray<keyof WatchedConfig> = [
   'dryRun',
   'tradingEnabled',
   'marketHoursCheck',
+  'sessionWindowGateEnabled',
   'drawdownKillThreshold',
 ]
 
@@ -117,6 +120,12 @@ export function classifySeverity(
     return 'warning'
   }
   if (field === 'marketHoursCheck') {
+    if (from === true && to === false) return 'critical'
+    if (from === false && to === true) return 'info'
+    return 'warning'
+  }
+  if (field === 'sessionWindowGateEnabled') {
+    // true → false: 開場前 fence が外れ 24h 常時評価に戻る = 緩む方向で critical
     if (from === true && to === false) return 'critical'
     if (from === false && to === true) return 'info'
     return 'warning'

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -3691,6 +3691,11 @@ const CONFIG_KEY_META: Record<string, ConfigKeyMeta> = {
     label: '場中チェック (bool)',
     detail: 'true で市場時間外の注文を防ぎます。false は 24 時間発注可 (sandbox 確認用)。',
   },
+  session_window_gate_enabled: {
+    label: '開場前ゲート (bool)',
+    detail:
+      'true で開場30分前〜引けの窓外は戦略判定を skip (US 09:00–16:00 ET / JP 08:30–15:30 JST、市場ごと)。cron は発火しますが評価しません。false は従来通り常時評価。',
+  },
   max_order_notional: {
     label: '1注文上限 (非推奨)',
     detail: '旧 generic 上限 (通貨別 cap 導入前の互換)。現在は参照されないので触らなくて OK。',

--- a/src/trading/domain/tradingCalendar.ts
+++ b/src/trading/domain/tradingCalendar.ts
@@ -198,3 +198,64 @@ export function isWithinUsCloseWindow(now: Date, minutesBeforeClose: number): bo
     etMinutes < US_REGULAR_CLOSE_ET_MINUTES
   )
 }
+
+/**
+ * 市場ごとのレギュラーセッション (開場 / 引け、市場ローカル分換算)。
+ * - US NYSE: 09:30–16:00 ET
+ * - JP TSE : 09:00–15:30 JST (引けは 2024-11-05 に 15:30 へ延長後の値)
+ *
+ * lunch break (JP 11:30–12:30) / early close (US 13:00 ET) は POC 未対応 —
+ * 窓内扱いで評価は走る (発注は marketHoursCheck / 板で自然に抑制される)。
+ */
+const MARKET_SESSION: Record<
+  TradingMarket,
+  { timeZone: string; openMinutes: number; closeMinutes: number }
+> = {
+  US: { timeZone: 'America/New_York', openMinutes: 9 * 60 + 30, closeMinutes: 16 * 60 },
+  JP: { timeZone: 'Asia/Tokyo', openMinutes: 9 * 60, closeMinutes: 15 * 60 + 30 },
+}
+
+/**
+ * `now` が **当該 market の取引日かつ「開場 `minutesBeforeOpen` 分前〜引け」**
+ * の窓内なら true (#session-window-gate)。戦略 cron を開場前まで停止するゲートに
+ * 使う (窓外は評価そのものを skip)。
+ *
+ * `isWithinUsCloseWindow` と異なり **開場側 (朝)** も判定するため、市場ローカルの
+ * 日付・曜日・時刻をすべて `Intl.DateTimeFormat(timeZone)` から 1 回で抽出する。
+ * 理由: JP 朝 (08:30 JST = 前日 23:30 UTC) は UTC 日付がズレるので、UTC 基準の
+ * `isTradingDay` では曜日・祝日判定を誤る。祝日は **市場ローカル日付**で
+ * `HOLIDAYS[market]` と照合する (2026/2027 を保持、範囲外は曜日判定のみに degrade)。
+ * DST は `Intl` が自動解決する。
+ */
+export function isWithinStrategyWindow(
+  now: Date,
+  market: TradingMarket,
+  minutesBeforeOpen: number,
+): boolean {
+  if (!Number.isFinite(minutesBeforeOpen) || minutesBeforeOpen < 0) return false
+  const session = MARKET_SESSION[market]
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: session.timeZone,
+    weekday: 'short',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).formatToParts(now)
+  const get = (type: Intl.DateTimeFormatPartTypes): string =>
+    parts.find((p) => p.type === type)?.value ?? ''
+  const weekday = get('weekday')
+  if (weekday === 'Sat' || weekday === 'Sun') return false
+  const ymd = `${get('year')}-${get('month')}-${get('day')}`
+  if (HOLIDAYS[market].has(ymd)) return false
+  const hour = Number(get('hour'))
+  const minute = Number(get('minute'))
+  if (!Number.isFinite(hour) || !Number.isFinite(minute)) return false
+  const localMinutes = (hour % 24) * 60 + minute // hour12:false で稀に '24' を返す Intl quirk 対策
+  return (
+    localMinutes >= session.openMinutes - minutesBeforeOpen &&
+    localMinutes < session.closeMinutes
+  )
+}

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -45,6 +45,7 @@ import {
 } from '../risk/vixRegimeFilter'
 import { detectAndNotifyVixRegimeChange } from '../../infrastructure/notification/vixRegimeChange'
 import { resolveTradingEnabled } from '../runtime/killSwitch'
+import { isWithinStrategyWindow } from '../domain/tradingCalendar'
 import { runPullbackScheduler, type PullbackDecisionTrace, type PullbackRunSummary } from './pullbackScheduler'
 import { BreakoutMomentumStrategy, TEST_DEFAULT_MOMENTUM_RULE } from './strategies/BreakoutMomentumStrategy'
 import {
@@ -79,6 +80,13 @@ const DEFAULT_EQUITY_JPY = 1_500_000
  */
 const SANITY_FAILED_COOLDOWN_MS = 30 * 60 * 1000
 
+/**
+ * #session-window-gate: 開場の何分前から戦略評価を再開するか (分)。
+ * `sessionWindowGateEnabled` が true の時のみ有効。窓 = [開場 - この値, 引け)。
+ * POC 段階では `INTRADAY_CLOSE_WINDOW_MIN` と同様 hard-code (config 化は別 PR)。
+ */
+const PRE_OPEN_WINDOW_MIN = 30
+
 export interface StrategyCronResult {
   summary: PullbackRunSummary
   symbols: string[]
@@ -90,6 +98,7 @@ export interface StrategyCronResult {
   skipReason?:
     | 'trading_disabled'
     | 'no_tradable_symbols'
+    | 'outside_session_window'
     | 'no_bridge_state'
     | 'portfolio_halted'
     | 'drawdown_kill'
@@ -222,6 +231,7 @@ export async function runStrategyCron(
     // 効いた瞬間も STATE_CHANGE 通知できる、#276)。
     tradingEnabled: effectiveTradingEnabled,
     marketHoursCheck: global.marketHoursCheck,
+    sessionWindowGateEnabled: global.sessionWindowGateEnabled,
     drawdownKillThreshold: global.drawdownKillThreshold,
   }
   await detectAndNotifyConfigStateChanges({
@@ -340,6 +350,30 @@ export async function runStrategyCron(
 
   if (universe.allowedSymbols.length === 0) {
     return { summary: emptySummary(), symbols: [], analysis: analysisBase(), skipReason: 'no_tradable_symbols' }
+  }
+
+  // セッションウィンドウ gate (#session-window-gate)。`sessionWindowGateEnabled`
+  // が true の時、開場 PRE_OPEN_WINDOW_MIN 分前〜引けの窓外は戦略評価そのものを
+  // skip する (cron は発火するが portfolio DO / VIX / 買付余力取得まで全て省く)。
+  // 市場ごとに判定し、窓内の currency だけを後段 run に進める (例: US だけ窓内なら
+  // USD run のみ)。flag off は従来挙動 (全 currency 常時評価)。skip は「設定通り」
+  // なので `trading_disabled` 同様 **通知しない** (noisy 回避)。
+  const sessionNow = new Date()
+  const activeCurrencies = new Set<SymbolCurrency>(
+    (['USD', 'JPY'] as const).filter(
+      (cur) =>
+        byCurrency[cur].length > 0 &&
+        (!global.sessionWindowGateEnabled ||
+          isWithinStrategyWindow(sessionNow, cur === 'JPY' ? 'JP' : 'US', PRE_OPEN_WINDOW_MIN)),
+    ),
+  )
+  if (global.sessionWindowGateEnabled && activeCurrencies.size === 0) {
+    return {
+      summary: emptySummary(),
+      symbols: universe.allowedSymbols,
+      analysis: analysisBase(),
+      skipReason: 'outside_session_window',
+    }
   }
 
   if (!env.SYMBOL_STATE) {
@@ -567,15 +601,17 @@ export async function runStrategyCron(
   // sub-run ごとに独立した summary が `vix` を持つので、aggregate もそれと
   // 揃えておく。`emptySummary()` は `vix` を埋めないので明示的に上書きする。
   const summary: PullbackRunSummary = { ...emptySummary(), vix: vixDecision }
+  // run は `activeCurrencies` (= 銘柄あり ∧ (gate off ∨ 窓内)) のみ構築する。
+  // gate off の時は両 currency が active なので従来挙動と一致する (#session-window-gate)。
   const runs: Array<{ currency: SymbolCurrency; equity: number; symbols: string[] }> = []
-  if (byCurrency.USD.length > 0) {
+  if (activeCurrencies.has('USD')) {
     runs.push({
       currency: 'USD',
       equity: sanitizeEquity(global.totalCapitalUsd, DEFAULT_EQUITY_USD),
       symbols: byCurrency.USD,
     })
   }
-  if (byCurrency.JPY.length > 0) {
+  if (activeCurrencies.has('JPY')) {
     runs.push({
       currency: 'JPY',
       equity: sanitizeEquity(global.totalCapitalJpy, DEFAULT_EQUITY_JPY),

--- a/test/helpers/configFixtures.ts
+++ b/test/helpers/configFixtures.ts
@@ -13,6 +13,7 @@ export function makeGlobalConfigSnapshot(
     dryRun: true,
     tradingEnabled: true,
     marketHoursCheck: false,
+    sessionWindowGateEnabled: false,
     maxOrderNotional: 100,
     maxOrderNotionalUsd: 100,
     maxOrderNotionalJpy: 100000,

--- a/test/infrastructure/db/globalConfigRepo.test.ts
+++ b/test/infrastructure/db/globalConfigRepo.test.ts
@@ -126,6 +126,11 @@ describe('loadGlobalConfig — pre-0015 fallback', () => {
     expect(result.vixCriticalThreshold).toBe(GLOBAL_CONFIG_DEFAULTS.vixCriticalThreshold)
     expect(result.vixWarningSizeScale).toBe(GLOBAL_CONFIG_DEFAULTS.vixWarningSizeScale)
 
+    // 0036 列 (session_window_gate_enabled) も legacy path では default (false) に畳む
+    expect(result.sessionWindowGateEnabled).toBe(
+      GLOBAL_CONFIG_DEFAULTS.sessionWindowGateEnabled,
+    )
+
     // pre_0015_fallback の 1 件だけ warn (legacy_load_failed は出ない)
     expect(warnSpy).toHaveBeenCalledTimes(1)
     const logged = JSON.parse(warnSpy.mock.calls[0]![0] as string)

--- a/test/infrastructure/notification/configStateChange.test.ts
+++ b/test/infrastructure/notification/configStateChange.test.ts
@@ -14,6 +14,7 @@ const baseCurrent: WatchedConfig = {
   dryRun: true,
   tradingEnabled: false,
   marketHoursCheck: false,
+  sessionWindowGateEnabled: false,
   drawdownKillThreshold: -0.02,
 }
 
@@ -29,6 +30,12 @@ describe('classifySeverity', () => {
   })
   it('trading_enabled true → false is info', () => {
     expect(classifySeverity('tradingEnabled', true, false)).toBe('info')
+  })
+  it('session_window_gate_enabled true → false (fence removed) is critical', () => {
+    expect(classifySeverity('sessionWindowGateEnabled', true, false)).toBe('critical')
+  })
+  it('session_window_gate_enabled false → true (fence added) is info', () => {
+    expect(classifySeverity('sessionWindowGateEnabled', false, true)).toBe('info')
   })
   it('drawdown_kill_threshold loosening (closer to 0) is critical', () => {
     expect(classifySeverity('drawdownKillThreshold', -0.05, -0.02)).toBe('critical')

--- a/test/trading/domain/tradingCalendar.test.ts
+++ b/test/trading/domain/tradingCalendar.test.ts
@@ -3,6 +3,7 @@ import {
   countTradingDaysBetween,
   inferTradingMarket,
   isTradingDay,
+  isWithinStrategyWindow,
   isWithinUsCloseWindow,
   nextTradingDay,
 } from '../../../src/trading/domain/tradingCalendar'
@@ -27,6 +28,60 @@ describe('isWithinUsCloseWindow (#intraday-only)', () => {
     expect(isWithinUsCloseWindow(new Date('2026-04-18T19:50:00.000Z'), 15)).toBe(false) // 土曜
     expect(isWithinUsCloseWindow(new Date('2026-01-01T20:50:00.000Z'), 15)).toBe(false) // 元日 (US 祝日)
     expect(isWithinUsCloseWindow(new Date('2026-04-20T19:50:00.000Z'), 0)).toBe(false) // window<=0
+  })
+})
+
+describe('isWithinStrategyWindow — US (#session-window-gate)', () => {
+  // 2026-04-20 は月曜、EDT (UTC-4) → 開場 09:30 ET = 13:30 UTC、引け 16:00 ET = 20:00 UTC。
+  // 窓 = [09:00 ET, 16:00 ET) (minutesBeforeOpen=30)。
+  it('開場30分前 (09:00 ET) は inclusive で true', () => {
+    expect(isWithinStrategyWindow(new Date('2026-04-20T13:00:00.000Z'), 'US', 30)).toBe(true) // 09:00 ET
+  })
+  it('窓の前 (08:59 ET) は false', () => {
+    expect(isWithinStrategyWindow(new Date('2026-04-20T12:59:00.000Z'), 'US', 30)).toBe(false) // 08:59 ET
+  })
+  it('日中 (12:00 ET) は true、引け (16:00 ET) は exclusive で false', () => {
+    expect(isWithinStrategyWindow(new Date('2026-04-20T16:00:00.000Z'), 'US', 30)).toBe(true) // 12:00 ET
+    expect(isWithinStrategyWindow(new Date('2026-04-20T19:59:00.000Z'), 'US', 30)).toBe(true) // 15:59 ET
+    expect(isWithinStrategyWindow(new Date('2026-04-20T20:00:00.000Z'), 'US', 30)).toBe(false) // 16:00 ET
+  })
+  it('DST-safe: 13:00 UTC は夏 (EDT) で 09:00 ET=true、冬 (EST) は 08:00 ET=false', () => {
+    expect(isWithinStrategyWindow(new Date('2026-04-20T13:00:00.000Z'), 'US', 30)).toBe(true) // EDT 09:00
+    expect(isWithinStrategyWindow(new Date('2026-01-05T13:00:00.000Z'), 'US', 30)).toBe(false) // EST 08:00
+    expect(isWithinStrategyWindow(new Date('2026-01-05T14:00:00.000Z'), 'US', 30)).toBe(true) // EST 09:00
+  })
+  it('週末 / 祝日 / 負の offset は false', () => {
+    expect(isWithinStrategyWindow(new Date('2026-04-18T16:00:00.000Z'), 'US', 30)).toBe(false) // 土曜
+    expect(isWithinStrategyWindow(new Date('2026-01-01T14:30:00.000Z'), 'US', 30)).toBe(false) // 元日
+    expect(isWithinStrategyWindow(new Date('2026-04-20T13:00:00.000Z'), 'US', -1)).toBe(false) // offset<0
+  })
+  it('minutesBeforeOpen=0 は開場 (09:30 ET) ちょうどから', () => {
+    expect(isWithinStrategyWindow(new Date('2026-04-20T13:00:00.000Z'), 'US', 0)).toBe(false) // 09:00 ET
+    expect(isWithinStrategyWindow(new Date('2026-04-20T13:30:00.000Z'), 'US', 0)).toBe(true) // 09:30 ET
+  })
+})
+
+describe('isWithinStrategyWindow — JP (#session-window-gate)', () => {
+  // JST = UTC+9 (DST なし)。開場 09:00 JST、引け 15:30 JST。窓 = [08:30 JST, 15:30 JST)。
+  it('回帰: 月曜 08:30 JST (=前日 23:30 UTC) で true (UTC 日付ズレを跨ぐ)', () => {
+    // 2026-04-20(月) 08:30 JST = 2026-04-19T23:30Z (UTC は日曜) でも JP 取引日として true。
+    expect(isWithinStrategyWindow(new Date('2026-04-19T23:30:00.000Z'), 'JP', 30)).toBe(true)
+  })
+  it('窓の前 (08:29 JST) は false', () => {
+    expect(isWithinStrategyWindow(new Date('2026-04-19T23:29:00.000Z'), 'JP', 30)).toBe(false)
+  })
+  it('引け前 (15:29 JST) true / 引け (15:30 JST) は exclusive で false', () => {
+    expect(isWithinStrategyWindow(new Date('2026-04-20T06:29:00.000Z'), 'JP', 30)).toBe(true) // 15:29 JST
+    expect(isWithinStrategyWindow(new Date('2026-04-20T06:30:00.000Z'), 'JP', 30)).toBe(false) // 15:30 JST
+  })
+  it('週末は false', () => {
+    expect(isWithinStrategyWindow(new Date('2026-04-18T03:00:00.000Z'), 'JP', 30)).toBe(false) // 土曜 12:00 JST
+  })
+  it('祝日は JST 日付で判定 (08:30 JST が前日 UTC でも休)', () => {
+    // 2026-05-04(月) みどりの日。10:00 JST = 同日 UTC。
+    expect(isWithinStrategyWindow(new Date('2026-05-04T01:00:00.000Z'), 'JP', 30)).toBe(false)
+    // 08:30 JST = 前日 (05-03) UTC でも、祝日判定は JST 日付 (05-04) を見るので false。
+    expect(isWithinStrategyWindow(new Date('2026-05-03T23:30:00.000Z'), 'JP', 30)).toBe(false)
   })
 })
 

--- a/test/trading/strategy/runStrategyCron.test.ts
+++ b/test/trading/strategy/runStrategyCron.test.ts
@@ -325,6 +325,83 @@ describe('runStrategyCron', () => {
     }
   })
 
+  // #session-window-gate: 開場30分前〜引けの窓外は戦略評価を skip する。
+  // 市場ごと判定 (USD→US / JPY→JP)。flag off は従来挙動。
+  describe('session window gate', () => {
+    // 2026-04-20(月) EDT。US 窓 [09:00,16:00 ET]、JP 窓 [08:30,15:30 JST]。
+    const T_US_IN = '2026-04-20T17:00:00.000Z' // US 13:00 ET (in) / JP 02:00 JST 火 (out)
+    const T_JP_IN = '2026-04-20T01:00:00.000Z' // JP 10:00 JST 月 (in) / US 21:00 ET 日 (out)
+    const T_US_OUT = '2026-04-20T06:00:00.000Z' // US 02:00 ET (out)
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    const jpyUniverse = () =>
+      makeSymbolUniverse({
+        allowedSymbols: ['7203'],
+        symbolCurrency: { '7203': 'JPY' },
+        symbolMarket: { '7203': 'JP' },
+        symbolLotSize: { '7203': 100 },
+      })
+
+    it('flag off では窓外でも outside_session_window で skip しない', async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date(T_US_OUT))
+      // default config は sessionWindowGateEnabled=false。窓外でも gate を通り、
+      // PORTFOLIO_STATE 未 bind で portfolio_halted まで進む (= gate で止まっていない)。
+      const result = await runStrategyCron(env)
+      expect(result.skipReason).not.toBe('outside_session_window')
+      expect(result.skipReason).toBe('portfolio_halted')
+    })
+
+    it('flag on + 全市場窓外 → outside_session_window で即 skip', async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date(T_US_OUT))
+      vi.mocked(loadGlobalConfigFrom).mockResolvedValue(
+        makeGlobalConfigSnapshot({ sessionWindowGateEnabled: true }),
+      )
+      const result = await runStrategyCron(env)
+      expect(result.skipReason).toBe('outside_session_window')
+      expect(result.summary.evaluated).toBe(0)
+    })
+
+    it('flag on + 窓内 → gate を通過して評価に進む', async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date(T_US_IN))
+      vi.mocked(loadGlobalConfigFrom).mockResolvedValue(
+        makeGlobalConfigSnapshot({ sessionWindowGateEnabled: true }),
+      )
+      const result = await runStrategyCron(env)
+      // gate 通過 → 後段 (PORTFOLIO_STATE 未 bind) で portfolio_halted。
+      expect(result.skipReason).not.toBe('outside_session_window')
+      expect(result.skipReason).toBe('portfolio_halted')
+    })
+
+    it('per-market: JPY 銘柄は US 窓内でも JP 窓外なら skip', async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date(T_US_IN)) // US in / JP out
+      vi.mocked(loadGlobalConfigFrom).mockResolvedValue(
+        makeGlobalConfigSnapshot({ sessionWindowGateEnabled: true }),
+      )
+      vi.mocked(loadSymbolUniverse).mockResolvedValue(jpyUniverse())
+      const result = await runStrategyCron(env)
+      expect(result.skipReason).toBe('outside_session_window')
+    })
+
+    it('per-market: JPY 銘柄は JP 窓内なら US 窓外でも評価に進む', async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date(T_JP_IN)) // JP in / US out
+      vi.mocked(loadGlobalConfigFrom).mockResolvedValue(
+        makeGlobalConfigSnapshot({ sessionWindowGateEnabled: true }),
+      )
+      vi.mocked(loadSymbolUniverse).mockResolvedValue(jpyUniverse())
+      const result = await runStrategyCron(env)
+      expect(result.skipReason).not.toBe('outside_session_window')
+      expect(result.skipReason).toBe('portfolio_halted')
+    })
+  })
+
 })
 
 describe('resolvePortfolioForRiskScale', () => {


### PR DESCRIPTION
## Summary

- `*/15` strategy cron を市場セッション外は **bar fetch / portfolio DO / VIX / buying power 取得の前** で short-circuit し、無駄な API コール・DO wake-up を抑止
- ウィンドウ: US 09:00–16:00 ET / JP 08:30–15:30 JST (開場 30 分前から)
- `global_config.session_window_gate_enabled` (default OFF) で制御。deploy だけでは挙動変化なし
- 昼休み・早引けは対象外 (既存の `marketHoursCheck` + spread guard で自然抑制)

## Changes

| Area | Files |
|---|---|
| Window helper | `src/trading/domain/tradingCalendar.ts` — `isWithinStrategyWindow()` |
| DB schema | `schema.ts` / `globalConfigRepo.ts` / migration `0036` |
| Cron gate | `runStrategyCron.ts` — `skipReason: 'outside_session_window'` |
| Notification | `configStateChange.ts` — ON→OFF = critical, OFF→ON = info |
| Dashboard | `dashboard.ts` — CONFIG_KEY_META に追加 |
| Tests | 12 window cases + 5 cron cases + config/notification |

## Test plan

- [x] `pnpm typecheck` pass
- [x] `pnpm test` pass (1566 tests)
- [ ] staging deploy → `session_window_gate_enabled = 1` → cron が休場中に `outside_session_window` で即 return することを確認
- [ ] 開場 30 分前〜閉場中は通常通り評価が走ることを確認