### PR TITLE
style: unify pills, buttons, banners and table density across dashboard

### DIFF
--- a/src/routes/dashboard/alerts.ts
+++ b/src/routes/dashboard/alerts.ts
@@ -9,7 +9,6 @@ import {
   inactiveTooltip,
   isSymbolInactive,
   logCopyRowBtn,
-  pillStyle,
   renderLogCopyScript,
   renderPaginationNav,
   safeJsonScript,
@@ -85,11 +84,11 @@ export interface AlertsBodyArgs {
  *   - 表示は最新 100 件 (`?limit=N` で 1〜500)
  *   - 行クリックで Slack/Discord に出したのと同じ message を JST 時刻と一緒に確認
  */
-/** severity → 日本語 pill (#alerts-trades-ui)。 */
-export const ALERT_SEVERITY_PILLS: Record<string, { ja: string; bg: string; fg: string }> = {
-  critical: { ja: '重大', bg: '#fdecec', fg: '#c22' },
-  warning: { ja: '警告', bg: '#fff4e6', fg: '#b25000' },
-  info: { ja: '情報', bg: '#eef2f8', fg: '#46608a' },
+/** severity → 日本語 pill (#alerts-trades-ui)。cls は共通 .pill variant (layout.ts)。 */
+export const ALERT_SEVERITY_PILLS: Record<string, { ja: string; cls: string }> = {
+  critical: { ja: '重大', cls: 'err' },
+  warning: { ja: '警告', cls: 'warn' },
+  info: { ja: '情報', cls: 'info' },
 }
 
 /** event type → 日本語。 */
@@ -111,8 +110,8 @@ export function alertsBody(args: AlertsBodyArgs): string {
   }
   const tbody = rows
     .map((r) => {
-      const sev = ALERT_SEVERITY_PILLS[r.severity] ?? { ja: r.severity, bg: '#f3f3f5', fg: '#86868b' }
-      const sevCell = `<span title="${esc(r.severity)}" style="${pillStyle(sev.bg, sev.fg)}">${esc(sev.ja)}</span>`
+      const sev = ALERT_SEVERITY_PILLS[r.severity] ?? { ja: r.severity, cls: 'neutral' }
+      const sevCell = `<span title="${esc(r.severity)}" class="pill ${sev.cls}">${esc(sev.ja)}</span>`
       const eventCell = `<span title="${esc(r.eventType)}" style="font-size:12px">${esc(ALERT_EVENT_LABELS[r.eventType] ?? r.eventType)}</span>`
       const symbolInactive = r.symbol ? isSymbolInactive(r.symbol, universe) : false
       const symbolCell = r.symbol
@@ -127,11 +126,11 @@ export function alertsBody(args: AlertsBodyArgs): string {
           ? `${esc(r.message.slice(0, ALERT_MESSAGE_FOLD))}…<details style="margin-top:2px"><summary class="muted" style="font-size:11px;cursor:pointer">全文</summary><code style="font-size:11px;white-space:pre-wrap;word-break:break-all">${esc(r.message)}</code></details>`
           : esc(r.message)
       // <details> (block) を含み得るので外側は div (CodeRabbit #469)。
-      const messageCell = `${shortLabel ? `<span style="${pillStyle('#fdecec', '#c22')}">${esc(shortLabel)}</span>` : ''}<div style="font-size:12px">${messageBody}</div>`
+      const messageCell = `${shortLabel ? `<span class="pill err">${esc(shortLabel)}</span>` : ''}<div style="font-size:12px">${messageBody}</div>`
       const causeCell = r.cause
         ? `<code style="font-size:11px">${esc(r.cause)}</code>`
         : '<span class="muted">—</span>'
-      return `<tr style="font-size:13px;vertical-align:top">
+      return `<tr style="vertical-align:top">
         <td>${logCopyRowBtn(r.id)}</td>
         <td class="muted" style="white-space:nowrap">${esc(fmtJst(r.timestamp))}</td>
         <td>${sevCell}</td>
@@ -145,7 +144,7 @@ export function alertsBody(args: AlertsBodyArgs): string {
     .join('')
   return `${filterPills}${countLine}
   <table>
-    <thead><tr style="font-size:12px">
+    <thead><tr>
       <th></th><th>日時 (JST)</th><th>重要度</th><th>種別</th><th>銘柄</th><th>要因</th><th>内容</th><th>requestId</th>
     </tr></thead>
     <tbody>${tbody}</tbody>
@@ -201,8 +200,9 @@ export function renderAlertFilterPills(
     const qs = next.toString()
     return qs.length === 0 ? '/dashboard/alerts' : `/dashboard/alerts?${qs}`
   }
+  // trades / cron の view 切替と同じ .chip 見た目に統一 (#dashboard-design)。
   const pill = (label: string, href: string, isActive: boolean): string =>
-    `<a href="${esc(href)}" style="margin-right:6px;${isActive ? 'background:#1d1d1f;color:#fff;' : ''}">${esc(label)}</a>`
+    `<a href="${esc(href)}" class="chip${isActive ? ' active' : ''}" style="margin-right:6px">${esc(label)}</a>`
   const sev = [
     pill('全 severity', buildHref('severity', null), active.length === 0),
     pill(

--- a/src/routes/dashboard/charts/equity.ts
+++ b/src/routes/dashboard/charts/equity.ts
@@ -279,12 +279,12 @@ export function renderPeriodReturnsTable(rows: PeriodReturn[]): string {
   const cells = rows
     .map((r) => {
       const cls = r.change > 0 ? 'ok' : r.change < 0 ? 'err' : 'muted'
-      return `<td class="${cls}" style="text-align:right">${esc(fmtSignedAmount(r.change))}</td>`
+      return `<td class="${cls} num">${esc(fmtSignedAmount(r.change))}</td>`
     })
     .join('')
   const heads = rows.map((r) => `<th>${esc(r.label)}</th>`).join('')
-  return `<h3 style="font-size:14px;margin:20px 0 6px">期間別リターン (実現 PnL 変化額)</h3>
-  <table style="font-size:13px">
+  return `<h3 class="sub-head">期間別リターン (実現 PnL 変化額)</h3>
+  <table>
     <thead><tr>${heads}</tr></thead>
     <tbody><tr>${cells}</tr></tbody>
   </table>`

--- a/src/routes/dashboard/charts/symbol.ts
+++ b/src/routes/dashboard/charts/symbol.ts
@@ -21,7 +21,7 @@ export function renderSymbolDecisionHistory(args: ChartsBodySymbol): string {
   if (rows.length === 0 || !args.focusSymbol) return ''
   const symbolCronHref = `/dashboard/cron?symbol=${encodeURIComponent(args.focusSymbol)}`
   return `<div style="margin-top:14px">
-    <h2 style="font-size:14px;margin:0 0 6px;display:flex;align-items:center;gap:10px">判定履歴 <span class="muted" style="font-size:11px;font-weight:normal">直近 ${rows.length} 件 — チャートの判定 pin と同じデータ</span>
+    <h2 class="section-head">判定履歴 <span class="muted" style="font-size:11px;font-weight:normal">直近 ${rows.length} 件 — チャートの判定 pin と同じデータ</span>
       <a href="${esc(symbolCronHref)}" style="font-size:11px">この銘柄の全件 →</a>
       <a href="/dashboard/trades?symbol=${encodeURIComponent(args.focusSymbol)}" style="font-size:11px">この銘柄の約定 →</a>
       <a href="/dashboard/cron" style="font-size:11px">全銘柄 →</a>

--- a/src/routes/dashboard/cron.ts
+++ b/src/routes/dashboard/cron.ts
@@ -260,7 +260,7 @@ export function renderCronViewPills(
 ): string {
   const symbolQs = symbolFilter ? `&symbol=${encodeURIComponent(symbolFilter)}` : ''
   const pill = (label: string, href: string, isActive: boolean): string =>
-    `<a href="${href}" style="margin-right:6px;padding:3px 12px;border-radius:14px;border:1px solid ${isActive ? '#1d1d1f' : '#d8d8de'};${isActive ? 'background:#1d1d1f;color:#fff;' : 'background:#fff;'}font-size:12px;text-decoration:none">${esc(label)}</a>`
+    `<a href="${href}" class="chip${isActive ? ' active' : ''}" style="margin-right:6px">${esc(label)}</a>`
   return `<nav style="margin-bottom:10px;display:flex;align-items:center;flex-wrap:wrap;gap:2px">${pill('一覧', `/dashboard/cron?limit=${limit}${symbolQs}`, active === 'list')}${pill('マトリクス', `/dashboard/cron?view=matrix${symbolQs}`, active === 'matrix')}</nav>`
 }
 
@@ -280,10 +280,10 @@ export function cronBody(
       ? `/dashboard/cron?symbol=${encodeURIComponent(symbolFilter)}&limit=${limit}`
       : `/dashboard/cron?limit=${limit}`
   const header = clientOrderIdFilter
-    ? `<p class="muted">注文 <code>${esc(clientOrderIdFilter)}</code> の判定のみ表示。<a href="/dashboard/trades?clientOrderId=${encodeURIComponent(clientOrderIdFilter)}">約定を見る</a> / <a href="/dashboard/cron">全件へ戻る</a> ${copyAllBtn}</p>`
+    ? `<p class="filter-banner">注文 <code>${esc(clientOrderIdFilter)}</code> の判定のみ表示。<a href="/dashboard/trades?clientOrderId=${encodeURIComponent(clientOrderIdFilter)}">約定を見る</a> / <a href="/dashboard/cron">全件へ戻る</a> ${copyAllBtn}</p>`
     : symbolFilter
-      ? `<p class="muted">Showing ${rows.length} decisions for <strong>${esc(displaySymbol(symbolFilter, universe))}</strong>。<a href="/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(symbolFilter)}">チャートで見る</a> / <a href="/dashboard/trades?symbol=${encodeURIComponent(symbolFilter)}">約定を見る</a> / <a href="/dashboard/cron">全銘柄へ戻る</a> / <a href="/dashboard/cron/json" target="_blank" rel="noreferrer">最新run JSON</a> ${copyAllBtn}</p>`
-      : `<p class="muted">Showing ${rows.length} decisions。<code>?symbol=SOXL</code> で絞り込み可能。<a href="/dashboard/cron/json" target="_blank" rel="noreferrer">最新run JSON</a> ${copyAllBtn}</p>`
+      ? `<p class="filter-banner">Showing ${rows.length} decisions for <strong>${esc(displaySymbol(symbolFilter, universe))}</strong>。<a href="/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(symbolFilter)}">チャートで見る</a> / <a href="/dashboard/trades?symbol=${encodeURIComponent(symbolFilter)}">約定を見る</a> / <a href="/dashboard/cron">全銘柄へ戻る</a> / <a href="/dashboard/cron/json" target="_blank" rel="noreferrer">最新run JSON</a> ${copyAllBtn}</p>`
+      : `<p class="filter-banner">Showing ${rows.length} decisions。<code>?symbol=SOXL</code> で絞り込み可能。<a href="/dashboard/cron/json" target="_blank" rel="noreferrer">最新run JSON</a> ${copyAllBtn}</p>`
   const pagination = renderPaginationNav({
     baseHref,
     before,
@@ -853,7 +853,7 @@ export function renderReasonTrendChart(trend: ReasonTrendPoint[]): string {
       window.addEventListener('resize', function () { chart.resize(); });
     });
   `
-  return `<h3 style="margin:20px 0 4px;font-size:14px">発注不成立の理由推移</h3>
+  return `<h3 class="sub-head">発注不成立の理由推移</h3>
   <div id="reason-trend-chart" style="width:100%;height:320px;background:#fff;border:1px solid #d0d0d5;border-radius:6px;margin-top:8px"></div>
   ${safeJsonScript('__matrixTrend', { categories: REASON_CATEGORIES, points: trend })}
   <script src="${ECHARTS_CDN}" defer></script>
@@ -873,7 +873,7 @@ export function decisionMatrixBody(
   opts: { days: number; limit: number; symbolFilter?: string },
 ): string {
   const pills = renderCronViewPills('matrix', opts.limit, opts.symbolFilter)
-  const header = `<p class="muted">直近 ${opts.days} 日 (JST) の 銘柄 × 日付 代表判定。セルクリックでその銘柄の判定一覧へ。<a href="/dashboard/cron/matrix/json" target="_blank" rel="noreferrer">JSON を開く</a></p>`
+  const header = `<p class="filter-banner">直近 ${opts.days} 日 (JST) の 銘柄 × 日付 代表判定。セルクリックでその銘柄の判定一覧へ。<a href="/dashboard/cron/matrix/json" target="_blank" rel="noreferrer">JSON を開く</a></p>`
   if (matrix.rows.length === 0) {
     return `${pills}${header}<p class="muted">判定ログがまだありません。</p>`
   }

--- a/src/routes/dashboard/events.ts
+++ b/src/routes/dashboard/events.ts
@@ -363,7 +363,7 @@ export function eventsBody(args: EventsBodyArgs): string {
           <td>${sym}</td>
           <td>${esc(r.earningsDate)}</td>
           <td>${esc(r.notes ?? '-')}</td>
-          <td><form method="post" action="/dashboard/events/earnings/${r.id}/delete" onsubmit="return confirm('${esc(r.symbol)} ${esc(r.earningsDate)} を削除します。よろしいですか？');" style="margin:0"><button type="submit" style="padding:3px 8px;font-size:12px;background:#c22;color:#fff;border:none;border-radius:4px;cursor:pointer">削除</button></form></td>
+          <td><form method="post" action="/dashboard/events/earnings/${r.id}/delete" onsubmit="return confirm('${esc(r.symbol)} ${esc(r.earningsDate)} を削除します。よろしいですか？');" style="margin:0"><button type="submit" class="btn-sm danger">削除</button></form></td>
         </tr>`
       })
       .join('')}</tbody>
@@ -385,7 +385,7 @@ export function eventsBody(args: EventsBodyArgs): string {
           <td><code>${esc(r.eventType)}</code></td>
           <td>${esc(r.notes ?? '-')}</td>
           <td>${esc(r.eventDate)}</td>
-          <td><form method="post" action="/dashboard/events/macro/${r.id}/delete" onsubmit="return confirm('${esc(r.eventType)} ${esc(r.eventDate)} を削除します。よろしいですか？');" style="margin:0"><button type="submit" style="padding:3px 8px;font-size:12px;background:#c22;color:#fff;border:none;border-radius:4px;cursor:pointer">削除</button></form></td>
+          <td><form method="post" action="/dashboard/events/macro/${r.id}/delete" onsubmit="return confirm('${esc(r.eventType)} ${esc(r.eventDate)} を削除します。よろしいですか？');" style="margin:0"><button type="submit" class="btn-sm danger">削除</button></form></td>
         </tr>`
       })
       .join('')}</tbody>
@@ -394,7 +394,7 @@ export function eventsBody(args: EventsBodyArgs): string {
   return `<p class="muted">期間: ${esc(from)} 〜 ${esc(to)} (now-30d 〜 now+30d)。<code>earnings_calendar</code> / <code>macro_event_calendar</code> は risk gate の avoid ソースです。
   add は <code>now-90d 〜 now+365d</code> の範囲に clamp します。delete は audit に記録されます。</p>
 
-<h2 style="font-size:15px;margin:20px 0 6px 0">決算 (earnings)</h2>
+<h2 class="sub-head">決算 (earnings)</h2>
 ${earningsErr}
 ${earningsNotice}
 <details${earningsFormOpen} style="margin-bottom:12px">
@@ -408,7 +408,7 @@ ${earningsNotice}
 </details>
 ${earningsTable}
 
-<h2 style="font-size:15px;margin:24px 0 6px 0">マクロイベント (macro)</h2>
+<h2 class="sub-head">マクロイベント (macro)</h2>
 ${macroErr}
 ${macroNotice}
 <details${macroFormOpen} style="margin-bottom:12px">

--- a/src/routes/dashboard/layout.ts
+++ b/src/routes/dashboard/layout.ts
@@ -107,6 +107,30 @@ export const STYLE = `
   .pill{display:inline-block;padding:1px 8px;border-radius:10px;font-size:11px;font-weight:700}
   .pill.dry{background:#057a55;color:#fff}.pill.live{background:#c22;color:#fff}
   .pill.on{background:#057a55;color:#fff}.pill.off{background:#86868b;color:#fff}
+  /* 状態 pill の色 variant (#dashboard-design)。旧 pillStyle() インライン展開の
+     置換 — 効果値 (600 / nowrap / 各色) は旧 pillStyle と同一。 */
+  .pill.ok,.pill.warn,.pill.err,.pill.info,.pill.neutral{font-weight:600;white-space:nowrap}
+  .pill.ok{background:#e6f6ec;color:#057a55}.pill.warn{background:#fff4e6;color:#b25000}
+  .pill.err{background:#fdecec;color:#c22}.pill.info{background:#eef2f8;color:#46608a}
+  .pill.neutral{background:#f3f3f5;color:#86868b}
+  /* 丸チップ (view 切替 / filter pill / JSON リンク / AI コピー)。active は黒反転 */
+  .chip{padding:3px 12px;border-radius:14px;border:1px solid #d8d8de;background:#fff;font-size:12px;text-decoration:none}
+  .chip.active{background:#1d1d1f;border-color:#1d1d1f;color:#fff}
+  button.chip{cursor:pointer}
+  /* 小ボタン / 小リンク (テーブル行内アクション・kill switch フォーム) */
+  .btn-sm{padding:3px 8px;font-size:12px;cursor:pointer}
+  a.btn-sm{text-decoration:none}
+  .btn-sm.danger{background:#c22;color:#fff;border:none;border-radius:4px}
+  .btn-sm.ok{background:#057a55;color:#fff;border:none;border-radius:4px}
+  /* 絞り込み中バナー (trades / cron 上部の説明行) */
+  .filter-banner{color:#86868b;font-size:12px;margin:0 0 6px}
+  /* セクション見出し (小ヘッダ)。sh-more は右端の「詳しく見る」導線 */
+  .section-head{display:flex;align-items:baseline;gap:10px;margin:0 2px 6px;font-size:13px;font-weight:700}
+  .section-head .sh-more{margin-left:auto;font-size:12px;font-weight:400}
+  /* ページ内の中見出し (h2/h3 のインライン指定を統一) */
+  .sub-head{margin:20px 0 6px;font-size:14px;font-weight:700}
+  /* 右寄せ数値セル */
+  .num{text-align:right;font-variant-numeric:tabular-nums}
   table{border-collapse:collapse;width:100%;background:#fff;border:1px solid #d0d0d5;border-radius:6px;overflow:hidden}
   th,td{padding:8px 10px;text-align:left;border-bottom:1px solid #e5e5ea;font-size:13px;font-variant-numeric:tabular-nums}
   th{background:#fafafa;font-weight:600}
@@ -334,12 +358,12 @@ export function killSwitchTopnav(state: KillSwitchBannerState | null): string {
     ? `<form method="post" action="/admin/trading/toggle" class="kill-switch-form" style="display:flex;flex-direction:column;gap:5px;margin-top:6px">
         <input type="hidden" name="enabled" value="false"/>
         <input type="text" name="reason" placeholder="停止理由 (必須)" required maxlength="256" style="padding:4px 6px;font-size:12px;width:100%;box-sizing:border-box"/>
-        <button type="submit" ${disabled} style="padding:5px 10px;font-size:12px;background:#c22;color:#fff;border:none;border-radius:4px;cursor:pointer">取引停止</button>
+        <button type="submit" ${disabled} class="btn-sm danger">取引停止</button>
        </form>`
     : `<form method="post" action="/admin/trading/toggle" class="kill-switch-form" onsubmit="return confirm('取引を再開します。本当によろしいですか？');" style="display:flex;flex-direction:column;gap:5px;margin-top:6px">
         <input type="hidden" name="enabled" value="true"/>
         <input type="text" name="reason" placeholder="再開理由 (必須)" required maxlength="256" style="padding:4px 6px;font-size:12px;width:100%;box-sizing:border-box"/>
-        <button type="submit" ${disabled} style="padding:5px 10px;font-size:12px;background:#057a55;color:#fff;border:none;border-radius:4px;cursor:pointer">取引再開</button>
+        <button type="submit" ${disabled} class="btn-sm ok">取引再開</button>
        </form>`
   return `<details class="topnav-killswitch">
     <summary>${statusLabel}</summary>

--- a/src/routes/dashboard/overview.ts
+++ b/src/routes/dashboard/overview.ts
@@ -153,7 +153,7 @@ export function collectOpenPositions(data: OverviewData): OpenPositionView[] {
  * ホームは要約、詳細は各専用ページ (/portfolio /positions /cron /alerts) へ。
  */
 export function sectionHead(title: string, moreHref: string): string {
-  return `<div style="display:flex;align-items:baseline;justify-content:space-between;margin:0 2px 6px"><span style="font-size:13px;font-weight:700">${esc(title)}</span><a href="${moreHref}" style="font-size:12px">詳しく見る →</a></div>`
+  return `<div class="section-head"><span>${esc(title)}</span><a class="sh-more" href="${moreHref}">詳しく見る →</a></div>`
 }
 
 /**

--- a/src/routes/dashboard/shared.ts
+++ b/src/routes/dashboard/shared.ts
@@ -165,7 +165,7 @@ export function exportMeta(schema: string): { schema: string; exportedAt: string
  */
 export function renderJsonToolbar(jsonHref: string, copyVarName: string | null): string {
   const copyBtn = copyVarName ? ` ${LOG_COPY_ALL_BTN}` : ''
-  return `<div style="margin:0 0 10px;display:flex;align-items:center;gap:8px;flex-wrap:wrap"><a href="${esc(jsonHref)}" target="_blank" rel="noreferrer" style="padding:3px 12px;border-radius:14px;border:1px solid #d8d8de;background:#fff;font-size:12px;text-decoration:none">JSON を開く</a>${copyBtn}</div>`
+  return `<div style="margin:0 0 10px;display:flex;align-items:center;gap:8px;flex-wrap:wrap"><a href="${esc(jsonHref)}" target="_blank" rel="noreferrer" class="chip">JSON を開く</a>${copyBtn}</div>`
 }
 
 export function parseJsonObject(value: string | null | undefined): unknown {
@@ -238,13 +238,10 @@ export function renderLogCopyScript(varName: string): string {
 }
 
 export const LOG_COPY_ALL_BTN =
-  '<button type="button" id="log-copy-all" style="padding:3px 12px;border-radius:14px;border:1px solid #d8d8de;background:#fff;font-size:12px;cursor:pointer">📋 表示中を AI 用にコピー</button>'
+  '<button type="button" id="log-copy-all" class="chip">📋 表示中を AI 用にコピー</button>'
 
 export const logCopyRowBtn = (id: number): string =>
   `<button type="button" class="log-copy-btn" data-id="${id}" title="この行の全データを AI 用にコピー" style="border:none;background:none;cursor:pointer;font-size:12px;padding:0 2px">📋</button>`
-
-export const pillStyle = (bg: string, fg: string): string =>
-  `display:inline-block;padding:1px 8px;border-radius:10px;font-size:11px;font-weight:600;background:${bg};color:${fg};white-space:nowrap`
 
 /**
  * cooldownUntil をポートフォリオテーブル向けに整形。null または past timestamp

--- a/src/routes/dashboard/symbols.ts
+++ b/src/routes/dashboard/symbols.ts
@@ -1236,7 +1236,7 @@ export function symbolsListBody(args: {
       const deleteForm = r.active
         ? '<span class="muted" style="font-size:11px" title="削除するには先に無効化してください">—</span>'
         : `<form method="post" action="${esc(deleteAction)}" style="display:inline" onsubmit="return confirm('${esc(r.symbol)} を完全に削除します (DB row 自体を消去、インバース対のリンクも解除)。元に戻せません。よろしいですか？');">
-            <button type="submit" style="padding:3px 8px;font-size:12px;background:#c22;color:#fff;border:none;border-radius:4px;cursor:pointer">削除</button>
+            <button type="submit" class="btn-sm danger">削除</button>
           </form>`
       const maxNotionalCell = r.maxNotional === null
         ? '<span class="muted" title="未設定 = global の MAX_ORDER_NOTIONAL を使用">— (global)</span>'
@@ -1305,9 +1305,9 @@ export function symbolsListBody(args: {
         <td>${esc(r.notes ?? '')}</td>
         <td class="muted" style="font-size:11px">${esc(dateOnly)}</td>
         <td>
-          <a href="${esc(editHref)}" style="padding:3px 8px;font-size:12px;text-decoration:none">編集</a>
+          <a href="${esc(editHref)}" class="btn-sm">編集</a>
           <form method="post" action="${esc(toggleAction)}" style="display:inline">
-            <button type="submit" style="padding:3px 8px;font-size:12px;cursor:pointer">${esc(toggleLabel)}</button>
+            <button type="submit" class="btn-sm">${esc(toggleLabel)}</button>
           </form>
           ${deleteForm}
         </td>

--- a/src/routes/dashboard/trades.ts
+++ b/src/routes/dashboard/trades.ts
@@ -3,7 +3,7 @@ import { type TradeJournalRow, tradeJournal } from '../../infrastructure/db/sche
 import { createDb } from '../../infrastructure/db/tradeJournalRepo'
 import { and, desc, eq, inArray, isNotNull, lt, or, type SQL } from 'drizzle-orm'
 import { formatRealizedPnl } from './cron'
-import { LOG_COPY_ALL_BTN, clampLimit, displaySymbol, esc, exportMeta, fmtJst, fmtNumber, inactiveTooltip, isSymbolInactive, logCopyRowBtn, parseCursor, pillStyle, renderLogCopyScript, renderPaginationNav, safeJsonScript } from './shared'
+import { LOG_COPY_ALL_BTN, clampLimit, displaySymbol, esc, exportMeta, fmtJst, fmtNumber, inactiveTooltip, isSymbolInactive, logCopyRowBtn, parseCursor, renderLogCopyScript, renderPaginationNav, safeJsonScript } from './shared'
 
 /** trade_journal の lifecycle イベント → 日本語ラベル + 色 (#alerts-trades-ui)。 */
 export const TRADE_EVENT_LABELS: Record<string, { ja: string; color: string }> = {
@@ -131,16 +131,16 @@ export function tradesBody(
     (filters.symbol ? `&symbol=${encodeURIComponent(filters.symbol)}` : '') +
     (filters.clientOrderId ? `&clientOrderId=${encodeURIComponent(filters.clientOrderId)}` : '')
   const viewPill = (label: string, v: string, active: boolean): string =>
-    `<a href="/dashboard/trades?view=${v}&limit=${limit}${filterQs}" style="margin-right:6px;padding:3px 12px;border-radius:14px;border:1px solid ${active ? '#1d1d1f' : '#d8d8de'};${active ? 'background:#1d1d1f;color:#fff;' : 'background:#fff;'}font-size:12px;text-decoration:none">${esc(label)}</a>`
+    `<a href="/dashboard/trades?view=${v}&limit=${limit}${filterQs}" class="chip${active ? ' active' : ''}" style="margin-right:6px">${esc(label)}</a>`
   const filterBanner = filters.clientOrderId
-    ? `<p class="muted" style="font-size:12px;margin:0 0 6px">注文 <code>${esc(filters.clientOrderId)}</code> の履歴のみ表示。<a href="/dashboard/cron?clientOrderId=${encodeURIComponent(filters.clientOrderId)}">判定を見る</a> / <a href="/dashboard/trades">全件へ戻る</a></p>`
+    ? `<p class="filter-banner">注文 <code>${esc(filters.clientOrderId)}</code> の履歴のみ表示。<a href="/dashboard/cron?clientOrderId=${encodeURIComponent(filters.clientOrderId)}">判定を見る</a> / <a href="/dashboard/trades">全件へ戻る</a></p>`
     : filters.symbol
-      ? `<p class="muted" style="font-size:12px;margin:0 0 6px">銘柄 <strong>${esc(displaySymbol(filters.symbol, universe))}</strong> のみ表示。<a href="/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(filters.symbol)}">チャートで見る</a> / <a href="/dashboard/cron?symbol=${encodeURIComponent(filters.symbol)}">判定を見る</a> / <a href="/dashboard/trades">全件へ戻る</a></p>`
+      ? `<p class="filter-banner">銘柄 <strong>${esc(displaySymbol(filters.symbol, universe))}</strong> のみ表示。<a href="/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(filters.symbol)}">チャートで見る</a> / <a href="/dashboard/cron?symbol=${encodeURIComponent(filters.symbol)}">判定を見る</a> / <a href="/dashboard/trades">全件へ戻る</a></p>`
       : ''
   // JSON export へのリンクは現在の絞り込み (view / limit / symbol / clientOrderId /
   // before) をそのまま引き継ぐ — 「画面で見ている部分集合と同じもの」を開くため。
   const jsonHref = `/dashboard/trades/json?view=${view}&limit=${limit}${filterQs}${before !== undefined ? `&before=${before}` : ''}`
-  const jsonLink = `<a href="${esc(jsonHref)}" target="_blank" rel="noreferrer" style="margin-left:4px;padding:3px 12px;border-radius:14px;border:1px solid #d8d8de;background:#fff;font-size:12px;text-decoration:none">JSON を開く</a>`
+  const jsonLink = `<a href="${esc(jsonHref)}" target="_blank" rel="noreferrer" class="chip" style="margin-left:4px">JSON を開く</a>`
   const pills = `<nav style="margin-bottom:10px;display:flex;align-items:center;flex-wrap:wrap;gap:2px">${viewPill('全イベント', 'all', view === 'all')}${viewPill('約定・手仕舞い', 'fills', view === 'fills')}${viewPill('エラー', 'errors', view === 'errors')}<span class="muted" style="font-size:12px;margin:0 8px">${rows.length} 件 (limit=${limit})</span>${rows.length > 0 ? LOG_COPY_ALL_BTN : ''}${jsonLink}</nav>`
   if (rows.length === 0) {
     return `${filterBanner}${pills}<p class="muted">該当するレコードがありません。</p>`
@@ -191,30 +191,30 @@ export function tradesBody(
       if (errorText) {
         const code = extractBrokerErrorCode(errorText)
         const short = code ? (BROKER_ERROR_LABELS[code] ?? code) : (r.errorClass ?? 'エラー')
-        statusCell = `<span style="${pillStyle('#fdecec', '#c22')}">エラー: ${esc(short)}</span>
+        statusCell = `<span class="pill err">エラー: ${esc(short)}</span>
           <details style="margin-top:2px"><summary class="muted" style="font-size:11px;cursor:pointer">全文</summary><code style="font-size:11px;white-space:pre-wrap;word-break:break-all">${esc(errorText)}</code></details>`
       } else if (r.brokerStatus === 'FILLED') {
-        statusCell = `<span style="${pillStyle('#e6f6ec', '#057a55')}">約定</span>`
+        statusCell = `<span class="pill ok">約定</span>`
       } else if (r.brokerStatus) {
-        statusCell = `<span style="${pillStyle('#fff4e6', '#b25000')}" title="${esc(r.brokerStatus)}">${esc(r.brokerStatus)}</span>`
+        statusCell = `<span class="pill warn" title="${esc(r.brokerStatus)}">${esc(r.brokerStatus)}</span>`
       } else {
         statusCell = '<span class="muted">—</span>'
       }
       const modeCell =
         r.mode === 'LIVE'
-          ? `<span style="${pillStyle('#fdecec', '#c22')}">実発注</span>`
+          ? `<span class="pill err">実発注</span>`
           : r.mode === 'DRY_RUN'
-            ? `<span style="${pillStyle('#f3f3f5', '#86868b')}">DRY</span>`
+            ? `<span class="pill neutral">DRY</span>`
             : '<span class="muted">—</span>'
-      return `<tr style="font-size:13px">
+      return `<tr>
         <td>${logCopyRowBtn(r.id)}</td>
         <td class="muted" style="white-space:nowrap">${esc(fmtJst(r.timestamp))}</td>
         <td style="white-space:nowrap">${eventCell}${decisionLink}</td>
         <td>${symbolCell}</td>
         <td style="white-space:nowrap">${sideCell}</td>
-        <td style="text-align:right" class="bp-num">${qtyCell}</td>
-        <td style="text-align:right" class="bp-num">${priceCell}</td>
-        <td style="text-align:right" class="bp-num">${pnlCell}</td>
+        <td class="num">${qtyCell}</td>
+        <td class="num">${priceCell}</td>
+        <td class="num">${pnlCell}</td>
         <td>${statusCell}</td>
         <td>${modeCell}</td>
       </tr>`
@@ -222,9 +222,9 @@ export function tradesBody(
     .join('')
   return `${filterBanner}${pills}
   <table>
-    <thead><tr style="font-size:12px">
+    <thead><tr>
       <th></th><th>日時 (JST)</th><th>イベント</th><th>銘柄</th><th>売買</th>
-      <th style="text-align:right">数量</th><th style="text-align:right">単価</th><th style="text-align:right">実現損益</th><th>状態</th><th>モード</th>
+      <th class="num">数量</th><th class="num">単価</th><th class="num">実現損益</th><th>状態</th><th>モード</th>
     </tr></thead>
     <tbody>${tbody}</tbody>
   </table>


### PR DESCRIPTION
## 概要

「画面自体の整理」対応 第 2 弾 (デザイン統一)。頻出インライン style を実測した上で、ページごとに微妙に違っていた pill / チップ / 小ボタン / フィルタバナー / テーブル密度 / 見出しを共通 CSS クラスへ寄せ、全ページの見た目を揃える。機能・リンク先・データは無変更。

> **base は #559 (dev/dashboard-ia)。#559 merge 後に base が自動で切り替わります。**

## 導入クラス (layout.ts STYLE)

- `.pill.ok/.warn/.err/.info/.neutral` — 旧 `pillStyle()` の色ペアを variant 化 (shared.ts の `pillStyle` は削除)
- `.chip` / `.chip.active` — view 切替・フィルタ pill・「JSON を開く」・AI コピー
- `.btn-sm` (+ `.danger` / `.ok`) — 行内小ボタン・kill switch フォーム
- `.filter-banner` / `.section-head` / `.sub-head` / `.num` (右寄せ + tabular-nums)

## 主な統一 (値を寄せた箇所は PR 内コメント参照)

- alerts のフィルタ pill を trades / cron と同じチップ見た目に統一
- cron のヘッダ行を trades と同じ 12px フィルタバナーに
- charts symbol「判定履歴」見出しを overview の section-head と同型に
- trades / alerts / equity の行単位 font-size 指定は global の 13px と重複していたため除去 (視覚同一)
- 一点物 (primary submit・brokerProbe の局所体系・pagination 等) は意図的にクラス化を見送り

## テスト

`pnpm typecheck` / `pnpm test` — **115 files / 1676 tests green**。既存テストの更新ゼロ (style アサーション 2 件は対象外パターンでそのまま通過)。

関連: #559 (IA 再編) の後続