### PR TITLE
feat: add trade markers, QQQ benchmark and period returns to equity chart

### DIFF
--- a/src/routes/dashboard/charts/benchmark.ts
+++ b/src/routes/dashboard/charts/benchmark.ts
@@ -1,0 +1,60 @@
+import type { Env } from '../../../config/env'
+import type { DailyBar } from '../../../trading/strategy/indicators'
+import { YahooBarClient } from '../../../infrastructure/quotes/YahooBarClient'
+
+/**
+ * overview タブの equity curve に重ねるベンチマーク銘柄。
+ * 現行 universe はレバレッジ NASDAQ 系 (TQQQ/SOXL 等) が主力なので、
+ * 「市場に乗っているだけ」との比較対象は QQQ (NASDAQ-100 1x) が最も素直。
+ */
+export const EQUITY_BENCHMARK_SYMBOL = 'QQQ'
+
+export interface BenchmarkPoint {
+  /** YYYY-MM-DD (Yahoo daily bar の UTC 日付) */
+  date: string
+  /** 期間先頭 close を 0% とした騰落率 (%)。+5.2 = +5.2% */
+  returnPct: number
+}
+
+/**
+ * 日足 bars → 期間先頭 close を 0% 基準とした騰落率 % 系列 (pure)。
+ *
+ * equity curve は「累積 realized PnL ($)」でありシード資金額を持たないため、
+ * ベンチマークを同じ $ 軸に載せることはできない。% 騰落率に正規化して
+ * 右 y 軸に重ね、「傾き / 方向」の比較だけを意図する (絶対値の比較は不能)。
+ * 不正 bar (close <= 0 / 非有限) は除外し、日付昇順に整えてから変換する。
+ */
+export function toBenchmarkReturns(bars: DailyBar[]): BenchmarkPoint[] {
+  const valid = bars.filter((b) => typeof b.close === 'number' && Number.isFinite(b.close) && b.close > 0)
+  if (valid.length === 0) return []
+  const sorted = [...valid].sort((a, b) => a.date.localeCompare(b.date))
+  const base = sorted[0]!.close
+  return sorted.map((b) => ({ date: b.date, returnPct: (b.close / base - 1) * 100 }))
+}
+
+/**
+ * ベンチマーク (QQQ) の騰落率系列を Yahoo 日足から取得する。
+ *
+ * - fetch は route (index.ts) 側から呼ぶ: `loadEquityCurve` は D1-pure を保ち、
+ *   network 依存をここに隔離する。Yahoo 失敗は throw をそのまま伝播 →
+ *   呼出元が `.catch(() => null)` で「series 省略 + 注記のみ」に落とす
+ *   (既存の fail-graceful 方針)。
+ * - `fromDate` (equity curve の先頭日) 以降の bar だけ残し、その先頭を 0% に。
+ * - `env` は現状未使用 (YahooBarClient は無認証)。将来ベンチマーク銘柄や
+ *   quote source を global_config で切り替える時の口として受けておく。
+ */
+export async function loadBenchmarkSeries(
+  env: Env,
+  fromDate: string,
+  now: Date = new Date(),
+): Promise<BenchmarkPoint[]> {
+  void env
+  const fromMs = new Date(`${fromDate}T00:00:00Z`).getTime()
+  if (!Number.isFinite(fromMs)) return []
+  // lookback は暦日差 + 余裕 5 日 (休場ずれ吸収)。YahooBarClient は正整数のみ
+  // 受けるので下限 5、Yahoo range 上限 (5y) を考慮して 1830 日で clamp。
+  const calendarDays = Math.ceil((now.getTime() - fromMs) / 86_400_000)
+  const lookback = Math.min(Math.max(calendarDays + 5, 5), 1830)
+  const bars = await new YahooBarClient().getDailyBars(EQUITY_BENCHMARK_SYMBOL, lookback)
+  return toBenchmarkReturns(bars.filter((b) => b.date >= fromDate))
+}

--- a/src/routes/dashboard/charts/equity.ts
+++ b/src/routes/dashboard/charts/equity.ts
@@ -1,5 +1,7 @@
 import { type ChartsBodyOverview, ECHARTS_CDN } from './shared'
