### PR TITLE
feat: consolidate nav into 4 groups and rebuild home as status dashboard

### DIFF
--- a/src/infrastructure/db/globalConfigRepo.ts
+++ b/src/infrastructure/db/globalConfigRepo.ts
@@ -123,7 +123,10 @@ export const GLOBAL_CONFIG_DEFAULTS: GlobalConfigSnapshot = Object.freeze({
  * の CSV を読み書きする。表示専用なので `GlobalConfigSnapshot` / cron 経路には通さず、
  * dashboard だけが参照する独立 read/write。
  */
-export const OVERVIEW_PANELS_DEFAULT = 'kpi,equity,composition,recent'
+// #dashboard-ia: status (資産サマリ帯) / positions (保有ポジション) を additive に
+// 追加。未設定 (列 NULL/空) の default は全表示。operator が保存済みの CSV は
+// そのまま尊重する (新 key は再保存まで OFF)。
+export const OVERVIEW_PANELS_DEFAULT = 'status,positions,kpi,equity,composition,recent'
 
 export async function loadOverviewPanelsCsv(db: DrizzleD1Database): Promise<string> {
   try {

--- a/src/routes/dashboard/index.ts
+++ b/src/routes/dashboard/index.ts
@@ -130,7 +130,7 @@ export const dashboard = new Hono<DashboardBindings>()
       const allDisplaySymbols = [...universe.allowedSymbols, ...universe.inactiveSymbols]
       const symbolClient = c.env.SYMBOL_STATE ? new SymbolStateClient(c.env.SYMBOL_STATE) : null
       const range = parseEquityRange(c.req.query('range'))
-      const [panelsCsv, portfolio, snapshots, sparkSnapshots, usdJpy, positions, strategyPriceMap, recentTrades, vixRegime, global] =
+      const [panelsCsv, portfolio, snapshots, sparkSnapshotsRaw, usdJpy, positions, strategyPriceMap, recentTrades, vixRegime, global] =
         await Promise.all([
           loadOverviewPanelsCsv(db),
           c.env.PORTFOLIO_STATE
@@ -138,7 +138,11 @@ export const dashboard = new Hono<DashboardBindings>()
             : Promise.resolve(null),
           safeLoadPortfolioSnapshots(c.env.DB, range),
           // 資産サマリ帯のスパークラインは range 指定と独立に直近 30 日固定。
-          safeLoadPortfolioSnapshots(c.env.DB, '30d'),
+          // range=30d (既定) のときは equity パネル用と同一クエリになるため
+          // 取得を省略し snapshots を再利用する (CodeRabbit #559: D1 二重取得)。
+          range === '30d'
+            ? Promise.resolve(null)
+            : safeLoadPortfolioSnapshots(c.env.DB, '30d'),
           // USDJPY は資産サマリ帯表示用。DO 不在 (帯を出さない) なら fetch 自体を省略。
           c.env.PORTFOLIO_STATE
             ? loadUsdJpyRate().catch(() => null)
@@ -166,7 +170,7 @@ export const dashboard = new Hono<DashboardBindings>()
         portfolio,
         snapshots,
         range,
-        sparkSnapshots,
+        sparkSnapshots: sparkSnapshotsRaw ?? snapshots,
         usdJpy,
         symbolStateBound: symbolClient !== null,
         positions,

--- a/src/routes/dashboard/index.ts
+++ b/src/routes/dashboard/index.ts
@@ -61,7 +61,7 @@ import { WebullTokenClient } from '../../infrastructure/webull/WebullTokenClient
 import { WebullTokenStateClient } from '../../trading/state/WebullTokenStateClient'
 import type { WebullTokenState } from '../../trading/state/WebullTokenStateDO'
 import { clampLimit, jsonPretty, messageOf, parseCursor, unavailable } from './shared'
-import { type DashboardBindings, loadKillSwitchState, renderLayout } from './layout'
+import { type DashboardBindings, loadKillSwitchState, renderAnalysisSubnav, renderLayout } from './layout'
 import { extractTokenFromPaste, renderWebullTokenBody } from './webullToken'
 import { brokerProbeBody } from './brokerProbe'
 import { ALL_OVERVIEW_PANELS, type OverviewData, loadRecentFills, overviewBody, parseOverviewPanels } from './overview'
@@ -130,13 +130,19 @@ export const dashboard = new Hono<DashboardBindings>()
       const allDisplaySymbols = [...universe.allowedSymbols, ...universe.inactiveSymbols]
       const symbolClient = c.env.SYMBOL_STATE ? new SymbolStateClient(c.env.SYMBOL_STATE) : null
       const range = parseEquityRange(c.req.query('range'))
-      const [panelsCsv, portfolio, snapshots, positions, strategyPriceMap, recentTrades, vixRegime, global] =
+      const [panelsCsv, portfolio, snapshots, sparkSnapshots, usdJpy, positions, strategyPriceMap, recentTrades, vixRegime, global] =
         await Promise.all([
           loadOverviewPanelsCsv(db),
           c.env.PORTFOLIO_STATE
             ? new PortfolioStateClient(c.env.PORTFOLIO_STATE).getPortfolio().catch(() => null)
             : Promise.resolve(null),
           safeLoadPortfolioSnapshots(c.env.DB, range),
+          // 資産サマリ帯のスパークラインは range 指定と独立に直近 30 日固定。
+          safeLoadPortfolioSnapshots(c.env.DB, '30d'),
+          // USDJPY は資産サマリ帯表示用。DO 不在 (帯を出さない) なら fetch 自体を省略。
+          c.env.PORTFOLIO_STATE
+            ? loadUsdJpyRate().catch(() => null)
+            : Promise.resolve(null),
           symbolClient
             ? Promise.all(
                 allDisplaySymbols.map(async (sym) => {
@@ -160,6 +166,9 @@ export const dashboard = new Hono<DashboardBindings>()
         portfolio,
         snapshots,
         range,
+        sparkSnapshots,
+        usdJpy,
+        symbolStateBound: symbolClient !== null,
         positions,
         strategyPriceMap,
         recentTrades,
@@ -233,7 +242,7 @@ export const dashboard = new Hono<DashboardBindings>()
   })
   .get('/trades', async (c) => {
     if (!c.env.DB) {
-      return c.html(renderLayout(c, '約定履歴', unavailable('DB not bound')))
+      return c.html(renderLayout(c, '約定履歴', unavailable('DB not bound'), renderAnalysisSubnav('trades')))
     }
     // クエリ解釈 + journal query は /trades/json と共用 (#dashboard-json-api)。
     const q = parseTradesQuery((key) => c.req.query(key))
@@ -255,6 +264,7 @@ export const dashboard = new Hono<DashboardBindings>()
           symbol: q.symbol,
           clientOrderId: q.clientOrderId,
         }),
+        renderAnalysisSubnav('trades'),
       ),
     )
   })
@@ -761,8 +771,10 @@ export const dashboard = new Hono<DashboardBindings>()
     }
   })
   .get('/cron', async (c) => {
+    // subnav の active は一覧 / マトリクスで切替 (履歴・分析 subnav #dashboard-ia)。
+    const cronSubnav = renderAnalysisSubnav(c.req.query('view') === 'matrix' ? 'matrix' : 'cron')
     if (!c.env.DB) {
-      return c.html(renderLayout(c, '戦略判定', unavailable('DB not bound')))
+      return c.html(renderLayout(c, '戦略判定', unavailable('DB not bound'), cronSubnav))
     }
     const limit = clampLimit(c.req.query('limit'))
     const before = parseCursor(c.req.query('before'))
@@ -788,10 +800,11 @@ export const dashboard = new Hono<DashboardBindings>()
               universe,
               { days, limit, symbolFilter },
             ),
+            cronSubnav,
           ),
         )
       } catch (err) {
-        return c.html(renderLayout(c, '戦略判定', unavailable(messageOf(err))))
+        return c.html(renderLayout(c, '戦略判定', unavailable(messageOf(err)), cronSubnav))
       }
     }
     const db = createDb(c.env.DB)
