### PR TITLE
chore: replace PRODUCTION_RELEASE_TOKEN with GitHub App token

### DIFF
--- a/.github/workflows/production-release-pr.yml
+++ b/.github/workflows/production-release-pr.yml
@@ -24,22 +24,16 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Validate production release token
-        env:
-          PRODUCTION_RELEASE_TOKEN: ${{ secrets.PRODUCTION_RELEASE_TOKEN }}
-        run: |
-          if [ -z "$PRODUCTION_RELEASE_TOKEN" ]; then
-            {
-              echo "::error::PRODUCTION_RELEASE_TOKEN secret is required."
-              echo "Use a fine-grained PAT or GitHub App installation token that can push release/production and create/update production PRs."
-              echo "The default GITHUB_TOKEN must not be used here because workflow-triggered PRs do not reliably trigger the production preflight pull_request workflow."
-            } >&2
-            exit 1
-          fi
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Ensure production branch exists
         env:
-          PRODUCTION_RELEASE_TOKEN: ${{ secrets.PRODUCTION_RELEASE_TOKEN }}
+          PRODUCTION_RELEASE_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           remote="https://x-access-token:${PRODUCTION_RELEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           if ! git ls-remote --exit-code --heads "$remote" production >/dev/null; then
@@ -53,7 +47,7 @@ jobs:
 
       - name: Update release branch
         env:
-          PRODUCTION_RELEASE_TOKEN: ${{ secrets.PRODUCTION_RELEASE_TOKEN }}
+          PRODUCTION_RELEASE_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           remote="https://x-access-token:${PRODUCTION_RELEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           remote_release_sha="$(git ls-remote --heads "$remote" release/production | cut -f1)"
@@ -88,7 +82,7 @@ jobs:
       - name: Check production delta
         id: production_delta
         env:
-          PRODUCTION_RELEASE_TOKEN: ${{ secrets.PRODUCTION_RELEASE_TOKEN }}
+          PRODUCTION_RELEASE_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           remote="https://x-access-token:${PRODUCTION_RELEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git fetch --no-tags "$remote" production:refs/remotes/origin/production
@@ -105,7 +99,7 @@ jobs:
       - name: Create or update production PR
         if: steps.production_delta.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ secrets.PRODUCTION_RELEASE_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           release_prs="$(
             git log --reverse --pretty=format:%s origin/production..release/production \
@@ -162,7 +156,7 @@ jobs:
       - name: Auto-update release PR branch (skip manual "Update branch")
         if: steps.production_delta.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ secrets.PRODUCTION_RELEASE_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           pr_number="$(gh pr list \
             --base production \

--- a/.github/workflows/production-release-pr.yml
+++ b/.github/workflows/production-release-pr.yml
@@ -30,6 +30,8 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Ensure production branch exists
         env:

--- a/docs/production-cd.md
+++ b/docs/production-cd.md
@@ -42,9 +42,14 @@ pnpm install --frozen-lockfile && pnpm deploy:production
 
 `production` がすでに `main` と同じ commit を指している場合、release PR に差分がないため workflow は PR 作成を skip して success にする。初回 bootstrap 直後や、production が main に追いついている状態ではこれが期待値。
 
-この workflow は default `GITHUB_TOKEN` を使わず、repository secret `PRODUCTION_RELEASE_TOKEN` を必須にする。`GITHUB_TOKEN` で workflow から PR を作成/更新すると、その PR の `pull_request` workflow が自動実行されず approval 待ちになり得るため。
+この workflow は default `GITHUB_TOKEN` を使わず、GitHub App token を使う。`GITHUB_TOKEN` で workflow から PR を作成/更新すると、その PR の `pull_request` workflow が自動実行されず approval 待ちになり得るため。また、CODEOWNER が自分自身なので App bot を PR 作成者にすることで self-approve 制限を回避する。
 
-`PRODUCTION_RELEASE_TOKEN` は fine-grained PAT か GitHub App installation token を使う。必要権限:
+必要な repository secrets:
+
+- `APP_ID`: GitHub App の ID
+- `APP_PRIVATE_KEY`: GitHub App の秘密鍵 (`.pem` の内容)
+
+GitHub App 側に必要な repository permissions:
 
 - Contents: read/write (`release/production` branch push)
 - Pull requests: read/write (`production` 向け PR の create/edit)


### PR DESCRIPTION
## 概要

`PRODUCTION_RELEASE_TOKEN`（ochanuco の PAT）を GitHub App token に切り替え。

App が PR 作成者になることで、ochanuco が CODEOWNER として approve できるようになる。

## 変更点

- `Validate production release token` ステップを削除
- `actions/create-github-app-token@v1` で App token を生成するステップを追加
- 全ての `secrets.PRODUCTION_RELEASE_TOKEN` 参照を `steps.app-token.outputs.token` に差し替え

## 事後作業

PR merge 後に `PRODUCTION_RELEASE_TOKEN` secret を削除する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * リリースPR作成フローで使用する認証方法を見直し、GitHub App トークンへ統一しました。
  * PR の作成・更新や自動差分反映など、関連処理が同一の認証トークンを参照するようになりました。
  * 旧来のトークン必須チェックの整理を行いました。
* **Documentation**
  * workflow の認証・権限要件に関する説明を更新し、必要な設定（APP_ID / APP_PRIVATE_KEY）を明記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->