-import { safeJsonScript } from '../shared'
+import type { BenchmarkPoint } from './benchmark'
+import { jstDayKey, resolveFillSide } from './loaders'
+import { esc, fmtNumber, safeJsonScript } from '../shared'
 
 export interface EquityPoint {
   date: string // YYYY-MM-DD (JST)
@@ -51,47 +53,361 @@ export function computeEquitySeries(
   return points
 }
 
+/** equity line に重ねる取引マーカー 1 件 (全銘柄の post_submit fill)。 */
+export interface EquityTradeMarker {
+  timestamp: string // ISO UTC (fill 時刻)
+  /** YYYY-MM-DD (JST)。equity curve の category 軸に載せるための日次キー。 */
+  date: string
+  symbol: string
+  side: 'BUY' | 'SELL'
+  filledPrice: number
+  filledQty: number | null
+  realizedPnl: number | null
+  /** クリック遷移先 `/dashboard/trades?clientOrderId=` 用。無い古い行は遷移なし。 */
+  clientOrderId: string | null
+}
+
+/**
+ * 全銘柄の post_submit fill を equity curve 用マーカーとして取得する。
+ *
+ * `loadSymbolChart` (loaders.ts) の fills SQL と同型だが symbol 条件なし。
+ * side は post_submit 行に無い (writer は pre_submit にしか入れない) ため
+ * client_order_id で pre_submit と self-JOIN、それも無い古い行は
+ * realized_pnl の有無から推測する (`resolveFillSide` 共用)。
+ * 期間フィルタは付けない: equity curve 自体が全期間 (trade_journal 全量の
+ * 日次集計) なので、マーカーも同範囲 = 全件で揃える。
+ */
+export async function loadEquityTradeMarkers(db: D1Database): Promise<EquityTradeMarker[]> {
+  const result = await db
+    .prepare(
+      `SELECT
+         ps.timestamp AS timestamp,
+         ps.symbol AS symbol,
+         pre.side AS pre_side,
+         ps.filled_price AS filled_price,
+         ps.filled_qty AS filled_qty,
+         ps.realized_pnl AS realized_pnl,
+         ps.client_order_id AS client_order_id
+       FROM trade_journal AS ps
+       LEFT JOIN trade_journal AS pre
+         ON pre.client_order_id = ps.client_order_id
+         AND pre.trade_event_type = 'pre_submit'
+       WHERE ps.trade_event_type = 'post_submit'
+         AND ps.filled_price IS NOT NULL
+       ORDER BY ps.id ASC`,
+    )
+    .all<{
+      timestamp: string
+      symbol: string
+      pre_side: string | null
+      filled_price: number | null
+      filled_qty: number | null
+      realized_pnl: number | null
+      client_order_id: string | null
+    }>()
+  const markers: EquityTradeMarker[] = []
+  for (const r of result.results ?? []) {
+    if (r.filled_price === null || !Number.isFinite(Number(r.filled_price))) continue
+    const date = jstDayKey(r.timestamp)
+    if (!date) continue // timestamp 不正な行は category 軸に載せられないので捨てる
+    markers.push({
+      timestamp: r.timestamp,
+      date,
+      symbol: r.symbol,
+      side: resolveFillSide(r.pre_side, r.realized_pnl),
+      filledPrice: Number(r.filled_price),
+      filledQty: r.filled_qty === null ? null : Number(r.filled_qty),
+      realizedPnl: r.realized_pnl === null ? null : Number(r.realized_pnl),
+      clientOrderId: r.client_order_id,
+    })
+  }
+  return markers
+}
+
+/** 期間別リターン 1 行 (PnL 変化額)。 */
+export interface PeriodReturn {
+  key: '1W' | '1M' | '3M' | 'YTD' | 'ALL'
+  /** 日本語ラベル (UI 表示用)。 */
+  label: string
+  /** 期間内の累積 realized PnL 変化額。シード資金を保持していないため % は出さない。 */
+  change: number
+}
+
+const JST_DAY_ONLY_FMT = new Intl.DateTimeFormat('en-CA', {
+  timeZone: 'Asia/Tokyo',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+})
+
+/**
+ * 期間別リターン (1W / 1M / 3M / YTD / ALL) を計算する (pure)。
+ *
+ * - 基準は「期間開始日 (JST) 前の最後の累積 PnL」。期間より古い point が
+ *   無ければ 0 (= curve の開始値) を基準にする。ALL は常に 0 基準。
+ * - `now` は引数で受ける (テスト容易性のため関数内で `Date.now()` は呼ばない)。
+ * - % は返さない: equity は累積 realized PnL でシード資金額 (分母) が無く、
+ *   変化率を計算すると初期の小さい累積値で数字が暴れて誤解を招く。
+ */
+export function computePeriodReturns(points: EquityPoint[], now: Date): PeriodReturn[] {
+  if (points.length === 0) return []
+  const latest = points[points.length - 1]!.cumulativePnl
+  const dayMs = 24 * 3600 * 1000
+  const jstDay = (d: Date): string => JST_DAY_ONLY_FMT.format(d)
+  const year = jstDay(now).slice(0, 4)
+  const defs: Array<{ key: PeriodReturn['key']; label: string; start: string | null }> = [
+    { key: '1W', label: '1週間', start: jstDay(new Date(now.getTime() - 7 * dayMs)) },
+    { key: '1M', label: '1か月', start: jstDay(new Date(now.getTime() - 30 * dayMs)) },
+    { key: '3M', label: '3か月', start: jstDay(new Date(now.getTime() - 90 * dayMs)) },
+    { key: 'YTD', label: '年初来', start: `${year}-01-01` },
+    { key: 'ALL', label: '全期間', start: null },
+  ]
+  return defs.map((d) => {
+    let baseline = 0
+    if (d.start !== null) {
+      // points は日付昇順。開始日より前の最後の累積値が基準。
+      for (const p of points) {
+        if (p.date < d.start) baseline = p.cumulativePnl
+        else break
+      }
+    }
+    return { key: d.key, label: d.label, change: latest - baseline }
+  })
+}
+
+/** 月次 PnL 1 本 (bar チャート用)。 */
+export interface MonthlyReturn {
+  /** YYYY-MM (JST)。 */
+  month: string
+  /** その月の realized PnL 増分 (= dailyPnl の月内合計)。 */
+  pnl: number
+}
+
+/**
+ * 月次 (JST) の PnL 増分を集計する (pure)。EquityPoint.date は既に JST の
+ * 日次キーなので、先頭 7 文字 (YYYY-MM) でグルーピングするだけでよい。
+ */
+export function computeMonthlyReturns(points: EquityPoint[]): MonthlyReturn[] {
+  const byMonth = new Map<string, number>()
+  for (const p of points) {
+    const month = p.date.slice(0, 7)
+    byMonth.set(month, (byMonth.get(month) ?? 0) + p.dailyPnl)
+  }
+  return [...byMonth.entries()]
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([month, pnl]) => ({ month, pnl }))
+}
+
+/** overview チャート描画用に整列済みの view model (client inline JS に渡す形)。 */
+export interface OverviewChartData {
+  /** category 軸 (equity 日付 ∪ マーカー日付、昇順)。 */
+  dates: string[]
+  /** `dates` と同 index の累積 PnL (equity point の無い日は直前値で forward-fill)。 */
+  equity: number[]
+  /** `dates` と同 index のドローダウン (%、0 or 負)。 */
+  drawdownPct: number[]
+  /** 各マーカー + その日の equity y 値 (scatter の座標)。 */
+  markers: Array<EquityTradeMarker & { y: number }>
+  /** `dates` と同 index の QQQ 騰落率 (%)。データ開始前は null。系列自体が無ければ null。 */
+  benchmark: Array<number | null> | null
+}
+
+/**
+ * equity curve / マーカー / ベンチマークを 1 本の category 軸に整列する (pure)。
+ *
+ * - 軸は equity 日付とマーカー日付の和集合: BUY fill は realized_pnl を生まない
+ *   ため equity curve に同日 point が無いことが多く、equity 日付だけを軸にすると
+ *   BUY マーカーの置き場が無くなる。マーカー日は直前の累積値で forward-fill。
+ * - 最初の equity point より前 (エントリーだけあって未確定の期間) は累積 0 扱い。
+ * - benchmark (QQQ) は日付キーで forward-fill して同軸に載せる。QQQ の date は
+ *   Yahoo の UTC 日付で JST キーと最大 1 日ずれるが、% 騰落率の傾き比較用途では
+ *   許容する (厳密な同日照合はしない)。
+ */
+export function buildOverviewChartData(
+  equityPoints: EquityPoint[],
+  markers: EquityTradeMarker[],
+  benchmark: BenchmarkPoint[] | null,
+): OverviewChartData {
+  const dateSet = new Set<string>(equityPoints.map((p) => p.date))
+  for (const m of markers) dateSet.add(m.date)
+  const dates = [...dateSet].sort()
+  const eqByDate = new Map(equityPoints.map((p) => [p.date, p]))
+  const equity: number[] = []
+  const drawdownPct: number[] = []
+  const yByDate = new Map<string, number>()
+  let cum = 0
+  let dd = 0
+  for (const d of dates) {
+    const p = eqByDate.get(d)
+    if (p) {
+      cum = p.cumulativePnl
+      dd = p.drawdownPct
+    }
+    equity.push(cum)
+    drawdownPct.push(dd * 100)
+    yByDate.set(d, cum)
+  }
+  const outMarkers = markers.map((m) => ({ ...m, y: yByDate.get(m.date) ?? 0 }))
+  let benchAligned: Array<number | null> | null = null
+  if (benchmark && benchmark.length > 0) {
+    const sorted = [...benchmark].sort((a, b) => a.date.localeCompare(b.date))
+    benchAligned = []
+    let bi = 0
+    let last: number | null = null
+    for (const d of dates) {
+      while (bi < sorted.length && sorted[bi]!.date <= d) {
+        last = sorted[bi]!.returnPct
+        bi += 1
+      }
+      benchAligned.push(last)
+    }
+  }
+  return { dates, equity, drawdownPct, markers: outMarkers, benchmark: benchAligned }
+}
+
+/** 符号付き金額表示 ("+12.34" / "-3.00")。色分けは class 側でやる。 */
+function fmtSignedAmount(v: number): string {
+  return `${v > 0 ? '+' : ''}${fmtNumber(v)}`
+}
+
+/**
+ * 期間別リターンの小テーブル (13px 基準、日本語ラベル)。
+ * % は出さない (シード資金を保持していない — computePeriodReturns 参照)。
+ */
+export function renderPeriodReturnsTable(rows: PeriodReturn[]): string {
+  if (rows.length === 0) return ''
+  const cells = rows
+    .map((r) => {
+      const cls = r.change > 0 ? 'ok' : r.change < 0 ? 'err' : 'muted'
+      return `<td class="${cls}" style="text-align:right">${esc(fmtSignedAmount(r.change))}</td>`
+    })
+    .join('')
+  const heads = rows.map((r) => `<th>${esc(r.label)}</th>`).join('')
+  return `<h3 style="font-size:14px;margin:20px 0 6px">期間別リターン (実現 PnL 変化額)</h3>
+  <table style="font-size:13px">
+    <thead><tr>${heads}</tr></thead>
+    <tbody><tr>${cells}</tr></tbody>
+  </table>`
+}
+
 export function renderOverviewTab(args: ChartsBodyOverview): string {
   if (args.equity.length === 0) {
     return `<p class="muted">まだ実 fill (realized_pnl) が無いためエクイティカーブを描けません。最初の SELL が約定すると表示されます。</p>`
   }
+  const vm = buildOverviewChartData(args.equity, args.tradeMarkers ?? [], args.benchmark ?? null)
+  const hasBenchmark = vm.benchmark !== null
+  // ベンチマーク注記: 左軸 ($) と右軸 (%) は意味の異なる系列の重ね描きである
+  // ことを明示する。取得失敗時は series を省略して注記だけ残す (fail-graceful)。
+  const benchmarkNote = hasBenchmark
+    ? 'ベンチマーク: 実現 PnL ($ 左軸) vs QQQ 騰落率 (% 右軸) — 意味の異なる系列の重ね描きなので傾き / 方向の比較のみに使う (絶対値は比較不能)。'
+    : 'ベンチマーク (QQQ 騰落率) は取得失敗のため非表示 (チャート本体には影響なし)。'
+  const markerNote =
+    (args.tradeMarkers ?? []).length > 0
+      ? ' 取引マーカー: 売り (SELL) は実現損益で緑 (益) / 赤 (損)、買い (BUY) は灰。点クリックで該当注文の約定履歴へ。'
+      : ''
   const initScript = `
     document.addEventListener('DOMContentLoaded', function () {
       if (typeof echarts === 'undefined') return;
       var data = window.__chartData;
-      var dates = data.equity.map(function (p) { return p.date; });
-      var equity = data.equity.map(function (p) { return p.cumulativePnl; });
-      var dd = data.equity.map(function (p) { return p.drawdownPct * 100; });
+      var vm = data.vm;
+      var escHtml = function (s) { return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'); };
+      var SIDE_JA = { BUY: '買い', SELL: '売り' };
+      function markerSeries(name, color, filter) {
+        var items = [];
+        for (var i = 0; i < vm.markers.length; i++) {
+          var m = vm.markers[i];
+          if (filter(m)) items.push({ value: [m.date, m.y], marker: m });
+        }
+        return { name: name, type: 'scatter', symbolSize: 9, z: 5, itemStyle: { color: color }, data: items };
+      }
+      var series = [
+        { name: '累積 realized PnL', type: 'line', data: vm.equity, smooth: false, areaStyle: { opacity: 0.1 }, lineStyle: { width: 2 } },
+        markerSeries('売り・益 (SELL)', '#057a55', function (m) { return m.side === 'SELL' && (m.realizedPnl || 0) >= 0; }),
+        markerSeries('売り・損 (SELL)', '#c22', function (m) { return m.side === 'SELL' && (m.realizedPnl || 0) < 0; }),
+        markerSeries('買い (BUY)', '#86868b', function (m) { return m.side !== 'SELL'; }),
+      ];
+      if (vm.benchmark) {
+        series.push({ name: 'QQQ 騰落率', type: 'line', yAxisIndex: 1, data: vm.benchmark, showSymbol: false, connectNulls: true, lineStyle: { width: 1, type: 'dashed', color: '#1471a8' }, itemStyle: { color: '#1471a8' } });
+      }
       var equityChart = echarts.init(document.getElementById('equity-chart'));
       equityChart.setOption({
-        title: { text: '累積 realized PnL', left: 'center', textStyle: { fontSize: 14 } },
-        tooltip: { trigger: 'axis', valueFormatter: function (v) { return Number(v).toFixed(2); } },
-        grid: { left: 50, right: 20, top: 40, bottom: 40 },
-        xAxis: { type: 'category', data: dates },
-        yAxis: { type: 'value', name: 'PnL', axisLabel: { formatter: '{value}' } },
-        series: [{ type: 'line', data: equity, smooth: false, areaStyle: { opacity: 0.1 }, lineStyle: { width: 2 } }],
+        title: { text: vm.benchmark ? '累積 realized PnL ($ 左軸) vs QQQ 騰落率 (% 右軸)' : '累積 realized PnL', left: 'center', textStyle: { fontSize: 14 } },
+        legend: { top: 24, textStyle: { fontSize: 11 } },
+        tooltip: {
+          trigger: 'axis',
+          formatter: function (params) {
+            if (!params || params.length === 0) return '';
+            var lines = [escHtml(params[0].axisValue)];
+            for (var i = 0; i < params.length; i++) {
+              var p = params[i];
+              if (p.data && p.data.marker) {
+                var m = p.data.marker;
+                var qty = m.filledQty == null ? '?' : m.filledQty;
+                var pnl = m.realizedPnl == null ? '' : ' / 実現損益 ' + Number(m.realizedPnl).toFixed(2);
+                lines.push(p.marker + escHtml(m.symbol) + ' ' + (SIDE_JA[m.side] || escHtml(m.side)) + ' ' + Number(m.filledPrice).toFixed(2) + ' × ' + qty + pnl);
+              } else if (p.value != null) {
+                var unit = p.seriesName === 'QQQ 騰落率' ? '%' : '';
+                lines.push(p.marker + escHtml(p.seriesName) + ': ' + Number(p.value).toFixed(2) + unit);
+              }
+            }
+            return lines.join('<br/>');
+          },
+        },
+        grid: { left: 50, right: vm.benchmark ? 55 : 20, top: 52, bottom: 40 },
+        xAxis: { type: 'category', data: vm.dates },
+        yAxis: [
+          { type: 'value', name: 'PnL', axisLabel: { formatter: '{value}' } },
+          { type: 'value', name: 'QQQ %', show: !!vm.benchmark, axisLabel: { formatter: '{value}%' }, splitLine: { show: false } },
+        ],
+        series: series,
+      });
+      equityChart.on('click', function (p) {
+        if (p && p.data && p.data.marker && p.data.marker.clientOrderId) {
+          window.location.href = '/dashboard/trades?clientOrderId=' + encodeURIComponent(p.data.marker.clientOrderId);
+        }
       });
       var ddChart = echarts.init(document.getElementById('dd-chart'));
       ddChart.setOption({
         title: { text: 'ドローダウン (累積 PnL の peak からの低下率)', left: 'center', textStyle: { fontSize: 14 } },
         tooltip: { trigger: 'axis', valueFormatter: function (v) { return Number(v).toFixed(2) + '%'; } },
         grid: { left: 50, right: 20, top: 40, bottom: 40 },
-        xAxis: { type: 'category', data: dates },
+        xAxis: { type: 'category', data: vm.dates },
         yAxis: { type: 'value', max: 0, axisLabel: { formatter: '{value}%' } },
-        series: [{ type: 'line', data: dd, areaStyle: { color: '#c22', opacity: 0.2 }, lineStyle: { color: '#c22', width: 1 } }],
+        series: [{ type: 'line', data: vm.drawdownPct, areaStyle: { color: '#c22', opacity: 0.2 }, lineStyle: { color: '#c22', width: 1 } }],
       });
-      window.addEventListener('resize', function () { equityChart.resize(); ddChart.resize(); });
+      var monthlyEl = document.getElementById('monthly-chart');
+      var monthlyChart = null;
+      if (monthlyEl && data.monthly && data.monthly.length > 0) {
+        monthlyChart = echarts.init(monthlyEl);
+        monthlyChart.setOption({
+          title: { text: '月次 realized PnL (JST 集計)', left: 'center', textStyle: { fontSize: 14 } },
+          tooltip: { trigger: 'axis', valueFormatter: function (v) { return Number(v).toFixed(2); } },
+          grid: { left: 50, right: 20, top: 40, bottom: 40 },
+          xAxis: { type: 'category', data: data.monthly.map(function (m) { return m.month; }) },
+          yAxis: { type: 'value', name: 'PnL' },
+          series: [{ type: 'bar', barMaxWidth: 40, data: data.monthly.map(function (m) { return { value: m.pnl, itemStyle: { color: m.pnl >= 0 ? '#057a55' : '#c22' } }; }) }],
+        });
+      }
+      window.addEventListener('resize', function () { equityChart.resize(); ddChart.resize(); if (monthlyChart) monthlyChart.resize(); });
     });
   `
+  const monthly = args.monthlyReturns ?? []
+  const monthlyChartHtml =
+    monthly.length > 0
+      ? `<div id="monthly-chart" style="width:100%;height:260px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;margin-top:12px"></div>`
+      : ''
   return `<p class="muted" style="font-size:12px">
     累積 realized PnL と peak からの下落率 (MaxDD)。戦略の長期パフォーマンス指標。
     シード資金額を保持していないため下落率は「累積 PnL の peak からの相対」で計算
     (peak ≤ 0 のときは 0%)。当日 intraday の risk halt 閾値 (drawdown_kill /
     risk_dd_halt) は別概念のため重畳しない。
+    ${esc(benchmarkNote)}${esc(markerNote)}
   </p>
-  <div id="equity-chart" style="width:100%;height:320px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;margin-top:12px"></div>
+  <div id="equity-chart" style="width:100%;height:340px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;margin-top:12px"></div>
   <div id="dd-chart" style="width:100%;height:280px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;margin-top:12px"></div>
-  ${safeJsonScript('__chartData', { equity: args.equity })}
+  ${renderPeriodReturnsTable(args.periodReturns ?? [])}
+  ${monthlyChartHtml}
+  ${safeJsonScript('__chartData', { vm, monthly })}
   <script src="${ECHARTS_CDN}" defer></script>
   <script>${initScript}</script>`
 }