@@ -812,12 +825,13 @@ export const dashboard = new Hono<DashboardBindings>()
           c,
           '戦略判定',
           cronBody(rows, limit, symbolFilter, universe, before, hasMore, clientOrderIdFilter),
+          cronSubnav,
         ),
       )
     } catch (err) {
       // migration 未適用 / 一時的な D1 エラーで 500 にせず unavailable に落とす
       // (CodeRabbit #132)。段階的デプロイ時の自己保護。
-      return c.html(renderLayout(c, '戦略判定', unavailable(messageOf(err))))
+      return c.html(renderLayout(c, '戦略判定', unavailable(messageOf(err)), cronSubnav))
     }
   })
   /**
@@ -842,7 +856,7 @@ export const dashboard = new Hono<DashboardBindings>()
   })
   .get('/alerts', async (c) => {
     if (!c.env.DB) {
-      return c.html(renderLayout(c, 'アラート', unavailable('DB not bound')))
+      return c.html(renderLayout(c, 'アラート', unavailable('DB not bound'), renderAnalysisSubnav('alerts')))
     }
     const limit = clampAlertLimit(c.req.query('limit'))
     const before = parseCursor(c.req.query('before'))
@@ -868,12 +882,13 @@ export const dashboard = new Hono<DashboardBindings>()
           c,
           'アラート',
           alertsBody({ rows, limit, severityFilter, eventTypeFilter, currentQuery, universe, before, hasMore }),
+          renderAnalysisSubnav('alerts'),
         ),
       )
     } catch (err) {
       // 0012 migration 未適用 (= notification_emit_log テーブル無し) を
       // 500 にせず unavailable に落とす。段階的デプロイ時の自己保護。
-      return c.html(renderLayout(c, 'アラート', unavailable(messageOf(err))))
+      return c.html(renderLayout(c, 'アラート', unavailable(messageOf(err)), renderAnalysisSubnav('alerts')))
     }
   })
   .get('/audit', async (c) => {

--- a/src/routes/dashboard/layout.ts
+++ b/src/routes/dashboard/layout.ts
@@ -58,6 +58,15 @@ export const STYLE = `
   .topnav-killswitch[open] summary{background:#f0f0f3}
   .ks-pop{position:absolute;right:0;top:calc(100% + 6px);background:#fff;border:1px solid #d0d0d5;border-radius:8px;padding:10px 12px;width:240px;box-shadow:0 4px 16px rgba(0,0,0,0.12);z-index:110;font-size:13px}
   .ks-pop .ks-title{font-weight:600;font-size:12px;margin-bottom:2px}
+  /* 運用ドロップダウン (#dashboard-ia): kill switch と同じ details パターンを
+     nav 内に置く。運用系 6 ページ (設定/銘柄管理/イベント/監査/診断/token) を
+     1 グループに畳んでグローバル nav を 4 項目に保つ。 */
+  .topnav-ops{margin:0;position:relative;flex:0 0 auto}
+  .topnav-ops summary{list-style:none;cursor:pointer;font-weight:400}
+  .topnav-ops summary::-webkit-details-marker{display:none}
+  .topnav-ops[open]>summary:not(.active){background:#f0f0f3}
+  .ops-pop{position:absolute;left:0;top:calc(100% + 6px);background:#fff;border:1px solid #d0d0d5;border-radius:8px;padding:6px;min-width:170px;box-shadow:0 4px 16px rgba(0,0,0,0.12);z-index:110;display:flex;flex-direction:column;gap:2px}
+  .ops-pop .nav-link{display:block}
   /* ページ固有 subnav (header 2段目)。topnav active より薄い装飾で階層差を出す */
   .subnav{display:flex;align-items:center;gap:2px;padding:3px 16px 6px;flex-wrap:wrap;border-top:1px solid #f0f0f3}
   .subnav-link{color:#1d1d1f;text-decoration:none;padding:3px 10px;border-radius:6px;font-size:12.5px;white-space:nowrap}
@@ -73,6 +82,10 @@ export const STYLE = `
     .topnav .nav-sep{display:none}
     .topnav .nav-link{font-size:14px;padding:8px 12px}
     .topnav-killswitch{order:5}
+    /* 折り畳み nav 内ではドロップダウンをインライン展開 (絶対配置 popup は
+       折り畳みメニューの高さ計算を壊すため) */
+    .topnav-ops{width:100%}
+    .ops-pop{position:static;box-shadow:none;border:none;padding:2px 0 2px 14px}
   }
   /* KPI カード */
   .kpi-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px;margin-bottom:16px}
@@ -174,7 +187,7 @@ export const STYLE = `
 
 export function renderLayout(
   c: {
-    req: { path: string }
+    req: { path: string; url: string }
     env: unknown
     var: { killSwitchState: KillSwitchBannerState | null }
   },
@@ -183,64 +196,119 @@ export function renderLayout(
   subnav = '',
 ): string {
   const killSwitch = killSwitchTopnav(c.var.killSwitchState)
-  return layout(title, body, c.req.path, killSwitch, subnav)
+  // active 判定はグループ単位の前方一致 (#dashboard-ia)。/charts は ?tab= で
+  // 「銘柄」(symbol/grid) と「履歴・分析」(overview/quality) に分かれるため
+  // query も見る。
+  let tab: string | null = null
+  try {
+    tab = new URL(c.req.url).searchParams.get('tab')
+  } catch {
+    // 相対 URL 等で parse できない場合は tab 無し (= overview) 扱い
+  }
+  return layout(title, body, resolveActiveNavGroup(c.req.path, tab), killSwitch, subnav)
 }
 
-/** グローバル nav 定義 (上部バー)。active link は path 完全一致で強調。 */
+/**
+ * グローバル nav (#dashboard-ia): 4 項目 + 運用ドロップダウンに削減。
+ * 資産系 (/positions /portfolio) はホームに統合したため nav からは外す
+ * (URL は直アクセス可のまま維持)。
+ */
+export type NavGroupKey = 'home' | 'symbol' | 'analysis' | 'ops'
+
 export const NAV_GROUPS: ReadonlyArray<{
-  label?: string
-  links: ReadonlyArray<{ href: string; text: string; title?: string }>
+  key: NavGroupKey
+  href: string
+  text: string
+  title?: string
 }> = [
-  { links: [{ href: '/dashboard', text: 'ホーム' }] },
+  { key: 'home', href: '/dashboard', text: 'ホーム', title: '今日の状況 (資産サマリ / 保有 / 直近の判定)' },
+  { key: 'symbol', href: '/dashboard/charts?tab=symbol', text: '銘柄', title: '個別銘柄チャート / 銘柄グリッド' },
+  { key: 'analysis', href: '/dashboard/trades', text: '履歴・分析', title: '約定履歴 / 戦略判定 / 取引品質 / 資産推移 / アラート' },
+]
+
+/** 運用ドロップダウン内リンク (低頻度の運用・管理ページ)。 */
+export const OPS_NAV_LINKS: ReadonlyArray<{ href: string; text: string; title?: string }> = [
+  { href: '/dashboard/config', text: '設定' },
+  { href: '/dashboard/symbols', text: '銘柄管理' },
+  { href: '/dashboard/events', text: 'イベント' },
+  { href: '/dashboard/audit', text: '監査ログ' },
   {
-    label: '取引状況',
-    links: [
-      { href: '/dashboard/positions', text: 'ポートフォリオ' },
-      { href: '/dashboard/portfolio', text: '口座サマリ' },
-      { href: '/dashboard/trades', text: '約定履歴' },
-    ],
+    href: '/dashboard/broker-probe',
+    text: 'broker 診断',
+    title: 'Webull broker に直接 quote/positions を投げて raw レスポンスを表示する診断ページ',
   },
   {
-    label: '戦略・監視',
-    links: [
-      { href: '/dashboard/cron', text: '戦略判定' },
-      { href: '/dashboard/charts', text: 'チャート' },
-      { href: '/dashboard/alerts', text: 'アラート' },
-      { href: '/dashboard/events', text: 'イベント' },
-    ],
-  },
-  {
-    label: '運用',
-    links: [
-      { href: '/dashboard/config', text: '設定' },
-      { href: '/dashboard/symbols', text: '銘柄管理' },
-      { href: '/dashboard/audit', text: '監査ログ' },
-      {
-        href: '/dashboard/broker-probe',
-        text: 'broker 診断',
-        title: 'Webull broker に直接 quote/positions を投げて raw レスポンスを表示する診断ページ',
-      },
-      {
-        href: '/dashboard/webull-token',
-        text: 'Webull token',
-        title: 'Webull x-access-token の状態確認 / 投入 / refresh (#21 Phase B)',
-      },
-    ],
+    href: '/dashboard/webull-token',
+    text: 'Webull token',
+    title: 'Webull x-access-token の状態確認 / 投入 / refresh (#21 Phase B)',
   },
 ]
 
-export function renderTopNav(activePath?: string): string {
-  // 上部バーではグループ label を出さず縦罫線で区切る (横幅節約)。
-  // グループの意味は各 link の title (hint) で補う。
-  return NAV_GROUPS.map((g) => {
-    return g.links
-      .map((l) => {
-        const active = activePath === l.href ? ' active' : ''
-        const t = l.title ? ` title="${esc(l.title)}"` : g.label ? ` title="${esc(g.label)}"` : ''
-        return `<a class="nav-link${active}" href="${l.href}"${t}>${esc(l.text)}</a>`
-      })
-      .join('')
-  }).join('<span class="nav-sep"></span>')
+/**
+ * 現在ページ → active nav グループの解決 (グループ単位の前方一致)。
+ * /positions /portfolio は nav 外の直アクセスページなので active 無し (null)。
+ */
+export function resolveActiveNavGroup(activePath?: string, tab?: string | null): NavGroupKey | null {
+  if (!activePath) return null
+  if (activePath === '/dashboard' || activePath === '/dashboard/') return 'home'
+  if (activePath === '/dashboard/charts') {
+    // symbol / grid タブは「銘柄」、overview (default) / quality は「履歴・分析」
+    return tab === 'symbol' || tab === 'grid' ? 'symbol' : 'analysis'
+  }
+  for (const p of ['/dashboard/trades', '/dashboard/cron', '/dashboard/alerts']) {
+    if (activePath === p || activePath.startsWith(`${p}/`)) return 'analysis'
+  }
+  for (const l of OPS_NAV_LINKS) {
+    if (activePath === l.href || activePath.startsWith(`${l.href}/`)) return 'ops'
+  }
+  return null
+}
+
+export function renderTopNav(active?: NavGroupKey | null): string {
+  const links = NAV_GROUPS.map((g) => {
+    const activeCls = active === g.key ? ' active' : ''
+    const t = g.title ? ` title="${esc(g.title)}"` : ''
+    return `<a class="nav-link${activeCls}" href="${g.href}"${t}>${esc(g.text)}</a>`
+  }).join('')
+  const opsLinks = OPS_NAV_LINKS.map((l) => {
+    const t = l.title ? ` title="${esc(l.title)}"` : ''
+    return `<a class="nav-link" href="${l.href}"${t}>${esc(l.text)}</a>`
+  }).join('')
+  // 運用は kill switch と同じ details ドロップダウン。summary 自体が現在地
+  // 表示を兼ねる (運用系ページでは active 装飾)。
+  return `${links}<span class="nav-sep"></span><details class="topnav-ops">
+    <summary class="nav-link${active === 'ops' ? ' active' : ''}">運用 ▾</summary>
+    <div class="ops-pop">${opsLinks}</div>
+  </details>`
+}
+
+/**
+ * 「履歴・分析」グループ共通の subnav (#dashboard-ia)。charts の
+ * `renderChartsSubnav` と同型で trades / cron / alerts の 3 ページに出す
+ * (charts ページ自体は既存の charts subnav のまま — subnav 2 本は出さない)。
+ */
+export type AnalysisSubnavKey = 'trades' | 'cron' | 'matrix' | 'quality' | 'equity' | 'alerts'
+
+export const ANALYSIS_SUBNAV_ITEMS: ReadonlyArray<{
+  key: AnalysisSubnavKey
+  href: string
+  label: string
+}> = [
+  { key: 'trades', href: '/dashboard/trades', label: '約定履歴' },
+  { key: 'cron', href: '/dashboard/cron', label: '戦略判定' },
+  { key: 'matrix', href: '/dashboard/cron?view=matrix', label: '判定マトリクス' },
+  { key: 'quality', href: '/dashboard/charts?tab=quality', label: '取引品質' },
+  { key: 'equity', href: '/dashboard/charts', label: '資産推移' },
+  { key: 'alerts', href: '/dashboard/alerts', label: 'アラート' },
+]
+
+export function renderAnalysisSubnav(active: AnalysisSubnavKey): string {
+  return ANALYSIS_SUBNAV_ITEMS.map((i) => {
+    if (i.key === active) {
+      return `<span class="subnav-link active">${esc(i.label)}</span>`
+    }
+    return `<a class="subnav-link" href="${i.href}">${esc(i.label)}</a>`
+  }).join('')
 }
 
 /**
@@ -288,7 +356,7 @@ export function killSwitchTopnav(state: KillSwitchBannerState | null): string {
 export function layout(
   title: string,
   body: string,
-  activePath?: string,
+  activeNav?: NavGroupKey | null,
   navRight = '',
   subnav = '',
 ): string {
@@ -305,7 +373,7 @@ export function layout(
   <div class="topnav">
     <div class="brand">Webull Trading</div>
     <button class="nav-toggle" onclick="this.nextElementSibling.classList.toggle('open')" aria-label="メニュー">☰</button>
-    <nav>${renderTopNav(activePath)}</nav>
+    <nav>${renderTopNav(activeNav)}</nav>
     ${navRight}
   </div>
   ${subnav ? `<nav class="subnav">${subnav}</nav>` : ''}

--- a/src/routes/dashboard/overview.ts
+++ b/src/routes/dashboard/overview.ts
@@ -4,16 +4,28 @@ import type { PortfolioEquitySnapshotRow } from '../../infrastructure/db/schema'
 import type { VixRegime } from '../../trading/risk/vixRegimeFilter'
 import type { SymbolState } from '../../trading/state/types'
 import { formatRealizedPnl } from './cron'
+import { ECHARTS_CDN } from './charts/shared'
 import { type EquityRange, renderPortfolioEquityChart, renderVixRegimeCell } from './portfolio'
-import { pickFreshQuote } from './positions'
-import { displaySymbol, esc, fmtJst, fmtNumber } from './shared'
+import { pickFreshQuote, positionsBody } from './positions'
+import { displaySymbol, esc, fmtJst, fmtNumber, safeJsonScript } from './shared'
 
 // #dashboard-mf-layout: overview パネル定義。設定で ON/OFF (default 全表示)。
-export type OverviewPanel = 'kpi' | 'equity' | 'composition' | 'recent'
+// #dashboard-ia で status (資産サマリ帯 + スパークライン) / positions (保有
+// ポジション) を additive に追加。既存 key の意味は変えない。
+export type OverviewPanel = 'status' | 'positions' | 'kpi' | 'equity' | 'composition' | 'recent'
 
-export const ALL_OVERVIEW_PANELS: readonly OverviewPanel[] = ['kpi', 'equity', 'composition', 'recent']
+export const ALL_OVERVIEW_PANELS: readonly OverviewPanel[] = [
+  'status',
+  'positions',
+  'kpi',
+  'equity',
+  'composition',
+  'recent',
+]
 
 export const OVERVIEW_PANEL_LABELS: Record<OverviewPanel, string> = {
+  status: '資産サマリ帯 (本日開始 equity / 実現損益 / 取引状態 / VIX / USDJPY + 資産スパークライン)',
+  positions: '保有ポジション (positions ページと同じテーブル)',
   kpi: 'KPI カード (総資産 / 当日損益 / 建玉数 / エクスポージャー)',
   equity: '資産推移チャート (期間タブ)',
   composition: '資産構成 + 含み損益ランキング',
@@ -41,6 +53,12 @@ export interface OverviewData {
   } | null
   snapshots: PortfolioEquitySnapshotRow[]
   range: EquityRange
+  /** 資産サマリ帯のスパークライン用 (直近 30 日固定。`snapshots` は ?range= 連動)。 */
+  sparkSnapshots: PortfolioEquitySnapshotRow[]
+  /** USDJPY レート (資産サマリ帯表示用)。取得失敗は null → "—" 表示。 */
+  usdJpy: number | null
+  /** SYMBOL_STATE binding の有無。false なら保有ポジションは誘導リンクのみ。 */
+  symbolStateBound: boolean
   positions: Array<{ sym: string; state: SymbolState | null; error: string | null }>
   strategyPriceMap: Map<string, { price: number; asOf: string }>
   recentTrades: Array<{
@@ -128,6 +146,108 @@ export function collectOpenPositions(data: OverviewData): OpenPositionView[] {
     })
   }
   return out
+}
+
+/**
+ * セクション見出し (h1 なし方針のまま「詳しく見る」導線を付ける小ヘッダ)。
+ * ホームは要約、詳細は各専用ページ (/portfolio /positions /cron /alerts) へ。
+ */
+export function sectionHead(title: string, moreHref: string): string {
+  return `<div style="display:flex;align-items:baseline;justify-content:space-between;margin:0 2px 6px"><span style="font-size:13px;font-weight:700">${esc(title)}</span><a href="${moreHref}" style="font-size:12px">詳しく見る →</a></div>`
+}
+
+/**
+ * 資産サマリ帯 (#dashboard-ia 最上段): /portfolio の要約をカード 1 枚に横並び。
+ * PORTFOLIO_STATE DO 不在 (portfolio === null) は帯を省略し、スパークラインも
+ * データ無しなら section ごと消える (graceful)。
+ */
+export function renderStatusPanel(data: OverviewData): string {
+  const spark = renderEquitySparkline(data.sparkSnapshots)
+  const p = data.portfolio
+  if (p === null && spark === '') return ''
+  let band = ''
+  if (p !== null) {
+    const pnlClass = p.dailyRealizedPnl >= 0 ? 'ok' : 'err'
+    const tradingPill = data.tradingEnabled
+      ? '<span class="pill on">取引 ON</span>'
+      : '<span class="pill off">取引 OFF</span>'
+    const item = (label: string, value: string) =>
+      `<div style="min-width:110px"><div class="kpi-label">${esc(label)}</div><div style="font-size:15px;font-weight:700;font-variant-numeric:tabular-nums">${value}</div></div>`
+    band = `<div style="display:flex;flex-wrap:wrap;gap:10px 22px;align-items:flex-end">
+      ${item('本日開始 equity', fmtNumber(p.dailyStartEquity, 2))}
+      ${item('本日実現損益', `<span class="${pnlClass}">${fmtNumber(p.dailyRealizedPnl, 2)}</span>`)}
+      ${item('取引 (effective)', tradingPill)}
+      ${item('VIX レジーム', `<span style="font-size:13px;font-weight:400">${renderVixRegimeCell(data.vixRegime)}</span>`)}
+      ${item('USDJPY', data.usdJpy === null ? '<span class="muted">—</span>' : fmtNumber(data.usdJpy, 2))}
+    </div>`
+  }
+  return `${sectionHead('資産サマリ', '/dashboard/portfolio')}<div class="panel">${band}${spark}</div>`
+}
+
+/**
+ * equity スパークライン (直近 30 日、高さ 80px)。portfolio_equity_snapshot の
+ * dailyStartEquity を 1 本線で描く。USD があれば USD、無ければ JPY。両方
+ * データ無しは '' (帯から省略)。
+ */
+export function renderEquitySparkline(snapshots: PortfolioEquitySnapshotRow[]): string {
+  const dates: string[] = []
+  const usd: Array<number | null> = []
+  const jpy: Array<number | null> = []
+  for (const row of snapshots) {
+    dates.push((row.snapshotAt ?? '').slice(0, 10))
+    usd.push(
+      typeof row.dailyStartEquityUsd === 'number' && Number.isFinite(row.dailyStartEquityUsd)
+        ? row.dailyStartEquityUsd
+        : null,
+    )
+    jpy.push(
+      typeof row.dailyStartEquityJpy === 'number' && Number.isFinite(row.dailyStartEquityJpy)
+        ? row.dailyStartEquityJpy
+        : null,
+    )
+  }
+  const hasUsd = usd.some((v) => v !== null)
+  const hasJpy = jpy.some((v) => v !== null)
+  if (!hasUsd && !hasJpy) return ''
+  const currency = hasUsd ? 'USD' : 'JPY'
+  const values = hasUsd ? usd : jpy
+  const initScript = `
+    document.addEventListener('DOMContentLoaded', function () {
+      if (typeof echarts === 'undefined') return;
+      var el = document.getElementById('home-equity-spark');
+      if (!el) return;
+      var d = window.__homeEquitySpark;
+      var chart = echarts.init(el);
+      chart.setOption({
+        grid: { left: 2, right: 2, top: 4, bottom: 2 },
+        xAxis: { type: 'category', data: d.dates, show: false },
+        yAxis: { type: 'value', show: false, min: 'dataMin', max: 'dataMax' },
+        tooltip: { trigger: 'axis', valueFormatter: function (v) { return v == null ? '—' : Number(v).toLocaleString('ja-JP'); } },
+        series: [{ type: 'line', data: d.values, showSymbol: false, connectNulls: false, lineStyle: { width: 1.5, color: '#06c' }, itemStyle: { color: '#06c' }, areaStyle: { opacity: 0.08, color: '#06c' } }],
+      });
+      window.addEventListener('resize', function () { chart.resize(); });
+    });
+  `
+  return `<div style="margin-top:10px">
+    <div class="muted" style="font-size:11px;margin-bottom:2px">資産推移 (直近 30 日, ${currency})</div>
+    <div id="home-equity-spark" style="width:100%;height:80px"></div>
+  </div>
+  ${safeJsonScript('__homeEquitySpark', { dates, values })}
+  <script src="${ECHARTS_CDN}" defer></script>
+  <script>${initScript}</script>`
+}
+
+/**
+ * 保有ポジション section (#dashboard-ia): positions ページと同じ loader 結果 /
+ * 同じテーブル renderer (`positionsBody`) を re-use する。SYMBOL_STATE 不在時は
+ * テーブルを省略して誘導リンクのみ。
+ */
+export function renderHomePositionsSection(data: OverviewData): string {
+  const head = sectionHead('保有ポジション', '/dashboard/positions')
+  if (!data.symbolStateBound) {
+    return `${head}<div class="panel"><p class="muted" style="margin:0">SYMBOL_STATE 未配線のため表示できません。<a href="/dashboard/positions">保有ポジションページ</a>を参照してください。</p></div>`
+  }
+  return `${head}<div style="margin-bottom:16px">${positionsBody(data.positions, data.strategyPriceMap, data.universe)}</div>`
 }
 
 export function kpiCard(label: string, value: string, sub?: string, subClass?: string): string {
@@ -219,7 +339,7 @@ export function renderRecentPanel(data: OverviewData): string {
     ? '<span class="pill on">取引 ON</span>'
     : '<span class="pill off">取引 OFF</span>'
   return `<div class="panel">
-    <div class="panel-title">最近の約定 / リスク状態</div>
+    <div class="panel-title" style="display:flex;justify-content:space-between;align-items:baseline"><span>最近の約定 / リスク状態</span><span style="font-weight:400;font-size:12px"><a href="/dashboard/cron">判定履歴 →</a> <a href="/dashboard/alerts" style="margin-left:8px">アラート →</a></span></div>
     <div class="panel-row">
       <div>${recentTable}<div style="margin-top:8px"><a href="/dashboard/trades">約定履歴をすべて見る →</a></div></div>
       <div>
@@ -274,7 +394,14 @@ export function buyingPowerBadge(): string {
 export function overviewBody(data: OverviewData): string {
   const open = collectOpenPositions(data)
   const sections: string[] = []
+  // 「今日の状況が 1 画面で分かる」順: 資産サマリ帯 → KPI → 保有 → 推移 →
+  // 構成 → 直近の約定/判定。詳細は各セクション見出しの「詳しく見る」で専用ページへ。
+  if (data.panels.has('status')) {
+    const status = renderStatusPanel(data)
+    if (status !== '') sections.push(status)
+  }
   if (data.panels.has('kpi')) sections.push(renderKpiPanel(data, open))
+  if (data.panels.has('positions')) sections.push(renderHomePositionsSection(data))
   if (data.panels.has('equity')) {
     sections.push(
       `<div class="panel">${renderPortfolioEquityChart(data.snapshots, data.range, '/dashboard')}</div>`,

--- a/src/routes/dashboard/overview.ts
+++ b/src/routes/dashboard/overview.ts
@@ -391,6 +391,19 @@ export function buyingPowerBadge(): string {
   </script>`
 }
 
+/**
+ * ECharts CDN の `<script src>` タグ重複除去 (CodeRabbit #559)。status
+ * (スパークライン) と equity (資産推移チャート) はどちらも単独 ON で成立する
+ * 必要があるため各自 CDN タグを持つ — 両方 ON のときだけここで 2 個目以降を
+ * 落とす (同一 src の二重ロードはキャッシュされるが parse/execute が無駄)。
+ */
+export function dedupeEchartsCdnTag(html: string): string {
+  const tag = `<script src="${ECHARTS_CDN}" defer></script>`
+  const parts = html.split(tag)
+  if (parts.length <= 2) return html
+  return parts[0] + tag + parts.slice(1).join('')
+}
+
 export function overviewBody(data: OverviewData): string {
   const open = collectOpenPositions(data)
   const sections: string[] = []
@@ -414,5 +427,5 @@ export function overviewBody(data: OverviewData): string {
       '<p class="muted">表示パネルが選択されていません。<a href="/dashboard/config">設定</a>でパネルを有効化してください。</p>',
     )
   }
-  return buyingPowerBadge() + sections.join('')
+  return dedupeEchartsCdnTag(buyingPowerBadge() + sections.join(''))
 }

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -101,7 +101,11 @@ describe('dashboard', () => {
     expect(res.status).toBe(200)
     const body = await res.text()
     expect(body).toContain('<title>ダッシュボード')
-    expect(body).toContain('/dashboard/positions')
+    // #dashboard-ia: nav は 4 項目に削減 (positions/portfolio はホーム統合で
+    // nav から外れたため、代わりに再編後のグローバル nav を検証)
+    expect(body).toContain('href="/dashboard/charts?tab=symbol"')
+    expect(body).toContain('href="/dashboard/trades"')
+    expect(body).toContain('運用 ▾')
   })
 
   // #276: kill-switch は全 page 共通でサイドバー下部に表示される (banner → sidebar
@@ -325,17 +329,18 @@ describe('dashboard', () => {
   })
 
   // #dashboard-mf-layout: overview パネル ON/OFF フォーム。createDb mock 未設定 →
-  // loadOverviewPanelsCsv が default fallback → 4 パネルすべて checked で描画。
+  // loadOverviewPanelsCsv が default fallback → 全パネル checked で描画
+  // (#dashboard-ia で status / positions が additive に増え 6 パネル)。
   it('renders overview panel toggle form on config page (all checked by default)', async () => {
     const env = { ...baseEnv, DB: {} as D1Database }
     const app = createApp()
     const res = await app.request('/dashboard/config', { headers: authHeader }, env)
     const body = await res.text()
     expect(body).toContain('action="/dashboard/config/overview-panels"')
-    for (const k of ['kpi', 'equity', 'composition', 'recent']) {
+    for (const k of ALL_OVERVIEW_PANELS) {
       expect(body).toContain(`value="${k}"`)
     }
-    expect((body.match(/name="panels"[^>]*checked/g) ?? []).length).toBe(4)
+    expect((body.match(/name="panels"[^>]*checked/g) ?? []).length).toBe(ALL_OVERVIEW_PANELS.length)
   })
 
   it('saves overview panel selection (303 redirect, CSV deduped + invalid dropped)', async () => {

--- a/test/routes/dashboardIa.test.ts
+++ b/test/routes/dashboardIa.test.ts
@@ -1,0 +1,376 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp } from '../../src/app'
+import { loadGlobalConfigFrom } from '../../src/infrastructure/db/globalConfigLoader'
+import { loadSymbolUniverse } from '../../src/infrastructure/db/symbolUniverse'
+import { loadPortfolioEquitySnapshots } from '../../src/infrastructure/db/portfolioEquitySnapshotRepo'
+import { loadUsdJpyRate } from '../../src/infrastructure/quotes/fxRate'
+import { loadRecentAlerts } from '../../src/infrastructure/notification/notificationEmitLog'
+import { resolveActiveNavGroup } from '../../src/routes/dashboard/layout'
+import { makeGlobalConfigSnapshot, makeSymbolUniverse } from '../helpers/configFixtures'
+
+/**
+ * #dashboard-ia — 情報アーキテクチャ再編のスモーク。
+ *
+ * 1. グローバル nav: 13 リンクのフラット並び → 4 項目 (ホーム / 銘柄 /
+ *    履歴・分析 / 運用ドロップダウン) + グループ単位の前方一致 active。
+ * 2. 履歴・分析 subnav: trades / cron / alerts の 3 ページに共通 subnav。
+ * 3. ホーム統合: 資産サマリ帯 + スパークライン + 保有ポジション (DO あり /
+ *    なしの graceful degrade)。
+ */
+
+vi.mock('../../src/infrastructure/db/globalConfigLoader', () => ({
+  loadGlobalConfigFrom: vi.fn(),
+}))
+vi.mock('../../src/infrastructure/db/symbolUniverse', () => ({
+  loadSymbolUniverse: vi.fn(),
+}))
+vi.mock('../../src/infrastructure/db/tradeJournalRepo', () => ({
+  createDb: vi.fn(),
+}))
+vi.mock('../../src/infrastructure/db/portfolioEquitySnapshotRepo', () => ({
+  loadPortfolioEquitySnapshots: vi.fn(),
+}))
+vi.mock('../../src/infrastructure/quotes/fxRate', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/infrastructure/quotes/fxRate')>()),
+  loadUsdJpyRate: vi.fn(),
+}))
+vi.mock('../../src/infrastructure/db/globalConfigRepo', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/infrastructure/db/globalConfigRepo')>()),
+  loadOverviewPanelsCsv: vi.fn(async () => ''),
+}))
+vi.mock('../../src/infrastructure/notification/notificationEmitLog', () => ({
+  loadRecentAlerts: vi.fn(),
+}))
+
+const baseEnv = { ACCESS_DEV_BYPASS_USER: 'admin' }
+const authHeader = {}
+
+/** D1 直叩き loader (loadRecentFills 等) 用の空返し fake。 */
+function fakeD1(): D1Database {
+  const stmt = {
+    bind() {
+      return stmt
+    },
+    async all() {
+      return { results: [] }
+    },
+    async first() {
+      return null
+    },
+    async run() {
+      return { success: true }
+    },
+    async raw() {
+      return []
+    },
+  }
+  return {
+    prepare: () => stmt,
+    batch: async () => [],
+  } as unknown as D1Database
+}
+
+function fakeSymbolStateNamespace() {
+  const stub = {
+    async getState(symbol: string) {
+      return {
+        symbol,
+        position: { qty: 10, avgPrice: 100, openedAt: '2026-06-20T00:00:00.000Z' },
+        pendingOrder: null,
+        lastSignalAt: null,
+        cooldownUntil: null,
+        settledCash: 0,
+        pendingSettlement: [],
+        lastExecutedPrice: null,
+        lastQuote: { price: 105, asOf: '2026-07-01T00:00:00Z', fetchedAt: '2026-07-01T00:00:00Z', source: 'yahoo' },
+        updatedAt: '2026-07-01T00:00:00.000Z',
+      }
+    },
+  }
+  return {
+    idFromName: (_name: string) => 'id',
+    get: (_id: string) => stub,
+  } as unknown
+}
+
+function fakePortfolioNamespace() {
+  const stub = {
+    async getPortfolio() {
+      return {
+        dailyStartEquity: 10000,
+        dailyRealizedPnl: -50,
+        openExposureUsd: 1200,
+        openExposureJpy: 0,
+        tradingDisabledUntil: null,
+        lastRolledAt: '2026-07-01T00:00:00.000Z',
+        updatedAt: '2026-07-01T00:00:00.000Z',
+      }
+    },
+  }
+  return {
+    idFromName: () => 'id',
+    get: () => stub,
+  } as unknown
+}
+
+const sparkRows = [
+  {
+    id: 1,
+    snapshotAt: '2026-06-30T00:00:00.000Z',
+    dailyStartEquityUsd: 10000,
+    dailyStartEquityJpy: null,
+    dailyRealizedPnlUsd: 0,
+    dailyRealizedPnlJpy: null,
+    drawdownPct: null,
+    requestId: null,
+  },
+  {
+    id: 2,
+    snapshotAt: '2026-07-01T00:00:00.000Z',
+    dailyStartEquityUsd: 10100,
+    dailyStartEquityJpy: null,
+    dailyRealizedPnlUsd: 100,
+    dailyRealizedPnlJpy: null,
+    drawdownPct: 0.01,
+    requestId: null,
+  },
+]
+
+describe('dashboard IA — global nav (#dashboard-ia)', () => {
+  beforeEach(() => {
+    vi.mocked(loadGlobalConfigFrom).mockResolvedValue(makeGlobalConfigSnapshot())
+    vi.mocked(loadSymbolUniverse).mockResolvedValue(
+      makeSymbolUniverse({ allowedSymbols: ['SOXL'], symbolCurrency: { SOXL: 'USD' } }),
+    )
+    vi.mocked(loadPortfolioEquitySnapshots).mockResolvedValue([])
+    vi.mocked(loadUsdJpyRate).mockResolvedValue(150.25)
+  })
+  afterEach(() => vi.resetAllMocks())
+
+  it('renders 4 groups + 運用 dropdown (positions/portfolio are not in the nav)', async () => {
+    const app = createApp()
+    const res = await app.request('/dashboard', { headers: authHeader }, baseEnv)
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    // 最初の <nav> (class 無し) がグローバル nav
+    const nav = body.match(/<nav>[\s\S]*?<\/nav>/)?.[0] ?? ''
+    expect(nav).toContain('href="/dashboard"')
+    expect(nav).toContain('>ホーム</a>')
+    expect(nav).toContain('href="/dashboard/charts?tab=symbol"')
+    expect(nav).toContain('>銘柄</a>')
+    expect(nav).toContain('href="/dashboard/trades"')
+    expect(nav).toContain('>履歴・分析</a>')
+    // 運用ドロップダウン (kill switch と同じ details パターン)
+    expect(nav).toContain('<details class="topnav-ops">')
+    expect(nav).toContain('運用 ▾')
+    for (const href of [
+      '/dashboard/config',
+      '/dashboard/symbols',
+      '/dashboard/events',
+      '/dashboard/audit',
+      '/dashboard/broker-probe',
+      '/dashboard/webull-token',
+    ]) {
+      expect(nav).toContain(`href="${href}"`)
+    }
+    // 資産系はホームに統合 → nav から外れる (URL 直アクセスは維持)
+    expect(nav).not.toContain('href="/dashboard/positions"')
+    expect(nav).not.toContain('href="/dashboard/portfolio"')
+    // ホームが active
+    expect(nav).toContain('class="nav-link active" href="/dashboard"')
+  })
+
+  it('activates 履歴・分析 for /trades /cron /alerts and /charts?tab=quality (group prefix match)', async () => {
+    const app = createApp()
+    for (const path of [
+      '/dashboard/trades',
+      '/dashboard/cron',
+      '/dashboard/alerts',
+      '/dashboard/charts?tab=quality',
+      '/dashboard/charts',
+    ]) {
+      const res = await app.request(path, { headers: authHeader }, baseEnv)
+      const body = await res.text()
+      expect(body, path).toContain('class="nav-link active" href="/dashboard/trades"')
+    }
+  })
+
+  it('activates 銘柄 for /charts?tab=symbol and ?tab=grid', async () => {
+    const app = createApp()
+    for (const path of ['/dashboard/charts?tab=symbol', '/dashboard/charts?tab=grid']) {
+      const res = await app.request(path, { headers: authHeader }, baseEnv)
+      const body = await res.text()
+      expect(body, path).toContain('class="nav-link active" href="/dashboard/charts?tab=symbol"')
+    }
+  })
+
+  it('activates 運用 summary on ops pages, and nothing on nav-less pages (/positions)', async () => {
+    const app = createApp()
+    const opsRes = await app.request('/dashboard/config', { headers: authHeader }, baseEnv)
+    expect(await opsRes.text()).toContain('<summary class="nav-link active">運用 ▾</summary>')
+    // /positions は nav 外の直アクセスページ → どのグループも active にしない
+    const posRes = await app.request('/dashboard/positions', { headers: authHeader }, baseEnv)
+    expect(posRes.status).toBe(200)
+    expect(await posRes.text()).not.toContain('nav-link active')
+  })
+
+  it('resolveActiveNavGroup: charts はタブで 銘柄 / 履歴・分析 に分かれる', () => {
+    expect(resolveActiveNavGroup('/dashboard')).toBe('home')
+    expect(resolveActiveNavGroup('/dashboard/charts', 'symbol')).toBe('symbol')
+    expect(resolveActiveNavGroup('/dashboard/charts', 'grid')).toBe('symbol')
+    expect(resolveActiveNavGroup('/dashboard/charts', 'quality')).toBe('analysis')
+    expect(resolveActiveNavGroup('/dashboard/charts', null)).toBe('analysis')
+    expect(resolveActiveNavGroup('/dashboard/cron')).toBe('analysis')
+    expect(resolveActiveNavGroup('/dashboard/symbols/SOXL/edit')).toBe('ops')
+    expect(resolveActiveNavGroup('/dashboard/positions')).toBeNull()
+    expect(resolveActiveNavGroup('/dashboard/portfolio')).toBeNull()
+  })
+})
+
+describe('dashboard IA — 履歴・分析 subnav (#dashboard-ia)', () => {
+  beforeEach(() => {
+    vi.mocked(loadGlobalConfigFrom).mockResolvedValue(makeGlobalConfigSnapshot())
+    vi.mocked(loadSymbolUniverse).mockResolvedValue(
+      makeSymbolUniverse({ allowedSymbols: ['SOXL'], symbolCurrency: { SOXL: 'USD' } }),
+    )
+  })
+  afterEach(() => vi.resetAllMocks())
+
+  it('trades page renders the shared subnav with 約定履歴 active', async () => {
+    const app = createApp()
+    const res = await app.request('/dashboard/trades', { headers: authHeader }, baseEnv)
+    const body = await res.text()
+    expect(body).toContain('<nav class="subnav">')
+    expect(body).toContain('<span class="subnav-link active">約定履歴</span>')
+    for (const href of [
+      '/dashboard/cron',
+      '/dashboard/cron?view=matrix',
+      '/dashboard/charts?tab=quality',
+      '/dashboard/charts',
+      '/dashboard/alerts',
+    ]) {
+      expect(body).toContain(`href="${href}"`)
+    }
+    expect(body).toContain('資産推移')
+  })
+
+  it('cron page activates 戦略判定, matrix view activates 判定マトリクス', async () => {
+    const app = createApp()
+    const cronBody = await (
+      await app.request('/dashboard/cron', { headers: authHeader }, baseEnv)
+    ).text()
+    expect(cronBody).toContain('<span class="subnav-link active">戦略判定</span>')
+    const matrixBody = await (
+      await app.request('/dashboard/cron?view=matrix', { headers: authHeader }, baseEnv)
+    ).text()
+    expect(matrixBody).toContain('<span class="subnav-link active">判定マトリクス</span>')
+  })
+
+  it('alerts page activates アラート', async () => {
+    vi.mocked(loadRecentAlerts).mockResolvedValue([])
+    const app = createApp()
+    const res = await app.request(
+      '/dashboard/alerts',
+      { headers: authHeader },
+      { ...baseEnv, DB: fakeD1() },
+    )
+    const body = await res.text()
+    expect(body).toContain('<span class="subnav-link active">アラート</span>')
+  })
+
+  it('charts page keeps its own subnav only (no double subnav)', async () => {
+    const app = createApp()
+    const res = await app.request(
+      '/dashboard/charts?tab=quality',
+      { headers: authHeader },
+      baseEnv,
+    )
+    const body = await res.text()
+    expect((body.match(/<nav class="subnav">/g) ?? []).length).toBe(1)
+    // charts 自前 subnav の active (title 付き span) が出ている
+    expect(body).toContain('class="subnav-link active"')
+    expect(body).toContain('>取引品質<')
+  })
+})
+
+describe('dashboard IA — home integration (#dashboard-ia)', () => {
+  beforeEach(() => {
+    vi.mocked(loadGlobalConfigFrom).mockResolvedValue(
+      makeGlobalConfigSnapshot({ tradingEnabled: true }),
+    )
+    vi.mocked(loadSymbolUniverse).mockResolvedValue(
+      makeSymbolUniverse({ allowedSymbols: ['SOXL'], symbolCurrency: { SOXL: 'USD' } }),
+    )
+    vi.mocked(loadPortfolioEquitySnapshots).mockResolvedValue(sparkRows)
+    vi.mocked(loadUsdJpyRate).mockResolvedValue(150.25)
+  })
+  afterEach(() => vi.resetAllMocks())
+
+  it('renders 資産サマリ帯 + スパークライン + 保有ポジション + 直近パネル when DOs are bound', async () => {
+    const env = {
+      ...baseEnv,
+      DB: fakeD1(),
+      SYMBOL_STATE: fakeSymbolStateNamespace(),
+      PORTFOLIO_STATE: fakePortfolioNamespace(),
+    }
+    const app = createApp()
+    const res = await app.request('/dashboard', { headers: authHeader }, env)
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    // 1. 資産サマリ帯 (portfolio 要約の横並びカード)
+    expect(body).toContain('資産サマリ')
+    expect(body).toContain('本日開始 equity')
+    expect(body).toContain('本日実現損益')
+    expect(body).toContain('取引 ON')
+    expect(body).toContain('USDJPY')
+    expect(body).toContain('150.25')
+    // 2. equity スパークライン (直近 30 日)
+    expect(body).toContain('id="home-equity-spark"')
+    expect(body).toContain('window.__homeEquitySpark')
+    // 3. 保有ポジション (positions と同じテーブル)
+    expect(body).toContain('保有ポジション')
+    expect(body).toContain('SOXL')
+    expect(body).toContain('平均取得単価')
+    // 4. 既存パネル (直近の約定 / リスク状態) + 導線リンク
+    expect(body).toContain('最近の約定 / リスク状態')
+    expect(body).toContain('href="/dashboard/portfolio"')
+    expect(body).toContain('href="/dashboard/positions"')
+    expect(body).toContain('href="/dashboard/cron"')
+    expect(body).toContain('href="/dashboard/alerts"')
+    // スパークラインは 30d 固定で別途 load される
+    expect(vi.mocked(loadPortfolioEquitySnapshots)).toHaveBeenCalledWith(env.DB, { limit: 30 })
+  })
+
+  it('home inline scripts (sparkline 含む) parse without syntax errors', async () => {
+    const env = {
+      ...baseEnv,
+      DB: fakeD1(),
+      SYMBOL_STATE: fakeSymbolStateNamespace(),
+      PORTFOLIO_STATE: fakePortfolioNamespace(),
+    }
+    const app = createApp()
+    const res = await app.request('/dashboard', { headers: authHeader }, env)
+    const body = await res.text()
+    const blocks = [...body.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]!)
+    expect(blocks.length).toBeGreaterThan(0)
+    for (const code of blocks) {
+      expect(() => new Function(code)).not.toThrow()
+    }
+  })
+
+  it('omits 資産サマリ帯 and shows positions guidance link when DOs are missing (graceful)', async () => {
+    vi.mocked(loadPortfolioEquitySnapshots).mockResolvedValue([])
+    const env = { ...baseEnv, DB: fakeD1() }
+    const app = createApp()
+    const res = await app.request('/dashboard', { headers: authHeader }, env)
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    // PORTFOLIO_STATE 不在 → 帯ごと省略 + USDJPY fetch も省略
+    expect(body).not.toContain('本日開始 equity')
+    expect(body).not.toContain('home-equity-spark')
+    expect(vi.mocked(loadUsdJpyRate)).not.toHaveBeenCalled()
+    // SYMBOL_STATE 不在 → テーブル省略 + /positions への誘導リンク
+    expect(body).toContain('SYMBOL_STATE 未配線')
+    expect(body).toContain('href="/dashboard/positions"')
+  })
+})

--- a/test/routes/dashboardIa.test.ts
+++ b/test/routes/dashboardIa.test.ts
@@ -374,3 +374,66 @@ describe('dashboard IA — home integration (#dashboard-ia)', () => {
     expect(body).toContain('href="/dashboard/positions"')
   })
 })
