### PR TITLE
feat: add decision matrix view with reject reason trends to cron page

### DIFF
--- a/src/routes/dashboard/cron.ts
+++ b/src/routes/dashboard/cron.ts
@@ -3,6 +3,9 @@ import { createDb } from '../../infrastructure/db/tradeJournalRepo'
 import { strategyDecisionLog, tradeJournal } from '../../infrastructure/db/schema'
 import { and, desc, eq, lt, type SQL } from 'drizzle-orm'
 import { LOG_COPY_ALL_BTN, currencyOfSymbol, displaySymbol, esc, fmtJst, fmtNumber, fmtPct, fmtPctSigned, fmtPriceCcy, inactiveTooltip, isSymbolInactive, logCopyRowBtn, parseJsonObject, renderLogCopyScript, renderPaginationNav, safeJsonScript } from './shared'
+// ECHARTS_CDN のみ利用。charts/shared 側の `import type { DecisionRow }` は
+// type-only なので runtime 循環にはならない。
+import { ECHARTS_CDN } from './charts/shared'
 
 /**
  * Strategy / sizing が出力する英語 reason を **初心者にも分かる日本語** に翻訳
@@ -245,6 +248,22 @@ export function renderCronSymbolRail(
   return `<aside class="symbol-rail"><div class="rail-head">銘柄</div>${allItem}${items}</aside>`
 }
 
+/**
+ * 一覧 / マトリクスのビュー切替 pill (trades の viewPill と同型の見た目、#PR-5)。
+ * `?symbol=` フィルタは切替を跨いで URL に伝搬させる (matrix 側は集計に使わない
+ * が、一覧へ戻った時に絞り込みが外れないように)。
+ */
+export function renderCronViewPills(
+  active: 'list' | 'matrix',
+  limit: number,
+  symbolFilter?: string,
+): string {
+  const symbolQs = symbolFilter ? `&symbol=${encodeURIComponent(symbolFilter)}` : ''
+  const pill = (label: string, href: string, isActive: boolean): string =>
+    `<a href="${href}" style="margin-right:6px;padding:3px 12px;border-radius:14px;border:1px solid ${isActive ? '#1d1d1f' : '#d8d8de'};${isActive ? 'background:#1d1d1f;color:#fff;' : 'background:#fff;'}font-size:12px;text-decoration:none">${esc(label)}</a>`
+  return `<nav style="margin-bottom:10px;display:flex;align-items:center;flex-wrap:wrap;gap:2px">${pill('一覧', `/dashboard/cron?limit=${limit}${symbolQs}`, active === 'list')}${pill('マトリクス', `/dashboard/cron?view=matrix${symbolQs}`, active === 'matrix')}</nav>`
+}
+
 export function cronBody(
   rows: DecisionRow[],
   limit: number,
@@ -272,10 +291,11 @@ export function cronBody(
     hasMore,
   })
   const rail = renderCronSymbolRail(universe, symbolFilter, limit)
+  const viewPills = renderCronViewPills('list', limit, symbolFilter)
   const main =
     rows.length === 0
