### PR TITLE
fix: replace cherry-pick with merge --squash in release branch creation

### DIFF
--- a/.github/workflows/production-release-pr.yml
+++ b/.github/workflows/production-release-pr.yml
@@ -60,13 +60,18 @@ jobs:
           # Fetch production so we can build release/production on top of it.
           git fetch --no-tags "$remote" production:refs/remotes/origin/production
 
-          # Start from production tip and cherry-pick non-merge commits from main
-          # that are not yet reachable from production. This keeps release/production
-          # linear so the no-merge-commits ruleset on production is always satisfied.
+          # Squash all changes from main that are not yet on production into a single
+          # commit on top of production. This keeps release/production linear (no merge
+          # commits) even when individual commits conflict with production's context.
+          # Individual commit history is preserved on main; production gets one
+          # release commit per deploy.
           git checkout -B release/production origin/production
-          while IFS= read -r sha; do
-            git cherry-pick "$sha"
-          done < <(git log --reverse --no-merges --cherry-pick --pretty=tformat:"%H" origin/production..origin/main)
+          git merge --squash origin/main
+          if git diff --cached --quiet; then
+            echo "::notice::No changes between production and main; nothing to commit."
+          else
+            git commit -m "release: sync production to main"
+          fi
 
           push_with_retry() {
             attempt=1


### PR DESCRIPTION
## 問題

`production-release-pr.yml` の cherry-pick ループが `.github/workflows/production-release-pr.yml` でコンフリクトして release PR が作れなくなった。

production と main でワークフローファイルが別経路で変更されており、cherry-pick の context が一致しないことが原因。

## 変更

cherry-pick ループ → `git merge --squash origin/main` に置き換え。

- main と production の差分を単一コミットとして production 上に積む
- コンフリクトが発生しない（ツリー全体の diff を適用するため）
- `release/production` は常にマージコミットなしの線形履歴を保つ
- 個別コミット履歴は main に残る

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * リリース用ブランチの更新方法が変更され、main の変更をまとめて反映する形になりました。
  * 差分がない場合は不要なコミットを作成せず、その旨を通知するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->