--- a/src/routes/dashboard/charts/shared.ts
+++ b/src/routes/dashboard/charts/shared.ts
@@ -4,7 +4,8 @@ import type { BuyabilityView } from '../../../trading/strategy/entryDistance'
 import type { EntryStatus, EntryStatusResult } from '../../../trading/strategy/entryStatus'
 import type { PairRegimeDecision } from '../../../trading/strategy/pairRegime'
 import type { SymbolAllocation } from '../../../trading/strategy/conditionalAllocation'
-import type { EquityPoint } from './equity'
+import type { EquityPoint, EquityTradeMarker, MonthlyReturn, PeriodReturn } from './equity'
+import type { BenchmarkPoint } from './benchmark'
 import type { SymbolChartData } from './loaders'
 import type { DecisionBreakdownPoint, PnlHistogramBin, TradeStats } from './quality'
 import type { DecisionRow } from '../cron'
@@ -40,6 +41,20 @@ export const CHART_TABS: Array<{ id: ChartsTab; label: string; hint: string }> =
 export interface ChartsBodyOverview {
   tab: 'overview'
   equity: EquityPoint[]
+  /**
+   * equity line に重ねる全銘柄の fill マーカー (#equity-enhance)。
+   * additive フィールドなので optional: 省略時はマーカー非表示 (旧呼出互換)。
+   */
+  tradeMarkers?: EquityTradeMarker[]
+  /**
+   * QQQ ベンチマーク騰落率系列 (右 y 軸に % で重ねる)。
+   * null = Yahoo fetch 失敗 (series 省略、注記のみ表示)。省略も同義。
+   */
+  benchmark?: BenchmarkPoint[] | null
+  /** 期間別リターン (1W / 1M / 3M / YTD / ALL の PnL 変化額)。 */
+  periodReturns?: PeriodReturn[]
+  /** 月次 (JST) PnL 増分 (bar チャート用)。 */
+  monthlyReturns?: MonthlyReturn[]
 }
 
 export interface ChartsBodyQuality {

--- a/src/routes/dashboard/index.ts
+++ b/src/routes/dashboard/index.ts
@@ -74,7 +74,8 @@ import { alertsBody, clampAlertLimit, parseAlertsQuery, parseEventTypeFilter, pa
 import { auditBody, clampAuditLimit, parseAuditDateFilter, trimQuery } from './audit'
 import { type StrategyParamsSnapshot, computeZoomRange, parseChartsTab, parseIsoTimestamp, renderChartsSubnav, strategyParamsFromGlobal } from './charts/shared'
 import { type SymbolChartRules, buildSymbolChartPacket, loadAllSymbolCharts, loadSymbolChart, pickDefaultSymbol } from './charts/loaders'
-import { loadEquityCurve } from './charts/equity'
+import { type EquityTradeMarker, computeMonthlyReturns, computePeriodReturns, loadEquityCurve, loadEquityTradeMarkers } from './charts/equity'
+import { loadBenchmarkSeries } from './charts/benchmark'
 import { computePnlHistogram, computeTradeStats, loadDecisionBreakdown, loadTradePnls } from './charts/quality'
 import { chartsBody, sortGridChartsByEntryPriority } from './charts/grid'
 import { type SymbolsListFilter, findSymbolConfigForView, loadAllSymbolConfigRows, symbolFormBody, symbolMapEditorBody, symbolsListBody } from './symbols'
@@ -93,7 +94,10 @@ export { DEFAULT_ZOOM_WINDOW_MS, computeZoomRange, parseChartsTab, parseIsoTimes
 export type { ChartsBodySymbol, ChartsTab, StrategyParamsSnapshot, SymbolPolicySummary } from './charts/shared'
 export { aggregateDailyCloses, anchorJstMidnight, computeChartWindowDays, computeLinearRegressionLine, computeRollingSma, densifyHorizontalLine, densifyTrendLine, deriveOpenPosition, extractSma50, fetchYahooBarsForChart, loadAllSymbolCharts, loadSymbolChart, mergeYahooAndCronPoints, pairClosedTrades, pickDefaultSymbol, resolveFillSide, selectLatestCronSnapshot } from './charts/loaders'
 export type { ClosedTradeSpan, OhlcBar, PivotPoint, SymbolChartData, SymbolChartDecision, SymbolChartMarker, SymbolChartPoint, SymbolChartPosition, SymbolChartRules, TrendLineSegment } from './charts/loaders'
-export { computeEquitySeries, loadEquityCurve } from './charts/equity'
+export { buildOverviewChartData, computeEquitySeries, computeMonthlyReturns, computePeriodReturns, loadEquityCurve, loadEquityTradeMarkers, renderPeriodReturnsTable } from './charts/equity'
+export type { EquityPoint, EquityTradeMarker, MonthlyReturn, OverviewChartData, PeriodReturn } from './charts/equity'
+export { EQUITY_BENCHMARK_SYMBOL, loadBenchmarkSeries, toBenchmarkReturns } from './charts/benchmark'
+export type { BenchmarkPoint } from './charts/benchmark'
 export { aggregateDecisionRows, computePnlHistogram, computeTradeStats, loadDecisionBreakdown, loadTradePnls } from './charts/quality'
 export type { DecisionBreakdownPoint, PnlHistogramBin, TradeStats } from './charts/quality'
 export { prevDailyClose, renderAllocationLine, renderBuyabilityPanel, renderDecisionPlotCaption, renderPairRegimeLine, renderPriceHeader, renderStrategyParamsPanel, renderSymbolPolicyLine, renderSymbolTab } from './charts/symbol'
@@ -377,9 +381,40 @@ export const dashboard = new Hono<DashboardBindings>()
       // - quality:  pnls (= stats / histogram) + decisions
       // - symbol:   universe + symbolChart
       if (tab === 'overview') {
-        const equity = await loadEquityCurve(c.env.DB)
+        // マーカー load 失敗 (一時的 D1 エラー等) は equity curve 本体を
+        // 巻き込まず空配列 fallback (マーカー無しで描画)。
+        const [equity, tradeMarkers] = await Promise.all([
+          loadEquityCurve(c.env.DB),
+          loadEquityTradeMarkers(c.env.DB).catch(() => [] as EquityTradeMarker[]),
+        ])
+        // QQQ ベンチマークは Yahoo fetch (network 依存) なので route 側で行い、
+        // `loadEquityCurve` は D1-pure を保つ。取得失敗は null → renderer が
+        // series を省略して注記だけ出す (チャート自体は壊さない fail-graceful)。
+        // 取得期間の先頭は equity / マーカー両方の最古日 (BUY だけで realized
+        // PnL が未確定の初期期間にもベンチマーク線を伸ばすため)。
+        const firstDates = [equity[0]?.date, tradeMarkers[0]?.date].filter(
+          (d): d is string => d !== undefined,
+        )
+        const fromDate = firstDates.length > 0 ? [...firstDates].sort()[0]! : null
+        const benchmark =
+          equity.length > 0 && fromDate !== null
+            ? await loadBenchmarkSeries(c.env, fromDate).catch(() => null)
+            : null
+        const now = new Date()
         return c.html(
-          renderLayout(c, 'チャート', chartsBody({ tab, equity }), renderChartsSubnav(tab)),
+          renderLayout(
+            c,
+            'チャート',
+            chartsBody({
+              tab,
+              equity,
+              tradeMarkers,
+              benchmark,
+              periodReturns: computePeriodReturns(equity, now),
+              monthlyReturns: computeMonthlyReturns(equity),
+            }),
+            renderChartsSubnav(tab),
+          ),
         )
       }
       if (tab === 'quality') {

--- a/test/routes/dashboardEquityEnhance.test.ts
+++ b/test/routes/dashboardEquityEnhance.test.ts
@@ -1,0 +1,283 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp } from '../../src/app'
+import { loadGlobalConfigFrom } from '../../src/infrastructure/db/globalConfigLoader'
+import { makeGlobalConfigSnapshot } from '../helpers/configFixtures'
+import {
+  type EquityPoint,
+  buildOverviewChartData,
+  computeMonthlyReturns,
+  computePeriodReturns,
+  toBenchmarkReturns,
+} from '../../src/routes/dashboard'
+
+vi.mock('../../src/infrastructure/db/globalConfigLoader', () => ({
+  loadGlobalConfigFrom: vi.fn(),
+}))
+
+// overview タブの QQQ ベンチマークは Yahoo fetch (network 依存)。テストでは
+// 常に失敗させて「series 省略 + 注記のみ」の fail-graceful 経路を検証する。
+vi.mock('../../src/infrastructure/quotes/YahooBarClient', () => ({
+  YahooBarClient: class {
+    async getDailyBars(): Promise<never> {
+      throw new Error('yahoo down (mocked)')
+    }
+    async getIntradayBars(): Promise<never> {
+      throw new Error('yahoo down (mocked)')
+    }
+  },
+  toYahooSymbol: (s: string) => s,
+}))
+
+const baseEnv = { ACCESS_DEV_BYPASS_USER: 'admin' }
+
+function pt(date: string, dailyPnl: number, cumulativePnl: number, drawdownPct = 0): EquityPoint {
+  return { date, dailyPnl, cumulativePnl, drawdownPct }
+}
+
+describe('computePeriodReturns', () => {
+  // 2026-07-03 09:00 JST (UTC 00:00)。JST 日 = 2026-07-03。
+  const now = new Date('2026-07-03T00:00:00Z')
+  const points = [
+    pt('2026-01-05', 10, 10),
+    pt('2026-03-01', 5, 15),
+    pt('2026-06-10', -3, 12),
+    pt('2026-07-01', 8, 20),
+  ]
+
+  it('1W/1M/3M/YTD/ALL の PnL 変化額を「期間開始日前の最後の累積値」基準で返す', () => {
+    const out = computePeriodReturns(points, now)
+    expect(out.map((r) => r.key)).toEqual(['1W', '1M', '3M', 'YTD', 'ALL'])
+    const byKey = Object.fromEntries(out.map((r) => [r.key, r.change]))
+    // 1W: 開始 2026-06-26 → 基準 12 (06-10) → 20 - 12 = 8
+    expect(byKey['1W']).toBeCloseTo(8)
+    // 1M: 開始 2026-06-03 → 基準 15 (03-01) → 5
+    expect(byKey['1M']).toBeCloseTo(5)
+    // 3M: 開始 2026-04-04 → 基準 15 → 5
+    expect(byKey['3M']).toBeCloseTo(5)
+    // YTD: 開始 2026-01-01 → 期間前 point 無し → 基準 0 → 20
+    expect(byKey['YTD']).toBeCloseTo(20)
+    expect(byKey['ALL']).toBeCloseTo(20)
+  })
+
+  it('ラベルは日本語 (UI 表示用)', () => {
+    const out = computePeriodReturns(points, now)
+    expect(out.map((r) => r.label)).toEqual(['1週間', '1か月', '3か月', '年初来', '全期間'])
+  })
+
+  it('JST 日付で期間境界を切る (UTC 15:00 = JST 翌日 00:00)', () => {
+    // UTC 2026-07-02 16:00 = JST 2026-07-03 01:00 → 1W 開始は 2026-06-26
+    const jstNext = computePeriodReturns(points, new Date('2026-07-02T16:00:00Z'))
+    // UTC 2026-07-02 14:00 = JST 2026-07-02 23:00 → 1W 開始は 2026-06-25
+    const jstSame = computePeriodReturns(points, new Date('2026-07-02T14:00:00Z'))
+    // どちらも 06-10 の point より後なので値は同じだが、YTD の年判定が
+    // JST 基準で計算されていることを年跨ぎで確認する。
+    expect(jstNext[3]!.change).toBeCloseTo(20)
+    expect(jstSame[3]!.change).toBeCloseTo(20)
+    // UTC 2025-12-31 16:00 = JST 2026-01-01 01:00 → YTD は 2026-01-01 開始
+    const out = computePeriodReturns([pt('2025-12-20', 7, 7), pt('2026-01-05', 3, 10)], new Date('2025-12-31T16:00:00Z'))
+    const ytd = out.find((r) => r.key === 'YTD')!
+    expect(ytd.change).toBeCloseTo(3) // 基準 = 2025-12-20 の累積 7
+  })
+
+  it('points 空なら空配列', () => {
+    expect(computePeriodReturns([], now)).toEqual([])
+  })
+})
+
+describe('computeMonthlyReturns', () => {
+  it('JST 月ごとに dailyPnl を合算して昇順で返す', () => {
+    const out = computeMonthlyReturns([
+      pt('2026-05-02', 3, 3),
+      pt('2026-05-20', -1, 2),
+      pt('2026-06-01', 4, 6),
+      pt('2026-04-30', 10, 10),
+    ])
+    expect(out).toEqual([
+      { month: '2026-04', pnl: 10 },
+      { month: '2026-05', pnl: 2 },
+      { month: '2026-06', pnl: 4 },
+    ])
+  })
+
+  it('points 空なら空配列', () => {
+    expect(computeMonthlyReturns([])).toEqual([])
+  })
+})
+
+describe('toBenchmarkReturns', () => {
+  const bar = (date: string, close: number) => ({ date, open: close, high: close, low: close, close })
+
+  it('先頭 close を 0% 基準にした騰落率 % 系列に変換する', () => {
+    const out = toBenchmarkReturns([bar('2026-01-01', 100), bar('2026-01-02', 110), bar('2026-01-03', 95)])
+    expect(out.map((p) => p.date)).toEqual(['2026-01-01', '2026-01-02', '2026-01-03'])
+    expect(out[0]!.returnPct).toBeCloseTo(0)
+    expect(out[1]!.returnPct).toBeCloseTo(10)
+    expect(out[2]!.returnPct).toBeCloseTo(-5)
+  })
+
+  it('不正 close (<= 0 / 非有限) を除外し、残りの先頭を基準にする', () => {
+    const out = toBenchmarkReturns([bar('2026-01-01', 0), bar('2026-01-02', 200), bar('2026-01-03', 210)])
+    expect(out.map((p) => p.date)).toEqual(['2026-01-02', '2026-01-03'])
+    expect(out[0]!.returnPct).toBeCloseTo(0)
+    expect(out[1]!.returnPct).toBeCloseTo(5)
+  })
+
+  it('日付順が乱れていても昇順に整えてから変換する', () => {
+    const out = toBenchmarkReturns([bar('2026-01-03', 120), bar('2026-01-01', 100)])
+    expect(out[0]).toEqual({ date: '2026-01-01', returnPct: 0 })
+    expect(out[1]!.returnPct).toBeCloseTo(20)
+  })
+
+  it('bars 空なら空配列', () => {
+    expect(toBenchmarkReturns([])).toEqual([])
+  })
+})
+
+describe('buildOverviewChartData', () => {
+  const equity = [pt('2026-06-10', 5, 5), pt('2026-06-20', 3, 8, -0.1)]
+  const marker = (date: string, side: 'BUY' | 'SELL') => ({
+    timestamp: `${date}T14:30:00Z`,
+    date,
+    symbol: 'SOXL',
+    side,
+    filledPrice: 30,
+    filledQty: 3,
+    realizedPnl: side === 'SELL' ? 5 : null,
+    clientOrderId: 'oid-1',
+  })
+
+  it('軸は equity 日付 ∪ マーカー日付、マーカー日は直前の累積で forward-fill', () => {
+    const vm = buildOverviewChartData(equity, [marker('2026-06-05', 'BUY'), marker('2026-06-15', 'BUY')], null)
+    expect(vm.dates).toEqual(['2026-06-05', '2026-06-10', '2026-06-15', '2026-06-20'])
+    // 最初の equity point 前は累積 0、06-15 は直前 (06-10) の 5 を引き継ぐ
+    expect(vm.equity).toEqual([0, 5, 5, 8])
+    expect(vm.drawdownPct[3]).toBeCloseTo(-10)
+    expect(vm.markers.map((m) => m.y)).toEqual([0, 5])
+    expect(vm.benchmark).toBeNull()
+  })
+
+  it('benchmark は日付キーで forward-fill、データ開始前は null', () => {
+    const vm = buildOverviewChartData(equity, [marker('2026-06-05', 'BUY')], [
+      { date: '2026-06-09', returnPct: 0 },
+      { date: '2026-06-16', returnPct: 2.5 },
+    ])
+    // 06-05 は benchmark 開始前 → null、06-10 は 06-09 の 0、06-20 は 06-16 の 2.5
+    expect(vm.benchmark).toEqual([null, 0, 2.5])
+  })
+})
+
+// --- overview タブ SSR スモーク (fake D1 + Yahoo 失敗 mock) ---
+
+function fakeOverviewDb(opts: {
+  equityRows?: Array<{ day: string; daily_pnl: number }>
+  fillRows?: Array<Record<string, unknown>>
+}): D1Database {
+  return {
+    prepare: (sql: string) => ({
+      all: async () => {
+        if (sql.includes('SUM(realized_pnl)')) return { results: opts.equityRows ?? [] }
+        if (sql.includes("trade_event_type = 'post_submit'")) return { results: opts.fillRows ?? [] }
+        return { results: [] }
+      },
+      bind: () => ({ all: async () => ({ results: [] }) }),
+    }),
+  } as unknown as D1Database
+}
+
+describe('GET /dashboard/charts?tab=overview (equity enhance SSR)', () => {
+  beforeEach(() => {
+    vi.mocked(loadGlobalConfigFrom).mockResolvedValue(makeGlobalConfigSnapshot())
+  })
+  afterEach(() => vi.resetAllMocks())
+
+  it('マーカー + 期間別テーブル + 月次チャートを描画し、Yahoo 失敗時はベンチマーク注記のみ', async () => {
+    const env = {
+      ...baseEnv,
+      DB: fakeOverviewDb({
+        equityRows: [
+          { day: '2026-06-10', daily_pnl: 5 },
+          { day: '2026-06-20', daily_pnl: 3 },
+        ],
+        fillRows: [
+          {
+            timestamp: '2026-06-09T14:30:00Z',
+            symbol: 'SOXL',
+            pre_side: 'BUY',
+            filled_price: 28.5,
+            filled_qty: 3,
+            realized_pnl: null,
+            client_order_id: 'oid-buy-1',
+          },
+          {
+            timestamp: '2026-06-20T14:30:00Z',
+            symbol: 'SOXL',
+            pre_side: 'SELL',
+            filled_price: 30.5,
+            filled_qty: 3,
+            realized_pnl: 6,
+            client_order_id: 'oid-sell-1',
+          },
+        ],
+      }),
+    }
+    const app = createApp()
+    const res = await app.request('/dashboard/charts?tab=overview', {}, env as never)
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    // チャート枠 + 期間別テーブル + 月次チャート
+    expect(body).toContain('id="equity-chart"')
+    expect(body).toContain('id="dd-chart"')
+    expect(body).toContain('期間別リターン')
+    expect(body).toContain('id="monthly-chart"')
+    expect(body).toContain('1週間')
+    expect(body).toContain('年初来')
+    // Yahoo mock 失敗 → ベンチマーク series 無し、注記のみ (fail-graceful)
+    expect(body).toContain('取得失敗のため非表示')
+    expect(body).not.toContain('QQQ 騰落率 (% 右軸) — 意味の異なる系列')
+    // マーカー payload (safeJsonScript) に fill が乗っている
+    expect(body).toContain('oid-sell-1')
+    expect(body).toContain('"markers"')
+    // クリック遷移先 (実装済みの trades フィルタ)
+    expect(body).toContain('/dashboard/trades?clientOrderId=')
+  })
+
+  it('全 inline script が構文エラーなく parse できる (#462 回帰ガード)', async () => {
+    const env = {
+      ...baseEnv,
+      DB: fakeOverviewDb({
+        equityRows: [{ day: '2026-06-10', daily_pnl: 5 }],
+        fillRows: [
+          {
+            timestamp: '2026-06-10T14:30:00Z',
+            symbol: 'SOXL',
+            pre_side: 'SELL',
+            filled_price: 30.5,
+            filled_qty: 3,
+            realized_pnl: 5,
+            client_order_id: 'oid-1',
+          },
+        ],
+      }),
+    }
+    const app = createApp()
+    const res = await app.request('/dashboard/charts?tab=overview', {}, env as never)
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    const blocks = [...body.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]!)
+    expect(blocks.length).toBeGreaterThan(0)
+    for (const code of blocks) {
+      // 構文エラーなら new Function が SyntaxError を throw する (実行はしない)。
+      expect(() => new Function(code)).not.toThrow()
+    }
+  })
+
+  it('実 fill が無ければ従来どおり案内メッセージのみ (Yahoo fetch もしない)', async () => {
+    const env = { ...baseEnv, DB: fakeOverviewDb({}) }
+    const app = createApp()
+    const res = await app.request('/dashboard/charts?tab=overview', {}, env as never)
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    expect(body).toContain('まだ実 fill (realized_pnl) が無いため')
+    expect(body).not.toContain('id="equity-chart"')
+  })
+})


### PR DESCRIPTION
## 概要

ダッシュボード UI/UX 改善 PR-4。charts 概要タブの equity curve を「いつ・どの取引で PnL が動いたか」「市場 (QQQ) と比べてどうか」まで読める形に強化する。

> **base は #554 (dev/dashboard-split)。merge 順: #552 → #554 → #557 → 本 PR**

## 変更点

- **取引マーカー**: post_submit fills を equity line 上に scatter (売り益 = 緑 / 売り損 = 赤 / 買い = グレー、日本語併記ラベル)。tooltip に銘柄 / side / 価格 × 数量 / 実現損益、クリックで `/dashboard/trades?clientOrderId=` の注文詳細へ
- **QQQ ベンチマーク**: Yahoo 日足を期間騰落率 % (先頭 = 0%) に変換し右 y 軸で重ねる。equity は累積実現 PnL ($ 左軸) のため意味の異なる系列である旨を UI に注記。Yahoo 失敗時は series 省略で fail-graceful
- **期間別リターン**: 1W / 1M / 3M / YTD / ALL の変化額テーブル + 月次 (JST) bar チャート。シード資金 (分母) を保持していないため % は出さない (理由コメント付き)

## 実装

- `loadEquityTradeMarkers(db)` (pre_submit self-JOIN で side 解決) / `computePeriodReturns` / `computeMonthlyReturns` / `toBenchmarkReturns` / `buildOverviewChartData` はすべて pure 関数で vitest 対象
- x 軸は equity 日付 ∪ マーカー日付の和集合 (BUY fill は realized PnL を生まず equity に同日 point が無いため forward-fill で整列)
- 新規 `charts/benchmark.ts` (`EQUITY_BENCHMARK_SYMBOL = 'QQQ'` 定数、将来 config 化の口をコメントで明示)

## テスト

`pnpm typecheck` / `pnpm test` — **111 files / 1629 tests green** (既存 1614 + 新規 15)。pure テスト 13 + SSR スモーク 3 (Yahoo mock 失敗で fail-graceful 検証、inline script 構文ガード)。

関連: #552 / #554 / #557 / #555 / #556

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ダッシュボードの概要チャートで、エクイティ曲線に売買マーカーとベンチマーク推移を重ねて表示できるようになりました。
  * 期間別・月次のリターン表示と、実現損益の推移テーブルを追加しました。

* **改善**
  * チャートの表示範囲や日付の整列がより自然になり、データ欠損時もできるだけ表示を維持するようになりました。
  * マーカーから該当取引の詳細ページへ移動しやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->