-      ? `${header}<p class="muted">判定ログがまだありません。</p>${pagination}`
-      : `${header}
+      ? `${viewPills}${header}<p class="muted">判定ログがまだありません。</p>${pagination}`
+      : `${viewPills}${header}
   ${renderDecisionTable(rows, universe, {
     copyVarName: '__cronCopy',
     showSymbol: true,
@@ -601,4 +621,306 @@ export function formatRealizedPnl(value: number): string {
   const sign = value > 0 ? '+' : ''
   const cls = value > 0 ? 'ok' : value < 0 ? 'err' : 'muted'
   return `<span class="${cls}">${sign}${value.toLocaleString('ja-JP', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>`
+}
+
+// ============================================================================
+// 判断トレースマトリクス (#PR-5): 銘柄 × 日付 の代表判定を一望する SSR ビュー
+// ============================================================================
+
+/**
+ * セルの代表判定を選ぶ優先度 (高い順)。「その日いちばん重要な出来事」を出す:
+ * 実際に動いた BUY / SELL が最優先、次に対処が必要な ERROR / REJECT / SKIP、
+ * 何も起きなかった HOLD は最後。decision enum は strategy_decision_log の
+ * 'BUY' / 'SELL' / 'HOLD' / 'SKIP' / 'REJECT' / 'ERROR' (schema.ts) に一致させる。
+ */
+export const MATRIX_DECISION_PRIORITY = ['BUY', 'SELL', 'ERROR', 'REJECT', 'SKIP', 'HOLD'] as const
+
+/** loadDecisionMatrix が返す日次集計 1 行 (日付 × symbol × decision × reason)。 */
+export interface DecisionMatrixSourceRow {
+  /** JST 日付 (YYYY-MM-DD) */
+  day: string
+  symbol: string
+  decision: string
+  reason: string | null
+  n: number
+}
+
+/**
+ * strategy_decision_log から直近 days 日 (JST 基準) の集計行を取る。
+ * quality.ts の loadDecisionBreakdown と同じ raw D1 スタイル (GROUP BY 集計は
+ * drizzle query builder より素の SQL の方が読みやすい)。days は defensive に
+ * 1..90 へ clamp してから整数を直接埋め込む (bind 不要にするため)。
+ */
+export async function loadDecisionMatrix(
+  db: D1Database,
+  days = 30,
+): Promise<DecisionMatrixSourceRow[]> {
+  const d = Math.min(Math.max(Math.trunc(days) || 30, 1), 90)
+  const result = await db
+    .prepare(
+      `SELECT date(timestamp, '+9 hours') AS day,
+              symbol,
+              decision,
+              reason,
+              COUNT(*) AS n
+       FROM strategy_decision_log
+       WHERE date(timestamp, '+9 hours') >= date('now', '+9 hours', '-${d - 1} days')
+       GROUP BY day, symbol, decision, reason
+       ORDER BY day ASC, symbol ASC, n DESC`,
+    )
+    .all<DecisionMatrixSourceRow>()
+  return (result.results ?? []).map((r) => ({ ...r, n: Number(r.n) }))
+}
+
+/** マトリクスの 1 セル: その日の代表判定 + 代表 reason。 */
+export interface DecisionMatrixCell {
+  decision: string
+  /** 代表 decision 内で最頻の raw reason (同数は集計順の先頭) */
+  reason: string | null
+  /** 代表 decision の件数 */
+  count: number
+  /** その日・その銘柄の全判定件数 */
+  total: number
+}
+
+export interface DecisionMatrix {
+  /** JST 日付 (昇順) */
+  dates: string[]
+  /** 銘柄昇順。cells は日付キー (判定が無い日はキーなし) */
+  rows: Array<{ symbol: string; cells: Record<string, DecisionMatrixCell> }>
+}
+
+/**
+ * 集計行 → 行 = 銘柄 / 列 = 日付 のマトリクスに整形する pure 関数。
+ * 代表判定は MATRIX_DECISION_PRIORITY 順。想定外 decision (将来追加など) は
+ * ERROR 相当の優先度で扱い、表示から漏れないようにする (quality.ts の
+ * aggregateDecisionRows と同思想)。
+ */
+export function buildDecisionMatrix(rows: DecisionMatrixSourceRow[]): DecisionMatrix {
+  const dateSet = new Set<string>()
+  const bySymbol = new Map<string, Map<string, DecisionMatrixSourceRow[]>>()
+  for (const r of rows) {
+    dateSet.add(r.day)
+    let byDay = bySymbol.get(r.symbol)
+    if (!byDay) {
+      byDay = new Map()
+      bySymbol.set(r.symbol, byDay)
+    }
+    const group = byDay.get(r.day)
+    if (group) group.push(r)
+    else byDay.set(r.day, [r])
+  }
+  const priorityOf = (decision: string): number => {
+    const i = (MATRIX_DECISION_PRIORITY as readonly string[]).indexOf(decision)
+    return i === -1 ? MATRIX_DECISION_PRIORITY.indexOf('ERROR') : i
+  }
+  const outRows = [...bySymbol.keys()].sort().map((symbol) => {
+    const cells: Record<string, DecisionMatrixCell> = {}
+    for (const [day, group] of bySymbol.get(symbol)!) {
+      let best = group[0]!
+      for (const g of group) {
+        if (priorityOf(g.decision) < priorityOf(best.decision)) best = g
+      }
+      let rep = best
+      let count = 0
+      let total = 0
+      for (const g of group) {
+        total += g.n
+        if (g.decision !== best.decision) continue
+        count += g.n
+        if (g.n > rep.n) rep = g
+      }
+      cells[day] = { decision: best.decision, reason: rep.reason, count, total }
+    }
+    return { symbol, cells }
+  })
+  return { dates: [...dateSet].sort(), rows: outRows }
+}
+
+/**
+ * reject / skip 理由のカテゴリ (推移チャートの凡例)。key は集計キー、label は
+ * 日本語凡例、color は quality タブの decision breakdown と同系の palette。
+ * カテゴリの粒度は「operator が次に何を確認すべきか」で切る (トレンド不成立
+ * なら待つだけ、資金制約なら入金/配分見直し、データ不足なら feed 調査、…)。
+ */
+export const REASON_CATEGORIES = [
+  { key: 'trend', label: 'トレンド不成立', color: '#1471a8' },
+  { key: 'pullback', label: '押し目条件', color: '#0e9f9f' },
+  { key: 'overheat', label: '過熱・ボラ過大', color: '#b25000' },
+  { key: 'sizing', label: '資金・サイズ制約', color: '#7c3aed' },
+  { key: 'spread', label: 'スプレッド過大', color: '#b58a00' },
+  { key: 'no_position', label: '建玉なし', color: '#4a5568' },
+  { key: 'data', label: 'データ不足', color: '#86868b' },
+  { key: 'cooldown', label: '取引停止・発注中', color: '#c05680' },
+  { key: 'broker', label: '発注失敗 (broker)', color: '#c22222' },
+  { key: 'other', label: 'その他', color: '#aaaaaa' },
+] as const
+
+export type ReasonCategoryKey = (typeof REASON_CATEGORIES)[number]['key']
+
+/**
+ * raw reason 文字列の prefix でカテゴリ化する pure 関数。パターンは
+ * localizeReason / describeCronReason が受ける canonical reason 一覧に対応
+ * させる。未知の形式 (将来追加 / 旧形式) は 'other' に落として合計が欠けない
+ * ようにする。
+ */
+export function categorizeReason(reason: string | null | undefined): ReasonCategoryKey {
+  if (!reason) return 'other'
+  if (/^(?:cooldown active|pending order)/.test(reason)) return 'cooldown'
+  if (/^(?:20d|50d) return /.test(reason) || /^price \S+ <= sma50/.test(reason)) return 'trend'
+  if (/^pullback /.test(reason) || /^invalid (?:10d|20d) high$/.test(reason)) return 'pullback'
+  if (/^(?:sma50 deviation|atr ratio) /.test(reason)) return 'overheat'
+  if (/^sizing rejected/.test(reason)) return 'sizing'
+  if (/^spread /.test(reason)) return 'spread'
+  if (/^SELL without position$/.test(reason)) return 'no_position'
+  if (/^(?:insufficient bars|invalid |bar fetch)/.test(reason)) return 'data'
+  if (/^broker submit error/.test(reason)) return 'broker'
+  return 'other'
+}
+
+export interface ReasonTrendPoint {
+  date: string
+  counts: Record<ReasonCategoryKey, number>
+}
+
+/**
+ * 発注不成立系 (REJECT / SKIP / ERROR) の日次件数をカテゴリ別に集計する
+ * pure 関数。BUY / SELL / HOLD は「不成立の理由」ではないため対象外。
+ */
+export function aggregateReasonTrend(rows: DecisionMatrixSourceRow[]): ReasonTrendPoint[] {
+  const emptyCounts = (): Record<ReasonCategoryKey, number> => {
+    const counts = {} as Record<ReasonCategoryKey, number>
+    for (const cat of REASON_CATEGORIES) counts[cat.key] = 0
+    return counts
+  }
+  const map = new Map<string, Record<ReasonCategoryKey, number>>()
+  for (const r of rows) {
+    if (r.decision !== 'REJECT' && r.decision !== 'SKIP' && r.decision !== 'ERROR') continue
+    let bucket = map.get(r.day)
+    if (!bucket) {
+      bucket = emptyCounts()
+      map.set(r.day, bucket)
+    }
+    bucket[categorizeReason(r.reason)] += r.n
+  }
+  return [...map.entries()]
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([date, counts]) => ({ date, counts }))
+}
+
+/**
+ * decision → セル pill の見た目。cls は既存の ok/warn/err/muted と同系色。
+ * short は 1 文字 (30 列並べても読める幅)、ja は tooltip 用の日本語併記。
+ */
+const MATRIX_DECISION_LABELS: Record<string, { short: string; ja: string; cls: string }> = {
+  BUY: { short: '買', ja: '買い', cls: 'mx-ok' },
+  SELL: { short: '売', ja: '売り', cls: 'mx-warn' },
+  HOLD: { short: '・', ja: '様子見/保有継続', cls: 'mx-muted' },
+  SKIP: { short: 'ス', ja: '発注スキップ', cls: 'mx-warn' },
+  REJECT: { short: '拒', ja: '発注拒否', cls: 'mx-err' },
+  ERROR: { short: '!', ja: 'エラー', cls: 'mx-err' },
+}
+
+/**
+ * REJECT / SKIP / ERROR 理由の日次推移 stacked bar (ECharts)。quality タブの
+ * decision breakdown と同型 (CDN load + window 変数 + DOMContentLoaded init)。
+ */
+export function renderReasonTrendChart(trend: ReasonTrendPoint[]): string {
+  if (trend.length === 0) {
+    return `<p class="muted" style="margin-top:12px">REJECT / SKIP / ERROR の判定がまだ無いため、理由推移チャートはありません。</p>`
+  }
+  const initScript = `
+    document.addEventListener('DOMContentLoaded', function () {
+      if (typeof echarts === 'undefined') return;
+      var data = window.__matrixTrend;
+      if (!data || !data.points || data.points.length === 0) return;
+      var el = document.getElementById('reason-trend-chart');
+      if (!el) return;
+      var chart = echarts.init(el);
+      chart.setOption({
+        title: { text: '発注不成立 (REJECT / SKIP / ERROR) 理由の日次推移', left: 'center', textStyle: { fontSize: 14 } },
+        tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+        legend: { top: 22, type: 'scroll' },
+        grid: { left: 50, right: 20, top: 64, bottom: 40 },
+        xAxis: { type: 'category', data: data.points.map(function (p) { return p.date; }) },
+        yAxis: { type: 'value', name: '件数' },
+        series: data.categories.map(function (cat) {
+          return { name: cat.label, type: 'bar', stack: 'reasons',
+            data: data.points.map(function (p) { return p.counts[cat.key] || 0; }),
+            itemStyle: { color: cat.color } };
+        }),
+      });
+      window.addEventListener('resize', function () { chart.resize(); });
+    });
+  `
+  return `<h3 style="margin:20px 0 4px;font-size:14px">発注不成立の理由推移</h3>
+  <div id="reason-trend-chart" style="width:100%;height:320px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;margin-top:8px"></div>
+  ${safeJsonScript('__matrixTrend', { categories: REASON_CATEGORIES, points: trend })}
+  <script src="${ECHARTS_CDN}" defer></script>
+  <script>${initScript}</script>`
+}
+
+/**
+ * マトリクスビュー本体。描画は SSR の HTML table (ECharts に頼らない):
+ * セル = decision の色 pill、title = 代表 reason の日本語、クリックで
+ * その銘柄の判定一覧へ。行頭は銘柄 (チャート銘柄タブへのリンク)。
+ * 30 列 × 銘柄数でも読めるよう 13px 基準 + 横スクロール wrapper。
+ */
+export function decisionMatrixBody(
+  matrix: DecisionMatrix,
+  trend: ReasonTrendPoint[],
+  universe: SymbolUniverse | null | undefined,
+  opts: { days: number; limit: number; symbolFilter?: string },
+): string {
+  const pills = renderCronViewPills('matrix', opts.limit, opts.symbolFilter)
+  const header = `<p class="muted">直近 ${opts.days} 日 (JST) の 銘柄 × 日付 代表判定。セルクリックでその銘柄の判定一覧へ。<a href="/dashboard/cron/matrix/json" target="_blank" rel="noreferrer">JSON を開く</a></p>`
+  if (matrix.rows.length === 0) {
+    return `${pills}${header}<p class="muted">判定ログがまだありません。</p>`
+  }
+  const style = `<style>
+  .mx-wrap{overflow-x:auto;background:#fff;border:1px solid #d0d0d5;border-radius:6px;padding:10px}
+  .mx-table{border-collapse:collapse;font-size:13px}
+  .mx-table th{font-size:11px;color:#86868b;font-weight:600;padding:2px 4px;text-align:center;white-space:nowrap}
+  .mx-table td{padding:2px 3px;text-align:center}
+  .mx-table td.mx-sym{text-align:left;white-space:nowrap;padding-right:10px}
+  .mx-table td.mx-sym a{text-decoration:none;color:#1d1d1f}
+  .mx-pill{display:inline-block;min-width:20px;padding:1px 5px;border-radius:9px;font-size:11px;font-weight:600;text-decoration:none;color:#fff}
+  .mx-pill.mx-ok{background:#057a55}
+  .mx-pill.mx-warn{background:#b25000}
+  .mx-pill.mx-err{background:#c22}
+  .mx-pill.mx-muted{background:#e8e8ed;color:#86868b}
+  .mx-legend{margin-top:8px;font-size:11px;color:#86868b;display:flex;flex-wrap:wrap;gap:10px}
+  </style>`
+  const headCells = matrix.dates
+    .map((d) => `<th title="${esc(d)}">${esc(d.slice(5).replace('-', '/'))}</th>`)
+    .join('')
+  const bodyRows = matrix.rows
+    .map((row) => {
+      const inactive = isSymbolInactive(row.symbol, universe)
+      const titleAttr = inactive ? ` title="${esc(inactiveTooltip(row.symbol, universe))}"` : ''
+      const symCell = `<td class="mx-sym"><a href="/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(row.symbol)}"${titleAttr}><strong${inactive ? ' class="symbol-disabled"' : ''}>${esc(displaySymbol(row.symbol, universe))}</strong></a></td>`
+      const cells = matrix.dates
+        .map((d) => {
+          const cell = row.cells[d]
+          if (!cell) return '<td><span class="muted">·</span></td>'
+          const label = MATRIX_DECISION_LABELS[cell.decision] ?? { short: '?', ja: cell.decision, cls: 'mx-err' }
+          const title = `${d} ${cell.decision} (${label.ja}、${cell.count}/${cell.total}件): ${localizeReason(cell.reason)}`
+          return `<td><a class="mx-pill ${label.cls}" href="/dashboard/cron?symbol=${encodeURIComponent(row.symbol)}" title="${esc(title)}">${esc(label.short)}</a></td>`
+        })
+        .join('')
+      return `<tr>${symCell}${cells}</tr>`
+    })
+    .join('')
+  const legend = `<div class="mx-legend">${Object.entries(MATRIX_DECISION_LABELS)
+    .map(([key, v]) => `<span><span class="mx-pill ${v.cls}">${esc(v.short)}</span> ${esc(key)} (${esc(v.ja)})</span>`)
+    .join('')}<span>· = 判定なし</span></div>`
+  return `${pills}${header}
+  <div class="mx-wrap">
+    <table class="mx-table">
+      <thead><tr><th style="text-align:left">銘柄</th>${headCells}</tr></thead>
+      <tbody>${bodyRows}</tbody>
+    </table>
+    ${legend}
+  </div>
+  ${renderReasonTrendChart(trend)}`
 }

--- a/src/routes/dashboard/index.ts
+++ b/src/routes/dashboard/index.ts
@@ -69,7 +69,7 @@ import { loadLatestStrategyPrices, positionsBody } from './positions'
 import { parseEquityRange, portfolioBody, safeLoadPortfolioSnapshots } from './portfolio'
 import { tradesBody } from './trades'
 import { configBody } from './config'
-import { cronBody, cronDecisionJson, loadDecisionRows } from './cron'
+import { aggregateReasonTrend, buildDecisionMatrix, cronBody, cronDecisionJson, decisionMatrixBody, loadDecisionMatrix, loadDecisionRows } from './cron'
 import { alertsBody, clampAlertLimit, parseAlertsQuery, parseEventTypeFilter, parseSeverityFilter } from './alerts'
 import { auditBody, clampAuditLimit, parseAuditDateFilter, trimQuery } from './audit'
 import { type StrategyParamsSnapshot, computeZoomRange, parseChartsTab, parseIsoTimestamp, renderChartsSubnav } from './charts/shared'
@@ -671,6 +671,29 @@ export const dashboard = new Hono<DashboardBindings>()
       return jsonPretty({ error: 'cron_json_export_failed', message: messageOf(err) }, 500)
     }
   })
