### PR TITLE
feat: add JSON export endpoints for positions/trades/symbol chart

### DIFF
--- a/src/routes/dashboard/charts/loaders.ts
+++ b/src/routes/dashboard/charts/loaders.ts
@@ -4,8 +4,8 @@ import { type EvalIndicatorPoint } from '../../../trading/strategy/entryDistance
 import type { PullbackIndicators } from '../../../trading/strategy/strategies/PullbackUptrendStrategy'
 import { SymbolStateClient } from '../../../trading/state/SymbolStateClient'
 import { YahooBarClient } from '../../../infrastructure/quotes/YahooBarClient'
-import { renderChartDecisionTrace } from '../cron'
-import { currencyOfSymbol, messageOf } from '../shared'
+import { type DecisionRow, cronDecisionJson, renderChartDecisionTrace } from '../cron'
+import { currencyOfSymbol, exportMeta, messageOf, parseJsonObject } from '../shared'
 
 /**
  * 銘柄チャートで focus する銘柄を決める (#158 Phase 4)。
@@ -976,4 +976,39 @@ export function jstDayKey(iso: string): string | null {
   const t = new Date(iso).getTime()
   if (!Number.isFinite(t)) return null
   return JST_DAY_FMT.format(new Date(t))
+}
+
+/**
+ * チャート銘柄タブの JSON export packet builder
+ * (schema: `dashboard_chart_symbol_export.v1`, #dashboard-json-api)。
+ *
+ * SSR の銘柄タブと同じ loader (`loadSymbolChart` + `loadDecisionRows`) の結果を
+ * そのまま機械可読化する。HTML 断片は含めない:
+ * - `decisions[].ladderHtml` (事前レンダリング済みラダー HTML) は表示専用なので
+ *   落とし、`chartDecisions` には構造化 field だけを残す。
+ * - 判定履歴側の trace は `decisionHistory[].trace` に parse 済み object で入る
+ *   (AI / スクリプトは raw JSON 文字列を再 parse しなくてよい)。
+ */
+export function buildSymbolChartPacket(chart: SymbolChartData, decisionRows: DecisionRow[]) {
+  return {
+    ...exportMeta('dashboard_chart_symbol_export.v1'),
+    symbol: chart.symbol,
+    /** SSR チャート overlay と同じ effective rule (global → role preset → override)。 */
+    rules: chart.rules,
+    points: chart.points,
+    markers: chart.markers,
+    position: chart.position,
+    trendLine: chart.trendLine,
+    intradayBars: chart.intradayBars,
+    latestCronPrice: chart.latestCronPrice,
+    latestCronTimestamp: chart.latestCronTimestamp,
+    evalIndicators: chart.evalIndicators ?? [],
+    chartDecisions: (chart.decisions ?? []).map(({ ladderHtml: _ladderHtml, ...rest }) => rest),
+    // SSR の判定履歴テーブル (直近 30 件、#decisions-chart-unify) 相当。
+    decisionHistory: decisionRows.map((r) => ({
+      ...cronDecisionJson(r),
+      requestId: r.requestId,
+      trace: parseJsonObject(r.traceJson ?? null),
+    })),
+  }
 }

--- a/src/routes/dashboard/charts/shared.ts
+++ b/src/routes/dashboard/charts/shared.ts
@@ -1,3 +1,4 @@
+import type { LoadedGlobalConfig } from '../../../infrastructure/db/globalConfigLoader'
 import type { SymbolUniverse } from '../../../infrastructure/db/symbolUniverse'
 import type { BuyabilityView } from '../../../trading/strategy/entryDistance'
 import type { EntryStatus, EntryStatusResult } from '../../../trading/strategy/entryStatus'
