### PR TITLE
fix: split decision REJECT into SKIP (internal gate) and REJECT (broker 4xx)

### DIFF
--- a/drizzle/0037_decision_skip_reject_taxonomy.sql
+++ b/drizzle/0037_decision_skip_reject_taxonomy.sql
@@ -1,0 +1,17 @@
+-- Decision 3値タクソノミ (data-only migration、schema 変更なし):
+--   SKIP   = bot 内部ゲートで見送り (broker 未到達) — 旧 REJECT の全ケース
+--   REJECT = broker が注文を確定拒否 (HTTP 4xx: 417 SELL_SHORT / TICKER_IS_DENY 等)
+--   ERROR  = それ以外の失敗 (5xx / ネットワーク断 / 想定外の例外)
+--
+-- 順序が重要: (1) を先に流さないと、(2) で作った新 REJECT 行が (1) に巻き込まれて
+-- SKIP に潰される。
+--
+-- (2) の reason パターンは WebullHttpClient が 4xx を即時 throw する唯一の message
+-- 形式 (`Webull request failed permanently with status 4xx: <body>`) に
+-- pullbackScheduler が `broker submit error: ` prefix を付けたもの。5xx / retry 尽き
+-- は `failed after N attempts ...`、ネットワーク断は `Webull order placement
+-- failed: ...` で、いずれもこの LIKE には一致しない (= ERROR のまま残る)。
+UPDATE strategy_decision_log SET decision = 'SKIP' WHERE decision = 'REJECT';--> statement-breakpoint
+UPDATE strategy_decision_log SET decision = 'REJECT'
+  WHERE decision = 'ERROR'
+    AND reason LIKE 'broker submit error: Webull request failed permanently with status 4%';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1782209104396,
       "tag": "0036_add_session_window_gate",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "6",
+      "when": 1783088190965,
+      "tag": "0037_decision_skip_reject_taxonomy",
+      "breakpoints": true
     }
   ]
 }

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -519,7 +519,7 @@ export type GlobalConfigInsert = typeof globalConfig.$inferInsert
 
 /**
  * Per-symbol decision log from `runPullbackScheduler`。1 row per
- * (cron fire × symbol)。HOLD / BUY / SELL / REJECT / ERROR 全ルートを残す。
+ * (cron fire × symbol)。HOLD / BUY / SELL / SKIP / REJECT / ERROR 全ルートを残す。
  * #128。運用で銘柄単位の診断 (なぜ BUY が出ないのか) に使う。
  * 7 日 TTL で quote feed cron が cleanup 同梱予定。
  */