+  /**
+   * 判断トレースマトリクス export (#PR-5)。`?view=matrix` と同じ packet を
+   * `dashboard_cron_matrix_export.v1` envelope で返す (AI 相談 / 外部集計用)。
+   */
+  .get('/cron/matrix/json', async (c) => {
+    if (!c.env.DB) {
+      return jsonPretty({ error: 'db_not_bound', message: 'DB binding is not configured' }, 503)
+    }
+    try {
+      const days = 30
+      const rows = await loadDecisionMatrix(c.env.DB, days)
+      const matrix = buildDecisionMatrix(rows)
+      return jsonPretty({
+        schema: 'dashboard_cron_matrix_export.v1',
+        exportedAt: new Date().toISOString(),
+        days,
+        rowCount: matrix.rows.length,
+        matrix,
+      })
+    } catch (err) {
+      return jsonPretty({ error: 'cron_matrix_export_failed', message: messageOf(err) }, 500)
+    }
+  })
   .get('/cron', async (c) => {
     if (!c.env.DB) {
       return c.html(renderLayout(c, '戦略判定', unavailable('DB not bound')))
@@ -680,6 +703,31 @@ export const dashboard = new Hono<DashboardBindings>()
     const symbolFilter = c.req.query('symbol')?.toUpperCase().trim() || undefined
     // trades の「判定→」から飛んでくる注文単位の絞り込み (#nav-links)。
     const clientOrderIdFilter = c.req.query('clientOrderId')?.trim() || undefined
+    // 判断トレースマトリクス (#PR-5)。symbol / clientOrderId フィルタは集計に
+    // 使わない (URL に付いてきても壊れない) が、一覧へ戻る pill に伝搬させる。
+    if (c.req.query('view') === 'matrix') {
+      try {
+        const days = 30
+        const [matrixRows, universe] = await Promise.all([
+          loadDecisionMatrix(c.env.DB, days),
+          loadSymbolUniverse(c.env).catch(() => null),
+        ])
+        return c.html(
+          renderLayout(
+            c,
+            '戦略判定',
+            decisionMatrixBody(
+              buildDecisionMatrix(matrixRows),
+              aggregateReasonTrend(matrixRows),
+              universe,
+              { days, limit, symbolFilter },
+            ),
+          ),
+        )
+      } catch (err) {
+        return c.html(renderLayout(c, '戦略判定', unavailable(messageOf(err))))
+      }
+    }
     const db = createDb(c.env.DB)
     try {
       const [rows, universe] = await Promise.all([

--- a/test/routes/dashboardDecisionMatrix.test.ts
+++ b/test/routes/dashboardDecisionMatrix.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createApp } from '../../src/app'
+import {
+  MATRIX_DECISION_PRIORITY,
+  REASON_CATEGORIES,
+  aggregateReasonTrend,
+  buildDecisionMatrix,
+  categorizeReason,
+  type DecisionMatrixSourceRow,
+} from '../../src/routes/dashboard/cron'
+
+vi.mock('../../src/infrastructure/db/symbolUniverse', () => ({
+  loadSymbolUniverse: vi.fn(async () => {
+    throw new Error('no universe in test')
+  }),
+}))
+
+const baseEnv = { ACCESS_DEV_BYPASS_USER: 'admin' }
+
+function srcRow(over: Partial<DecisionMatrixSourceRow> = {}): DecisionMatrixSourceRow {
+  return {
+    day: '2026-07-01',
+    symbol: 'SOXL',
+    decision: 'HOLD',
+    reason: 'price 30.5 <= sma50 31.2',
+    n: 1,
+    ...over,
+  }
+}
+
+/**
+ * loadDecisionMatrix は raw D1 (prepare → all) で読むため、fake は
+ * dashboardTradesAlertsUi.test.ts の drizzle chain fake ではなく prepare fake。
+ */
+function fakeMatrixD1(rows: DecisionMatrixSourceRow[]): D1Database {
+  return {
+    prepare: () => ({
+      all: async () => ({ results: rows }),
+    }),
+  } as unknown as D1Database
+}
+
+describe('buildDecisionMatrix (pure)', () => {
+  it('行 = 銘柄 (昇順)、列 = JST 日付 (昇順) に整形する', () => {
+    const matrix = buildDecisionMatrix([
+      srcRow({ day: '2026-07-02', symbol: 'TQQQ' }),
+      srcRow({ day: '2026-07-01', symbol: 'SOXL' }),
+      srcRow({ day: '2026-07-03', symbol: 'SOXL' }),
+    ])
+    expect(matrix.dates).toEqual(['2026-07-01', '2026-07-02', '2026-07-03'])
+    expect(matrix.rows.map((r) => r.symbol)).toEqual(['SOXL', 'TQQQ'])
+    expect(matrix.rows[0]!.cells['2026-07-01']).toBeDefined()
+    expect(matrix.rows[0]!.cells['2026-07-02']).toBeUndefined()
+  })
+
+  it('代表判定は BUY > SELL > ERROR > REJECT > SKIP > HOLD の優先度で選ぶ', () => {
+    expect(MATRIX_DECISION_PRIORITY).toEqual(['BUY', 'SELL', 'ERROR', 'REJECT', 'SKIP', 'HOLD'])
+    const matrix = buildDecisionMatrix([
+      srcRow({ decision: 'HOLD', n: 5 }),
+      srcRow({ decision: 'BUY', reason: 'pullback -0.03 in uptrend (20d return 0.08)', n: 1 }),
+      srcRow({ decision: 'SKIP', reason: 'sizing rejected: zero qty', n: 2 }),
+    ])
+    const cell = matrix.rows[0]!.cells['2026-07-01']!
+    // 件数最多の HOLD ではなく、優先度最高の BUY が代表になる
+    expect(cell.decision).toBe('BUY')
+    expect(cell.reason).toBe('pullback -0.03 in uptrend (20d return 0.08)')
+    expect(cell.count).toBe(1)
+    expect(cell.total).toBe(8)
+  })
+
+  it('代表 reason は代表 decision 内の最頻 (同数は集計順の先頭)', () => {
+    const matrix = buildDecisionMatrix([
+      srcRow({ decision: 'SKIP', reason: 'sizing rejected: zero qty', n: 1 }),
+      srcRow({ decision: 'SKIP', reason: 'SELL without position', n: 3 }),
+      srcRow({ decision: 'HOLD', n: 10 }),
+    ])
+    const cell = matrix.rows[0]!.cells['2026-07-01']!
+    expect(cell.decision).toBe('SKIP')
+    expect(cell.reason).toBe('SELL without position')
+    expect(cell.count).toBe(4)
+    expect(cell.total).toBe(14)
+  })
+
+  it('想定外 decision は ERROR 相当の優先度で扱う (REJECT より上、SELL より下)', () => {
+    const matrix = buildDecisionMatrix([
+      srcRow({ decision: 'REJECT', n: 1 }),
+      srcRow({ decision: 'FUTURE_ENUM', reason: null, n: 1 }),
+    ])
+    expect(matrix.rows[0]!.cells['2026-07-01']!.decision).toBe('FUTURE_ENUM')
+    const withSell = buildDecisionMatrix([
+      srcRow({ decision: 'FUTURE_ENUM', n: 1 }),
+      srcRow({ decision: 'SELL', reason: 'take-profit hit: pnl 0.09 >= 0.08', n: 1 }),
+    ])
+    expect(withSell.rows[0]!.cells['2026-07-01']!.decision).toBe('SELL')
+  })
+
+  it('空入力は空マトリクス', () => {
+    const matrix = buildDecisionMatrix([])
+    expect(matrix.dates).toEqual([])
+    expect(matrix.rows).toEqual([])
+  })
+})
+
+describe('categorizeReason (pure)', () => {
+  it('canonical reason の prefix でカテゴリ化する', () => {
+    expect(categorizeReason('20d return 0.01 <= 0.05 trend threshold')).toBe('trend')
+    expect(categorizeReason('50d return -0.02 <= 0.05 trend threshold')).toBe('trend')
+    expect(categorizeReason('price 30.5 <= sma50 31.2')).toBe('trend')
+    expect(categorizeReason('pullback -0.01 > -0.03 (not deep enough)')).toBe('pullback')
+    expect(categorizeReason('invalid 20d high')).toBe('pullback')
+    expect(categorizeReason('sma50 deviation 0.4 > 0.3 (overextended)')).toBe('overheat')
+    expect(categorizeReason('atr ratio 2.1 > 1.8 (volatility elevated)')).toBe('overheat')
+    expect(categorizeReason('sizing rejected: zero qty')).toBe('sizing')
+    expect(
+      categorizeReason('sizing rejected: lot-size-round (raw qty 0.5 < lot 1, stop 2, entry 30)'),
+    ).toBe('sizing')
+    expect(categorizeReason('spread 1.2% exceeds US limit 0.8%')).toBe('spread')
+    expect(categorizeReason('SELL without position')).toBe('no_position')
+    expect(categorizeReason('insufficient bars for indicators')).toBe('data')
+    expect(categorizeReason('invalid price: NaN')).toBe('data')
+    expect(categorizeReason('bar fetch: Yahoo 500')).toBe('data')
+    expect(categorizeReason('broker submit error: 417 TICKER_IS_DENY')).toBe('broker')
+    expect(categorizeReason('cooldown active until 2026-07-01T00:00:00Z')).toBe('cooldown')
+    expect(categorizeReason('pending order in flight')).toBe('cooldown')
+  })
+
+  it('未知 / 空の reason は other に落ちる', () => {
+    expect(categorizeReason(null)).toBe('other')
+    expect(categorizeReason(undefined)).toBe('other')
+    expect(categorizeReason('')).toBe('other')
+    expect(categorizeReason('some future reason format')).toBe('other')
+  })
+
+  it('全カテゴリ key は REASON_CATEGORIES に定義されている (凡例と集計キーの整合)', () => {
+    const keys = REASON_CATEGORIES.map((c) => c.key)
+    for (const reason of [
+      '20d return 0.01 <= 0.05 trend threshold',
+      'pullback -0.01 > -0.03 (not deep enough)',
+      'sizing rejected: zero qty',
+      null,
+    ]) {
+      expect(keys).toContain(categorizeReason(reason))
+    }
+  })
+})
+
+describe('aggregateReasonTrend (pure)', () => {
+  it('REJECT / SKIP / ERROR のみをカテゴリ別に日次集計する (BUY/SELL/HOLD は対象外)', () => {
+    const trend = aggregateReasonTrend([
+      srcRow({ day: '2026-07-01', decision: 'SKIP', reason: 'sizing rejected: zero qty', n: 2 }),
+      srcRow({ day: '2026-07-01', decision: 'REJECT', reason: 'broker submit error: 417', n: 1 }),
+      srcRow({ day: '2026-07-01', decision: 'HOLD', n: 10 }),
+      srcRow({ day: '2026-07-01', decision: 'BUY', reason: 'pullback in uptrend', n: 1 }),
+      srcRow({ day: '2026-07-02', decision: 'ERROR', reason: 'bar fetch: timeout', n: 3 }),
+    ])
+    expect(trend.map((p) => p.date)).toEqual(['2026-07-01', '2026-07-02'])
+    expect(trend[0]!.counts.sizing).toBe(2)
+    expect(trend[0]!.counts.broker).toBe(1)
+    expect(trend[0]!.counts.trend).toBe(0)
+    expect(trend[1]!.counts.data).toBe(3)
+  })
+
+  it('対象 decision が無ければ空配列', () => {
+    expect(aggregateReasonTrend([srcRow({ decision: 'HOLD', n: 5 })])).toEqual([])
+  })
+})
+
+describe('/dashboard/cron?view=matrix SSR スモーク', () => {
+  const matrixRows: DecisionMatrixSourceRow[] = [
+    srcRow({ day: '2026-07-01', symbol: 'SOXL', decision: 'HOLD', n: 3 }),
+    srcRow({
+      day: '2026-07-02',
+      symbol: 'SOXL',
+      decision: 'BUY',
+      reason: 'pullback -0.03 in uptrend (20d return 0.08)',
+      n: 1,
+    }),
+    srcRow({
+      day: '2026-07-02',
+      symbol: 'TQQQ',
+      decision: 'SKIP',
+      reason: 'sizing rejected: zero qty',
+      n: 2,
+    }),
+  ]
+
+  it('マトリクス表 + ビュー切替 pill + JSON リンク + 理由推移チャートを描画する', async () => {
+    const app = createApp()
+    const res = await app.request(
+      '/dashboard/cron?view=matrix',
+      { headers: {} },
+      { ...baseEnv, DB: fakeMatrixD1(matrixRows) },
+    )
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    // ビュー切替 pill (一覧 / マトリクス)
+    expect(body).toContain('>一覧</a>')
+    expect(body).toContain('>マトリクス</a>')
+    // JSON export リンク
+    expect(body).toContain('href="/dashboard/cron/matrix/json"')
+    // 行頭 = 銘柄 → チャート銘柄タブへのリンク
+    expect(body).toContain('href="/dashboard/charts?tab=symbol&symbol=SOXL"')
+    // セル = 色 pill + セルクリックで cron 絞り込みへ
+    expect(body).toContain('class="mx-pill mx-ok"')
+    expect(body).toContain('href="/dashboard/cron?symbol=SOXL"')
+    // title に代表 reason の日本語 (localizeReason)
+    expect(body).toContain('買い: 上昇トレンド中の押し目買い')
+    // 横スクロール wrapper
+    expect(body).toContain('overflow-x:auto')
+    // 理由推移チャート (SKIP があるので描画される)
+    expect(body).toContain('id="reason-trend-chart"')
+    expect(body).toContain('window.__matrixTrend')
+    // inline script の構文回帰ガード (#462 と同じ new Function 検証)
+    for (const m of body.matchAll(/<script>([\s\S]*?)<\/script>/g)) {
+      expect(() => new Function(m[1]!)).not.toThrow()
+    }
+  })
+
+  it('?symbol= フィルタが URL に付いてきても壊れない (pill に伝搬)', async () => {
+    const app = createApp()
+    const res = await app.request(
+      '/dashboard/cron?view=matrix&symbol=SOXL',
+      { headers: {} },
+      { ...baseEnv, DB: fakeMatrixD1(matrixRows) },
+    )
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    expect(body).toContain('href="/dashboard/cron?limit=50&symbol=SOXL"')
+  })
+
+  it('判定ログ 0 件でも空メッセージで 200', async () => {
+    const app = createApp()
+    const res = await app.request(
+      '/dashboard/cron?view=matrix',
+      { headers: {} },
+      { ...baseEnv, DB: fakeMatrixD1([]) },
+    )
+    expect(res.status).toBe(200)
+    expect(await res.text()).toContain('判定ログがまだありません')
+  })
+
+  it('D1 エラーは 500 にせず unavailable に落とす', async () => {
+    const app = createApp()
+    const brokenDb = {
+      prepare: () => ({
+        all: async () => {
+          throw new Error('no such table: strategy_decision_log')
+        },
+      }),
+    } as unknown as D1Database
+    const res = await app.request(
+      '/dashboard/cron?view=matrix',
+      { headers: {} },
+      { ...baseEnv, DB: brokenDb },
+    )
+    expect(res.status).toBe(200)
+    expect(await res.text()).toContain('利用不可')
+  })
+})
+
+describe('GET /dashboard/cron/matrix/json', () => {
+  it('dashboard_cron_matrix_export.v1 envelope で matrix packet を返す', async () => {
+    const app = createApp()
+    const res = await app.request(
+      '/dashboard/cron/matrix/json',
+      { headers: {} },
+      {
+        ...baseEnv,
+        DB: fakeMatrixD1([
+          srcRow({ day: '2026-07-01', symbol: 'SOXL', decision: 'BUY', reason: 'entry', n: 1 }),
+        ]),
+      },
+    )
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as Record<string, unknown>
+    expect(json.schema).toBe('dashboard_cron_matrix_export.v1')
+    expect(json.days).toBe(30)
+    expect(json.rowCount).toBe(1)
+    expect(typeof json.exportedAt).toBe('string')
+    const matrix = json.matrix as { dates: string[]; rows: Array<{ symbol: string }> }
+    expect(matrix.dates).toEqual(['2026-07-01'])
+    expect(matrix.rows[0]!.symbol).toBe('SOXL')
+  })
+
+  it('DB 未 bind は 503 の error envelope', async () => {
+    const app = createApp()
+    const res = await app.request('/dashboard/cron/matrix/json', { headers: {} }, { ...baseEnv })
+    expect(res.status).toBe(503)
+    const json = (await res.json()) as Record<string, unknown>
+    expect(json.error).toBe('db_not_bound')
+  })
+})


### PR DESCRIPTION
## 概要

ダッシュボード UI/UX 改善 PR-5。戦略判定ページに「銘柄 × 日付」のマトリクスビューと reject/skip 理由の推移チャートを追加し、「なぜ最近発注されていないのか」を一目で追えるようにする。

> **base は #554 (dev/dashboard-split)。前段 merge 後に base が自動で切り替わります。merge 順: #552 → #554 → JSON API PR → 本 PR**

## 変更点

- **`/dashboard/cron?view=matrix`**: 一覧 / マトリクスの pill 切替。行 = 銘柄、列 = 直近 30 日 (JST)、セル = その日の代表判定の色 pill (優先度 BUY > SELL > ERROR > REJECT > SKIP > HOLD、title に代表 reason の日本語)。SSR の HTML table (ECharts 不使用、13px 基準・横スクロール対応)。セルクリックで該当銘柄の判定一覧へ
- **reject 理由の推移**: reason を 10 カテゴリに prefix 正規化 (`categorizeReason`) し、REJECT / SKIP / ERROR の日次件数をカテゴリ別 stacked bar (quality タブと同型) で表示
- **`GET /dashboard/cron/matrix/json`**: `dashboard_cron_matrix_export.v1` envelope で同じ packet を返す (AI 会話材料)

## 実装

- `loadDecisionMatrix(db, days=30)` は quality タブの `loadDecisionBreakdown` と同スタイルの raw D1 集計 (`date(timestamp,'+9 hours')`)
- `buildDecisionMatrix` / `categorizeReason` / `aggregateReasonTrend` は pure 関数で vitest 対象
- 未知の decision 値は ERROR 相当で扱い表示から漏れない (quality タブと同思想)

## テスト

`pnpm typecheck` / `pnpm test` — **111 files / 1630 tests green** (既存 1614 + 新規 16)。pure テスト + SSR スモーク + json 200/503 + inline script 構文検証。

関連: #552 (PR-1) / #554 (PR-2) / 計画は oolong の改善計画ノート