@@ -67,6 +68,28 @@ export interface StrategyParamsSnapshot {
   maxSma50DeviationPct: number
   /** ボラ過熱ガード閾値 `atr20/baselineAtr20` 上限。 */
   maxAtrRatio: number
+}
+
+/**
+ * global_config の pullback default 群 → `StrategyParamsSnapshot` の組み立てを
+ * 1 か所に寄せる (#dashboard-json-api)。SSR 銘柄タブと
+ * `/dashboard/charts/symbol/json` が共用する — 2 か所に literal が増えると
+ * 「画面のパラメータ表と JSON の rules がずれる」drift になるため、field の
+ * 追加・変更は必ずこの関数経由で行うこと。
+ */
+export function strategyParamsFromGlobal(global: LoadedGlobalConfig): StrategyParamsSnapshot {
+  return {
+    stopPct: global.pullbackDefaultStopPct,
+    takeProfitPct: global.pullbackDefaultTakeProfitPct,
+    timeStopDays: global.pullbackDefaultTimeStopDays,
+    pullbackMax: global.pullbackDefaultPullbackMax,
+    pullbackMin: global.pullbackDefaultPullbackMin,
+    minReturn50d: global.pullbackDefaultMinReturn50d,
+    requireAboveSma50: global.pullbackDefaultRequireAboveSma50,
+    kAtr: global.pullbackDefaultKAtr,
+    maxSma50DeviationPct: global.pullbackDefaultMaxSma50DeviationPct,
+    maxAtrRatio: global.pullbackDefaultMaxAtrRatio,
+  }
 }
 
 /**

--- a/src/routes/dashboard/charts/symbol.ts
+++ b/src/routes/dashboard/charts/symbol.ts
@@ -25,6 +25,7 @@ export function renderSymbolDecisionHistory(args: ChartsBodySymbol): string {
       <a href="${esc(symbolCronHref)}" style="font-size:11px">この銘柄の全件 →</a>
       <a href="/dashboard/trades?symbol=${encodeURIComponent(args.focusSymbol)}" style="font-size:11px">この銘柄の約定 →</a>
       <a href="/dashboard/cron" style="font-size:11px">全銘柄 →</a>
+      <a href="/dashboard/charts/symbol/json?symbol=${encodeURIComponent(args.focusSymbol)}" target="_blank" rel="noreferrer" style="font-size:11px" title="チャート + 判定履歴の機械可読版 (#dashboard-json-api)">この銘柄の JSON →</a>
     </h2>
     ${renderDecisionTable(rows, args.universe, {
       copyVarName: '__decisionCopy',

--- a/src/routes/dashboard/index.ts
+++ b/src/routes/dashboard/index.ts
@@ -29,7 +29,7 @@ import { buildSymbolRules } from '../../trading/strategy/symbolRuleResolution'
 import { evaluatePairRegime, type PairRegimeDecision } from '../../trading/strategy/pairRegime'
 import { computeConditionalAllocation } from '../../trading/strategy/conditionalAllocation'
 import type { SymbolRule } from '../../trading/strategy/strategies/PullbackUptrendStrategy'
-import { and, asc, desc, eq, inArray, isNotNull, lt, or, type SQL } from 'drizzle-orm'
+import { and, asc, desc, eq } from 'drizzle-orm'
 import { PortfolioStateClient } from '../../trading/state/PortfolioStateClient'
 import { SymbolStateClient } from '../../trading/state/SymbolStateClient'
 import { loadUsdJpyRate } from '../../infrastructure/quotes/fxRate'
@@ -65,15 +65,15 @@ import { type DashboardBindings, loadKillSwitchState, renderLayout } from './lay
 import { extractTokenFromPaste, renderWebullTokenBody } from './webullToken'
 import { brokerProbeBody } from './brokerProbe'
 import { ALL_OVERVIEW_PANELS, type OverviewData, loadRecentFills, overviewBody, parseOverviewPanels } from './overview'
-import { loadLatestStrategyPrices, positionsBody } from './positions'
+import { buildPositionsPacket, loadLatestStrategyPrices, loadPositionsPageData, positionsBody } from './positions'
 import { parseEquityRange, portfolioBody, safeLoadPortfolioSnapshots } from './portfolio'
-import { tradesBody } from './trades'
+import { buildTradesPacket, loadTradeJournalRows, parseTradesQuery, tradesBody } from './trades'
 import { configBody } from './config'
 import { cronBody, cronDecisionJson, loadDecisionRows } from './cron'
 import { alertsBody, clampAlertLimit, parseAlertsQuery, parseEventTypeFilter, parseSeverityFilter } from './alerts'
 import { auditBody, clampAuditLimit, parseAuditDateFilter, trimQuery } from './audit'
-import { type StrategyParamsSnapshot, computeZoomRange, parseChartsTab, parseIsoTimestamp, renderChartsSubnav } from './charts/shared'
-import { type SymbolChartRules, loadAllSymbolCharts, loadSymbolChart, pickDefaultSymbol } from './charts/loaders'
+import { type StrategyParamsSnapshot, computeZoomRange, parseChartsTab, parseIsoTimestamp, renderChartsSubnav, strategyParamsFromGlobal } from './charts/shared'
+import { type SymbolChartRules, buildSymbolChartPacket, loadAllSymbolCharts, loadSymbolChart, pickDefaultSymbol } from './charts/loaders'
 import { loadEquityCurve } from './charts/equity'
 import { computePnlHistogram, computeTradeStats, loadDecisionBreakdown, loadTradePnls } from './charts/quality'
 import { chartsBody, sortGridChartsByEntryPriority } from './charts/grid'
@@ -175,24 +175,29 @@ export const dashboard = new Hono<DashboardBindings>()
     if (!c.env.DB || !c.env.SYMBOL_STATE) {
       return c.html(renderLayout(c, 'ポートフォリオ', unavailable('DB or SYMBOL_STATE not bound')))
     }
-    const universe = await loadSymbolUniverse(c.env)
-    const client = new SymbolStateClient(c.env.SYMBOL_STATE)
-    // inactive 銘柄も表示する (operator visibility) — chart に飛んで状態を確認したり
-    // 再有効化判断したりするのに必要。cron / risk gate は引き続き allowedSymbols のみ評価。
-    const allDisplaySymbols = [...universe.allowedSymbols, ...universe.inactiveSymbols]
-    const [rows, strategyPriceMap] = await Promise.all([
-      Promise.all(
-        allDisplaySymbols.map(async (sym) => {
-          try {
-            return { sym, state: await client.getState(sym), error: null as string | null }
-          } catch (err) {
-            return { sym, state: null as SymbolState | null, error: messageOf(err) }
-          }
-        }),
-      ),
-      loadLatestStrategyPrices(c.env.DB, allDisplaySymbols),
-    ])
-    return c.html(renderLayout(c, 'ポートフォリオ', positionsBody(rows, strategyPriceMap, universe)))
+    // loader は /positions/json と共用 (#dashboard-json-api) — 「画面で見る内容 =
+    // AI に渡す JSON」を同一の取得結果から作る。
+    const data = await loadPositionsPageData(c.env)
+    return c.html(
+      renderLayout(c, 'ポートフォリオ', positionsBody(data.rows, data.strategyPriceMap, data.universe)),
+    )
+  })
+  /**
+   * positions の JSON export (#dashboard-json-api)。read-only GET のみ。
+   * schema / envelope 規約は shared.ts の `exportMeta` docstring 参照。
+   */
+  .get('/positions/json', async (c) => {
+    if (!c.env.DB || !c.env.SYMBOL_STATE) {
+      return jsonPretty(
+        { error: 'binding_not_configured', message: 'DB or SYMBOL_STATE binding is not configured' },
+        503,
+      )
+    }
+    try {
+      return jsonPretty(buildPositionsPacket(await loadPositionsPageData(c.env)))
+    } catch (err) {
+      return jsonPretty({ error: 'positions_json_export_failed', message: messageOf(err) }, 500)
+    }
   })
   .get('/portfolio', async (c) => {
     if (!c.env.PORTFOLIO_STATE) {
@@ -226,55 +231,44 @@ export const dashboard = new Hono<DashboardBindings>()
     if (!c.env.DB) {
       return c.html(renderLayout(c, '約定履歴', unavailable('DB not bound')))
     }
-    const limit = clampLimit(c.req.query('limit'))
-    const before = parseCursor(c.req.query('before'))
-    // view filter: 全イベント (default) / 約定・手仕舞いのみ / エラーのみ。
-    // ジャーナルは 1 注文で複数 lifecycle 行を持つため、operator の主目的
-    // (「何が約定した?」「何が失敗した?」) を 1 クリックで絞れるようにする。
-    const view = ((v) => (v === 'fills' || v === 'errors' ? v : 'all'))(c.req.query('view'))
-    // 銘柄 / 注文 (clientOrderId) 絞り込み (#nav-links)。clientOrderId は
-    // 1 注文の lifecycle 行 (pre_submit / post_submit / エラー) を縦に並べる
-    // 「注文詳細ビュー」として機能する。cron の判定行からここへ飛ぶ。
-    const symbolFilter = c.req.query('symbol')?.toUpperCase().trim() || undefined
-    const clientOrderIdFilter = c.req.query('clientOrderId')?.trim() || undefined
+    // クエリ解釈 + journal query は /trades/json と共用 (#dashboard-json-api)。
+    const q = parseTradesQuery((key) => c.req.query(key))
     const db = createDb(c.env.DB)
-    const baseQuery = db.select().from(tradeJournal)
-    const conditions: SQL[] = []
-    if (view === 'fills') {
-      conditions.push(inArray(tradeJournal.tradeEventType, ['fill', 'exit']))
-    } else if (view === 'errors') {
-      conditions.push(or(isNotNull(tradeJournal.errorMessage), isNotNull(tradeJournal.errorClass))!)
-    }
-    if (symbolFilter) {
-      conditions.push(eq(tradeJournal.symbol, symbolFilter))
-    }
-    if (clientOrderIdFilter) {
-      conditions.push(eq(tradeJournal.clientOrderId, clientOrderIdFilter))
-    }
-    if (before !== undefined) {
-      conditions.push(lt(tradeJournal.id, before))
-    }
-    const filtered = conditions.length > 0
-      ? baseQuery.where(conditions.length === 1 ? conditions[0] : and(...conditions))
-      : baseQuery
     // universe を並行 load して銘柄表示を「番号-会社名」(JP) に整形。
     // load 失敗時は `null` を tradesBody に渡し、symbol そのまま表示で fallback。
     const [rows, universe] = await Promise.all([
-      filtered.orderBy(desc(tradeJournal.id)).limit(limit + 1),
+      // hasMore 判定のため 1 行余分に取る (limit + 1)。
+      loadTradeJournalRows(db, { ...q, limit: q.limit + 1 }),
       loadSymbolUniverse(c.env).catch(() => null),
     ])
-    const hasMore = rows.length > limit
+    const hasMore = rows.length > q.limit
     if (hasMore) rows.pop()
     return c.html(
       renderLayout(
         c,
         '約定履歴',
-        tradesBody(rows, limit, universe, view, before, hasMore, {
-          symbol: symbolFilter,
-          clientOrderId: clientOrderIdFilter,
+        tradesBody(rows, q.limit, universe, q.view, q.before, hasMore, {
+          symbol: q.symbol,
+          clientOrderId: q.clientOrderId,
         }),
       ),
     )
+  })
+  /**
+   * trades の JSON export (#dashboard-json-api)。SSR と同じクエリ解釈 + 同じ
+   * journal query を通し、rows は trade_journal の row そのまま返す。
+   */
+  .get('/trades/json', async (c) => {
+    if (!c.env.DB) {
+      return jsonPretty({ error: 'db_not_bound', message: 'DB binding is not configured' }, 503)
+    }
+    const q = parseTradesQuery((key) => c.req.query(key))
+    try {
+      const rows = await loadTradeJournalRows(createDb(c.env.DB), q)
+      return jsonPretty(buildTradesPacket(rows, q))
+    } catch (err) {
+      return jsonPretty({ error: 'trades_json_export_failed', message: messageOf(err) }, 500)
+    }
   })
   .get('/config', async (c) => {
     if (!c.env.DB) {
@@ -317,6 +311,53 @@ export const dashboard = new Hono<DashboardBindings>()
       }),
     )
     return c.redirect('/dashboard/config', 303)
+  })
+  /**
+   * チャート銘柄タブの JSON export (#dashboard-json-api)。SSR の symbol タブと
+   * 同じ loader (`loadSymbolChart` + `loadDecisionRows`) / 同じ effective rule
+   * (`strategyParamsFromGlobal` → `buildSymbolRules`) を通す。
+   *
+   * Hono の path マッチは完全一致なので理論上 `/charts` に食われないが、route は
+   * 定義順マッチのため、将来 `/charts/:sub` 系が生えた時の取り違え事故を避けて
+   * `/charts` より前に定義しておく (JSON が返ることはテストで担保)。
+   */
+  .get('/charts/symbol/json', async (c) => {
+    if (!c.env.DB) {
+      return jsonPretty({ error: 'db_not_bound', message: 'DB binding is not configured' }, 503)
+    }
+    const symbol = c.req.query('symbol')?.toUpperCase().trim()
+    if (!symbol) {
+      return jsonPretty({ error: 'symbol_required', message: 'query param ?symbol=X is required' }, 400)
+    }
+    try {
+      const [universe, global] = await Promise.all([
+        loadSymbolUniverse(c.env),
+        loadGlobalConfigFrom(c.env, c.get('requestId')),
+      ])
+      // SSR symbol タブと同じ effective rule 解決 (global → role preset →
+      // override)。SSR が universe 外 symbol を default symbol に差し替えるのと
+      // 違い、こちらは要求 symbol をそのまま使う (未知 symbol は空チャートで
+      // 返る — API 利用者には 404 より「空データ」の方が判別しやすい)。
+      const defaultEntryRule: SymbolRule = strategyParamsFromGlobal(global)
+      const effectiveRules = buildSymbolRules(defaultEntryRule, universe)
+      const entryRule = effectiveRules[symbol] ?? defaultEntryRule
+      const rules: SymbolChartRules = {
+        pullbackMax: entryRule.pullbackMax,
+        pullbackMin: entryRule.pullbackMin,
+        stopPct: entryRule.stopPct,
+        takeProfitPct: entryRule.takeProfitPct,
+        timeStopDays: entryRule.timeStopDays,
+      }
+      const chart = await loadSymbolChart(c.env, symbol, rules)
+      // 判定履歴は SSR と同じ loader / 同じ件数 (直近 30)。load 失敗 (migration
+      // 未適用等) はチャート本体を巻き込まず空配列に落とす (SSR と同挙動)。
+      const decisionRows = await loadDecisionRows(createDb(c.env.DB), { symbol, limit: 30 }).catch(
+        () => [],
+      )
+      return jsonPretty(buildSymbolChartPacket(chart, decisionRows))
+    } catch (err) {
+      return jsonPretty({ error: 'chart_symbol_export_failed', message: messageOf(err) }, 500)
+    }
   })
   .get('/charts', async (c) => {
     if (!c.env.DB) {
@@ -469,18 +510,8 @@ export const dashboard = new Hono<DashboardBindings>()
             ? defaultSymbol
             : universe.allowedSymbols[0] ?? universe.inactiveSymbols[0] ?? null
       // global_config の pullback default (パネルの「銘柄別」タグの比較基準)。
-      const globalParams: StrategyParamsSnapshot = {
-        stopPct: global.pullbackDefaultStopPct,
-        takeProfitPct: global.pullbackDefaultTakeProfitPct,
-        timeStopDays: global.pullbackDefaultTimeStopDays,
-        pullbackMax: global.pullbackDefaultPullbackMax,
-        pullbackMin: global.pullbackDefaultPullbackMin,
-        minReturn50d: global.pullbackDefaultMinReturn50d,
-        requireAboveSma50: global.pullbackDefaultRequireAboveSma50,
-        kAtr: global.pullbackDefaultKAtr,
-        maxSma50DeviationPct: global.pullbackDefaultMaxSma50DeviationPct,
-        maxAtrRatio: global.pullbackDefaultMaxAtrRatio,
-      }
+      // 組み立ては /charts/symbol/json と共用の helper に寄せる (#dashboard-json-api)。
+      const globalParams: StrategyParamsSnapshot = strategyParamsFromGlobal(global)
       // cron と同じ effective rule — global default → role preset → per-symbol
       // override (#452)。drift するとダッシュボードの入場ライン / stop・TP
       // preview / パラメータ表が cron 判定とずれるので必ず buildSymbolRules を

--- a/src/routes/dashboard/positions.ts
+++ b/src/routes/dashboard/positions.ts
@@ -1,9 +1,11 @@
-import type { SymbolUniverse } from '../../infrastructure/db/symbolUniverse'
+import type { Env } from '../../config/env'
+import { type SymbolUniverse, loadSymbolUniverse } from '../../infrastructure/db/symbolUniverse'
 import { createDb } from '../../infrastructure/db/tradeJournalRepo'
 import { strategyDecisionLog } from '../../infrastructure/db/schema'
 import { desc, eq } from 'drizzle-orm'
+import { SymbolStateClient } from '../../trading/state/SymbolStateClient'
 import type { SymbolState } from '../../trading/state/types'
-import { JST_FORMATTER, displaySymbol, esc, fmtJst, fmtNumber, formatCooldown, inactiveTooltip, isSymbolInactive } from './shared'
+import { JST_FORMATTER, displaySymbol, esc, exportMeta, fmtJst, fmtNumber, formatCooldown, inactiveTooltip, isSymbolInactive, messageOf, renderJsonToolbar } from './shared'
 
 /**
  * 各銘柄の「strategy が直近に判定で使った価格」を取得。
@@ -85,12 +87,122 @@ export function pickFreshQuote(
     : { price: webull.price, source: webull.source, asOf: webull.asOf }
 }
 
+/** positions ページの loader 結果 (SSR / JSON export 共用)。 */
+export interface PositionsPageData {
+  rows: Array<{ sym: string; state: SymbolState | null; error: string | null }>
+  strategyPriceMap: Map<string, { price: number; asOf: string }>
+  universe: SymbolUniverse
+}
+
+/**
+ * positions ページの loader (#dashboard-json-api)。SSR (`/dashboard/positions`)
+ * と JSON export (`/dashboard/positions/json`) が共用する — 「画面で見る内容 =
+ * AI に渡す JSON」を同一の取得結果から作るため、取得ロジックはここ 1 本に寄せる。
+ */
+export async function loadPositionsPageData(env: Env): Promise<PositionsPageData> {
+  if (!env.DB || !env.SYMBOL_STATE) {
+    throw new Error('DB or SYMBOL_STATE not bound')
+  }
+  const universe = await loadSymbolUniverse(env)
+  const client = new SymbolStateClient(env.SYMBOL_STATE)
+  // inactive 銘柄も表示する (operator visibility) — chart に飛んで状態を確認したり
+  // 再有効化判断したりするのに必要。cron / risk gate は引き続き allowedSymbols のみ評価。
+  const allDisplaySymbols = [...universe.allowedSymbols, ...universe.inactiveSymbols]
+  const [rows, strategyPriceMap] = await Promise.all([
+    Promise.all(
+      allDisplaySymbols.map(async (sym) => {
+        try {
+          return { sym, state: await client.getState(sym), error: null as string | null }
+        } catch (err) {
+          return { sym, state: null as SymbolState | null, error: messageOf(err) }
+        }
+      }),
+    ),
+    loadLatestStrategyPrices(env.DB, allDisplaySymbols),
+  ])
+  return { rows, strategyPriceMap, universe }
+}
+
+/** JSON export の 1 銘柄行。SSR テーブルの表示列と同じ情報の機械可読版。 */
+export interface PositionExportRow {
+  symbol: string
+  displayName: string | null
+  qty: number | null
+  avgPrice: number | null
+  quote: ResolvedQuote | null
+  /** 未実現損益 (%)。SSR の「評価損益」列と同じ式 (現在値 vs 平均取得単価)。 */
+  unrealizedPnlPct: number | null
+  pendingOrderSide: string | null
+  cooldownUntil: string | null
+  inactive: boolean
+  /** DO 取得失敗時のみ非 null。この行の他 field は null になる。 */
+  error: string | null
+}
+
+/**
+ * positions packet builder (schema: `dashboard_positions_export.v1`)。
+ *
+ * SSR の positionsBody と同じ loader 結果から pure に組み立てる。SymbolState の
+ * 内部管理 field (settledCash / pendingSettlement / appliedClientOrderIds) は
+ * 画面にも出していないので packet にも載せない — export は画面同等に絞る。
+ */
+export function buildPositionsPacket(data: PositionsPageData) {
+  const positions: PositionExportRow[] = data.rows.map((r) => {
+    const inactive = isSymbolInactive(r.sym, data.universe)
+    const displayName = data.universe.symbolName[r.sym.toUpperCase()] ?? null
+    if (r.error !== null || r.state === null) {
+      return {
+        symbol: r.sym,
+        displayName,
+        qty: null,
+        avgPrice: null,
+        quote: null,
+        unrealizedPnlPct: null,
+        pendingOrderSide: null,
+        cooldownUntil: null,
+        inactive,
+        error: r.error ?? '状態取得不可',
+      }
+    }
+    const s = r.state
+    const pos = s.position
+    // 現在値の解決は SSR と同じ pickFreshQuote (Webull snapshot vs Yahoo bars の
+    // 新しい方)。画面と JSON で「現在値」がずれると AI 相談時に混乱するため。
+    const webull = s.lastQuote
+      ? { price: s.lastQuote.price, source: s.lastQuote.source, asOf: s.lastQuote.asOf ?? s.lastQuote.fetchedAt }
+      : null
+    const quote = pickFreshQuote(webull, data.strategyPriceMap.get(s.symbol) ?? null)
+    const unrealizedPnlPct =
+      pos !== null && quote !== null && pos.avgPrice > 0
+        ? ((quote.price - pos.avgPrice) / pos.avgPrice) * 100
+        : null
+    return {
+      symbol: s.symbol,
+      displayName,
+      qty: pos?.qty ?? null,
+      avgPrice: pos?.avgPrice ?? null,
+      quote,
+      unrealizedPnlPct,
+      pendingOrderSide: s.pendingOrder?.side ?? null,
+      cooldownUntil: s.cooldownUntil,
+      inactive,
+      error: null,
+    }
+  })
+  return {
+    ...exportMeta('dashboard_positions_export.v1'),
+    rowCount: positions.length,
+    positions,
+  }
+}
+
 export function positionsBody(
   rows: Array<{ sym: string; state: SymbolState | null; error: string | null }>,
   strategyPriceMap: Map<string, { price: number; asOf: string }>,
   universe?: SymbolUniverse | null,
 ): string {
-  if (rows.length === 0) return `<p class="muted">有効な銘柄がありません。</p>`
+  const toolbar = renderJsonToolbar('/dashboard/positions/json', null)
+  if (rows.length === 0) return `${toolbar}<p class="muted">有効な銘柄がありません。</p>`
   const tbody = rows
     .map((r) => {
       const inactive = isSymbolInactive(r.sym, universe)
@@ -130,7 +242,7 @@ export function positionsBody(
       </tr>`
     })
     .join('')
-  return `<p class="muted" style="font-size:12px">
+  return `${toolbar}<p class="muted" style="font-size:12px">
     評価損益は未実現 (現在値 vs 平均取得単価)。実約定損益は
     <a href="/dashboard/cron">/dashboard/cron</a> 「実 損益」列を参照。
   </p>

--- a/src/routes/dashboard/shared.ts
+++ b/src/routes/dashboard/shared.ts
@@ -132,6 +132,42 @@ export function jsonPretty(payload: unknown, status = 200): Response {
   })
 }
 
+/**
+ * dashboard JSON export の schema バージョニング規約 (#dashboard-json-api)。
+ *
+ * - schema 名は `dashboard_<page>_export.v<N>` 形式 (例: `dashboard_cron_export.v1`)。
+ * - additive change (フィールド追加のみ) は同じ version のまま。
+ * - 既存フィールドの型変更・意味変更・削除は破壊的変更なので v<N+1> に上げる。
+ * - envelope は共通で `{ schema, exportedAt, filter?, rowCount?, ... }`:
+ *   - `schema`     : 上記の versioned 識別子。AI / スクリプトが期待形を判別する鍵。
+ *   - `exportedAt` : 生成時刻 (ISO UTC)。鮮度判断・キャッシュ判定用。
+ *   - `filter`     : クエリ絞り込みを持つページのみ。「この JSON は何の部分集合か」を明示。
+ *   - `rowCount`   : 主行配列を持つページのみ。truncation 検知用。
+ * - secret になり得る値 (token / key / account_id) は絶対に載せない。
+ *
+ * packet builder (`buildXxxPacket`) はこの helper で envelope 共通部を作り、
+ * ページ固有 field を続ける。「画面で見る内容 = AI に渡す JSON」を保つため、
+ * packet は SSR と同じ loader の結果から pure に組み立てること。
+ */
+export function exportMeta(schema: string): { schema: string; exportedAt: string } {
+  return { schema, exportedAt: new Date().toISOString() }
+}
+
+/**
+ * 「JSON を開く」リンク + (任意で) AI 用全件コピーボタンを並べた小さな帯
+ * (#dashboard-json-api)。SSR ページのヘッダ帯に置き、同じ内容の機械可読版へ
+ * 1 クリックで到達できるようにする。
+ *
+ * `copyVarName` は `safeJsonScript` で埋めた copy payload のグローバル変数名。
+ * non-null ならページ内に `renderLogCopyScript(copyVarName)` が既にいる前提で
+ * `LOG_COPY_ALL_BTN` (id=log-copy-all) を並べる — 配線は script 側が id で拾う。
+ * copy payload を持たないページは null (リンクのみ)。
+ */
+export function renderJsonToolbar(jsonHref: string, copyVarName: string | null): string {
+  const copyBtn = copyVarName ? ` ${LOG_COPY_ALL_BTN}` : ''
+  return `<div style="margin:0 0 10px;display:flex;align-items:center;gap:8px;flex-wrap:wrap"><a href="${esc(jsonHref)}" target="_blank" rel="noreferrer" style="padding:3px 12px;border-radius:14px;border:1px solid #d8d8de;background:#fff;font-size:12px;text-decoration:none">JSON を開く</a>${copyBtn}</div>`
+}
+
 export function parseJsonObject(value: string | null | undefined): unknown {
   if (!value) return null
   try {

--- a/src/routes/dashboard/trades.ts
+++ b/src/routes/dashboard/trades.ts
@@ -1,7 +1,9 @@
 import type { SymbolUniverse } from '../../infrastructure/db/symbolUniverse'
-import type { TradeJournalRow } from '../../infrastructure/db/schema'
+import { type TradeJournalRow, tradeJournal } from '../../infrastructure/db/schema'
+import { createDb } from '../../infrastructure/db/tradeJournalRepo'
+import { and, desc, eq, inArray, isNotNull, lt, or, type SQL } from 'drizzle-orm'
 import { formatRealizedPnl } from './cron'
-import { LOG_COPY_ALL_BTN, displaySymbol, esc, fmtJst, fmtNumber, inactiveTooltip, isSymbolInactive, logCopyRowBtn, pillStyle, renderLogCopyScript, renderPaginationNav, safeJsonScript } from './shared'
+import { LOG_COPY_ALL_BTN, clampLimit, displaySymbol, esc, exportMeta, fmtJst, fmtNumber, inactiveTooltip, isSymbolInactive, logCopyRowBtn, parseCursor, pillStyle, renderLogCopyScript, renderPaginationNav, safeJsonScript } from './shared'
 
 /** trade_journal の lifecycle イベント → 日本語ラベル + 色 (#alerts-trades-ui)。 */
 export const TRADE_EVENT_LABELS: Record<string, { ja: string; color: string }> = {
@@ -29,6 +31,91 @@ export function extractBrokerErrorCode(message: string): string | null {
   return bare ? bare[1]! : null
 }
 
+/** trades ページのクエリ解釈結果 (SSR / JSON export 共用)。 */
+export interface TradesQuery {
+  view: 'all' | 'fills' | 'errors'
+  symbol?: string
+  clientOrderId?: string
+  limit: number
+  before?: number
+}
+
+/**
+ * `?view/symbol/clientOrderId/limit/before` の解釈を 1 か所に寄せる
+ * (#dashboard-json-api)。SSR と `/json` が別々に解釈すると「画面で見た絞り込み
+ * と JSON の絞り込みが微妙に違う」drift 事故になるため。
+ *
+ * - view: 全イベント (default) / 約定・手仕舞いのみ / エラーのみ。ジャーナルは
+ *   1 注文で複数 lifecycle 行を持つため、operator の主目的 (「何が約定した?」
+ *   「何が失敗した?」) を 1 クリックで絞れるようにする。
+ * - symbol / clientOrderId: 銘柄 / 注文単位の絞り込み (#nav-links)。
+ *   clientOrderId は 1 注文の lifecycle 行を縦に並べる「注文詳細ビュー」。
+ */
+export function parseTradesQuery(query: (key: string) => string | undefined): TradesQuery {
+  const view = ((v) => (v === 'fills' || v === 'errors' ? v : 'all'))(query('view'))
+  const out: TradesQuery = { view, limit: clampLimit(query('limit')) }
+  const symbol = query('symbol')?.toUpperCase().trim()
+  if (symbol) out.symbol = symbol
+  const clientOrderId = query('clientOrderId')?.trim()
+  if (clientOrderId) out.clientOrderId = clientOrderId
+  const before = parseCursor(query('before'))
+  if (before !== undefined) out.before = before
+  return out
+}
+
+/**
+ * trade_journal から絞り込み済みの行を新しい順に取る (SSR / JSON export 共用)。
+ * SSR 側は `limit + 1` を渡して hasMore 判定に使う (呼び出し側で pop)。
+ */
+export async function loadTradeJournalRows(
+  db: ReturnType<typeof createDb>,
+  q: TradesQuery,
+): Promise<TradeJournalRow[]> {
+  const baseQuery = db.select().from(tradeJournal)
+  const conditions: SQL[] = []
+  if (q.view === 'fills') {
+    conditions.push(inArray(tradeJournal.tradeEventType, ['fill', 'exit']))
+  } else if (q.view === 'errors') {
+    conditions.push(or(isNotNull(tradeJournal.errorMessage), isNotNull(tradeJournal.errorClass))!)
+  }
+  if (q.symbol) {
+    conditions.push(eq(tradeJournal.symbol, q.symbol))
+  }
+  if (q.clientOrderId) {
+    conditions.push(eq(tradeJournal.clientOrderId, q.clientOrderId))
+  }
+  if (q.before !== undefined) {
+    conditions.push(lt(tradeJournal.id, q.before))
+  }
+  const filtered = conditions.length > 0
+    ? baseQuery.where(conditions.length === 1 ? conditions[0] : and(...conditions))
+    : baseQuery
+  return filtered.orderBy(desc(tradeJournal.id)).limit(q.limit)
+}
+
+/**
+ * trades packet builder (schema: `dashboard_trades_export.v1`)。
+ *
+ * rows は trade_journal の row そのまま (`__tradesCopy` の rows と同等) —
+ * 表示で省略した field も含めて AI に渡す。filter を envelope に明記するのは
+ * 「この JSON は trade_journal 全体か、どの絞り込みの部分集合か」を受け手が
+ * 誤解しないため (SSR の filter バナー相当)。
+ */
+export function buildTradesPacket(rows: TradeJournalRow[], q: TradesQuery) {
+  return {
+    ...exportMeta('dashboard_trades_export.v1'),
+    filter: {
+      view: q.view,
+      symbol: q.symbol ?? null,
+      clientOrderId: q.clientOrderId ?? null,
+      limit: q.limit,
+      before: q.before ?? null,
+    },
+    rowCount: rows.length,
+    rows,
+  }
+}
+
 export function tradesBody(
   rows: TradeJournalRow[],
   limit: number,
@@ -50,7 +137,11 @@ export function tradesBody(
     : filters.symbol
       ? `<p class="muted" style="font-size:12px;margin:0 0 6px">銘柄 <strong>${esc(displaySymbol(filters.symbol, universe))}</strong> のみ表示。<a href="/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(filters.symbol)}">チャートで見る</a> / <a href="/dashboard/cron?symbol=${encodeURIComponent(filters.symbol)}">判定を見る</a> / <a href="/dashboard/trades">全件へ戻る</a></p>`
       : ''
-  const pills = `<nav style="margin-bottom:10px;display:flex;align-items:center;flex-wrap:wrap;gap:2px">${viewPill('全イベント', 'all', view === 'all')}${viewPill('約定・手仕舞い', 'fills', view === 'fills')}${viewPill('エラー', 'errors', view === 'errors')}<span class="muted" style="font-size:12px;margin:0 8px">${rows.length} 件 (limit=${limit})</span>${rows.length > 0 ? LOG_COPY_ALL_BTN : ''}</nav>`
+  // JSON export へのリンクは現在の絞り込み (view / limit / symbol / clientOrderId /
+  // before) をそのまま引き継ぐ — 「画面で見ている部分集合と同じもの」を開くため。
+  const jsonHref = `/dashboard/trades/json?view=${view}&limit=${limit}${filterQs}${before !== undefined ? `&before=${before}` : ''}`
+  const jsonLink = `<a href="${esc(jsonHref)}" target="_blank" rel="noreferrer" style="margin-left:4px;padding:3px 12px;border-radius:14px;border:1px solid #d8d8de;background:#fff;font-size:12px;text-decoration:none">JSON を開く</a>`
+  const pills = `<nav style="margin-bottom:10px;display:flex;align-items:center;flex-wrap:wrap;gap:2px">${viewPill('全イベント', 'all', view === 'all')}${viewPill('約定・手仕舞い', 'fills', view === 'fills')}${viewPill('エラー', 'errors', view === 'errors')}<span class="muted" style="font-size:12px;margin:0 8px">${rows.length} 件 (limit=${limit})</span>${rows.length > 0 ? LOG_COPY_ALL_BTN : ''}${jsonLink}</nav>`
   if (rows.length === 0) {
     return `${filterBanner}${pills}<p class="muted">該当するレコードがありません。</p>`
   }

--- a/test/routes/dashboardJsonApi.test.ts
+++ b/test/routes/dashboardJsonApi.test.ts
@@ -1,0 +1,328 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp } from '../../src/app'
+import { loadGlobalConfigFrom } from '../../src/infrastructure/db/globalConfigLoader'
+import { loadSymbolUniverse } from '../../src/infrastructure/db/symbolUniverse'
+import { createDb } from '../../src/infrastructure/db/tradeJournalRepo'
+import { loadSymbolChart } from '../../src/routes/dashboard/charts/loaders'
+import type { SymbolChartData } from '../../src/routes/dashboard/charts/loaders'
+import { makeGlobalConfigSnapshot, makeSymbolUniverse } from '../helpers/configFixtures'
+
+vi.mock('../../src/infrastructure/db/globalConfigLoader', () => ({
+  loadGlobalConfigFrom: vi.fn(),
+}))
+vi.mock('../../src/infrastructure/db/symbolUniverse', () => ({
+  loadSymbolUniverse: vi.fn(),
+}))
+vi.mock('../../src/infrastructure/db/tradeJournalRepo', async () => {
+  const actual = await vi.importActual<typeof import('../../src/infrastructure/db/tradeJournalRepo')>(
+    '../../src/infrastructure/db/tradeJournalRepo',
+  )
+  return { ...actual, createDb: vi.fn() }
+})
+// loadSymbolChart は内部で env.DB raw SQL / Yahoo / DO を触るため、/json route の
+// 契約 (schema / ladderHtml 除去 / rules 伝搬) 検証には stub で十分。
+vi.mock('../../src/routes/dashboard/charts/loaders', async () => {
+  const actual = await vi.importActual<typeof import('../../src/routes/dashboard/charts/loaders')>(
+    '../../src/routes/dashboard/charts/loaders',
+  )
+  return { ...actual, loadSymbolChart: vi.fn() }
+})
+
+const baseEnv = { ACCESS_DEV_BYPASS_USER: 'admin' }
+const authHeader = {}
+
+function fakeSymbolStateNamespace() {
+  const stub = {
+    async getState(symbol: string) {
+      return {
+        symbol,
+        position: { qty: 10, avgPrice: 100, openedAt: '2026-06-20T00:00:00.000Z' },
+        pendingOrder: null,
+        lastSignalAt: null,
+        cooldownUntil: null,
+        settledCash: 0,
+        pendingSettlement: [],
+        lastExecutedPrice: null,
+        lastQuote: { price: 105, asOf: '2026-07-01T00:00:00Z', fetchedAt: '2026-07-01T00:00:00Z', source: 'yahoo' },
+        updatedAt: '2026-07-01T00:00:00.000Z',
+      }
+    },
+  }
+  return {
+    idFromName: (_name: string) => 'id',
+    get: (_id: string) => stub,
+  } as unknown
+}
+
+/** trades loader (select→from→where→orderBy→limit) 用の fake chain。 */
+function fakeJournalDb(rows: Array<Record<string, unknown>>) {
+  const chain = {
+    where: vi.fn(() => chain),
+    orderBy: vi.fn(() => chain),
+    limit: vi.fn(async () => rows),
+  }
+  const db = {
+    select: vi.fn(() => ({ from: vi.fn(() => chain) })),
+  }
+  return { db, chain }
+}
+
+/** loadDecisionRows (select→from→leftJoin→where→orderBy→limit) 用の fake chain。 */
+function fakeCronDb(rows: unknown[]) {
+  const query = {
+    from: vi.fn(() => query),
+    leftJoin: vi.fn(() => query),
+    where: vi.fn(() => query),
+    orderBy: vi.fn(() => query),
+    limit: vi.fn(async () => rows),
+  }
+  return {
+    select: vi.fn(() => query),
+  }
+}
+
+function journalRow(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 1,
+    timestamp: '2026-07-01T01:00:00.000Z',
+    tradeEventType: 'fill',
+    symbol: 'SOXL',
+    side: 'BUY',
+    quantity: 3,
+    limitPrice: 30.5,
+    filledQty: 3,
+    filledPrice: 30.4,
+    brokerStatus: 'FILLED',
+    mode: 'LIVE',
+    errorMessage: null,
+    realizedPnl: null,
+    exitReason: null,
+    ...over,
+  }
+}
+
+describe('dashboard JSON export API (#dashboard-json-api)', () => {
+  beforeEach(() => {
+    vi.mocked(loadGlobalConfigFrom).mockResolvedValue(makeGlobalConfigSnapshot())
+    vi.mocked(loadSymbolUniverse).mockResolvedValue(
+      makeSymbolUniverse({
+        allowedSymbols: ['SOXL'],
+        inactiveSymbols: ['SOXS'],
+        symbolCurrency: { SOXL: 'USD', SOXS: 'USD' },
+        symbolName: { SOXL: 'Direxion Semiconductor Bull 3X' },
+      }),
+    )
+  })
+  afterEach(() => vi.resetAllMocks())
+
+  describe('GET /dashboard/positions/json', () => {
+    it('returns schema v1 with the same quote/pnl resolution as the SSR table', async () => {
+      const env = {
+        ...baseEnv,
+        DB: {} as D1Database,
+        SYMBOL_STATE: fakeSymbolStateNamespace(),
+      }
+      const app = createApp()
+      const res = await app.request('/dashboard/positions/json', { headers: authHeader }, env)
+      expect(res.status).toBe(200)
+      expect(res.headers.get('content-type')).toContain('application/json')
+      const json = (await res.json()) as Record<string, any>
+      expect(json.schema).toBe('dashboard_positions_export.v1')
+      expect(typeof json.exportedAt).toBe('string')
+      expect(json.rowCount).toBe(2)
+      const soxl = json.positions[0]
+      expect(soxl.symbol).toBe('SOXL')
+      expect(soxl.displayName).toBe('Direxion Semiconductor Bull 3X')
+      expect(soxl.qty).toBe(10)
+      expect(soxl.avgPrice).toBe(100)
+      // SSR の「現在値」列と同じ pickFreshQuote の結果 (Webull snapshot 側採用)
+      expect(soxl.quote).toEqual({ price: 105, source: 'yahoo', asOf: '2026-07-01T00:00:00Z' })
+      expect(soxl.unrealizedPnlPct).toBe(5)
+      expect(soxl.pendingOrderSide).toBeNull()
+      expect(soxl.inactive).toBe(false)
+      expect(soxl.error).toBeNull()
+      // inactive 銘柄も SSR 同様に含まれ、flag が立つ
+      const soxs = json.positions[1]
+      expect(soxs.symbol).toBe('SOXS')
+      expect(soxs.inactive).toBe(true)
+      // SymbolState の内部管理 field は export しない (画面同等に絞る)
+      expect(soxl).not.toHaveProperty('settledCash')
+      expect(soxl).not.toHaveProperty('appliedClientOrderIds')
+    })
+
+    it('returns 503 when SYMBOL_STATE is not bound', async () => {
+      const env = { ...baseEnv, DB: {} as D1Database }
+      const app = createApp()
+      const res = await app.request('/dashboard/positions/json', { headers: authHeader }, env)
+      expect(res.status).toBe(503)
+      const json = (await res.json()) as Record<string, any>
+      expect(json.error).toBe('binding_not_configured')
+    })
+  })
+
+  describe('GET /dashboard/trades/json', () => {
+    it('applies the same ?view/symbol/clientOrderId filters as SSR and echoes them in the envelope', async () => {
+      const { db, chain } = fakeJournalDb([journalRow()])
+      vi.mocked(createDb).mockReturnValue(db as never)
+      const app = createApp()
+      const res = await app.request(
+        '/dashboard/trades/json?view=fills&symbol=soxl&clientOrderId=coid-1&limit=10',
+        { headers: authHeader },
+        { ...baseEnv, DB: {} as D1Database },
+      )
+      expect(res.status).toBe(200)
+      const json = (await res.json()) as Record<string, any>
+      expect(json.schema).toBe('dashboard_trades_export.v1')
+      // filter の明記 (この JSON が何の部分集合かを AI が誤解しないため)
+      expect(json.filter).toEqual({
+        view: 'fills',
+        symbol: 'SOXL',
+        clientOrderId: 'coid-1',
+        limit: 10,
+        before: null,
+      })
+      expect(json.rowCount).toBe(1)
+      // rows は trade_journal row そのまま (__tradesCopy と同等)
+      expect(json.rows[0].id).toBe(1)
+      expect(json.rows[0].tradeEventType).toBe('fill')
+      // フィルタが実際に SQL where に乗っている + limit は SSR と違い +1 しない
+      expect(chain.where).toHaveBeenCalledTimes(1)
+      expect(chain.limit).toHaveBeenCalledWith(10)
+    })
+
+    it('returns 503 when DB is not bound', async () => {
+      const app = createApp()
+      const res = await app.request('/dashboard/trades/json', { headers: authHeader }, baseEnv)
+      expect(res.status).toBe(503)
+      const json = (await res.json()) as Record<string, any>
+      expect(json.error).toBe('db_not_bound')
+    })
+  })
+
+  describe('GET /dashboard/charts/symbol/json', () => {
+    const fakeChart: SymbolChartData = {
+      symbol: 'SOXL',
+      points: [{ timestamp: '2026-07-01T00:00:00Z', price: 30, sma50: 28, high20d: 31, low20d: 27 }],
+      markers: [],
+      position: { avgPrice: 29, openedAt: '2026-06-20T00:00:00Z' },
+      rules: { pullbackMax: -0.03, pullbackMin: -0.06, stopPct: -0.04, takeProfitPct: 0.07, timeStopDays: 10 },
+      trendLine: null,
+      intradayBars: [],
+      latestCronPrice: 30,
+      latestCronTimestamp: '2026-07-01T00:00:00Z',
+      decisions: [
+        {
+          id: 11,
+          timestamp: '2026-07-01T00:00:00Z',
+          price: 30,
+          decision: 'SKIP',
+          reason: 'pullback -0.01 > -0.03 (not deep enough)',
+          ladderHtml: '<div>ladder-html-fragment</div>',
+        },
+      ],
+      evalIndicators: [],
+    }
+
+    const decisionRow = {
+      id: 11,
+      timestamp: '2026-07-01T00:00:00.000Z',
+      requestId: 'req-1',
+      symbol: 'SOXL',
+      decision: 'SKIP',
+      reason: 'pullback -0.01 > -0.03 (not deep enough)',
+      price: 30,
+      indicatorsJson: '{"price":30,"sma50":28}',
+      clientOrderId: null,
+      traceJson: '[{"label":"entry.above_sma50","passed":true}]',
+      filledPrice: null,
+      filledQty: null,
+      realizedPnl: null,
+      brokerStatus: null,
+    }
+
+    it('returns schema v1 without HTML fragments and with parsed trace/indicators', async () => {
+      vi.mocked(loadSymbolChart).mockResolvedValue(fakeChart)
+      vi.mocked(createDb).mockReturnValue(fakeCronDb([decisionRow]) as never)
+      const app = createApp()
+      // 小文字 symbol は SSR 同様 upper-case に正規化される
+      const res = await app.request(
+        '/dashboard/charts/symbol/json?symbol=soxl',
+        { headers: authHeader },
+        { ...baseEnv, DB: {} as D1Database },
+      )
+      expect(res.status).toBe(200)
+      // /charts SSR route に食われず JSON が返る (route 定義順の担保)
+      expect(res.headers.get('content-type')).toContain('application/json')
+      const body = await res.text()
+      const json = JSON.parse(body) as Record<string, any>
+      expect(json.schema).toBe('dashboard_chart_symbol_export.v1')
+      expect(json.symbol).toBe('SOXL')
+      expect(json.rules).toEqual(fakeChart.rules)
+      expect(json.points).toHaveLength(1)
+      expect(json.position).toEqual({ avgPrice: 29, openedAt: '2026-06-20T00:00:00Z' })
+      // 判定 pin は構造化 field のみ — HTML 断片 (ladderHtml) は落ちる
+      expect(json.chartDecisions[0]).toEqual({
+        id: 11,
+        timestamp: '2026-07-01T00:00:00Z',
+        price: 30,
+        decision: 'SKIP',
+        reason: 'pullback -0.01 > -0.03 (not deep enough)',
+      })
+      expect(body).not.toContain('ladderHtml')
+      expect(body).not.toContain('ladder-html-fragment')
+      // 判定履歴は traceJson / indicatorsJson が parse 済み object で入る
+      expect(json.decisionHistory[0].trace).toEqual([{ label: 'entry.above_sma50', passed: true }])
+      expect(json.decisionHistory[0].indicators).toEqual({ price: 30, sma50: 28 })
+      expect(json.decisionHistory[0].requestId).toBe('req-1')
+      // loader は SSR と同じ symbol / effective rules で呼ばれる
+      const [, calledSymbol, calledRules] = vi.mocked(loadSymbolChart).mock.calls[0]!
+      expect(calledSymbol).toBe('SOXL')
+      expect(calledRules).toEqual({
+        pullbackMax: -0.03,
+        pullbackMin: -0.06,
+        stopPct: -0.04,
+        takeProfitPct: 0.07,
+        timeStopDays: 10,
+      })
+    })
+
+    it('returns 400 when ?symbol= is missing', async () => {
+      const app = createApp()
+      const res = await app.request(
+        '/dashboard/charts/symbol/json',
+        { headers: authHeader },
+        { ...baseEnv, DB: {} as D1Database },
+      )
+      expect(res.status).toBe(400)
+      const json = (await res.json()) as Record<string, any>
+      expect(json.error).toBe('symbol_required')
+    })
+
+    it('returns 503 when DB is not bound', async () => {
+      const app = createApp()
+      const res = await app.request('/dashboard/charts/symbol/json?symbol=SOXL', { headers: authHeader }, baseEnv)
+      expect(res.status).toBe(503)
+      const json = (await res.json()) as Record<string, any>
+      expect(json.error).toBe('db_not_bound')
+    })
+
+    it('degrades decisionHistory to [] when the decision-log query fails (SSR parity)', async () => {
+      vi.mocked(loadSymbolChart).mockResolvedValue(fakeChart)
+      const failingDb = {
+        select: vi.fn(() => {
+          throw new Error('no such table: strategy_decision_log')
+        }),
+      }
+      vi.mocked(createDb).mockReturnValue(failingDb as never)
+      const app = createApp()
+      const res = await app.request(
+        '/dashboard/charts/symbol/json?symbol=SOXL',
+        { headers: authHeader },
+        { ...baseEnv, DB: {} as D1Database },
+      )
+      expect(res.status).toBe(200)
+      const json = (await res.json()) as Record<string, any>
+      expect(json.decisionHistory).toEqual([])
+    })
+  })
+})


### PR DESCRIPTION
## 概要

ダッシュボード UI/UX 改善 PR-3。「画面で見る内容 = AI に渡す JSON」を単一の packet builder 由来にする JSON API 分離の第 1 弾。`/dashboard/cron/json` の precedent を positions / trades / 銘柄チャートへ横展開する。

> **base は #554 (dev/dashboard-split)。merge 順: #552 → #554 → 本 PR → #555 / #556**

## 追加ルート (read-only GET のみ)

| Route | Schema |
|---|---|
| `GET /dashboard/positions/json` | `dashboard_positions_export.v1` |
| `GET /dashboard/trades/json` | `dashboard_trades_export.v1` (`?view/symbol/clientOrderId/limit/before` を SSR と同一関数で解釈) |
| `GET /dashboard/charts/symbol/json?symbol=X` | `dashboard_chart_symbol_export.v1` (`ladderHtml` 除去、trace/indicators は parse 済み object) |

## 設計

- **単一ソース化**: `loadPositionsPageData` / `parseTradesQuery` + `loadTradeJournalRows` / `buildSymbolChartPacket` を SSR と JSON が共用。index.ts のインライン query 構築はページモジュールへ移設
- **schema 規約を明文化** (shared.ts `exportMeta()` docstring): `dashboard_<page>_export.v<N>`、additive は同 version・破壊的変更は v+1、envelope `{schema, exportedAt, filter?, rowCount?}`、secret 禁止
- **UI 導線**: `renderJsonToolbar()` を positions に配置、trades は pills 末尾にフィルタ引き継ぎ「JSON を開く」、charts symbol は判定履歴見出しに「この銘柄の JSON →」。cron は既存リンクが十分なため追加なし
- DB / DO 未バインドは 503、symbol 欠落は 400 (fail-closed)

## テスト

`pnpm typecheck` / `pnpm test` — **111 files / 1622 tests green** (既存 1614 + 新規 8)。200+schema 一致 / 503 / 400 / filter 伝搬 / ladderHtml 非含有 / trace parse 済みをカバー。

後続の MCP サーバ化 (#553) はこの packet builder をそのまま tool 出力契約として使う。

関連: #552 / #554 / #555 / #556 / #553