+
+describe('dashboard IA — CodeRabbit #559 対応', () => {
+  beforeEach(() => {
+    vi.mocked(loadGlobalConfigFrom).mockResolvedValue(
+      makeGlobalConfigSnapshot({ tradingEnabled: true }),
+    )
+    vi.mocked(loadSymbolUniverse).mockResolvedValue(
+      makeSymbolUniverse({ allowedSymbols: ['SOXL'], symbolCurrency: { SOXL: 'USD' } }),
+    )
+    vi.mocked(loadPortfolioEquitySnapshots).mockResolvedValue(sparkRows)
+    vi.mocked(loadUsdJpyRate).mockResolvedValue(150.25)
+  })
+  afterEach(() => vi.resetAllMocks())
+
+  it('?range=30d ではスナップショットを 1 回だけ取得しスパークラインに再利用する', async () => {
+    const env = {
+      ...baseEnv,
+      DB: fakeD1(),
+      SYMBOL_STATE: fakeSymbolStateNamespace(),
+      PORTFOLIO_STATE: fakePortfolioNamespace(),
+    }
+    const app = createApp()
+    const res = await app.request('/dashboard?range=30d', { headers: authHeader }, env)
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    // equity パネル用と同一クエリ (limit 30) なので D1 取得は 1 回に畳む
+    expect(vi.mocked(loadPortfolioEquitySnapshots)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(loadPortfolioEquitySnapshots)).toHaveBeenCalledWith(env.DB, { limit: 30 })
+    // スパークライン自体は再利用データで描画される
+    expect(body).toContain('id="home-equity-spark"')
+  })
+
+  it('既定 range (90d) ではスパークライン用 30d を別途取得する (挙動不変)', async () => {
+    const env = {
+      ...baseEnv,
+      DB: fakeD1(),
+      SYMBOL_STATE: fakeSymbolStateNamespace(),
+      PORTFOLIO_STATE: fakePortfolioNamespace(),
+    }
+    const app = createApp()
+    const res = await app.request('/dashboard', { headers: authHeader }, env)
+    expect(res.status).toBe(200)
+    expect(vi.mocked(loadPortfolioEquitySnapshots)).toHaveBeenCalledTimes(2)
+    expect(vi.mocked(loadPortfolioEquitySnapshots)).toHaveBeenCalledWith(env.DB, { limit: 90 })
+    expect(vi.mocked(loadPortfolioEquitySnapshots)).toHaveBeenCalledWith(env.DB, { limit: 30 })
+  })
+
+  it('status + equity 両パネル ON でも ECharts CDN script タグは 1 個に畳まれる', async () => {
+    const env = {
+      ...baseEnv,
+      DB: fakeD1(),
+      SYMBOL_STATE: fakeSymbolStateNamespace(),
+      PORTFOLIO_STATE: fakePortfolioNamespace(),
+    }
+    const app = createApp()
+    const res = await app.request('/dashboard', { headers: authHeader }, env)
+    const body = await res.text()
+    // スパークラインと資産推移チャートの両方が描画されている前提で
+    expect(body).toContain('id="home-equity-spark"')
+    const cdnTags = body.match(/<script src="[^"]*echarts[^"]*" defer><\/script>/g) ?? []
+    expect(cdnTags.length).toBe(1)
+  })
+})