@@ -530,16 +530,20 @@ export const strategyDecisionLog = sqliteTable(
     timestamp: text('timestamp').notNull(),
     requestId: text('request_id'),
     symbol: text('symbol').notNull(),
-    /** 'BUY' / 'SELL' / 'HOLD' / 'REJECT' / 'ERROR' */
+    /**
+     * 'BUY' / 'SELL' / 'HOLD' / 'SKIP' / 'REJECT' / 'ERROR'。
+     * SKIP = bot 内部ゲート見送り (broker 未到達) / REJECT = broker 4xx 確定拒否 /
+     * ERROR = 原因不明・一時的 (5xx / ネットワーク / 想定外の例外)。
+     */
     decision: text('decision').notNull(),
-    /** signal.reason (HOLD) / sizing.capReason (REJECT) / error.message (ERROR) */
+    /** signal.reason (HOLD) / sizing.capReason (SKIP) / error.message (REJECT/ERROR) */
     reason: text('reason'),
     price: real('price'),
     /** indicators snapshot JSON (debug 用、optional) */
     indicatorsJson: text('indicators_json'),
     /**
      * BUY/SELL 成立時の client_order_id。dashboard が trade_journal と JOIN
-     * して realized_pnl を引くためのキー (#143)。HOLD/REJECT/ERROR は null。
+     * して realized_pnl を引くためのキー (#143)。HOLD/SKIP/REJECT/ERROR は null。
      */
     clientOrderId: text('client_order_id'),
     /**

--- a/src/infrastructure/logger/strategyDecisionLog.ts
+++ b/src/infrastructure/logger/strategyDecisionLog.ts
@@ -1,4 +1,5 @@
 import type { DrizzleD1Database } from 'drizzle-orm/d1'
+import type { StrategyDecision } from '../../trading/domain/StrategyDecision'
 import { strategyDecisionLog } from '../db/schema'
 import { createDb } from '../db/tradeJournalRepo'
 
@@ -6,7 +7,7 @@ export interface StrategyDecisionRecord {
   timestamp: string
   requestId?: string
   symbol: string
-  decision: 'BUY' | 'SELL' | 'HOLD' | 'REJECT' | 'ERROR'
+  decision: StrategyDecision
   reason?: string | null
   price?: number | null
   indicatorsJson?: string | null

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1729,7 +1729,7 @@ const STYLE = `
   .tl-output{padding:6px 10px;border-radius:6px;background:#eef;border:1px solid #cfe0ff}
   .tl-output.tl-out-buy{background:#eafaf0;border-color:#a8e0bf}
   .tl-output.tl-out-sell{background:#fdeeee;border-color:#f0bcbc}
-  .tl-output.tl-out-reject,.tl-output.tl-out-error{background:#fdf2e8;border-color:#f0d2a8}
+  .tl-output.tl-out-skip,.tl-output.tl-out-reject,.tl-output.tl-out-error{background:#fdf2e8;border-color:#f0d2a8}
   .reason-panel code{white-space:pre-wrap;word-break:break-word}
   .reason-panel pre{margin:4px 0 0;white-space:pre-wrap;word-break:break-word;font-size:12px}
   .symbol-disabled{opacity:0.5;font-style:italic;text-decoration:line-through}
@@ -3867,11 +3867,12 @@ function fmtPct(s: string): string {
  * 判定ラベル (10 種):
  *   - 保有前の評価系 4 種: 様子見 / 買い / 発注中 / データ不足
  *   - 保有中の exit 系 4 種: 利食い / 損切り / 時間切れ / 保有継続
- *   - 発注拒否系 2 種: 発注スキップ (pre-submit) / 発注エラー (broker 拒否)
+ *   - 発注不成立系 2 種: 発注スキップ (pre-submit) / 発注失敗 (broker submit 失敗)
  *
  * `発注スキップ` は sizing / 同グループ建玉上限 / 売買単位未満などで
- * **注文送出前** に止めた場合。`発注エラー` は broker に送ったが拒否された
- * 場合 (broker submit error) — 原因が手元か相手方かを区別するため別ラベル。
+ * **注文送出前** に止めた場合 (decision=SKIP)。`発注失敗` は broker に送ったが
+ * 成立しなかった場合 (broker submit error) — 確定拒否 (REJECT) か一時的失敗
+ * (ERROR) かは decision 列が区別する。
  *
  * trading-strategist review に基づき、日本株・信用取引の伝統語 (押し目 /
  * 含み損益 / 建玉 / 単元 / 移動平均線割れ / 日柄 / 手仕舞い / 騰落率 / ロスカット
@@ -3979,7 +3980,7 @@ export function localizeReason(en: string | null | undefined): string {
   s = s.replace(/^invalid position qty: (\S+)$/, 'データ不足: 建玉数が無効 ($1)')
   s = s.replace(/^invalid expiresAt/, 'データ不足: 注文有効期限が無効')
   s = s.replace(/^bar fetch: /, 'データ不足: 日足取得失敗 — ')
-  s = s.replace(/^broker submit error: /, '発注エラー: 証券会社側で拒否 — ')
+  s = s.replace(/^broker submit error: /, '発注失敗: 証券会社への発注が成立せず — ')
 
   return s
 }
@@ -4460,9 +4461,9 @@ function renderDecisionTable(
           ? 'ok'
           : r.decision === 'SELL'
             ? 'warn'
-            : r.decision === 'ERROR'
+            : r.decision === 'ERROR' || r.decision === 'REJECT'
               ? 'err'
-              : r.decision === 'REJECT'
+              : r.decision === 'SKIP'
                 ? 'warn'
                 : 'muted'
       // 実 fill 結果 (trade_journal post_submit から JOIN、#143)
@@ -4823,13 +4824,13 @@ export function computeEquitySeries(
  * Decision breakdown chart 用の日次集計 (#158 Phase 2)。
  *
  * strategy_decision_log を JST 日次でグルーピングし、各 decision
- * (BUY/SELL/HOLD/REJECT/ERROR) のカウントを返す。トレーダーは
- * 「BUY/SELL が出すぎ・出なさすぎ」「REJECT が偏ってないか」を一目で
- * 見たいので、1 日 1 行 × 5 系列の stacked bar 用のデータ形にする。
+ * (BUY/SELL/HOLD/SKIP/REJECT/ERROR) のカウントを返す。トレーダーは
+ * 「BUY/SELL が出すぎ・出なさすぎ」「SKIP/REJECT が偏ってないか」を一目で
+ * 見たいので、1 日 1 行 × 6 系列の stacked bar 用のデータ形にする。
  *
  * 直近 90 日のみ (それ以上はチャートが詰まって読めない)。
  */
-const DECISION_KEYS = ['BUY', 'SELL', 'HOLD', 'REJECT', 'ERROR'] as const
+const DECISION_KEYS = ['BUY', 'SELL', 'HOLD', 'SKIP', 'REJECT', 'ERROR'] as const
 type DecisionKey = (typeof DECISION_KEYS)[number]
 
 export interface DecisionBreakdownPoint {
@@ -4859,7 +4860,7 @@ export function aggregateDecisionRows(
   for (const r of rows) {
     let bucket = map.get(r.day)
     if (!bucket) {
-      bucket = { BUY: 0, SELL: 0, HOLD: 0, REJECT: 0, ERROR: 0 }
+      bucket = { BUY: 0, SELL: 0, HOLD: 0, SKIP: 0, REJECT: 0, ERROR: 0 }
       map.set(r.day, bucket)
     }
     // 想定外 decision (将来追加など) は ERROR バケットに寄せて見落とし防止
@@ -5047,8 +5048,8 @@ export interface SymbolChartMarker {
  * eval 時刻 (`timestamp`) × eval 価格 (`price`) に色分けの点を打ち、点クリックで
  * `ladderHtml` (= 既存 `renderDecisionLadder` の出力) を脇のパネルに表示する。
  *
- * HOLD (保有継続 / 様子見の定常状態) は省き、判定が動いた BUY/SELL/REJECT/ERROR
- * のみを載せる。価格線・fill ピン・position/preview 線が HOLD 状態は既に表現済み。
+ * HOLD (保有継続 / 様子見の定常状態) は省き、判定が動いた BUY/SELL/SKIP/REJECT/
+ * ERROR のみを載せる。価格線・fill ピン・position/preview 線が HOLD 状態は既に表現済み。
  */
 export interface SymbolChartDecision {
   /** strategy_decision_log の行 id。点の一意キー兼デバッグ用。 */
@@ -5056,7 +5057,7 @@ export interface SymbolChartDecision {
   timestamp: string // ISO UTC (eval 時刻)
   /** eval 時の評価価格 (= strategy_decision_log.price)。y 位置に使う。 */
   price: number
-  decision: 'BUY' | 'SELL' | 'REJECT' | 'ERROR'
+  decision: 'BUY' | 'SELL' | 'SKIP' | 'REJECT' | 'ERROR'
   /** 生 reason (英語)。tooltip では localize して表示。 */
   reason: string | null
   /**
@@ -5109,12 +5110,12 @@ export function computeChartWindowDays(timeStopDays: number): number {
 /**
  * チャートに重ねる判定点の上限 (最新側から採用)。payload サイズ (各点が
  * 事前レンダリングのラダー HTML を持つ) と視認性のガード。HOLD を除いた
- * BUY/SELL/REJECT/ERROR のみが対象なので通常はこの上限に届かない。
+ * BUY/SELL/SKIP/REJECT/ERROR のみが対象なので通常はこの上限に届かない。
  */
 const MAX_CHART_DECISIONS = 250
 
 /** チャート判定点として描画する decision 種別 (HOLD は定常状態なので除外)。 */
-const CHART_PLOTTED_DECISIONS: ReadonlySet<string> = new Set(['BUY', 'SELL', 'REJECT', 'ERROR'])
+const CHART_PLOTTED_DECISIONS: ReadonlySet<string> = new Set(['BUY', 'SELL', 'SKIP', 'REJECT', 'ERROR'])
 
 export interface PivotPoint {
   /** ISO UTC timestamp of the daily bar */
@@ -5178,7 +5179,7 @@ export interface SymbolChartData {
   /** `latestCronPrice` の timestamp (ISO Z)。preview line の to-end 用。null 時 preview 描画スキップ。 */
   latestCronTimestamp: string | null
   /**
-   * チャートに重ねる cron 判定イベント (BUY/SELL/REJECT/ERROR、HOLD 除外)。
+   * チャートに重ねる cron 判定イベント (BUY/SELL/SKIP/REJECT/ERROR、HOLD 除外)。
    * 文字ログ↔グラフ同期用 (#decision-trace)。最新側 `MAX_CHART_DECISIONS` 件まで。
    * 追加 (additive) フィールドなので optional: 古い fixture / grid payload では
    * 省略され、レンダラ側は `|| []` で安全に扱う。
@@ -5274,7 +5275,7 @@ export async function loadSymbolChart(
         low20d: indicators.low20d,
       }
     })
-  // 判定点 (文字ログ↔グラフ同期 #decision-trace): HOLD を除く BUY/SELL/REJECT/
+  // 判定点 (文字ログ↔グラフ同期 #decision-trace): HOLD を除く BUY/SELL/SKIP/REJECT/
   // ERROR を eval 時刻 × eval 価格でチャートに重ねる。各点はクリック時に出す
   // ラダー HTML を server-side で事前レンダリング (renderDecisionLadder 流用)。
   // 最新側 MAX_CHART_DECISIONS 件に cap (各点が HTML を持つため payload ガード)。
@@ -6233,14 +6234,14 @@ function renderQualityTab(args: ChartsBodyQuality): string {
     document.addEventListener('DOMContentLoaded', function () {
       if (typeof echarts === 'undefined') return;
       var data = window.__chartData;
-      var DECISION_KEYS = ['BUY', 'SELL', 'HOLD', 'REJECT', 'ERROR'];
-      var DECISION_COLORS = { BUY: '#057a55', SELL: '#1471a8', HOLD: '#aaa', REJECT: '#b25000', ERROR: '#c22' };
+      var DECISION_KEYS = ['BUY', 'SELL', 'HOLD', 'SKIP', 'REJECT', 'ERROR'];
+      var DECISION_COLORS = { BUY: '#057a55', SELL: '#1471a8', HOLD: '#aaa', SKIP: '#b25000', REJECT: '#7c3aed', ERROR: '#c22' };
       var dbDates = data.decisions.map(function (p) { return p.date; });
       var dbEl = document.getElementById('decision-chart');
       if (dbEl && dbDates.length > 0) {
         var dbChart = echarts.init(dbEl);
         dbChart.setOption({
-          title: { text: '日次 Decision breakdown (BUY / SELL / HOLD / REJECT / ERROR)', left: 'center', textStyle: { fontSize: 14 } },
+          title: { text: '日次 Decision breakdown (BUY / SELL / HOLD / SKIP / REJECT / ERROR)', left: 'center', textStyle: { fontSize: 14 } },
           tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
           legend: { top: 22 },
           grid: { left: 50, right: 20, top: 60, bottom: 40 },
@@ -6655,13 +6656,13 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
       });
 
       // 判定点 (#decision-trace のグラフ同期): cron の判定イベント (HOLD を除く
-      // BUY/SELL/REJECT/ERROR) を eval 時刻 × eval 価格に色分けでプロットする。
+      // BUY/SELL/SKIP/REJECT/ERROR) を eval 時刻 × eval 価格に色分けでプロットする。
       // 点クリックで脇パネルに判定トレース・ラダー (server 事前レンダリング HTML)
       // を出し、文字ログとグラフを 1 画面で同期させる。category mode では eval
       // 時刻を最近接 ohlc index に snap (markPoint と同じ手法、xForTimestamp 流用)。
       // 色は取引品質タブの DECISION_COLORS と揃える。
-      var DECISION_COLORS = { BUY: '#057a55', SELL: '#1471a8', REJECT: '#b25000', ERROR: '#c22' };
-      var DECISION_LABEL_JA = { BUY: '買い', SELL: '売り', REJECT: '見送り', ERROR: 'エラー' };
+      var DECISION_COLORS = { BUY: '#057a55', SELL: '#1471a8', SKIP: '#b25000', REJECT: '#7c3aed', ERROR: '#c22' };
+      var DECISION_LABEL_JA = { BUY: '買い', SELL: '売り', SKIP: '見送り (bot判定)', REJECT: '拒否 (証券会社)', ERROR: 'エラー (原因不明・一時的)' };
       function escHtml(s) {
         return String(s == null ? '' : s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
       }
@@ -7205,7 +7206,8 @@ export function renderSymbolTab(args: ChartsBodySymbol): string {
           }] : []),
           // 判定点 scatter: cron 判定イベントを価格チャートに重ねる。z を最前面に
           // 寄せて (candle z:5 / 線 z:6-8 より上) クリック可能にする。REJECT/ERROR
-          // (= 弾かれた点) は少し大きくして「なぜ買えなかったか」を目立たせる。
+          // (= broker 拒否 / 失敗) は少し大きくして目立たせる。SKIP (bot 内部
+          // ゲート見送り) は定常運転に近いので通常サイズ。
           // tooltip は item trigger で decision + reason 要約 (詳細は click→ラダー)。
           ...(decisionPoints.length > 0 ? [{
             name: '判定', type: 'scatter', data: decisionPoints,
@@ -8805,7 +8807,7 @@ export function renderDecisionPlotCaption(chart: SymbolChartData | null): string
     ● は cron の判定イベント。点をクリックすると下に判定トレースが出ます (文字ログとグラフを同期)。HOLD (保有継続 / 様子見) は省略。${capped}
   </p>
   <div style="font-size:12px;margin:0 0 4px">
-    ${dot('#057a55', '買い (BUY)')}${dot('#1471a8', '売り (SELL)')}${dot('#b25000', '見送り (REJECT)')}${dot('#c22', 'エラー (ERROR)')}
+    ${dot('#057a55', '買い (BUY)')}${dot('#1471a8', '売り (SELL)')}${dot('#b25000', '見送り・bot判定 (SKIP)')}${dot('#7c3aed', '拒否・証券会社 (REJECT)')}${dot('#c22', 'エラー (ERROR)')}
   </div>`
 }
 

--- a/src/trading/domain/StrategyDecision.ts
+++ b/src/trading/domain/StrategyDecision.ts
@@ -1,0 +1,12 @@
+/**
+ * strategy_decision_log の decision 分類 (3値タクソノミ)。
+ *
+ * - `BUY` / `SELL` / `HOLD`: strategy 判定そのまま。
+ * - `SKIP`: bot 内部ゲートで見送り (**broker 未到達**)。risk gate / sizing 0株 /
+ *   スプレッド超過 / 買付余力プール / inverse-pair など、旧 `REJECT` の全ケース。
+ * - `REJECT`: broker が注文を**確定拒否** (HTTP 4xx: 417 SELL_SHORT /
+ *   Insufficient Buying Power / TICKER_IS_DENY 等)。
+ * - `ERROR`: それ以外の失敗 = 原因不明・一時的 (ネットワーク断 / 5xx /
+ *   想定外の例外)。
+ */
+export type StrategyDecision = 'BUY' | 'SELL' | 'HOLD' | 'SKIP' | 'REJECT' | 'ERROR'

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -2,8 +2,9 @@ import type { BarClient } from '../../infrastructure/quotes/BarClient'
 import { logPostSubmit, logPreSubmit } from '../../infrastructure/logger/tradeJournal'
 import { classifyBrokerErrorCause } from '../../infrastructure/notification/brokerErrorSurge'
 import type { Notifier } from '../../infrastructure/notification/Notifier'
-import { isSellQtyExceedError, isTickerDenyError } from '../../shared/errors'
+import { BrokerRequestError, isSellQtyExceedError, isTickerDenyError } from '../../shared/errors'
 import type { DecisionTraceStep } from '../domain/Signal'
+import type { StrategyDecision } from '../domain/StrategyDecision'
 import { inferTradingMarket, isWithinUsCloseWindow } from '../domain/tradingCalendar'
 import type { Execution } from '../execution/Execution'
 import type { PositionStore } from '../state/PositionStore'
@@ -119,13 +120,13 @@ export interface PullbackSchedulerOptions {
    */
   intradayOnlySymbols?: Set<string>
   /**
-   * Per-symbol decision sink。HOLD / BUY / SELL / REJECT / ERROR の各 route で
-   * 1 回ずつ呼ばれる。実装は D1 INSERT が典型 (#128)、テストは fake 注入可能。
-   * 呼び出し側が失敗を throw しないのが前提 (logging failure isolation)。
+   * Per-symbol decision sink。HOLD / BUY / SELL / SKIP / REJECT / ERROR の各
+   * route で 1 回ずつ呼ばれる。実装は D1 INSERT が典型 (#128)、テストは fake
+   * 注入可能。呼び出し側が失敗を throw しないのが前提 (logging failure isolation)。
    */
   onDecision?: (record: {
     symbol: string
-    decision: 'BUY' | 'SELL' | 'HOLD' | 'REJECT' | 'ERROR'
+    decision: StrategyDecision
     reason?: string
     price?: number
     indicatorsJson?: string
@@ -193,14 +194,14 @@ export interface PullbackSchedulerOptions {
   vixDecision?: VixRegimeFilterDecision
   /**
    * Entry 抑止 symbol → 理由 (#452)。role が entry 無効 (cash_parking / 定義のみ
-   * の role / enum 外 'unknown') の銘柄の BUY を REJECT する。SELL / HOLD は
+   * の role / enum 外 'unknown') の銘柄の BUY を SKIP する。SELL / HOLD は
    * 対象外 (exit 経路を妨げない)。未注入なら skip (POC 後方互換)。production
    * (`runStrategyCron`) は `buildEntrySuppressedSymbols` の結果を渡す。
    */
   entrySuppressedSymbols?: Record<string, string>
   /**
    * ペアレジーム layer (#472)。mode='observe' は zone/score を trace に残すだけ
-   * (gate しない)、'enforce' は zone が許可しない側の BUY を REJECT し、保有と
+   * (gate しない)、'enforce' は zone が許可しない側の BUY を SKIP し、保有と
    * 反対 zone への flip で SELL (regime_flip) を出す。未注入 = 従来挙動。
    * production (`runStrategyCron`) は global_config + inverse_pairs から組む。
    */
@@ -334,7 +335,7 @@ export interface PullbackRunSummary {
 
 export interface PullbackDecisionTrace {
   symbol: string
-  decision: 'BUY' | 'SELL' | 'HOLD' | 'REJECT' | 'ERROR'
+  decision: StrategyDecision
   reason?: string
   price?: number
   indicatorsJson?: string
@@ -550,7 +551,7 @@ export async function runPullbackScheduler(
     const indicators = computePullbackIndicators(bars, intradayPrice)
     if (!indicators) {
       summary.rejected.push({ symbol: upper, reason: 'insufficient bars for indicators' })
-      await emitDecision({ symbol: upper, decision: 'REJECT', reason: 'insufficient bars for indicators' })
+      await emitDecision({ symbol: upper, decision: 'SKIP', reason: 'insufficient bars for indicators' })
       continue
     }
 
@@ -632,7 +633,7 @@ export async function runPullbackScheduler(
     }
 
     // ペアレジーム (#472): zone/score を全評価の trace に残す (HOLD 含む —
-    // observe 期間の監査が目的なので BUY/REJECT 時だけでは足りない)。
+    // observe 期間の監査が目的なので BUY/SKIP 時だけでは足りない)。
     const regime = regimeBySymbol.get(upper)
     if (regime && options.pairRegime) {
       const d = regime.decision
@@ -641,7 +642,7 @@ export async function runPullbackScheduler(
         state.position !== null && Number.isFinite(state.position.qty) && state.position.qty > 0
       const observeNote =
         options.pairRegime.mode === 'observe' && !allowed && signal.action === 'BUY'
-          ? ' [observe: enforce なら REJECT]'
+          ? ' [observe: enforce なら SKIP]'
           : ''
       const neutralHoldNote =
         held && d.zone === 'neutral'
@@ -743,7 +744,7 @@ export async function runPullbackScheduler(
     }
 
     // ペアレジーム BUY gate (#472、enforce のみ): zone が許可しない側の entry を
-    // REJECT。SELL / exit は一切妨げない。zone permits, gates decide — ここを
+    // SKIP。SELL / exit は一切妨げない。zone permits, gates decide — ここを
     // 通っても以降の全 gate (role / sizing / risk / 余力) は従来どおり評価される。
     if (options.pairRegime?.mode === 'enforce' && signal.action === 'BUY') {
       const regimeGate = regimeBySymbol.get(upper)
@@ -757,7 +758,7 @@ export async function runPullbackScheduler(
           summary.rejected.push({ symbol: upper, reason })
           await emitDecision({
             symbol: upper,
-            decision: 'REJECT',
+            decision: 'SKIP',
             reason,
             price: indicators.price,
             indicatorsJson: JSON.stringify(indicators),
@@ -779,7 +780,7 @@ export async function runPullbackScheduler(
       summary.rejected.push({ symbol: upper, reason })
       await emitDecision({
         symbol: upper,
-        decision: 'REJECT',
+        decision: 'SKIP',
         reason,
         price: indicators.price,
         indicatorsJson: JSON.stringify(indicators),
@@ -819,7 +820,7 @@ export async function runPullbackScheduler(
         summary.rejected.push({ symbol: upper, reason })
         await emitDecision({
           symbol: upper,
-          decision: 'REJECT',
+          decision: 'SKIP',
           reason,
           price: indicators.price,
           indicatorsJson: JSON.stringify(indicators),
@@ -854,7 +855,7 @@ export async function runPullbackScheduler(
         summary.rejected.push({ symbol: upper, reason })
         await emitDecision({
           symbol: upper,
-          decision: 'REJECT',
+          decision: 'SKIP',
           reason,
           price: indicators.price,
           indicatorsJson: JSON.stringify(indicators),
@@ -993,7 +994,7 @@ export async function runPullbackScheduler(
         summary.rejected.push({ symbol: upper, reason })
         await emitDecision({
           symbol: upper,
-          decision: 'REJECT',
+          decision: 'SKIP',
           reason,
           price: indicators.price,
           trace: appendTrace(signal.trace, traceStep('scheduler.price_valid', false, indicators.price, '>', 0)),
@@ -1006,7 +1007,7 @@ export async function runPullbackScheduler(
         summary.rejected.push({ symbol: upper, reason })
         await emitDecision({
           symbol: upper,
-          decision: 'REJECT',
+          decision: 'SKIP',
           reason,
           price: indicators.price,
           trace: appendTrace(signal.trace, traceStep('scheduler.notional_valid', false, notional, '>', 0)),
@@ -1021,7 +1022,7 @@ export async function runPullbackScheduler(
         summary.rejected.push({ symbol: upper, reason })
         await emitDecision({
           symbol: upper,
-          decision: 'REJECT',
+          decision: 'SKIP',
           reason,
           price: indicators.price,
           trace: appendTrace(signal.trace, traceStep('scheduler.sell_position_exists', false, false, 'exists', true)),
@@ -1033,7 +1034,7 @@ export async function runPullbackScheduler(
         summary.rejected.push({ symbol: upper, reason })
         await emitDecision({
           symbol: upper,
-          decision: 'REJECT',
+          decision: 'SKIP',
           reason,
           price: indicators.price,
           trace: appendTrace(signal.trace, traceStep('scheduler.position_qty_valid', false, state.position.qty, '>', 0)),
@@ -1045,7 +1046,7 @@ export async function runPullbackScheduler(
         summary.rejected.push({ symbol: upper, reason })
         await emitDecision({
           symbol: upper,
-          decision: 'REJECT',
+          decision: 'SKIP',
           reason,
           price: indicators.price,
           trace: appendTrace(signal.trace, traceStep('scheduler.price_valid', false, indicators.price, '>', 0)),
@@ -1058,7 +1059,7 @@ export async function runPullbackScheduler(
         summary.rejected.push({ symbol: upper, reason })
         await emitDecision({
           symbol: upper,
-          decision: 'REJECT',
+          decision: 'SKIP',
           reason,
           price: indicators.price,
           trace: appendTrace(signal.trace, traceStep('scheduler.notional_valid', false, notional, '>', 0)),
@@ -1085,7 +1086,7 @@ export async function runPullbackScheduler(
         summary.rejected.push({ symbol: upper, reason })
         await emitDecision({
           symbol: upper,
-          decision: 'REJECT',
+          decision: 'SKIP',
           reason,
           price: indicators.price,
           indicatorsJson: JSON.stringify(indicators),
@@ -1114,7 +1115,7 @@ export async function runPullbackScheduler(
         summary.rejected.push({ symbol: upper, reason })
         await emitDecision({
           symbol: upper,
-          decision: 'REJECT',
+          decision: 'SKIP',
           reason,
           price: indicators.price,
           indicatorsJson: JSON.stringify(indicators),
@@ -1170,7 +1171,7 @@ export async function runPullbackScheduler(
         summary.rejected.push({ symbol: upper, reason })
         await emitDecision({
           symbol: upper,
-          decision: 'REJECT',
+          decision: 'SKIP',
           reason,
           price: indicators.price,
           indicatorsJson: JSON.stringify(indicators),
@@ -1195,7 +1196,7 @@ export async function runPullbackScheduler(
         summary.rejected.push({ symbol: upper, reason })
         await emitDecision({
           symbol: upper,
-          decision: 'REJECT',
+          decision: 'SKIP',
           reason,
           price: indicators.price,
           indicatorsJson: JSON.stringify(indicators),
@@ -1214,7 +1215,7 @@ export async function runPullbackScheduler(
       summary.rejected.push({ symbol: upper, reason })
       await emitDecision({
         symbol: upper,
-        decision: 'REJECT',
+        decision: 'SKIP',
         reason,
         price: indicators.price,
         trace: appendTrace(signal.trace, traceStep('scheduler.pending_lock_expiry_valid', false, expiresAtMs, '>', now().getTime())),
@@ -1232,7 +1233,7 @@ export async function runPullbackScheduler(
       summary.rejected.push({ symbol: upper, reason })
       await emitDecision({
         symbol: upper,
-        decision: 'REJECT',
+        decision: 'SKIP',
         reason,
         price: indicators.price,
         trace: appendTrace(signal.trace, traceStep('scheduler.pending_lock_acquired', false, false, '==', true)),
@@ -1299,9 +1300,16 @@ export async function runPullbackScheduler(
           symbol: upper,
           message: messageOf(error),
         })
+        // broker 4xx = 注文の**確定拒否** (417 SELL_SHORT / TICKER_IS_DENY /
+        // Insufficient Buying Power 等、再送しても解消しない) → REJECT。
+        // それ以外 (5xx / ネットワーク断 / 非 BrokerRequestError 例外) は
+        // 原因不明・一時的として ERROR のまま。
+        const brokerStatus = error instanceof BrokerRequestError ? error.brokerStatus : undefined
+        const isBrokerReject =
+          brokerStatus !== undefined && brokerStatus >= 400 && brokerStatus < 500
         await emitDecision({
           symbol: upper,
-          decision: 'ERROR',
+          decision: isBrokerReject ? 'REJECT' : 'ERROR',
           // DB には英語 canonical で保存。表示層 (localizeReason) で日本語化。
           // localize は `^broker submit error: ` を prefix match するので、発注内容
           // (何口 / $ と ¥) は **message の後ろ**に付けて prefix を壊さない (#417)。

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -1302,11 +1302,12 @@ export async function runPullbackScheduler(
         })
         // broker 4xx = 注文の**確定拒否** (417 SELL_SHORT / TICKER_IS_DENY /
         // Insufficient Buying Power 等、再送しても解消しない) → REJECT。
-        // それ以外 (5xx / ネットワーク断 / 非 BrokerRequestError 例外) は
+        // 429 (rate limit) は再送で解消しうる一時的失敗なので除外して ERROR。
+        // それ以外 (5xx / ネットワーク断 / 非 BrokerRequestError 例外) も
         // 原因不明・一時的として ERROR のまま。
         const brokerStatus = error instanceof BrokerRequestError ? error.brokerStatus : undefined
         const isBrokerReject =
-          brokerStatus !== undefined && brokerStatus >= 400 && brokerStatus < 500
+          brokerStatus !== undefined && brokerStatus >= 400 && brokerStatus < 500 && brokerStatus !== 429
         await emitDecision({
           symbol: upper,
           decision: isBrokerReject ? 'REJECT' : 'ERROR',

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -424,7 +424,7 @@ describe('dashboard', () => {
           timestamp: '2026-04-23T00:00:00.000Z',
           requestId: 'req-1',
           symbol: '7203',
-          decision: 'REJECT',
+          decision: 'SKIP',
           reason: 'sizing rejected: lot-size-round (raw qty 79 < lot 100, stop 286.00, entry 3765)',
           price: 3765,
           indicatorsJson: '{"price":3765,"return50d":0.45873692367299496}',
@@ -462,7 +462,7 @@ describe('dashboard', () => {
           timestamp: '2026-06-06T00:00:00.000Z',
           requestId: 'req-tr',
           symbol: 'TQQQ',
-          decision: 'REJECT',
+          decision: 'SKIP',
           reason: 'sizing rejected: lot-size-round',
           price: 76,
           indicatorsJson: '{"price":76}',
@@ -496,8 +496,8 @@ describe('dashboard', () => {
     expect(body).toContain('発注数量が1株/1単元以上ある') // ❌ deciding step
     expect(body).toContain('◀ 採用') // 採用された(最後の)ステップに矢印
     expect(body).toContain('lot-size-round') // message
-    expect(body).toContain('tl-out-reject') // 出力ボックス (REJECT 色)
-    expect(body).toContain('出力: <strong>REJECT</strong>')
+    expect(body).toContain('tl-out-skip') // 出力ボックス (SKIP 色)
+    expect(body).toContain('出力: <strong>SKIP</strong>')
   })
 
   it('omits the ladder when trace_json is null (graceful, pre-migration rows)', async () => {
@@ -539,7 +539,7 @@ describe('dashboard', () => {
           timestamp: '2026-04-23T00:00:00.000Z',
           requestId: 'req-1',
           symbol: '7203',
-          decision: 'REJECT',
+          decision: 'SKIP',
           reason: 'sizing rejected: lot-size-round (raw qty 79 < lot 100, stop 286.00, entry 3765)',
           price: 3765,
           indicatorsJson: '{"price":3765}',
@@ -828,8 +828,8 @@ describe('aggregateDecisionRows', () => {
       { day: '2026-04-24', decision: 'SELL', n: 1 },
     ])
     expect(out).toEqual([
-      { date: '2026-04-23', counts: { BUY: 1, SELL: 0, HOLD: 5, REJECT: 2, ERROR: 0 } },
-      { date: '2026-04-24', counts: { BUY: 0, SELL: 1, HOLD: 8, REJECT: 0, ERROR: 0 } },
+      { date: '2026-04-23', counts: { BUY: 1, SELL: 0, HOLD: 5, SKIP: 0, REJECT: 2, ERROR: 0 } },
+      { date: '2026-04-24', counts: { BUY: 0, SELL: 1, HOLD: 8, SKIP: 0, REJECT: 0, ERROR: 0 } },
     ])
   })
 
@@ -1955,7 +1955,7 @@ describe('renderDecisionPlotCaption (判定点プロットの凡例 + 件数)', 
   }
   const oneDecision: SymbolChartDecision = {
     id: 1, timestamp: '2026-06-06T14:00:00.000Z', price: 80,
-    decision: 'REJECT', reason: 'overextension', ladderHtml: '<div>x</div>',
+    decision: 'SKIP', reason: 'overextension', ladderHtml: '<div>x</div>',
   }
 
   it('chart null / decisions 無し / 空配列なら空文字', () => {
@@ -1967,7 +1967,8 @@ describe('renderDecisionPlotCaption (判定点プロットの凡例 + 件数)', 
     const html = renderDecisionPlotCaption(chartWith([oneDecision]))
     expect(html).toContain('買い (BUY)')
     expect(html).toContain('売り (SELL)')
-    expect(html).toContain('見送り (REJECT)')
+    expect(html).toContain('見送り・bot判定 (SKIP)')
+    expect(html).toContain('拒否・証券会社 (REJECT)')
     expect(html).toContain('エラー (ERROR)')
     expect(html).toContain('HOLD')
     expect(html).toContain('クリック')
@@ -2014,7 +2015,7 @@ describe('renderSymbolTab — 判定点 scatter + click-to-trace の配線', () 
     const html = renderSymbolTab(symbolArgs([
       {
         id: 1, timestamp: '2026-06-06T14:00:00.000Z', price: 80,
-        decision: 'REJECT', reason: 'overextension',
+        decision: 'SKIP', reason: 'overextension',
         ladderHtml: '<div>LADDER_EMBED_MARKER</div>',
       },
     ]))
@@ -2026,13 +2027,14 @@ describe('renderSymbolTab — 判定点 scatter + click-to-trace の配線', () 
     // < に escape されるが marker テキストは残る)
     expect(html).toContain('LADDER_EMBED_MARKER')
     // 凡例キャプションも出る
-    expect(html).toContain('見送り (REJECT)')
+    expect(html).toContain('見送り・bot判定 (SKIP)')
+    expect(html).toContain('拒否・証券会社 (REJECT)')
   })
 
   it('decisions が無ければ凡例は出ず payload も空 (scatter JS は静的に常駐 / runtime で 0 件描画)', () => {
     const html = renderSymbolTab(symbolArgs([]))
     // 凡例キャプションは decisions があるときだけ出す
-    expect(html).not.toContain('見送り (REJECT)')
+    expect(html).not.toContain('見送り・bot判定 (SKIP)')
     // payload の decisions は空配列 (= runtime で scatter 0 点)
     expect(html).toContain('"decisions":[]')
     // placeholder パネルは常に描画

--- a/test/routes/dashboardTradesAlertsUi.test.ts
+++ b/test/routes/dashboardTradesAlertsUi.test.ts
@@ -184,7 +184,7 @@ describe('/dashboard/cron AI 用コピー (#alerts-trades-ui)', () => {
       timestamp: '2026-06-10T17:45:45.592Z',
       requestId: 'run-1',
       symbol: 'USMV',
-      decision: 'REJECT',
+      decision: 'SKIP',
       reason: 'role: low_volatility entry is not enabled (#452)',
       price: 95.46,
       indicatorsJson: '{"price":95.46}',

--- a/test/routes/localizeReason.test.ts
+++ b/test/routes/localizeReason.test.ts
@@ -173,9 +173,9 @@ describe('localizeReason (日本株・信用取引の伝統的語彙)', () => {
       )
     })
 
-    it('broker submit error → 証券会社側で拒否', () => {
+    it('broker submit error → 発注失敗 (確定拒否か一時的かは decision 列が区別)', () => {
       expect(localizeReason('broker submit error: Webull 429')).toBe(
-        '発注エラー: 証券会社側で拒否 — Webull 429',
+        '発注失敗: 証券会社への発注が成立せず — Webull 429',
       )
     })
   })

--- a/test/trading/risk/perSymbolRiskGateParity.test.ts
+++ b/test/trading/risk/perSymbolRiskGateParity.test.ts
@@ -102,7 +102,7 @@ describe('per-symbol risk gate parity (TradingService vs runPullbackScheduler) �
   // 各シナリオで:
   //   1. pure helper の判定
   //   2. TradingService.executeTrade() の `riskDecision`
-  //   3. runPullbackScheduler の REJECT decision
+  //   3. runPullbackScheduler の SKIP decision
   // が同じ reason で reject (or 同じく approve) することを確認する。
 
   const tradingConfig: TradingConfig = {
@@ -172,7 +172,7 @@ describe('per-symbol risk gate parity (TradingService vs runPullbackScheduler) �
       now: () => now,
     })
     expect(summary.buys).toBe(0)
-    const reject = summary.decisions.find((d) => d.decision === 'REJECT')
+    const reject = summary.decisions.find((d) => d.decision === 'SKIP')
     expect(reject?.reason).toContain('halt or stale quote')
   })
 
@@ -220,7 +220,7 @@ describe('per-symbol risk gate parity (TradingService vs runPullbackScheduler) �
       now: () => now,
     })
     expect(summary.buys).toBe(0)
-    const reject = summary.decisions.find((d) => d.decision === 'REJECT')
+    const reject = summary.decisions.find((d) => d.decision === 'SKIP')
     expect(reject?.reason).toContain('inverse-pair exposure')
   })
 

--- a/test/trading/strategy/pullbackScheduler.test.ts
+++ b/test/trading/strategy/pullbackScheduler.test.ts
@@ -3,6 +3,7 @@ import type { BarClient, IntradayBar } from '../../../src/infrastructure/quotes/
 import type { Notifier, NotificationEvent } from '../../../src/infrastructure/notification/Notifier'
 import {
   BrokerClientError,
+  BrokerRateLimitError,
   BrokerServerError,
   WEBULL_SELL_QTY_EXCEED_CODE,
 } from '../../../src/shared/errors'
@@ -1855,6 +1856,19 @@ describe('runPullbackScheduler broker submit decision taxonomy (SKIP/REJECT/ERRO
 
   it('非 BrokerRequestError (ネットワーク断など) → ERROR', async () => {
     const summary = await runWith(new Error('fetch failed: network down'))
+    const d = summary.decisions.find((x) => x.symbol === 'AAPL')
+    expect(d?.decision).toBe('ERROR')
+    expect(d?.reason).toMatch(/^broker submit error: /)
+  })
+
+  it('BrokerRateLimitError 429 (rate limit、一時的) → ERROR (REJECT にしない)', async () => {
+    const summary = await runWith(
+      new BrokerRateLimitError(
+        'Webull request failed after 3 attempts with last status 429: <no body>',
+        'placeOrder',
+        { brokerStatus: 429 },
+      ),
+    )
     const d = summary.decisions.find((x) => x.symbol === 'AAPL')
     expect(d?.decision).toBe('ERROR')
     expect(d?.reason).toMatch(/^broker submit error: /)

--- a/test/trading/strategy/pullbackScheduler.test.ts
+++ b/test/trading/strategy/pullbackScheduler.test.ts
@@ -193,7 +193,7 @@ describe('runPullbackScheduler', () => {
     expect(summary.decisions).toEqual([
       {
         symbol: 'AAPL',
-        decision: 'REJECT',
+        decision: 'SKIP',
         reason: 'insufficient bars for indicators',
       },
     ])
@@ -402,7 +402,7 @@ describe('runPullbackScheduler per-symbol risk gate (#138 parity)', () => {
     })
     expect(summary.buys).toBe(0)
     expect(execution.calls).toHaveLength(0)
-    const reject = summary.decisions.find((d) => d.decision === 'REJECT')
+    const reject = summary.decisions.find((d) => d.decision === 'SKIP')
     expect(reject?.reason).toContain('insufficient settled cash')
   })
 
@@ -430,7 +430,7 @@ describe('runPullbackScheduler per-symbol risk gate (#138 parity)', () => {
     })
     expect(summary.buys).toBe(0)
     expect(execution.calls).toHaveLength(0)
-    const reject = summary.decisions.find((d) => d.decision === 'REJECT')
+    const reject = summary.decisions.find((d) => d.decision === 'SKIP')
     expect(reject?.reason).toContain('halt or stale quote')
   })
 
@@ -459,7 +459,7 @@ describe('runPullbackScheduler per-symbol risk gate (#138 parity)', () => {
     })
     expect(summary.buys).toBe(0)
     expect(execution.calls).toHaveLength(0)
-    const reject = summary.decisions.find((d) => d.decision === 'REJECT')
+    const reject = summary.decisions.find((d) => d.decision === 'SKIP')
     expect(reject?.reason).toContain('bid/ask missing')
   })
 
@@ -513,7 +513,7 @@ describe('runPullbackScheduler per-symbol risk gate (#138 parity)', () => {
     })
     expect(summary.buys).toBe(0)
     expect(execution.calls).toHaveLength(0)
-    const reject = summary.decisions.find((d) => d.decision === 'REJECT')
+    const reject = summary.decisions.find((d) => d.decision === 'SKIP')
     expect(reject?.reason).toContain('inverse-pair exposure')
   })
 
@@ -601,7 +601,7 @@ describe('runPullbackScheduler earnings calendar gate (#196)', () => {
     })
     expect(summary.buys).toBe(0)
     expect(execution.calls).toHaveLength(0)
-    const reject = summary.decisions.find((d) => d.decision === 'REJECT')
+    const reject = summary.decisions.find((d) => d.decision === 'SKIP')
     expect(reject?.reason).toContain('risk: earnings_within_1bd')
   })
 
@@ -695,7 +695,7 @@ describe('runPullbackScheduler macro event gate (#196 2/3)', () => {
     })
     expect(summary.buys).toBe(0)
     expect(execution.calls).toHaveLength(0)
-    const reject = summary.decisions.find((d) => d.decision === 'REJECT')
+    const reject = summary.decisions.find((d) => d.decision === 'SKIP')
     expect(reject?.reason).toContain('risk: macro_event_gate: CPI')
   })
 
@@ -804,7 +804,7 @@ describe('runPullbackScheduler macro event gate (#196 2/3)', () => {
       now: () => now,
     })
     expect(summary.buys).toBe(0)
-    const reject = summary.decisions.find((d) => d.decision === 'REJECT')
+    const reject = summary.decisions.find((d) => d.decision === 'SKIP')
     expect(reject?.reason).toContain('earnings_within_1bd')
     expect(reject?.reason).not.toContain('macro_event_gate')
   })
@@ -1154,7 +1154,7 @@ describe('runPullbackScheduler SELL_QTY_EXCEED fallback (#215 follow-up)', () =>
     expect(overrideCalls).toHaveLength(0)
     expect(summary.sells).toBe(0)
     expect(summary.errors).toHaveLength(1)
-    const errDecision = summary.decisions.find((d) => d.decision === 'ERROR')
+    const errDecision = summary.decisions.find((d) => d.decision === 'REJECT')
     expect(errDecision?.reason).toContain('OAUTH_OPENAPI_OTHER_ERROR')
   })
 
@@ -1350,7 +1350,7 @@ describe('runPullbackScheduler sanity_failed cooldown gate', () => {
     expect(checkSpy).toHaveBeenCalledWith('9697')
     expect(summary.buys).toBe(0)
     expect(execution.calls).toHaveLength(0)
-    const reject = summary.decisions.find((d) => d.decision === 'REJECT')
+    const reject = summary.decisions.find((d) => d.decision === 'SKIP')
     expect(reject?.reason).toContain('sanity_failed cooldown active')
     expect(reject?.reason).toContain('30min')
     expect(reject?.trace?.map((s) => s.label)).toContain('risk.sanity_failed_cooldown')
@@ -1408,7 +1408,7 @@ describe('runPullbackScheduler sanity_failed cooldown gate', () => {
     expect(checkSpy).toHaveBeenCalledWith('9697')
     expect(summary.buys).toBe(0)
     expect(execution.calls).toHaveLength(0)
-    const reject = summary.decisions.find((d) => d.decision === 'REJECT')
+    const reject = summary.decisions.find((d) => d.decision === 'SKIP')
     expect(reject?.reason).toContain('sanity_failed cooldown active')
   })
 
@@ -1464,7 +1464,7 @@ describe('runPullbackScheduler sanity_failed cooldown gate', () => {
     expect(execution.calls).toHaveLength(1)
     expect((execution.calls[0] as { symbol: string }).symbol).toBe('AAPL')
     const reject = summary.decisions.find((d) => d.symbol === '9697')
-    expect(reject?.decision).toBe('REJECT')
+    expect(reject?.decision).toBe('SKIP')
     expect(reject?.reason).toContain('sanity_failed cooldown active')
   })
 })
@@ -1575,7 +1575,7 @@ describe('runPullbackScheduler per-symbol lot_size (#symbol-lot-size)', () => {
     expect(summary.buys).toBe(0)
     expect(execution.calls).toHaveLength(0)
     const aapl = summary.decisions.find((d) => d.symbol === 'AAPL')
-    expect(aapl?.decision).toBe('REJECT')
+    expect(aapl?.decision).toBe('SKIP')
     expect(aapl?.reason).toMatch(/missing-lot-size/)
     expect(summary.rejected).toContainEqual(
       expect.objectContaining({ symbol: 'AAPL', reason: expect.stringMatching(/missing-lot-size/) }),
@@ -1676,7 +1676,7 @@ describe('runPullbackScheduler buying-power pool gate (#415)', () => {
     expect(summary.buys).toBe(0)
     expect(execution.calls).toHaveLength(0)
     const aapl = summary.decisions.find((d) => d.symbol === 'AAPL')
-    expect(aapl?.decision).toBe('REJECT')
+    expect(aapl?.decision).toBe('SKIP')
     expect(aapl?.reason).toMatch(/buying-power unavailable/)
   })
 
@@ -1715,7 +1715,7 @@ describe('runPullbackScheduler buying-power pool gate (#415)', () => {
     expect(summary.buys).toBe(0)
     expect(execution.calls).toHaveLength(0)
     const aapl = summary.decisions.find((d) => d.symbol === 'AAPL')
-    expect(aapl?.decision).toBe('REJECT')
+    expect(aapl?.decision).toBe('SKIP')
     expect(aapl?.reason).toMatch(/insufficient buying power/)
   })
 
@@ -1740,13 +1740,13 @@ describe('runPullbackScheduler buying-power pool gate (#415)', () => {
     })
     expect(summary.buys).toBe(1)
     expect(execution.calls).toHaveLength(1)
-    const rejected = summary.decisions.filter((d) => d.decision === 'REJECT')
+    const rejected = summary.decisions.filter((d) => d.decision === 'SKIP')
     expect(rejected.some((d) => /insufficient buying power/.test(d.reason ?? ''))).toBe(true)
   })
 })
 
 describe('runPullbackScheduler broker-error decision embeds order amount (#417)', () => {
-  it('includes qty + USD/JPY notional in the ERROR reason for a USD symbol', async () => {
+  it('includes qty + USD/JPY notional in the REJECT reason for a USD symbol', async () => {
     const throwing: Execution & { calls: unknown[] } = {
       calls: [],
       async execute(intent) {
@@ -1768,7 +1768,7 @@ describe('runPullbackScheduler broker-error decision embeds order amount (#417)'
       fxJpyPerSymbolCcy: 150,
       now: () => now,
     })
-    const err = summary.decisions.find((d) => d.decision === 'ERROR')
+    const err = summary.decisions.find((d) => d.decision === 'REJECT')
     expect(err).toBeDefined()
     // localize 用の prefix は維持 (発注内容は message の後ろ)。
     expect(err?.reason).toMatch(/^broker submit error: /)
@@ -1795,9 +1795,87 @@ describe('runPullbackScheduler broker-error decision embeds order amount (#417)'
       fxJpyPerSymbolCcy: 1,
       now: () => now,
     })
-    const err = summary.decisions.find((d) => d.decision === 'ERROR')
+    const err = summary.decisions.find((d) => d.decision === 'REJECT')
     expect(err?.reason).toMatch(/発注内容: \d+口 @ ¥/)
     expect(err?.reason).not.toContain('USD/JPY')
+  })
+})
+
+describe('runPullbackScheduler broker submit decision taxonomy (SKIP/REJECT/ERROR)', () => {
+  function throwingExecution(err: Error): Execution & { calls: unknown[] } {
+    const calls: unknown[] = []
+    return {
+      calls,
+      async execute(intent) {
+        calls.push(intent)
+        throw err
+      },
+    }
+  }
+
+  async function runWith(err: Error) {
+    return runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution: throwingExecution(err),
+      symbolLotSizeMap: { AAPL: 1 },
+      now: () => now,
+    })
+  }
+
+  it('BrokerRequestError 4xx (確定拒否) → REJECT', async () => {
+    const summary = await runWith(
+      new BrokerClientError(
+        'Webull request failed permanently with status 417: {"error_code":"OAUTH_OPENAPI_ORDER_BUYING_POWER_NOT_ENOUGH"}',
+        'placeOrder',
+        { brokerStatus: 417 },
+      ),
+    )
+    const d = summary.decisions.find((x) => x.symbol === 'AAPL')
+    expect(d?.decision).toBe('REJECT')
+    expect(d?.reason).toMatch(/^broker submit error: /)
+    // summary 構造は従来どおり errors 側に載る (分類のみの変更)
+    expect(summary.errors).toHaveLength(1)
+  })
+
+  it('BrokerRequestError 5xx (一時的) → ERROR', async () => {
+    const summary = await runWith(
+      new BrokerServerError(
+        'Webull request failed after 3 attempts with last status 502: <no body>',
+        'placeOrder',
+        { brokerStatus: 502 },
+      ),
+    )
+    const d = summary.decisions.find((x) => x.symbol === 'AAPL')
+    expect(d?.decision).toBe('ERROR')
+    expect(d?.reason).toMatch(/^broker submit error: /)
+  })
+
+  it('非 BrokerRequestError (ネットワーク断など) → ERROR', async () => {
+    const summary = await runWith(new Error('fetch failed: network down'))
+    const d = summary.decisions.find((x) => x.symbol === 'AAPL')
+    expect(d?.decision).toBe('ERROR')
+    expect(d?.reason).toMatch(/^broker submit error: /)
+  })
+
+  it('内部ゲート見送り (broker 未到達) → SKIP (broker には一切 submit しない)', async () => {
+    const execution = throwingExecution(new Error('must not be called'))
+    const summary = await runPullbackScheduler({
+      symbols: ['AAPL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({}),
+      execution,
+      symbolLotSizeMap: { AAPL: 1 },
+      entrySuppressedSymbols: { AAPL: 'role: cash_parking (entry 無効)' },
+      now: () => now,
+    })
+    const d = summary.decisions.find((x) => x.symbol === 'AAPL')
+    expect(d?.decision).toBe('SKIP')
+    expect(execution.calls).toHaveLength(0)
+    expect(summary.errors).toHaveLength(0)
   })
 })
 
@@ -1874,7 +1952,7 @@ describe('runPullbackScheduler role entry suppression (#452)', () => {
     })
     expect(summary.buys).toBe(0)
     expect(execution.calls).toHaveLength(0)
-    const reject = summary.decisions.find((d) => d.decision === 'REJECT')
+    const reject = summary.decisions.find((d) => d.decision === 'SKIP')
     expect(reject?.symbol).toBe('SGOV')
     expect(reject?.reason).toContain('cash_parking')
     expect(reject?.trace?.map((s) => s.label)).toContain('risk.role_entry_suppressed')
@@ -2035,7 +2113,7 @@ describe('runPullbackScheduler half entry (#452 段階判定)', () => {
     })
     expect(summary.buys).toBe(0)
     expect(execution.calls).toHaveLength(0)
-    const reject = summary.decisions.find((d) => d.decision === 'REJECT')
+    const reject = summary.decisions.find((d) => d.decision === 'SKIP')
     expect(reject?.reason).toContain('inverse')
   })
 })
@@ -2154,7 +2232,7 @@ describe('inverse_hedge role enabled but inverse-pair gate still wins (#457)', (
     })
     expect(summary.buys).toBe(0)
     expect(execution.calls).toHaveLength(0)
-    const reject = summary.decisions.find((d) => d.decision === 'REJECT')
+    const reject = summary.decisions.find((d) => d.decision === 'SKIP')
     expect(reject?.reason).toContain('inverse')
   })
 })
@@ -2191,8 +2269,8 @@ describe('runPullbackScheduler TICKER_IS_DENY hook (#460)', () => {
     })
     expect(hook).toHaveBeenCalledWith('USMV')
     expect(summary.errors).toHaveLength(1)
-    // 通常の ERROR decision / journal は従来どおり残る (hook は追加動作)
-    expect(summary.decisions.find((d) => d.decision === 'ERROR')?.reason).toContain('TICKER_IS_DENY')
+    // broker 417 確定拒否なので REJECT decision / journal は従来どおり残る (hook は追加動作)
+    expect(summary.decisions.find((d) => d.decision === 'REJECT')?.reason).toContain('TICKER_IS_DENY')
   })
 
   it('does not call the hook for other broker errors', async () => {
@@ -2282,7 +2360,7 @@ describe('runPullbackScheduler pair regime layer (#472)', () => {
     }
   }
 
-  it('enforce: zone=bull はブル側 BUY を通し、ベア側 BUY を REJECT する', async () => {
+  it('enforce: zone=bull はブル側 BUY を通し、ベア側 BUY を SKIP する', async () => {
     const execution = mockExecution()
     const summary = await runPullbackScheduler({
       symbols: ['SOXL', 'SOXS'],
@@ -2295,12 +2373,12 @@ describe('runPullbackScheduler pair regime layer (#472)', () => {
     })
     expect(summary.buys).toBe(1)
     expect((execution.calls[0] as { symbol: string }).symbol).toBe('SOXL')
-    const reject = summary.decisions.find((d) => d.decision === 'REJECT' && d.symbol === 'SOXS')
+    const reject = summary.decisions.find((d) => d.decision === 'SKIP' && d.symbol === 'SOXS')
     expect(reject?.reason).toContain('pair_regime: zone=bull blocks bear entry')
     expect(reject?.trace?.map((s) => s.label)).toContain('risk.pair_regime')
   })
 
-  it('enforce: zone=neutral は両側 BUY を REJECT する (chop 帯の遮断)', async () => {
+  it('enforce: zone=neutral は両側 BUY を SKIP する (chop 帯の遮断)', async () => {
     const execution = mockExecution()
     const summary = await runPullbackScheduler({
       symbols: ['SOXL', 'SOXS'],
@@ -2338,11 +2416,11 @@ describe('runPullbackScheduler pair regime layer (#472)', () => {
     // SOXL は保有中 → strategy の SELL (TP) がそのまま通る (unknown でも exit は妨げない)
     expect(summary.sells).toBe(1)
     // SOXS の BUY は unknown で block
-    const reject = summary.decisions.find((d) => d.decision === 'REJECT' && d.symbol === 'SOXS')
+    const reject = summary.decisions.find((d) => d.decision === 'SKIP' && d.symbol === 'SOXS')
     expect(reject?.reason).toContain('zone=unknown')
   })
 
-  it('observe: gate せず trace に zone と「enforce なら REJECT」を残す', async () => {
+  it('observe: gate せず trace に zone と「enforce なら SKIP」を残す', async () => {
     const execution = mockExecution()
     const summary = await runPullbackScheduler({
       symbols: ['SOXS'],


### PR DESCRIPTION
## 背景

strategy_decision_log の `REJECT` は bot 内部ゲートの見送りを指すが、「Webull に弾かれた」ように誤読される(実際にユーザーが誤読)。broker 拒否とシステムエラーが `ERROR` に混在していた問題も同根。

## 新分類

| decision | 意味 |
|---|---|
| `SKIP` | bot 内部ゲートで見送り (broker 未到達) — 旧 REJECT の全ケース |
| `REJECT` | broker が注文を確定拒否 (HTTP 4xx: 417 SELL_SHORT / Insufficient Buying Power / TICKER_IS_DENY 等) |
| `ERROR` | それ以外 = 原因不明・一時的 (5xx / ネットワーク断 / 想定外例外) |

## 変更

- `StrategyDecision` 共有型を新設、内部ゲートの emit 全17箇所を SKIP に変更
- broker submit catch で `BrokerRequestError.brokerStatus` 4xx → REJECT、それ以外 ERROR
- dashboard: 日本語併記 (SKIP=見送り(bot判定) / REJECT=拒否(証券会社) / ERROR=エラー(原因不明・一時的))、凡例・集計・チャート判定点・色分けに SKIP 追加
- `drizzle/0037` data-only migration: 旧 REJECT→SKIP を先行、旧 ERROR のうち `status 4xx` 確定拒否パターン→REJECT

## 検証

- pnpm typecheck / pnpm test: 1571 passed
- migration は SQL 順序含め sqlite3 でサンプル検証済み。LIKE パターンは 4xx 即時 throw の唯一の message 形式に限定し、5xx/retry-exhausted/network 形式への誤爆なし

## Note

- 発注経路 (Strategy → Risk → Execution) の構造・fail-closed 挙動は不変。分類とラベルのみ
- deploy 後に staging → production の順で D1 migration 適用が必要 (data-only、schema 変更なし)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 判定ログとダッシュボードで `SKIP` を新しい区分として表示・集計できるようになりました。
  * 内訳グラフ、銘柄チャート、トレース表示にも `SKIP` が反映されます。
* **Bug Fixes**
  * 発注失敗と見送り（`SKIP`）の区別をより正確にし、状況に応じて `REJECT` / `ERROR` の扱いも整理しました。
* **Documentation**
  * 判定カテゴリと各ラベルの意味（理由表示など）をわかりやすく整理しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->