### PR TITLE
fix: add open_or_close to sell orders to prevent 417 CASH_ACCOUNT_NOT_ALLOW_SELL_SHORT

### DIFF
--- a/src/infrastructure/webull/dto.ts
+++ b/src/infrastructure/webull/dto.ts
@@ -74,8 +74,9 @@ export interface WebullV2OrderEntry {
   support_trading_session: string
   side: 'BUY' | 'SELL'
   /**
-   * ロングの開閉を明示する。未送信時に Webull JP が SELL を空売り開始とみなし
-   * キャッシュ口座で 417 CASH_ACCOUNT_NOT_ALLOW_SELL_SHORT を返した実績あり。
+   * ロングの開閉を明示する。v1 / v2 両スキーマで必須。
+   * 未送信時に Webull JP が SELL を空売り開始とみなし、キャッシュ口座で
+   * 417 CASH_ACCOUNT_NOT_ALLOW_SELL_SHORT を返した実績あり (v1 本番, 2026-06-25)。
    * BUY → 'OPEN'、SELL → 'CLOSE' を常に送る。
    */
   open_or_close: 'OPEN' | 'CLOSE'

--- a/src/infrastructure/webull/dto.ts
+++ b/src/infrastructure/webull/dto.ts
@@ -73,6 +73,12 @@ export interface WebullV2OrderEntry {
   /** v1: 'N'、v2: 'CORE' (新 enum)。 */
   support_trading_session: string
   side: 'BUY' | 'SELL'
+  /**
+   * ロングの開閉を明示する。未送信時に Webull JP が SELL を空売り開始とみなし
+   * キャッシュ口座で 417 CASH_ACCOUNT_NOT_ALLOW_SELL_SHORT を返した実績あり。
+   * BUY → 'OPEN'、SELL → 'CLOSE' を常に送る。
+   */
+  open_or_close: 'OPEN' | 'CLOSE'
   time_in_force: 'DAY'
   entrust_type: 'QTY'
   account_tax_type: 'GENERAL' | 'SPECIFIC'

--- a/src/infrastructure/webull/mapper.ts
+++ b/src/infrastructure/webull/mapper.ts
@@ -29,6 +29,7 @@ export function toWebullPlaceOrderRequest(
     order_type: 'MARKET' as const,
     quantity: String(intent.quantity),
     side: intent.side,
+    open_or_close: (intent.side === 'BUY' ? 'OPEN' : 'CLOSE') as 'OPEN' | 'CLOSE',
     time_in_force: 'DAY' as const,
     entrust_type: 'QTY' as const,
     account_tax_type: 'SPECIFIC' as const,

--- a/src/infrastructure/webull/mapper.ts
+++ b/src/infrastructure/webull/mapper.ts
@@ -29,6 +29,7 @@ export function toWebullPlaceOrderRequest(
     order_type: 'MARKET' as const,
     quantity: String(intent.quantity),
     side: intent.side,
+    // v1/v2 両スキーマで送る。未送信時に SELL が空売り開始と誤認されキャッシュ口座で 417。
     open_or_close: (intent.side === 'BUY' ? 'OPEN' : 'CLOSE') as 'OPEN' | 'CLOSE',
     time_in_force: 'DAY' as const,
     entrust_type: 'QTY' as const,

--- a/test/infrastructure/webull/mapper.test.ts
+++ b/test/infrastructure/webull/mapper.test.ts
@@ -14,6 +14,11 @@ const intent: OrderIntent = {
   clientOrderId: 'coid-test',
 }
 
+const sellIntent: OrderIntent = {
+  ...intent,
+  side: 'SELL',
+}
+
 // #251 / #256: Place Order body schema version の差分テスト。
 // v1 (default / 現挙動) と v2 (新 OpenAPI docs) の body shape を検証。
 describe('toWebullPlaceOrderRequest', () => {
@@ -31,6 +36,7 @@ describe('toWebullPlaceOrderRequest', () => {
       expect(order.support_trading_session).toBe('N')
       expect(order.combo_type).toBeUndefined()
       expect(order.side).toBe('BUY')
+      expect(order.open_or_close).toBe('OPEN')
       expect(order.quantity).toBe('4')
     })
 
@@ -40,6 +46,12 @@ describe('toWebullPlaceOrderRequest', () => {
       expect(body.new_orders[0].support_trading_session).toBe('N')
       expect(body.new_orders[0].limit_price).toBe('12.500')
       expect(body.new_orders[0].combo_type).toBeUndefined()
+    })
+
+    it('SELL intent sets open_or_close=CLOSE to prevent 417 CASH_ACCOUNT_NOT_ALLOW_SELL_SHORT', () => {
+      const body = toWebullPlaceOrderRequest(sellIntent, 'v1', 'acct-1')
+      expect(body.new_orders[0].side).toBe('SELL')
+      expect(body.new_orders[0].open_or_close).toBe('CLOSE')
     })
   })
 


### PR DESCRIPTION
## 問題

TQQQ 4株保有中（Webull 口座で確認済み）のストップロス SELL 発注が 417 で拒否された。

```
OAUTH_OPENAPI_CASH_ACCOUNT_NOT_ALLOW_SELL_SHORT
Cash accounts do not allow short selling.
```

## 原因

`mapper.ts` が `side: 'SELL'` のみ送っており `open_or_close` フィールドを未送信。
Webull JP は `open_or_close` が未指定の SELL を空売り開始とみなし、キャッシュ口座で拒否する。

## 変更

- `dto.ts`: `WebullV2OrderEntry` に `open_or_close: 'OPEN' | 'CLOSE'` を追加
- `mapper.ts`: `BUY → 'OPEN'`、`SELL → 'CLOSE'` を `baseEntry` に追加（v1/v2 共通）
- `mapper.test.ts`: SELL 時に `open_or_close='CLOSE'` が設定されることを確認するテストを追加

## 確認方法

この PR マージ → production deploy 後、次回ストップロス or 利確 SELL 発注が通れば確定。
フィールド名 `open_or_close` が Webull JP API で無視される場合は同 417 が継続するため、その場合はフィールド名を API docs で再確認する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 注文送信時に、買い注文は `OPEN`、売り注文は `CLOSE` が必ず送られるよう更新しました。
  * 売り注文の判定ずれによる誤送信リスクを低減しました。
* **Tests**
  * 買い・売り両ケースで `open_or_close` の送信値が期待どおりになることを検証するテストを追加・強化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->