### PR TITLE
fix: snapshot main tree in release branch instead of squash-merging

### DIFF
--- a/.github/workflows/production-release-pr.yml
+++ b/.github/workflows/production-release-pr.yml
@@ -60,13 +60,18 @@ jobs:
           # Fetch production so we can build release/production on top of it.
           git fetch --no-tags "$remote" production:refs/remotes/origin/production
 
-          # Squash all changes from main that are not yet on production into a single
-          # commit on top of production. This keeps release/production linear (no merge
-          # commits) even when individual commits conflict with production's context.
-          # Individual commit history is preserved on main; production gets one
-          # release commit per deploy.
+          # Snapshot main's tree wholesale on top of production (no 3-way merge).
+          # The release intent is "production := current main content", and release
+          # commits never flow back to main, so the merge-base between the two
+          # branches stays frozen at the last pre-squash-flow release. A frozen
+          # base makes `git merge --squash` accumulate spurious conflicts over
+          # time (add/add on files added after the base and later modified on
+          # main, lockfile churn) — observed 2026-07-03 when 0037 + pnpm-lock
+          # conflicts blocked release PR creation. read-tree sidesteps merging
+          # entirely: the index becomes exactly main's tree, production history
+          # stays linear with one release commit per deploy.
           git checkout -B release/production origin/production
-          git merge --squash origin/main
+          git read-tree -u --reset origin/main
           if git diff --cached --quiet; then
             echo "::notice::No changes between production and main; nothing to commit."
           else
@@ -165,8 +170,9 @@ jobs:
             gh pr create --base production --head release/production --title "$title" --body-file release-pr-body.md
           fi
 
-      # release/production は production をベースにチェリーピックで作成するため、
-      # 通常は production と fast-forward 関係にあり BEHIND にはならない。
+      # release/production は production の先端に main の snapshot commit を1つ
+      # 積む形で作成するため、通常は production と fast-forward 関係にあり
+      # BEHIND にはならない。
       # production に新コミットが来て BEHIND になった場合は update-branch (merge commit
       # を生成) ではなく、このワークフローを再実行して release/production を作り直す。
       - name: Check release PR branch is not behind


### PR DESCRIPTION
## 症状

main への push 後、production release PR が作成されない。workflow の `Update release branch` step が conflict で fail (`0037_...sql` add/add / `pnpm-lock.yaml` / workflow 自身)。

## 根本原因

#538 の squash 方式は release commit が main に還流しないため、**production↔main の merge-base が 12eb4e8 (6/24) で永久凍結**される。凍結 base からの 3-way merge は、base 以降に追加→変更されたファイル (今回の 0037) で add/add conflict、renovate の lockfile 更新で content conflict を蓄積する。時間経過で必ず再発する構造的問題 (#542 のマージ方法とは無関係)。

## 修正

リリースの意味は「production := main の現在内容」の snapshot でありマージではないので、`git merge --squash origin/main` を `git read-tree -u --reset origin/main` に置換。index が main の tree そのものになるため conflict が原理的に発生しない。production の linear 履歴 (1リリース=1コミット) は維持。

## 検証

production 先端から read-tree でシミュレーション実行: 生成 tree のハッシュが `origin/main^{tree}` と完全一致 (`4916ffe...`)、`git diff --cached` 非空でコミット生成も正常。

## Note

マージ後に production-release-pr workflow を workflow_dispatch で再実行すれば、止まっていたリリース PR が生成されます。