### PR TITLE
fix: rewrite 0037 prefix match with substr to fit D1 LIKE pattern limit

### DIFF
--- a/drizzle/0037_decision_skip_reject_taxonomy.sql
+++ b/drizzle/0037_decision_skip_reject_taxonomy.sql
@@ -3,15 +3,24 @@
 --   REJECT = broker が注文を確定拒否 (HTTP 4xx: 417 SELL_SHORT / TICKER_IS_DENY 等)
 --   ERROR  = それ以外の失敗 (5xx / ネットワーク断 / 想定外の例外)
 --
--- 順序が重要: (1) を先に流さないと、(2) で作った新 REJECT 行が (1) に巻き込まれて
--- SKIP に潰される。
+-- 判定は内容ベースで冪等:
+--   (1) 旧 REJECT (内部ゲート見送り) → SKIP。新分類の REJECT (broker 拒否) は
+--       reason が必ず `broker submit error: ` で始まるので除外する。旧 REJECT の
+--       reason prefix は risk:/sizing/role:/insufficient bars のみ (本番実データで
+--       全件確認済) なので、この guard により新コード先行稼働後の再実行も安全。
+--   (2) 旧 ERROR のうち broker 4xx 確定拒否 → REJECT。WebullHttpClient が 4xx を
+--       即時 throw する唯一の message 形式 (`... failed permanently with status
+--       4xx:`) に限定。5xx/retry 尽きは `failed after N attempts ...`、ネットワーク
+--       断は別 message で、いずれも一致しない (= ERROR のまま残る)。
 --
--- (2) の reason パターンは WebullHttpClient が 4xx を即時 throw する唯一の message
--- 形式 (`Webull request failed permanently with status 4xx: <body>`) に
--- pullbackScheduler が `broker submit error: ` prefix を付けたもの。5xx / retry 尽き
--- は `failed after N attempts ...`、ネットワーク断は `Webull order placement
--- failed: ...` で、いずれもこの LIKE には一致しない (= ERROR のまま残る)。
-UPDATE strategy_decision_log SET decision = 'SKIP' WHERE decision = 'REJECT';--> statement-breakpoint
+-- 長い LIKE パターンは D1 の SQLITE_LIMIT_LIKE_PATTERN_LENGTH (50 bytes) を超えて
+-- `LIKE or GLOB pattern too complex` になるため (staging 適用失敗で実証)、
+-- substr() の等値比較で prefix match する。長さは prefix 文字列の実長:
+--   'broker submit error: ' = 21 chars
+--   'broker submit error: Webull request failed permanently with status 4' = 68 chars
+UPDATE strategy_decision_log SET decision = 'SKIP'
+  WHERE decision = 'REJECT'
+    AND COALESCE(substr(reason, 1, 21), '') != 'broker submit error: ';--> statement-breakpoint
 UPDATE strategy_decision_log SET decision = 'REJECT'
   WHERE decision = 'ERROR'
-    AND reason LIKE 'broker submit error: Webull request failed permanently with status 4%';
+    AND substr(reason, 1, 68) = 'broker submit error: Webull request failed permanently with status 4';


### PR DESCRIPTION
## 背景

#541 の migration 0037 が staging 適用で `LIKE or GLOB pattern too complex` (D1 の SQLITE_LIMIT_LIKE_PATTERN_LENGTH = 50 bytes、パターンは 68 chars) で失敗。バッチはアトミックなので部分適用なし (staging の REJECT 565件・d1_migrations とも無傷を確認済)。0037 はどの環境にも未適用のためファイルを直接修正。

## 変更

- 長い LIKE → `substr()` 等値比較 (長さ 21 / 68 は Python で実測)
- 両 statement を内容ベースの冪等ガードに変更:
  - (1) REJECT→SKIP は `broker submit error: ` prefix の行 (= 新分類の broker 拒否) を除外。production に新コードが先行稼働中でも再実行安全
  - (2) は元から冪等。NULL reason も COALESCE で SKIP 側に倒す

## 検証

- sqlite3 でサンプル7行 (内部ゲート/NULL/新形式REJECT/4xx/429/bar fetch) に2回適用: 期待どおり変換・2回目は無変化
- 本番実データで prefix 分布を確認: 旧 REJECT 746件は全件内部ゲート prefix、ERROR は 4xx形式 676件 (→REJECT) + Yahoo bar fetch 11件 (→ERROR 維持)