### PR TITLE
feat: rule-based NYSE holiday calendar + quote staleness in spread reason (issue #547)

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -3972,6 +3972,18 @@ export function localizeReason(en: string | null | undefined): string {
   )
   s = s.replace(/^sizing rejected: zero qty$/, '買付余力不足: 1株分の余力なし')
 
+  // === Per-symbol risk gate: spread guard (#547) ===
+  // spread reject は臨時休場 (session gate をルールで書けない閉場) のバック
+  // ストップを兼ねる。鮮度 suffix があれば「板が古い = 休場・閉場中の可能性」を
+  // 明示する。suffix なし (旧形式 / asOf 欠落) は従来通り数値のみ。
+  s = s.replace(
+    /^spread ([\d.]+)% exceeds (US|JP) limit ([\d.]+)%(?: \(quote asOf ([^,]+), ([\d.]+)h stale\))?$/,
+    (_m, pct, mkt, lim, asOf, hours) =>
+      `発注スキップ: 気配スプレッド過大 (${pct}% > ${mkt} 上限 ${lim}%${
+        asOf ? `、板情報は ${fmtJst(asOf)} 時点 / ${hours}時間前 — 休場・閉場中の可能性` : ''
+      })`,
+  )
+
   // === Scheduler inline ===
   s = s.replace(/^SELL without position$/, '発注スキップ: 手仕舞い対象の建玉なし')
   s = s.replace(/^insufficient bars for indicators$/, 'データ不足: 指標計算に必要な日柄不足')

--- a/src/trading/domain/tradingCalendar.ts
+++ b/src/trading/domain/tradingCalendar.ts
@@ -260,6 +260,9 @@ export function isUsMarketEarlyCloseDay(date: Date): boolean {
  * 指定 market の営業日なら true。土日 + 祝日で false。
  */
 export function isTradingDay(date: Date, market: TradingMarket): boolean {
+  // invalid Date は getUTC*() が NaN になり土日/祝日判定をすり抜けて「営業日」
+  // 側 (fail-open) に落ちるため、先に弾く (fail-closed)。
+  if (!Number.isFinite(date.getTime())) return false
   if (isWeekend(date)) return false
   if (market === 'US') {
     // US は従来どおり UTC 日付基準のままルール判定へ委譲 (#547)。static set

--- a/src/trading/domain/tradingCalendar.ts
+++ b/src/trading/domain/tradingCalendar.ts
@@ -1,24 +1,28 @@
 /**
  * 取引所カレンダー (JP 東証 / US NYSE)。
  *
- * 現状は 2026 / 2027 分だけ static テーブルで持つ。POC 運用に入る前に
- * **2028 以降を追記する** こと (下の HOLIDAYS テーブル参照)。米国の
- * early close (感謝祭翌日 13:00 close 等) は POC では扱わない。
+ * US (NYSE) の全日休場・半日取引 (13:00 ET close) は #547 でルール計算
+ * (`isUsMarketHoliday` / `isUsMarketEarlyCloseDay`) に移行済みで年次メンテ不要。
+ * JP は 2026 / 2027 分だけ static テーブルで持つ。POC 運用を続けるなら
+ * **JP の 2028 以降を追記する** こと (下の HOLIDAYS テーブル参照)。
  *
- * 祝日判定は UTC で比較する。Date 引数は UTC 日付として扱われ、
- * getUTCFullYear / getUTCMonth / getUTCDate の組で YYYY-MM-DD に丸めて
- * set と突き合わせる。時刻成分は無視する。
+ * `isTradingDay` / `nextTradingDay` / `countTradingDaysBetween` の祝日判定は
+ * UTC 日付基準 (時刻成分は無視)。市場ローカル暦日 (ET / JST) 基準の関数
+ * (`isUsMarketHoliday` / `evaluateStrategyWindow` 等) は各 doc comment 参照。
  */
 
 export type TradingMarket = 'JP' | 'US'
 
 const MS_PER_DAY = 86_400_000
 
-// TODO(annual): 2028 以降の祝日を運用入り前に追記する。
+// TODO(annual): JP の 2028 以降の祝日を運用入り前に追記する。
 // JP: 東証休業日 (国民の祝日 + 振替休日 + 年始 1/1–1/3 + 大晦日 12/31)
 // US NYSE: 9 祝日 + Good Friday。土日と重なる祝日は observed day (振替) を入れる。
+//   ※ US の単一情報源は #547 でルール計算 (`isUsMarketHoliday`) に移った。
+//   この US set は infrastructure 層の `NYSE_CLOSURES` re-export (#354) 向けに
+//   残しており、ルールとの整合はテストで担保する (tradingCalendar.test.ts)。
 //
-// このテーブルは market holiday set の単一情報源 (#354)。
+// JP テーブルは market holiday set の単一情報源 (#354)。
 // `src/infrastructure/calendar/{us,jp}MarketCalendar.ts` の tz-aware
 // session-day check も `NYSE_CLOSURES` / `TSE_CLOSURES` re-export を経由して
 // 同じデータを参照する。
@@ -86,14 +90,15 @@ export const HOLIDAYS: Record<TradingMarket, ReadonlySet<string>> = {
     '2027-09-06', // Labor Day
     '2027-11-25', // Thanksgiving
     '2027-12-24', // Christmas observed (Dec 25 is Sat)
-    '2027-12-31', // New Year's Day observed (Jan 1 2028 is Sat)
+    // 2027-12-31 は休場にしない: NYSE Rule 7.2 (年末の営業最終日は 1/1 が土曜
+    // でも開ける)。実例: 2022-01-01 (土) に対し 2021-12-31 は通常立会だった。
   ]),
 }
 
 /**
  * `HOLIDAYS` の market 別 alias。infrastructure 層の tz-aware session-day check
- * が import するためだけに公開する (#354)。新しい消費者は `HOLIDAYS[market]`
- * を使うか、`isTradingDay` 等の関数 API を使うこと。
+ * が import するためだけに公開する (#354)。新しい消費者は `isTradingDay` /
+ * `isUsMarketHoliday` 等の関数 API を使うこと (US はルール計算が単一情報源、#547)。
  */
 export const NYSE_CLOSURES: ReadonlySet<string> = HOLIDAYS.US
 export const TSE_CLOSURES: ReadonlySet<string> = HOLIDAYS.JP
@@ -107,11 +112,160 @@ function isWeekend(date: Date): boolean {
   return dow === 0 || dow === 6
 }
 
+// ---------------------------------------------------------------------------
+// US (NYSE) ルール計算カレンダー (#547)
+//
+// 静的テーブルの年次追記を不要にするため、休場・半日取引を規則から導出する。
+// 臨時休場 (服喪・災害等の unscheduled closure) は規則で書けないため対象外 —
+// その日は評価が走ってしまうが、閉場で板が更新されず spread gate
+// (perSymbolRiskGate) が stale quote を reject するのがバックストップ。
+// ---------------------------------------------------------------------------
+
+/** proleptic Gregorian の曜日 (0=Sun .. 6=Sat)。month は 1–12。 */
+function dayOfWeek(year: number, month: number, day: number): number {
+  return new Date(Date.UTC(year, month - 1, day)).getUTCDay()
+}
+
+/**
+ * 復活祭 (Easter Sunday) の月日 (month は 1–12)。Computus の Anonymous
+ * Gregorian algorithm (Meeus / Jones / Butcher)。Good Friday の導出にだけ使う。
+ */
+function computeEasterSunday(year: number): { month: number; day: number } {
+  const a = year % 19
+  const b = Math.floor(year / 100)
+  const c = year % 100
+  const d = Math.floor(b / 4)
+  const e = b % 4
+  const f = Math.floor((b + 8) / 25)
+  const g = Math.floor((b - f + 1) / 3)
+  const h = (19 * a + b - d - g + 15) % 30
+  const i = Math.floor(c / 4)
+  const k = c % 4
+  const l = (32 + 2 * e + 2 * i - h - k) % 7
+  const m = Math.floor((a + 11 * h + 22 * l) / 451)
+  const month = Math.floor((h + l - 7 * m + 114) / 31)
+  const day = ((h + l - 7 * m + 114) % 31) + 1
+  return { month, day }
+}
+
+/** Good Friday = 復活祭の 2 日前 (Date.UTC の日付正規化で月跨ぎを吸収)。 */
+function computeGoodFriday(year: number): { month: number; day: number } {
+  const easter = computeEasterSunday(year)
+  const gf = new Date(Date.UTC(year, easter.month - 1, easter.day - 2))
+  return { month: gf.getUTCMonth() + 1, day: gf.getUTCDate() }
+}
+
+/**
+ * 振替付き固定祝日 (New Year 1/1, Juneteenth 6/19, Independence 7/4,
+ * Christmas 12/25)。土曜に当たる年は前日金曜、日曜に当たる年は翌月曜が休場。
+ *
+ * 例外 (NYSE Rule 7.2): 1/1 が土曜の年は前年 12/31 (金) へ振替**しない**
+ * (年末の営業最終日は開ける。実例: 2022-01-01 が土曜で 2021-12-31 は通常立会)。
+ * 下の判定では「前日金曜」候補が day 0 となり構造的にマッチしないため、
+ * 追加分岐なしでこの例外を満たす。
+ */
+const US_FIXED_HOLIDAYS: ReadonlyArray<{ month: number; day: number }> = [
+  { month: 1, day: 1 },
+  { month: 6, day: 19 },
+  { month: 7, day: 4 },
+  { month: 12, day: 25 },
+]
+
+/**
+ * NYSE 全日休場判定のルール本体。year/month/day は **America/New_York の暦日**
+ * (month 1–12)。休場は observed day (振替後の平日) のみ true — 土日そのものは
+ * false を返すので、呼び出し側の週末判定と組み合わせる。
+ */
+function isUsMarketHolidayYmd(year: number, month: number, day: number): boolean {
+  const dow = dayOfWeek(year, month, day)
+  for (const holiday of US_FIXED_HOLIDAYS) {
+    if (holiday.month !== month) continue
+    if (day === holiday.day && dow >= 1 && dow <= 5) return true
+    if (day === holiday.day - 1 && dow === 5) return true // 祝日が土曜 → 前日金曜が休場
+    if (day === holiday.day + 1 && dow === 1) return true // 祝日が日曜 → 翌月曜が休場
+  }
+  if (dow === 1) {
+    if (month === 1 && day >= 15 && day <= 21) return true // MLK Day (1月第3月曜)
+    if (month === 2 && day >= 15 && day <= 21) return true // Presidents' Day (2月第3月曜)
+    if (month === 5 && day >= 25) return true // Memorial Day (5月最終月曜)
+    if (month === 9 && day <= 7) return true // Labor Day (9月第1月曜)
+  }
+  if (dow === 4 && month === 11 && day >= 22 && day <= 28) return true // Thanksgiving (11月第4木曜)
+  const goodFriday = computeGoodFriday(year)
+  return month === goodFriday.month && day === goodFriday.day
+}
+
+/**
+ * NYSE 半日取引 (13:00 ET close) 判定のルール本体 (暦日は ET、month 1–12)。
+ *  - 7/3: 7/4 が火〜金の年 (= 7/3 が月〜木)。7/4 が土曜の年の 7/3 は全日休場
+ *    (振替) 側なので対象外、7/4 が月曜の年の 7/3 は日曜で対象外
+ *  - 感謝祭翌日 (11月第4木曜の翌金曜)
+ *  - 12/24: 12/25 が火〜金の年 (= 12/24 が月〜木)。12/25 が土曜の年の 12/24 は
+ *    全日休場 (振替) 側なので対象外
+ */
+function isUsMarketEarlyCloseYmd(year: number, month: number, day: number): boolean {
+  const dow = dayOfWeek(year, month, day)
+  if (month === 7 && day === 3) return dow >= 1 && dow <= 4
+  if (month === 11 && dow === 5 && day >= 23 && day <= 29) return true
+  if (month === 12 && day === 24) return dow >= 1 && dow <= 4
+  return false
+}
+
+/**
+ * `date` (UTC instant) の America/New_York 暦日を数値 y/m/d で返す。
+ * `Intl.DateTimeFormat#formatToParts` ベース (DST 自動解決。format() の出力
+ * 文字列に依存しないのは #349 と同じ理由)。抽出失敗は null。
+ */
+function extractEtYmd(date: Date): { year: number; month: number; day: number } | null {
+  if (!Number.isFinite(date.getTime())) return null
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/New_York',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(date)
+  const get = (type: Intl.DateTimeFormatPartTypes): number =>
+    Number(parts.find((p) => p.type === type)?.value)
+  const year = get('year')
+  const month = get('month')
+  const day = get('day')
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) return null
+  return { year, month, day }
+}
+
+/**
+ * `date` 時点の **America/New_York 暦日** が NYSE 全日休場 (祝日 + 振替) なら
+ * true (#547)。固定日 + 振替 / 第n月曜 / Memorial / Thanksgiving / Good Friday
+ * (Computus) をルール計算するので年次テーブル追記は不要。土日は false
+ * (observed day のみ休場扱い)。臨時休場は対象外 — spread gate がバックストップ
+ * (上のセクションコメント参照)。
+ */
+export function isUsMarketHoliday(date: Date): boolean {
+  const ymd = extractEtYmd(date)
+  if (ymd === null) return false
+  return isUsMarketHolidayYmd(ymd.year, ymd.month, ymd.day)
+}
+
+/**
+ * `date` 時点の ET 暦日が NYSE 半日取引 (13:00 ET close) 日なら true (#547)。
+ * 対象: 7/3 (7/4 が平日の年) / 感謝祭翌日 / 12/24 (12/25 が平日の年)。
+ */
+export function isUsMarketEarlyCloseDay(date: Date): boolean {
+  const ymd = extractEtYmd(date)
+  if (ymd === null) return false
+  return isUsMarketEarlyCloseYmd(ymd.year, ymd.month, ymd.day)
+}
+
 /**
  * 指定 market の営業日なら true。土日 + 祝日で false。
  */
 export function isTradingDay(date: Date, market: TradingMarket): boolean {
   if (isWeekend(date)) return false
+  if (market === 'US') {
+    // US は従来どおり UTC 日付基準のままルール判定へ委譲 (#547)。static set
+    // 参照と同じ semantics を保ちつつ、テーブル切れ (2028 以降) が無くなる。
+    return !isUsMarketHolidayYmd(date.getUTCFullYear(), date.getUTCMonth() + 1, date.getUTCDate())
+  }
   const ymd = toYmdUtc(date)
   return !HOLIDAYS[market].has(ymd)
 }
@@ -168,17 +322,19 @@ export function inferTradingMarket(symbol: string): TradingMarket {
 /** US NYSE レギュラー引け = 16:00 ET (分換算)。 */
 const US_REGULAR_CLOSE_ET_MINUTES = 16 * 60
 
+/** US NYSE 半日取引の引け = 13:00 ET (分換算、#547)。 */
+const US_EARLY_CLOSE_ET_MINUTES = 13 * 60
+
 /**
- * `now` が **US 取引日かつ NYSE 引け (16:00 ET) の `minutesBeforeClose` 分前〜引け**
+ * `now` が **US 取引日かつ NYSE 引けの `minutesBeforeClose` 分前〜引け**
  * の窓内なら true (#intraday-only)。レバ ETF をオーバーナイト持ち越さず引け前に
- * 強制クローズするのに使う。
+ * 強制クローズするのに使う。半日取引日 (感謝祭翌日等) は引けを 13:00 ET に
+ * 短縮して判定する (#547)。
  *
  * ET wall-clock は `Intl.DateTimeFormat('America/New_York')` で取得し DST 自動対応
- * (macroEventGate と同手法)。引け窓は午後 ET なので UTC 日付 == ET 日付 (深夜跨ぎ
- * 無し) → `isTradingDay(now,'US')` を UTC 基準で使って問題ない。
- *
- * 注意: early close (感謝祭翌日 13:00 ET 等) は POC 未対応 — その日は窓に当たらず
- * 持ち越しうる (`tradingCalendar` 冒頭コメント参照)。
+ * (macroEventGate と同手法)。引け窓は 13:00/16:00 ET どちらでも午後 ET なので
+ * UTC 日付 == ET 日付 (深夜跨ぎ無し) → `isTradingDay(now,'US')` と半日取引判定を
+ * UTC 日付基準で使って問題ない。
  */
 export function isWithinUsCloseWindow(now: Date, minutesBeforeClose: number): boolean {
   if (!Number.isFinite(minutesBeforeClose) || minutesBeforeClose <= 0) return false
@@ -193,19 +349,23 @@ export function isWithinUsCloseWindow(now: Date, minutesBeforeClose: number): bo
   const minute = Number(parts.find((p) => p.type === 'minute')?.value)
   if (!Number.isFinite(hour) || !Number.isFinite(minute)) return false
   const etMinutes = (hour % 24) * 60 + minute // hour12:false で稀に '24' を返す Intl quirk 対策
-  return (
-    etMinutes >= US_REGULAR_CLOSE_ET_MINUTES - minutesBeforeClose &&
-    etMinutes < US_REGULAR_CLOSE_ET_MINUTES
+  const closeEtMinutes = isUsMarketEarlyCloseYmd(
+    now.getUTCFullYear(),
+    now.getUTCMonth() + 1,
+    now.getUTCDate(),
   )
+    ? US_EARLY_CLOSE_ET_MINUTES
+    : US_REGULAR_CLOSE_ET_MINUTES
+  return etMinutes >= closeEtMinutes - minutesBeforeClose && etMinutes < closeEtMinutes
 }
 
 /**
  * 市場ごとのレギュラーセッション (開場 / 引け、市場ローカル分換算)。
- * - US NYSE: 09:30–16:00 ET
+ * - US NYSE: 09:30–16:00 ET (半日取引日は 13:00 ET 引け、#547)
  * - JP TSE : 09:00–15:30 JST (引けは 2024-11-05 に 15:30 へ延長後の値)
  *
- * lunch break (JP 11:30–12:30) / early close (US 13:00 ET) は POC 未対応 —
- * 窓内扱いで評価は走る (発注は marketHoursCheck / 板で自然に抑制される)。
+ * lunch break (JP 11:30–12:30) は POC 未対応 — 窓内扱いで評価は走る
+ * (発注は marketHoursCheck / 板で自然に抑制される)。
  */
 const MARKET_SESSION: Record<
   TradingMarket,
@@ -216,23 +376,33 @@ const MARKET_SESSION: Record<
 }
 
 /**
+ * #session-window-gate の判定結果 (#547)。
+ * - 'market_holiday': 全日休場 (US はルール計算、JP は HOLIDAYS static テーブル。
+ *   土日は恒常的で operator への情報量が無いため従来通り 'outside_window')
+ * - 'in_window': 取引日かつ [開場 - minutesBeforeOpen, 引け)
+ * - 'outside_window': それ以外 (窓外 / 土日 / 引数不正は fail-closed で窓外扱い)
+ */
+export type StrategyWindowVerdict = 'in_window' | 'outside_window' | 'market_holiday'
+
+/**
  * `now` が **当該 market の取引日かつ「開場 `minutesBeforeOpen` 分前〜引け」**
- * の窓内なら true (#session-window-gate)。戦略 cron を開場前まで停止するゲートに
- * 使う (窓外は評価そのものを skip)。
+ * の窓のどこに居るかを返す (#session-window-gate)。戦略 cron を開場前まで停止する
+ * ゲートに使う (窓外は評価そのものを skip)。US の半日取引日は引けを 13:00 ET に
+ * 短縮する (#547)。
  *
  * `isWithinUsCloseWindow` と異なり **開場側 (朝)** も判定するため、市場ローカルの
  * 日付・曜日・時刻をすべて `Intl.DateTimeFormat(timeZone)` から 1 回で抽出する。
  * 理由: JP 朝 (08:30 JST = 前日 23:30 UTC) は UTC 日付がズレるので、UTC 基準の
- * `isTradingDay` では曜日・祝日判定を誤る。祝日は **市場ローカル日付**で
- * `HOLIDAYS[market]` と照合する (2026/2027 を保持、範囲外は曜日判定のみに degrade)。
- * DST は `Intl` が自動解決する。
+ * `isTradingDay` では曜日・祝日判定を誤る。祝日は **市場ローカル日付** で判定する
+ * (US はルール計算で年次メンテ不要、JP は HOLIDAYS static — 2026/2027 を保持、
+ * 範囲外は曜日判定のみに degrade)。DST は `Intl` が自動解決する。
  */
-export function isWithinStrategyWindow(
+export function evaluateStrategyWindow(
   now: Date,
   market: TradingMarket,
   minutesBeforeOpen: number,
-): boolean {
-  if (!Number.isFinite(minutesBeforeOpen) || minutesBeforeOpen < 0) return false
+): StrategyWindowVerdict {
+  if (!Number.isFinite(minutesBeforeOpen) || minutesBeforeOpen < 0) return 'outside_window'
   const session = MARKET_SESSION[market]
   const parts = new Intl.DateTimeFormat('en-US', {
     timeZone: session.timeZone,
@@ -247,15 +417,39 @@ export function isWithinStrategyWindow(
   const get = (type: Intl.DateTimeFormatPartTypes): string =>
     parts.find((p) => p.type === type)?.value ?? ''
   const weekday = get('weekday')
-  if (weekday === 'Sat' || weekday === 'Sun') return false
-  const ymd = `${get('year')}-${get('month')}-${get('day')}`
-  if (HOLIDAYS[market].has(ymd)) return false
+  if (weekday === 'Sat' || weekday === 'Sun') return 'outside_window'
+  const year = Number(get('year'))
+  const month = Number(get('month'))
+  const day = Number(get('day'))
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) {
+    return 'outside_window'
+  }
+  if (market === 'US') {
+    if (isUsMarketHolidayYmd(year, month, day)) return 'market_holiday'
+  } else if (HOLIDAYS[market].has(`${get('year')}-${get('month')}-${get('day')}`)) {
+    return 'market_holiday'
+  }
   const hour = Number(get('hour'))
   const minute = Number(get('minute'))
-  if (!Number.isFinite(hour) || !Number.isFinite(minute)) return false
+  if (!Number.isFinite(hour) || !Number.isFinite(minute)) return 'outside_window'
   const localMinutes = (hour % 24) * 60 + minute // hour12:false で稀に '24' を返す Intl quirk 対策
-  return (
-    localMinutes >= session.openMinutes - minutesBeforeOpen &&
-    localMinutes < session.closeMinutes
-  )
+  const closeMinutes =
+    market === 'US' && isUsMarketEarlyCloseYmd(year, month, day)
+      ? US_EARLY_CLOSE_ET_MINUTES
+      : session.closeMinutes
+  return localMinutes >= session.openMinutes - minutesBeforeOpen && localMinutes < closeMinutes
+    ? 'in_window'
+    : 'outside_window'
+}
+
+/**
+ * `now` が窓内 ('in_window') なら true。休場と窓外の区別が要らない呼び出し側
+ * 向けの薄い wrapper (#session-window-gate)。
+ */
+export function isWithinStrategyWindow(
+  now: Date,
+  market: TradingMarket,
+  minutesBeforeOpen: number,
+): boolean {
+  return evaluateStrategyWindow(now, market, minutesBeforeOpen) === 'in_window'
 }

--- a/src/trading/risk/perSymbolRiskGate.ts
+++ b/src/trading/risk/perSymbolRiskGate.ts
@@ -150,7 +150,7 @@ export function evaluatePerSymbolRisk(
   //    bid/ask 欠損は source 次第: Yahoo 等 bid/ask 非対応 source は適用外で通し、
   //    それ以外 (Webull 等) は fail-closed (issue #411 で恒久対応 = Webull bid/ask)。
   if (side === 'BUY') {
-    const spreadReason = evaluateSpreadGate(symbol, state.lastQuote, config.spreadLimits)
+    const spreadReason = evaluateSpreadGate(symbol, state.lastQuote, config.spreadLimits, now)
     if (spreadReason !== null) {
       return reject(spreadReason)
     }
@@ -189,6 +189,7 @@ function evaluateSpreadGate(
   symbol: string,
   lastQuote: QuoteSnapshot | null,
   limits: { US: number; JP: number },
+  now: Date,
 ): string | null {
   if (lastQuote === null) return null
   const bid = lastQuote.bid
@@ -216,9 +217,25 @@ function evaluateSpreadGate(
     return 'spread invalid: crossed book, non-finite, or non-positive bid/ask'
   }
   if (spreadPct > limit) {
-    return `spread ${(spreadPct * 100).toFixed(3)}% exceeds ${market} limit ${(limit * 100).toFixed(3)}%`
+    // 臨時休場 (服喪・緊急閉場) はカレンダーのルール計算 (tradingCalendar #547)
+    // で書けず session window gate をすり抜ける。その場合はこの spread reject が
+    // バックストップになるため、quote 鮮度を併記して「板が古い = 閉場中の可能性」
+    // が reason 単体で読めるようにする。
+    return `spread ${(spreadPct * 100).toFixed(3)}% exceeds ${market} limit ${(limit * 100).toFixed(3)}%${formatQuoteStaleness(lastQuote.asOf, now)}`
   }
   return null
+}
+
+/**
+ * `" (quote asOf <ISO>, <N>h stale)"` suffix (#547)。asOf 欠落 / parse 不能は
+ * 空文字を返し、reason は従来形のまま。clock skew による負値は 0.0h に clamp。
+ */
+function formatQuoteStaleness(asOf: string | undefined, now: Date): string {
+  if (!asOf) return ''
+  const asOfMs = new Date(asOf).getTime()
+  if (!Number.isFinite(asOfMs)) return ''
+  const staleHours = Math.max(0, (now.getTime() - asOfMs) / 3_600_000)
+  return ` (quote asOf ${asOf}, ${staleHours.toFixed(1)}h stale)`
 }
 
 function evaluateGap(state: SymbolState, thresholdPct: number): string | null {

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -45,7 +45,7 @@ import {
 } from '../risk/vixRegimeFilter'
 import { detectAndNotifyVixRegimeChange } from '../../infrastructure/notification/vixRegimeChange'
 import { resolveTradingEnabled } from '../runtime/killSwitch'
-import { isWithinStrategyWindow } from '../domain/tradingCalendar'
+import { evaluateStrategyWindow, type StrategyWindowVerdict } from '../domain/tradingCalendar'
 import { runPullbackScheduler, type PullbackDecisionTrace, type PullbackRunSummary } from './pullbackScheduler'
 import { BreakoutMomentumStrategy, TEST_DEFAULT_MOMENTUM_RULE } from './strategies/BreakoutMomentumStrategy'
 import {
@@ -99,6 +99,7 @@ export interface StrategyCronResult {
     | 'trading_disabled'
     | 'no_tradable_symbols'
     | 'outside_session_window'
+    | 'market_holiday'
     | 'no_bridge_state'
     | 'portfolio_halted'
     | 'drawdown_kill'
@@ -356,23 +357,37 @@ export async function runStrategyCron(
   // が true の時、開場 PRE_OPEN_WINDOW_MIN 分前〜引けの窓外は戦略評価そのものを
   // skip する (cron は発火するが portfolio DO / VIX / 買付余力取得まで全て省く)。
   // 市場ごとに判定し、窓内の currency だけを後段 run に進める (例: US だけ窓内なら
-  // USD run のみ)。flag off は従来挙動 (全 currency 常時評価)。skip は「設定通り」
-  // なので `trading_disabled` 同様 **通知しない** (noisy 回避)。
+  // USD run のみ)。休場日 (US はルール計算 / JP は static テーブル、#547) は
+  // `market_holiday`、それ以外の窓外は `outside_session_window` と skip 理由を
+  // 区別する — 2026-07-03 振替休場で stale-quote SKIP が量産された際、reason から
+  // 休場が読めなかった反省。US 半日取引日は引けが 13:00 ET に短縮される (#547)。
+  // flag off は従来挙動 (全 currency 常時評価)。skip は「設定通り」なので
+  // `trading_disabled` 同様 **通知しない** (noisy 回避)。
   const sessionNow = new Date()
+  const windowVerdicts: StrategyWindowVerdict[] = []
   const activeCurrencies = new Set<SymbolCurrency>(
-    (['USD', 'JPY'] as const).filter(
-      (cur) =>
-        byCurrency[cur].length > 0 &&
-        (!global.sessionWindowGateEnabled ||
-          isWithinStrategyWindow(sessionNow, cur === 'JPY' ? 'JP' : 'US', PRE_OPEN_WINDOW_MIN)),
-    ),
+    (['USD', 'JPY'] as const).filter((cur) => {
+      if (byCurrency[cur].length === 0) return false
+      if (!global.sessionWindowGateEnabled) return true
+      const verdict = evaluateStrategyWindow(
+        sessionNow,
+        cur === 'JPY' ? 'JP' : 'US',
+        PRE_OPEN_WINDOW_MIN,
+      )
+      windowVerdicts.push(verdict)
+      return verdict === 'in_window'
+    }),
   )
   if (global.sessionWindowGateEnabled && activeCurrencies.size === 0) {
+    // 全対象 market が休場のときだけ `market_holiday` (休場と窓外が混在する場合、
+    // 休場だけでは skip の説明にならないので従来ラベルに倒す)。
+    const allHoliday =
+      windowVerdicts.length > 0 && windowVerdicts.every((v) => v === 'market_holiday')
     return {
       summary: emptySummary(),
       symbols: universe.allowedSymbols,
       analysis: analysisBase(),
-      skipReason: 'outside_session_window',
+      skipReason: allHoliday ? 'market_holiday' : 'outside_session_window',
     }
   }
 

--- a/test/routes/localizeReason.test.ts
+++ b/test/routes/localizeReason.test.ts
@@ -167,6 +167,23 @@ describe('localizeReason (日本株・信用取引の伝統的語彙)', () => {
       )
     })
 
+    it('spread reject (鮮度 suffix 付き) → 休場・閉場中の可能性を明示 (#547)', () => {
+      // UTC 2026-07-02T20:00:00.000Z → JST 2026-07-03 05:00:00
+      expect(
+        localizeReason(
+          'spread 15.121% exceeds US limit 0.250% (quote asOf 2026-07-02T20:00:00.000Z, 19.3h stale)',
+        ),
+      ).toBe(
+        '発注スキップ: 気配スプレッド過大 (15.121% > US 上限 0.250%、板情報は 2026-07-03 05:00:00 JST 時点 / 19.3時間前 — 休場・閉場中の可能性)',
+      )
+    })
+
+    it('spread reject (suffix なしの旧形式) → 数値のみ翻訳', () => {
+      expect(localizeReason('spread 15.121% exceeds US limit 0.250%')).toBe(
+        '発注スキップ: 気配スプレッド過大 (15.121% > US 上限 0.250%)',
+      )
+    })
+
     it('insufficient bars → 日柄不足', () => {
       expect(localizeReason('insufficient bars for indicators')).toBe(
         'データ不足: 指標計算に必要な日柄不足',

--- a/test/trading/domain/tradingCalendar.test.ts
+++ b/test/trading/domain/tradingCalendar.test.ts
@@ -107,6 +107,11 @@ describe('isWithinStrategyWindow — JP (#session-window-gate)', () => {
 })
 
 describe('isTradingDay', () => {
+  it('invalid Date は fail-closed で false (US/JP とも)', () => {
+    expect(isTradingDay(new Date('invalid'), 'US')).toBe(false)
+    expect(isTradingDay(new Date('invalid'), 'JP')).toBe(false)
+  })
+
   it('returns false for weekends', () => {
     // Sat
     expect(isTradingDay(new Date('2026-04-18T10:00:00.000Z'), 'US')).toBe(false)

--- a/test/trading/domain/tradingCalendar.test.ts
+++ b/test/trading/domain/tradingCalendar.test.ts
@@ -1,12 +1,33 @@
 import { describe, expect, it } from 'vitest'
 import {
   countTradingDaysBetween,
+  evaluateStrategyWindow,
+  HOLIDAYS,
   inferTradingMarket,
   isTradingDay,
+  isUsMarketEarlyCloseDay,
+  isUsMarketHoliday,
   isWithinStrategyWindow,
   isWithinUsCloseWindow,
   nextTradingDay,
 } from '../../../src/trading/domain/tradingCalendar'
+
+/** `ymd` の ET 日中 (17:00Z = 12:00 EST / 13:00 EDT) — ET 暦日 == UTC 暦日 == ymd。 */
+const etMidday = (ymd: string) => new Date(`${ymd}T17:00:00.000Z`)
+
+/** `year` の全日を ET 日中 instant で走査し、predicate が true の ymd を集める。 */
+function scanYear(year: number, predicate: (d: Date) => boolean): string[] {
+  const hits: string[] = []
+  for (
+    let t = Date.UTC(year, 0, 1, 17);
+    t < Date.UTC(year + 1, 0, 1);
+    t += 86_400_000
+  ) {
+    const d = new Date(t)
+    if (predicate(d)) hits.push(d.toISOString().slice(0, 10))
+  }
+  return hits
+}
 
 describe('isWithinUsCloseWindow (#intraday-only)', () => {
   // 2026-04-20 は月曜 (US 取引日)、EDT (UTC-4) → NYSE 引け 16:00 ET = 20:00 UTC。
@@ -167,5 +188,210 @@ describe('inferTradingMarket', () => {
   it('treats alphabetic symbols as US', () => {
     expect(inferTradingMarket('SOXL')).toBe('US')
     expect(inferTradingMarket('AAPL')).toBe('US')
+  })
+})
+
+// NYSE 公式カレンダーの既知休場日 (2026–2030)。assert 値は自前計算ではなく
+// 公式カレンダー / 祝日規則の既知日 (#547 タスク指定の Good Friday 含む)。
+// 2028 に New Year 休場が無いのは NYSE Rule 7.2 (1/1 が土曜 → 前年 12/31 に
+// 振替しない) のため。
+const NYSE_EXPECTED_CLOSURES: Record<number, string[]> = {
+  2026: [
+    '2026-01-01', // New Year's Day
+    '2026-01-19', // MLK Day
+    '2026-02-16', // Presidents' Day
+    '2026-04-03', // Good Friday
+    '2026-05-25', // Memorial Day
+    '2026-06-19', // Juneteenth
+    '2026-07-03', // Independence Day observed (7/4 = 土)
+    '2026-09-07', // Labor Day
+    '2026-11-26', // Thanksgiving
+    '2026-12-25', // Christmas
+  ],
+  2027: [
+    '2027-01-01',
+    '2027-01-18',
+    '2027-02-15',
+    '2027-03-26', // Good Friday
+    '2027-05-31',
+    '2027-06-18', // Juneteenth observed (6/19 = 土)
+    '2027-07-05', // Independence Day observed (7/4 = 日)
+    '2027-09-06',
+    '2027-11-25',
+    '2027-12-24', // Christmas observed (12/25 = 土)
+  ],
+  2028: [
+    // New Year 休場なし (1/1 = 土、Rule 7.2)
+    '2028-01-17',
+    '2028-02-21',
+    '2028-04-14', // Good Friday
+    '2028-05-29',
+    '2028-06-19',
+    '2028-07-04',
+    '2028-09-04',
+    '2028-11-23',
+    '2028-12-25',
+  ],
+  2029: [
+    '2029-01-01',
+    '2029-01-15',
+    '2029-02-19',
+    '2029-03-30', // Good Friday
+    '2029-05-28',
+    '2029-06-19',
+    '2029-07-04',
+    '2029-09-03',
+    '2029-11-22',
+    '2029-12-25',
+  ],
+  2030: [
+    '2030-01-01',
+    '2030-01-21',
+    '2030-02-18',
+    '2030-04-19', // Good Friday
+    '2030-05-27',
+    '2030-06-19',
+    '2030-07-04',
+    '2030-09-02',
+    '2030-11-28',
+    '2030-12-25',
+  ],
+}
+
+describe('isUsMarketHoliday — NYSE 休場ルール計算 (#547)', () => {
+  for (const [year, expected] of Object.entries(NYSE_EXPECTED_CLOSURES)) {
+    it(`${year}: 年間走査が NYSE 公式カレンダーの休場日と完全一致する`, () => {
+      expect(scanYear(Number(year), isUsMarketHoliday)).toEqual(expected)
+    })
+  }
+
+  it('Good Friday (Computus): 2026–2030 の既知日', () => {
+    for (const gf of ['2026-04-03', '2027-03-26', '2028-04-14', '2029-03-30', '2030-04-19']) {
+      expect(isUsMarketHoliday(etMidday(gf)), gf).toBe(true)
+    }
+  })
+
+  it('振替境界: 7/4=土→7/3休場、7/4=日→7/5休場、7/4=平日→7/4のみ', () => {
+    // 2026: 7/4 土 → 7/3 (金) が休場。7/4 当日 (土) は observed でないので false。
+    expect(isUsMarketHoliday(etMidday('2026-07-03'))).toBe(true)
+    expect(isUsMarketHoliday(etMidday('2026-07-04'))).toBe(false)
+    // 2027: 7/4 日 → 7/5 (月) が休場。前週金曜 7/2 は通常営業。
+    expect(isUsMarketHoliday(etMidday('2027-07-05'))).toBe(true)
+    expect(isUsMarketHoliday(etMidday('2027-07-02'))).toBe(false)
+    // 2028: 7/4 火 (平日) → 休場は 7/4 のみ。7/3 (月) は半日取引であって休場ではない。
+    expect(isUsMarketHoliday(etMidday('2028-07-04'))).toBe(true)
+    expect(isUsMarketHoliday(etMidday('2028-07-03'))).toBe(false)
+    expect(isUsMarketHoliday(etMidday('2028-07-05'))).toBe(false)
+  })
+
+  it('NYSE Rule 7.2: 1/1 が土曜でも前年 12/31 (金) は休場にしない', () => {
+    // 2028-01-01 は土曜。実例: 2022-01-01 (土) に対し 2021-12-31 は通常立会。
+    expect(isUsMarketHoliday(etMidday('2027-12-31'))).toBe(false)
+    expect(isUsMarketHoliday(etMidday('2021-12-31'))).toBe(false)
+  })
+
+  it('判定は America/New_York 暦日基準 (UTC 日付をそのまま使わない)', () => {
+    // 2026-07-04T02:00Z = ET では 7/3 (金) 22:00 → 休場日
+    expect(isUsMarketHoliday(new Date('2026-07-04T02:00:00.000Z'))).toBe(true)
+    // 2026-07-03T03:00Z = ET では 7/2 (木) 23:00 → 通常営業日
+    expect(isUsMarketHoliday(new Date('2026-07-03T03:00:00.000Z'))).toBe(false)
+  })
+
+  it('static HOLIDAYS.US テーブル (NYSE_CLOSURES re-export 用) とルールが一致する', () => {
+    for (const year of [2026, 2027]) {
+      const fromTable = [...HOLIDAYS.US].filter((d) => d.startsWith(String(year))).sort()
+      expect(scanYear(year, isUsMarketHoliday)).toEqual(fromTable)
+    }
+  })
+
+  it('invalid Date は false (呼び出し側の窓判定で fail-closed)', () => {
+    expect(isUsMarketHoliday(new Date(Number.NaN))).toBe(false)
+  })
+})
+
+describe('isUsMarketEarlyCloseDay — 半日取引 (13:00 ET close) ルール計算 (#547)', () => {
+  const EXPECTED_EARLY_CLOSE: Record<number, string[]> = {
+    2026: ['2026-11-27', '2026-12-24'], // 7/3 は全日休場側 (7/4=土)
+    2027: ['2027-11-26'], // 7/3=土、12/24 は Christmas observed で全日休場側
+    2028: ['2028-07-03', '2028-11-24'], // 12/25=月 → 12/24 は日曜で対象外
+    2029: ['2029-07-03', '2029-11-23', '2029-12-24'],
+    2030: ['2030-07-03', '2030-11-29', '2030-12-24'],
+  }
+
+  for (const [year, expected] of Object.entries(EXPECTED_EARLY_CLOSE)) {
+    it(`${year}: 年間走査が既知の半日取引日と完全一致する`, () => {
+      expect(scanYear(Number(year), isUsMarketEarlyCloseDay)).toEqual(expected)
+    })
+  }
+
+  it('全日休場と半日取引は排他 (7/3・12/24 の振替年)', () => {
+    expect(isUsMarketEarlyCloseDay(etMidday('2026-07-03'))).toBe(false) // 全日休場
+    expect(isUsMarketEarlyCloseDay(etMidday('2027-12-24'))).toBe(false) // 全日休場
+    expect(isUsMarketEarlyCloseDay(etMidday('2028-07-03'))).toBe(true)
+  })
+})
+
+describe('evaluateStrategyWindow — 休場 / 半日取引 (#547)', () => {
+  it('US 祝日 (2026-07-03 振替休場) は窓内時刻でも market_holiday', () => {
+    expect(evaluateStrategyWindow(etMidday('2026-07-03'), 'US', 30)).toBe('market_holiday')
+    expect(isWithinStrategyWindow(etMidday('2026-07-03'), 'US', 30)).toBe(false)
+  })
+  it('JP 祝日は market_holiday (static テーブル)', () => {
+    // 2026-05-04(月) みどりの日、10:00 JST。
+    expect(evaluateStrategyWindow(new Date('2026-05-04T01:00:00.000Z'), 'JP', 30)).toBe(
+      'market_holiday',
+    )
+  })
+  it('土日・時間外は従来通り outside_window (休場ラベルにしない)', () => {
+    expect(evaluateStrategyWindow(new Date('2026-04-18T16:00:00.000Z'), 'US', 30)).toBe(
+      'outside_window',
+    ) // 土曜
+    expect(evaluateStrategyWindow(new Date('2026-04-20T06:00:00.000Z'), 'US', 30)).toBe(
+      'outside_window',
+    ) // 02:00 ET
+  })
+  it('通常取引日の日中は in_window', () => {
+    expect(evaluateStrategyWindow(new Date('2026-04-20T17:00:00.000Z'), 'US', 30)).toBe(
+      'in_window',
+    )
+  })
+  it('Rule 7.2: 2027-12-31 (金) は通常営業として in_window', () => {
+    expect(evaluateStrategyWindow(etMidday('2027-12-31'), 'US', 30)).toBe('in_window')
+  })
+  it('半日取引日 (2026-11-27) は引けが 13:00 ET に短縮される', () => {
+    // EST (UTC-5): 12:59 ET = 17:59Z は窓内、13:00 ET = 18:00Z は窓外。
+    expect(evaluateStrategyWindow(new Date('2026-11-27T17:59:00.000Z'), 'US', 30)).toBe(
+      'in_window',
+    )
+    expect(evaluateStrategyWindow(new Date('2026-11-27T18:00:00.000Z'), 'US', 30)).toBe(
+      'outside_window',
+    )
+    // 比較: 通常日 (2026-11-30 月) の 13:00 ET は窓内のまま。
+    expect(evaluateStrategyWindow(new Date('2026-11-30T18:00:00.000Z'), 'US', 30)).toBe(
+      'in_window',
+    )
+  })
+})
+
+describe('isWithinUsCloseWindow — 半日取引 (#547)', () => {
+  it('半日取引日は 13:00 ET 引け基準の窓になる', () => {
+    // 2026-11-27 (感謝祭翌日、EST)。窓 = [12:45, 13:00 ET)。
+    expect(isWithinUsCloseWindow(new Date('2026-11-27T17:50:00.000Z'), 15)).toBe(true) // 12:50 ET
+    expect(isWithinUsCloseWindow(new Date('2026-11-27T18:00:00.000Z'), 15)).toBe(false) // 13:00 ET
+    // 16:00 ET 基準の旧窓 (15:50 ET) は半日取引日には当たらない。
+    expect(isWithinUsCloseWindow(new Date('2026-11-27T20:50:00.000Z'), 15)).toBe(false)
+  })
+})
+
+describe('isTradingDay / nextTradingDay — US ルール計算化で 2028 以降も判定 (#547)', () => {
+  it('2028 の祝日 (旧 static テーブル範囲外) を休場と判定する', () => {
+    expect(isTradingDay(new Date('2028-07-04T10:00:00.000Z'), 'US')).toBe(false)
+    expect(isTradingDay(new Date('2028-11-23T10:00:00.000Z'), 'US')).toBe(false)
+    expect(isTradingDay(new Date('2028-07-05T10:00:00.000Z'), 'US')).toBe(true)
+  })
+  it('US: 2027-12-30 (木) の翌営業日は 2027-12-31 (Rule 7.2 で営業)', () => {
+    expect(
+      nextTradingDay(new Date('2027-12-30T10:00:00.000Z'), 'US').toISOString().slice(0, 10),
+    ).toBe('2027-12-31')
   })
 })

--- a/test/trading/risk/perSymbolRiskGate.test.ts
+++ b/test/trading/risk/perSymbolRiskGate.test.ts
@@ -239,6 +239,40 @@ describe('evaluatePerSymbolRisk — spread guard', () => {
     expect(decision.reasons[0]).toContain('spread')
   })
 
+  it('reject reason に quote 鮮度 (asOf + Nh stale) を併記する (#547)', () => {
+    // 臨時休場 (session gate をすり抜ける閉場) では fetchedAt は新鮮なまま
+    // asOf だけが古くなる — その stale 板の wide spread reject が休場由来と
+    // reason 単体で読めることを確認する。now - asOf = 19h18m = 19.3h。
+    const asOf = '2026-04-20T19:12:00.000Z'
+    const state: SymbolState = {
+      ...emptySymbolState('DFEN', () => now),
+      lastQuote: quote(100, 1_000, { bid: 99.0, ask: 101.0, asOf }), // spread 2%
+    }
+    const decision = evaluatePerSymbolRisk(
+      { symbol: 'DFEN', side: 'BUY', intentPrice: 100, intentNotional: 100, state, now },
+      baseConfig,
+    )
+    expect(decision.approved).toBe(false)
+    expect(decision.reasons[0]).toBe(
+      `spread 2.000% exceeds US limit 0.250% (quote asOf ${asOf}, 19.3h stale)`,
+    )
+  })
+
+  it('asOf が parse 不能 / 欠落なら鮮度 suffix なしの従来 message (#547)', () => {
+    for (const asOf of ['not-a-date', '']) {
+      const state: SymbolState = {
+        ...emptySymbolState('DFEN', () => now),
+        lastQuote: quote(100, 1_000, { bid: 99.0, ask: 101.0, asOf }),
+      }
+      const decision = evaluatePerSymbolRisk(
+        { symbol: 'DFEN', side: 'BUY', intentPrice: 100, intentNotional: 100, state, now },
+        baseConfig,
+      )
+      expect(decision.approved).toBe(false)
+      expect(decision.reasons[0]).toBe('spread 2.000% exceeds US limit 0.250%')
+    }
+  })
+
   it('approves SELL when spread is wide (exit priority)', () => {
     const state: SymbolState = {
       ...emptySymbolState('SPY', () => now),

--- a/test/trading/strategy/runStrategyCron.test.ts
+++ b/test/trading/strategy/runStrategyCron.test.ts
@@ -400,6 +400,71 @@ describe('runStrategyCron', () => {
       expect(result.skipReason).not.toBe('outside_session_window')
       expect(result.skipReason).toBe('portfolio_halted')
     })
+
+    // 2026-07-03 は Independence Day 振替休場 (7/4=土)。13:00 ET は通常なら窓内の
+    // 時刻だが、休場日は market_holiday として skip する (#547 — 実際にこの日
+    // stale quote の spread SKIP が量産され、reason から休場と読めなかった)。
+    const T_US_HOLIDAY = '2026-07-03T17:00:00.000Z'
+
+    it('flag on + US 祝日 → market_holiday で skip (#547)', async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date(T_US_HOLIDAY))
+      vi.mocked(loadGlobalConfigFrom).mockResolvedValue(
+        makeGlobalConfigSnapshot({ sessionWindowGateEnabled: true }),
+      )
+      const result = await runStrategyCron(env)
+      expect(result.skipReason).toBe('market_holiday')
+      expect(result.summary.evaluated).toBe(0)
+    })
+
+    it('flag off では祝日でも gate で止まらない (従来挙動)', async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date(T_US_HOLIDAY))
+      const result = await runStrategyCron(env)
+      expect(result.skipReason).not.toBe('market_holiday')
+      expect(result.skipReason).toBe('portfolio_halted')
+    })
+
+    it('休場と窓外が混在する場合は outside_session_window に倒す', async () => {
+      vi.useFakeTimers()
+      // US = 祝日 / JP = 土曜 02:00 JST (窓外)。全 market skip だが「全休場」では
+      // ないので従来ラベル。
+      vi.setSystemTime(new Date(T_US_HOLIDAY))
+      vi.mocked(loadGlobalConfigFrom).mockResolvedValue(
+        makeGlobalConfigSnapshot({ sessionWindowGateEnabled: true }),
+      )
+      vi.mocked(loadSymbolUniverse).mockResolvedValue(
+        makeSymbolUniverse({
+          allowedSymbols: ['SOXL', '7203'],
+          symbolCurrency: { SOXL: 'USD', '7203': 'JPY' },
+          symbolMarket: { SOXL: 'US', '7203': 'JP' },
+          symbolLotSize: { SOXL: 1, '7203': 100 },
+        }),
+      )
+      const result = await runStrategyCron(env)
+      expect(result.skipReason).toBe('outside_session_window')
+    })
+
+    it('半日取引日 (2026-11-27) は 13:00 ET 以降 outside_session_window (#547)', async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-11-27T18:30:00.000Z')) // 13:30 ET (早引け後)
+      vi.mocked(loadGlobalConfigFrom).mockResolvedValue(
+        makeGlobalConfigSnapshot({ sessionWindowGateEnabled: true }),
+      )
+      const result = await runStrategyCron(env)
+      expect(result.skipReason).toBe('outside_session_window')
+    })
+
+    it('半日取引日でも 13:00 ET 前は評価に進む', async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-11-27T17:00:00.000Z')) // 12:00 ET
+      vi.mocked(loadGlobalConfigFrom).mockResolvedValue(
+        makeGlobalConfigSnapshot({ sessionWindowGateEnabled: true }),
+      )
+      const result = await runStrategyCron(env)
+      expect(result.skipReason).not.toBe('outside_session_window')
+      expect(result.skipReason).toBe('portfolio_halted')
+    })
   })
 
 })


### PR DESCRIPTION
## 概要

2026-07-03 (7/4=土の振替休場) に cron が休場を知らず、stale quote の spread 15.121% SKIP を量産した件の恒久対応。closes #547

## 変更

1. **ルール計算の祝日判定** (`tradingCalendar.ts`): 固定日+振替 / 第n月曜 / Memorial / Thanksgiving / Good Friday (Computus, Meeus-Jones-Butcher)。半日取引 (7/3・感謝祭翌日・12/24, 13:00 ET close) もルール化。**年次テーブル更新が不要になる**。ET 暦日基準 (formatToParts で DST 対応)
2. **session window gate 組み込み**: 全 market 休場日は `skipReason: market_holiday` で評価スキップ。半日取引日は窓を 13:00 ET で打ち切り (intraday 強制クローズ窓も同様に短縮 — 16:00 基準のままだと半日取引日に構造的に死ぬため)
3. **spread gate reason に鮮度併記**: `spread X% exceeds US limit 0.250% (quote asOf …, 19.3h stale)` + localizeReason に「休場・閉場中の可能性」訳。臨時休場 (服喪等・ルール化不能) のバックストップが自己説明的になる

## タスク外の挙動修正 1件 (レビュー注目点)

既存 static テーブルの **2027-12-31 を営業日に修正**。NYSE Rule 7.2 では 1/1 が土曜の年は前年 12/31 に振替しない (実例: 2021-12-31 は通常立会)。既存テーブルが誤っていた。

## 検証

- 2026–2030 の年間走査が NYSE 既知休場日と完全一致する assert
- 振替境界 (7/4=土/日/平日)、半日取引の排他 (7/4=土の年は 7/3 が全日休場側)
- ET タイムゾーン境界 (UTC 深夜が ET 前日になるケース)
- typecheck + 1607 tests green (+36)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 米国（NYSE）の祝日・半日取引日を反映したセッション判定を改善し、営業可否の精度が向上しました。
  * 取引停止理由で「市場休場」を区別して返せるようになりました。
* **Bug Fixes**
  * スプレッド超過による発注スキップ時に、鮮度（見積り時刻の経過）とJST時刻を含む表示へ改善しました。
  * 休場・引け前後の窓判定が、実際の市場ルールに沿うよう更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->