### PR DESCRIPTION
## 概要

「画面自体の整理」フィードバックへの対応 第 1 弾 (IA 再編)。グローバル nav を 13 リンク → 4 項目に削減し、ホームを「今日の状況が 1 画面で分かる」ダッシュボードに再構成する。

## 変更点

### ナビ再編 (13 → 4)

- **ホーム / 銘柄 / 履歴・分析 / 運用 ▾** の 4 項目。運用系 6 ページ (設定・銘柄管理・イベント・監査・broker 診断・token) は kill switch と同じ details ドロップダウンへ
- active 判定を完全一致 → グループ前方一致に変更。`/charts` は `?tab=` で「銘柄」(symbol/grid) と「履歴・分析」(overview/quality) に分岐
- **既存 URL は全て残す** (/positions /portfolio も直アクセス可)。nav から消えるだけ
- モバイル折り畳み時はドロップダウンをインライン展開

### 履歴・分析 subnav

trades / cron / alerts に共通 subnav (約定履歴・戦略判定・判定マトリクス・取引品質・資産推移・アラート) を追加。charts は既存 subnav のまま (2 本出さない)

### ホーム統合

上から: **資産サマリ帯** (本日開始 equity / 実現損益 / 取引 ON・OFF / VIX / USDJPY + 30 日スパークライン) → KPI → **保有ポジション** (positions と同じテーブルを re-use) → 資産推移チャート → 資産構成 → 最近の約定。各セクションに「詳しく見る →」導線。DO 不在は帯ごと省略 (graceful)。パネル ON/OFF 機構は新 key (`status` / `positions`) を additive 追加

## テスト

`pnpm typecheck` / `pnpm test` — **112 files / 1676 tests green** (ベース 1664 + 新規 12)。既存アサーション更新は 2 箇所のみ (旧フラット nav のリンク存在 / パネル数 4 → ALL_OVERVIEW_PANELS.length)、いずれも構造変更に対応する正当な更新。

関連: #552 #554 #555 #556 #557 #558 / 後続: デザイン統一 PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ダッシュボード概要に「ステータス（資産サマリ＋スパークライン）」と「ポジション」を追加しました。
  * 概要パネルの見出しと導線を拡充しました（判定履歴・アラート）。
* **改善**
  * 上部ナビゲーションを整理し、運用関連はドロップダウンで集約しました。
  * `/dashboard` 配下でアクティブ表示とサブナビの整合性を向上しました。
  * 設定未完了時も代替表示を切り替え、表示の一貫性を改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->