### PR TITLE
feat: add read-only MCP server exposing dashboard packets (#553)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -55,9 +55,16 @@ export function createApp() {
   app.route('/admin', admin)
   app.use('/dashboard/*', accessJwtMiddleware())
   app.route('/dashboard', dashboard)
+  // Read-only MCP server (#553 append)。/dashboard と同じ Access JWT 検証を
+  // 通す (service token も同じ検証を通過する)。ワイルドカード `/mcp/*` は
+  // `/mcp` 単一 path に効かない router があるため base path にも明示的に張る。
+  app.use('/mcp', accessJwtMiddleware())
+  app.use('/mcp/*', accessJwtMiddleware())
+  app.route('/mcp', mcp)
   app.onError(errorHandler)
   return app
 }
 
 import { admin } from './routes/admin'
 import { dashboard } from './routes/dashboard'
+import { mcp } from './routes/mcp'

--- a/src/routes/dashboard/charts/equity.ts
+++ b/src/routes/dashboard/charts/equity.ts
@@ -1,7 +1,7 @@
 import { type ChartsBodyOverview, ECHARTS_CDN } from './shared'
 import type { BenchmarkPoint } from './benchmark'
 import { jstDayKey, resolveFillSide } from './loaders'
-import { esc, fmtNumber, safeJsonScript } from '../shared'
+import { esc, exportMeta, fmtNumber, safeJsonScript } from '../shared'
 
 export interface EquityPoint {
   date: string // YYYY-MM-DD (JST)
@@ -196,6 +196,24 @@ export function computeMonthlyReturns(points: EquityPoint[]): MonthlyReturn[] {
   return [...byMonth.entries()]
     .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
     .map(([month, pnl]) => ({ month, pnl }))
+}
+
+/**
+ * equity packet builder (schema: `dashboard_equity_export.v1`, #553)。
+ *
+ * MCP `get_equity` 用。チャート overview タブと同じ loader (`loadEquityCurve`)
+ * の結果と同じ pure 集計 (期間別 / 月次リターン) を envelope に包むだけ —
+ * 「画面で見る内容 = AI に渡す JSON」の規約 (shared.ts `exportMeta`) に従い、
+ * 集計ロジックをここへ寄せて SSR との drift を作らない。
+ * `now` は引数で受ける (computePeriodReturns と同じテスト容易性の理由)。
+ */
+export function buildEquityPacket(points: EquityPoint[], now: Date) {
+  return {
+    ...exportMeta('dashboard_equity_export.v1'),
+    points,
+    periodReturns: computePeriodReturns(points, now),
+    monthlyReturns: computeMonthlyReturns(points),
+  }
 }
 
 /** overview チャート描画用に整列済みの view model (client inline JS に渡す形)。 */

--- a/src/routes/dashboard/cron.ts
+++ b/src/routes/dashboard/cron.ts
@@ -1,8 +1,8 @@
 import type { SymbolUniverse } from '../../infrastructure/db/symbolUniverse'
 import { createDb } from '../../infrastructure/db/tradeJournalRepo'
 import { strategyDecisionLog, tradeJournal } from '../../infrastructure/db/schema'
-import { and, desc, eq, lt, type SQL } from 'drizzle-orm'
-import { LOG_COPY_ALL_BTN, currencyOfSymbol, displaySymbol, esc, fmtJst, fmtNumber, fmtPct, fmtPctSigned, fmtPriceCcy, inactiveTooltip, isSymbolInactive, logCopyRowBtn, parseJsonObject, renderLogCopyScript, renderPaginationNav, safeJsonScript } from './shared'
+import { and, asc, desc, eq, lt, type SQL } from 'drizzle-orm'
+import { LOG_COPY_ALL_BTN, clampLimit, currencyOfSymbol, displaySymbol, esc, fmtJst, fmtNumber, fmtPct, fmtPctSigned, fmtPriceCcy, inactiveTooltip, isSymbolInactive, logCopyRowBtn, parseJsonObject, renderLogCopyScript, renderPaginationNav, safeJsonScript } from './shared'
 // ECHARTS_CDN のみ利用。charts/shared 側の `import type { DecisionRow }` は
 // type-only なので runtime 循環にはならない。
 import { ECHARTS_CDN } from './charts/shared'
@@ -593,6 +593,113 @@ export function cronDecisionJson(row: {
       filledQty: row.filledQty,
       realizedPnl: row.realizedPnl,
     },
+  }
+}
+
+/** `runCronJsonExport` の戻り値。route は `jsonPretty(payload, status)` するだけ。 */
+export interface CronJsonExportResult {
+  payload: unknown
+  status: 200 | 400 | 404
+}
+
+/**
+ * `/dashboard/cron/json` と MCP `get_cron_decisions` の共通本体 (#553)。
+ *
+ * route の inline 実装をそのまま移設したもの — payload のフィールド構成・
+ * key 順・エラー分岐は route 時代と byte 一致を保つこと (schema:
+ * `dashboard_cron_export.v1`)。route からは requestId / decisionId のみ渡る
+ * (= 既存挙動不変)。symbol / limit は MCP 専用の追加絞り込みで、requestId /
+ * decisionId が無いときだけ効く (loadDecisionRows 共用、新しい順)。
+ */
+export async function runCronJsonExport(
+  db: ReturnType<typeof createDb>,
+  opts: { requestId?: string; decisionId?: string; symbol?: string; limit?: number },
+): Promise<CronJsonExportResult> {
+  const requestedRequestId = opts.requestId?.trim()
+  const requestedDecisionId = opts.decisionId?.trim()
+  let decisionId: number | undefined
+  if (requestedDecisionId && requestedDecisionId.length > 0) {
+    if (!/^[1-9]\d*$/.test(requestedDecisionId)) {
+      return { payload: { error: 'invalid_decision_id', message: 'decisionId must be a positive integer' }, status: 400 }
+    }
+    decisionId = Number(requestedDecisionId)
+    if (!Number.isSafeInteger(decisionId) || decisionId <= 0) {
+      return { payload: { error: 'invalid_decision_id', message: 'decisionId must be a positive integer' }, status: 400 }
+    }
+  }
+  let requestId = requestedRequestId && requestedRequestId.length > 0
+    ? requestedRequestId
+    : undefined
+  // MCP 専用の symbol 絞り込み: requestId / decisionId 指定より弱い優先度。
+  // 「最新 request の全銘柄」ではなく「この銘柄の直近 N 判定」を返す。
+  if (!requestId && decisionId === undefined && opts.symbol && opts.symbol.trim().length > 0) {
+    const symbol = opts.symbol.toUpperCase().trim()
+    const limit = clampLimit(opts.limit !== undefined ? String(opts.limit) : undefined)
+    const rows = await loadDecisionRows(db, { symbol, limit })
+    return {
+      payload: {
+        schema: 'dashboard_cron_export.v1',
+        exportedAt: new Date().toISOString(),
+        symbol,
+        limit,
+        rowCount: rows.length,
+        decisions: rows.map((r) => ({ ...cronDecisionJson(r), requestId: r.requestId })),
+      },
+      status: 200,
+    }
+  }
+  if (!requestId && decisionId === undefined) {
+    const latest = await db
+      .select({ requestId: strategyDecisionLog.requestId })
+      .from(strategyDecisionLog)
+      .orderBy(desc(strategyDecisionLog.id))
+      .limit(50)
+    requestId = latest.find((row) => row.requestId !== null)?.requestId ?? undefined
+  }
+  if (!requestId && decisionId === undefined) {
+    return { payload: { error: 'no_cron_logs', message: 'strategy_decision_log has no request_id rows' }, status: 404 }
+  }
+
+  const filter = decisionId !== undefined
+    ? eq(strategyDecisionLog.id, decisionId)
+    : eq(strategyDecisionLog.requestId, requestId as string)
+  const rows = await db
+    .select({
+      id: strategyDecisionLog.id,
+      timestamp: strategyDecisionLog.timestamp,
+      requestId: strategyDecisionLog.requestId,
+      symbol: strategyDecisionLog.symbol,
+      decision: strategyDecisionLog.decision,
+      reason: strategyDecisionLog.reason,
+      price: strategyDecisionLog.price,
+      indicatorsJson: strategyDecisionLog.indicatorsJson,
+      clientOrderId: strategyDecisionLog.clientOrderId,
+      traceJson: strategyDecisionLog.traceJson,
+      filledPrice: tradeJournal.filledPrice,
+      filledQty: tradeJournal.filledQty,
+      realizedPnl: tradeJournal.realizedPnl,
+      brokerStatus: tradeJournal.brokerStatus,
+    })
+    .from(strategyDecisionLog)
+    .leftJoin(
+      tradeJournal,
+      and(
+        eq(strategyDecisionLog.clientOrderId, tradeJournal.clientOrderId),
+        eq(tradeJournal.tradeEventType, 'post_submit'),
+      ),
+    )
+    .where(filter)
+    .orderBy(asc(strategyDecisionLog.id))
+
+  return {
+    payload: {
+      schema: 'dashboard_cron_export.v1',
+      exportedAt: new Date().toISOString(),
+      ...(decisionId !== undefined ? { decisionId } : { requestId }),
+      rowCount: rows.length,
+      decisions: rows.map(cronDecisionJson),
+    },
+    status: 200,
   }
 }
 

--- a/src/routes/dashboard/index.ts
+++ b/src/routes/dashboard/index.ts
@@ -11,7 +11,6 @@ import {
   getTradableStatusForSymbol,
   loadTradableAllowlist,
 } from '../../infrastructure/db/tradableInstrumentsRepo'
-import { strategyDecisionLog, tradeJournal } from '../../infrastructure/db/schema'
 import { loadRecentAudit, type LoadAuditOptions } from '../../infrastructure/db/configAuditLog'
 import {
   loadRecentAlerts,
@@ -29,7 +28,7 @@ import { buildSymbolRules } from '../../trading/strategy/symbolRuleResolution'
 import { evaluatePairRegime, type PairRegimeDecision } from '../../trading/strategy/pairRegime'
 import { computeConditionalAllocation } from '../../trading/strategy/conditionalAllocation'
 import type { SymbolRule } from '../../trading/strategy/strategies/PullbackUptrendStrategy'
-import { and, asc, desc, eq } from 'drizzle-orm'
+import { eq } from 'drizzle-orm'
 import { PortfolioStateClient } from '../../trading/state/PortfolioStateClient'
 import { SymbolStateClient } from '../../trading/state/SymbolStateClient'
 import { loadUsdJpyRate } from '../../infrastructure/quotes/fxRate'
@@ -69,7 +68,7 @@ import { buildPositionsPacket, loadLatestStrategyPrices, loadPositionsPageData, 
 import { parseEquityRange, portfolioBody, safeLoadPortfolioSnapshots } from './portfolio'
 import { buildTradesPacket, loadTradeJournalRows, parseTradesQuery, tradesBody } from './trades'
 import { configBody } from './config'
-import { aggregateReasonTrend, buildDecisionMatrix, cronBody, cronDecisionJson, decisionMatrixBody, loadDecisionMatrix, loadDecisionRows } from './cron'
+import { aggregateReasonTrend, buildDecisionMatrix, cronBody, decisionMatrixBody, loadDecisionMatrix, loadDecisionRows, runCronJsonExport } from './cron'
 import { alertsBody, clampAlertLimit, parseAlertsQuery, parseEventTypeFilter, parseSeverityFilter } from './alerts'
 import { auditBody, clampAuditLimit, parseAuditDateFilter, trimQuery } from './audit'
 import { type StrategyParamsSnapshot, computeZoomRange, parseChartsTab, parseIsoTimestamp, renderChartsSubnav, strategyParamsFromGlobal } from './charts/shared'
@@ -680,73 +679,14 @@ export const dashboard = new Hono<DashboardBindings>()
     if (!c.env.DB) {
       return jsonPretty({ error: 'db_not_bound', message: 'DB binding is not configured' }, 503)
     }
-    const db = createDb(c.env.DB)
-    const requestedRequestId = c.req.query('requestId')?.trim()
-    const requestedDecisionId = c.req.query('decisionId')?.trim()
+    // 本体は MCP `get_cron_decisions` と共用の runCronJsonExport (#553)。
+    // route からは requestId / decisionId のみ渡す — 移設前と出力 byte 一致。
     try {
-      let decisionId: number | undefined
-      if (requestedDecisionId && requestedDecisionId.length > 0) {
-        if (!/^[1-9]\d*$/.test(requestedDecisionId)) {
-          return jsonPretty({ error: 'invalid_decision_id', message: 'decisionId must be a positive integer' }, 400)
-        }
-        decisionId = Number(requestedDecisionId)
-        if (!Number.isSafeInteger(decisionId) || decisionId <= 0) {
-          return jsonPretty({ error: 'invalid_decision_id', message: 'decisionId must be a positive integer' }, 400)
-        }
-      }
-      let requestId = requestedRequestId && requestedRequestId.length > 0
-        ? requestedRequestId
-        : undefined
-      if (!requestId && decisionId === undefined) {
-        const latest = await db
-          .select({ requestId: strategyDecisionLog.requestId })
-          .from(strategyDecisionLog)
-          .orderBy(desc(strategyDecisionLog.id))
-          .limit(50)
-        requestId = latest.find((row) => row.requestId !== null)?.requestId ?? undefined
-      }
-      if (!requestId && decisionId === undefined) {
-        return jsonPretty({ error: 'no_cron_logs', message: 'strategy_decision_log has no request_id rows' }, 404)
-      }
-
-      const filter = decisionId !== undefined
-        ? eq(strategyDecisionLog.id, decisionId)
-        : eq(strategyDecisionLog.requestId, requestId as string)
-      const rows = await db
-        .select({
-          id: strategyDecisionLog.id,
-          timestamp: strategyDecisionLog.timestamp,
-          requestId: strategyDecisionLog.requestId,
-          symbol: strategyDecisionLog.symbol,
-          decision: strategyDecisionLog.decision,
-          reason: strategyDecisionLog.reason,
-          price: strategyDecisionLog.price,
-          indicatorsJson: strategyDecisionLog.indicatorsJson,
-          clientOrderId: strategyDecisionLog.clientOrderId,
-          traceJson: strategyDecisionLog.traceJson,
-          filledPrice: tradeJournal.filledPrice,
-          filledQty: tradeJournal.filledQty,
-          realizedPnl: tradeJournal.realizedPnl,
-          brokerStatus: tradeJournal.brokerStatus,
-        })
-        .from(strategyDecisionLog)
-        .leftJoin(
-          tradeJournal,
-          and(
-            eq(strategyDecisionLog.clientOrderId, tradeJournal.clientOrderId),
-            eq(tradeJournal.tradeEventType, 'post_submit'),
-          ),
-        )
-        .where(filter)
-        .orderBy(asc(strategyDecisionLog.id))
-
-      return jsonPretty({
-        schema: 'dashboard_cron_export.v1',
-        exportedAt: new Date().toISOString(),
-        ...(decisionId !== undefined ? { decisionId } : { requestId }),
-        rowCount: rows.length,
-        decisions: rows.map(cronDecisionJson),
+      const { payload, status } = await runCronJsonExport(createDb(c.env.DB), {
+        requestId: c.req.query('requestId'),
+        decisionId: c.req.query('decisionId'),
       })
+      return jsonPretty(payload, status)
     } catch (err) {
       return jsonPretty({ error: 'cron_json_export_failed', message: messageOf(err) }, 500)
     }

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -1,0 +1,329 @@
+import { Hono } from 'hono'
+import type { AppBindings } from '../app'
+import type { Env } from '../config/env'
+import { rateLimit } from '../middleware/rateLimit'
+import { loadGlobalConfigFrom } from '../infrastructure/db/globalConfigLoader'
+import { loadSymbolUniverse } from '../infrastructure/db/symbolUniverse'
+import { createDb } from '../infrastructure/db/tradeJournalRepo'
+import { buildSymbolRules } from '../trading/strategy/symbolRuleResolution'
+import type { SymbolRule } from '../trading/strategy/strategies/PullbackUptrendStrategy'
+import { buildPositionsPacket, loadPositionsPageData } from './dashboard/positions'
+import { buildTradesPacket, loadTradeJournalRows, parseTradesQuery } from './dashboard/trades'
+import { loadDecisionRows, runCronJsonExport } from './dashboard/cron'
+import { buildEquityPacket, loadEquityCurve } from './dashboard/charts/equity'
+import { strategyParamsFromGlobal } from './dashboard/charts/shared'
+import { type SymbolChartRules, buildSymbolChartPacket, loadSymbolChart } from './dashboard/charts/loaders'
+import { messageOf } from './dashboard/shared'
+
+/**
+ * Read-only MCP server (#553) — dashboard の JSON export packet を
+ * Model Context Protocol の tools として公開する。
+ *
+ * 設計方針:
+ * - **書き込み tool は作らない (fail-closed)**。全 tool が既存 packet builder
+ *   (`dashboard_<page>_export.v<N>`) の read-only 出力をそのまま返すだけ。
+ * - **SDK 非依存**: POC 方針 (依存を増やさない) に従い、JSON-RPC 2.0 を素の
+ *   Hono handler で処理する streamable HTTP (POST /mcp)。SSE (GET) は spec 上
+ *   optional なので非対応 = 405。session 管理も持たない (stateless)。
+ * - **認証は Cloudflare Access に一任**: app.ts で `/dashboard` と同じ
+ *   `accessJwtMiddleware()` を適用する。MCP クライアントは Access service
+ *   token (CF-Access-Client-Id/Secret ヘッダ) で同じ検証を通る — 新しい
+ *   認証機構は作らない。
+ * - packet builder は HTTP 経由でなく同一 Worker 内で直接呼ぶ。schema
+ *   フィールドがそのまま tool の出力契約になる。
+ */
+
+/** initialize が client の protocolVersion を echo できない時の fallback。 */
+const MCP_PROTOCOL_VERSION = '2025-03-26'
+
+const SERVER_INFO = { name: 'webull-trading-dashboard', version: '0.1.0' }
+
+type JsonRpcId = string | number
+
+interface ToolText {
+  type: 'text'
+  text: string
+}
+
+/** MCP tools/call の結果形。エラーは throw せず isError: true で返す。 */
+interface ToolResult {
+  content: ToolText[]
+  isError?: boolean
+}
+
+function rpcResult(id: JsonRpcId, result: unknown) {
+  return { jsonrpc: '2.0' as const, id, result }
+}
+
+function rpcError(id: JsonRpcId | null, code: number, message: string) {
+  return { jsonrpc: '2.0' as const, id, error: { code, message } }
+}
+
+function toolOk(packet: unknown): ToolResult {
+  return { content: [{ type: 'text', text: JSON.stringify(packet) }] }
+}
+
+/**
+ * tool 実行エラー (binding 未設定 / 引数不正 / loader 失敗) は JSON-RPC error
+ * でも HTTP 500 でもなく isError: true の text で返す — MCP spec 上、LLM が
+ * 読んで自己修正できるのは tool result 側のエラーだけのため。
+ */
+function toolError(message: string): ToolResult {
+  return { content: [{ type: 'text', text: message }], isError: true }
+}
+
+/**
+ * tools/list に返す定義。inputSchema は JSON Schema。description は
+ * 「何が返るか + AI がどう使うか」を書く (LLM の tool 選択がこれに依存する)。
+ */
+const TOOLS = [
+  {
+    name: 'get_positions',
+    description:
+      '保有ポジション一覧 (dashboard_positions_export.v1)。銘柄ごとの数量・平均取得単価・現在値・評価損益 (%)・未約定注文・クールダウンを返す。現在の建玉状況の確認や損益の相談の起点に使う。',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'get_trades',
+    description:
+      '約定履歴 trade_journal (dashboard_trades_export.v1)。view で全イベント / 約定・手仕舞いのみ / エラーのみを切り替え、symbol / clientOrderId / limit で絞り込める。個別注文の lifecycle 追跡や発注エラーの調査に使う。',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        view: {
+          type: 'string',
+          enum: ['all', 'fills', 'errors'],
+          description: '絞り込みビュー (省略時 all)',
+        },
+        symbol: { type: 'string', description: '銘柄 (例 SOXL / 1357)' },
+        clientOrderId: { type: 'string', description: '注文単位の lifecycle 絞り込み' },
+        limit: { type: 'number', description: '最大件数 (既定 50、上限 200)' },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'get_cron_decisions',
+    description:
+      '戦略判定ログ (dashboard_cron_export.v1)。引数なしなら最新 cron 実行 1 回分の全銘柄判定、requestId / decisionId / symbol で絞り込める。「なぜ買った / 買わなかったか」の reason・indicators を読むのに使う。',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        requestId: { type: 'string', description: 'cron 実行 1 回分の requestId' },
+        decisionId: { type: 'number', description: '判定 1 行の id (単一判定の詳細)' },
+        symbol: { type: 'string', description: 'この銘柄の直近判定だけを新しい順に返す' },
+        limit: { type: 'number', description: 'symbol 指定時の最大件数 (既定 50、上限 200)' },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'get_equity',
+    description:
+      'エクイティカーブ (dashboard_equity_export.v1)。日次 realized PnL の累積・ドローダウン率・期間別 (1W/1M/3M/YTD/ALL) と月次のリターンを返す。戦略の長期パフォーマンス評価に使う。',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'get_symbol_chart',
+    description:
+      '銘柄チャートデータ (dashboard_chart_symbol_export.v1)。日足 + SMA50 + 判定マーカー + その銘柄の有効ルール (stop / TP / 押し目閾値) + 判定履歴 30 件を返す。個別銘柄のエントリー / エグジット状況の分析に使う。',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        symbol: { type: 'string', description: '銘柄 (必須、例 SOXL / 1357)' },
+      },
+      required: ['symbol'],
+      additionalProperties: false,
+    },
+  },
+] as const
+
+type ToolName = (typeof TOOLS)[number]['name']
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v)
+}
+
+/** tool argument を string | undefined に正規化 (number も許容して文字列化)。 */
+function stringArg(args: Record<string, unknown>, key: string): string | undefined {
+  const v = args[key]
+  if (typeof v === 'string') return v
+  if (typeof v === 'number' && Number.isFinite(v)) return String(v)
+  return undefined
+}
+
+function numberArg(args: Record<string, unknown>, key: string): number | undefined {
+  const v = args[key]
+  return typeof v === 'number' && Number.isFinite(v) ? v : undefined
+}
+
+/**
+ * tool 本体。binding 未設定・引数不正・loader 失敗はすべて isError で返し、
+ * HTTP 500 にしない (呼び出し側 LLM に理由を読ませて再試行させる)。
+ */
+async function callTool(
+  env: Env,
+  requestId: string | undefined,
+  name: ToolName,
+  args: Record<string, unknown>,
+): Promise<ToolResult> {
+  switch (name) {
+    case 'get_positions': {
+      if (!env.DB || !env.SYMBOL_STATE) {
+        return toolError('DB or SYMBOL_STATE binding is not configured')
+      }
+      return toolOk(buildPositionsPacket(await loadPositionsPageData(env)))
+    }
+    case 'get_trades': {
+      if (!env.DB) return toolError('DB binding is not configured')
+      // クエリ解釈は /dashboard/trades(/json) と同じ parseTradesQuery を通す —
+      // 「画面の絞り込みと tool の絞り込みが微妙に違う」drift を作らない。
+      const q = parseTradesQuery((key) => stringArg(args, key))
+      const rows = await loadTradeJournalRows(createDb(env.DB), q)
+      return toolOk(buildTradesPacket(rows, q))
+    }
+    case 'get_cron_decisions': {
+      if (!env.DB) return toolError('DB binding is not configured')
+      const { payload, status } = await runCronJsonExport(createDb(env.DB), {
+        requestId: stringArg(args, 'requestId'),
+        decisionId: stringArg(args, 'decisionId'),
+        symbol: stringArg(args, 'symbol'),
+        limit: numberArg(args, 'limit'),
+      })
+      if (status !== 200) {
+        const p = payload as { error?: string; message?: string }
+        return toolError(`${p.error ?? 'error'}: ${p.message ?? 'cron export failed'}`)
+      }
+      return toolOk(payload)
+    }
+    case 'get_equity': {
+      if (!env.DB) return toolError('DB binding is not configured')
+      return toolOk(buildEquityPacket(await loadEquityCurve(env.DB), new Date()))
+    }
+    case 'get_symbol_chart': {
+      const symbol = stringArg(args, 'symbol')?.toUpperCase().trim()
+      if (!symbol) return toolError('symbol is required (e.g. { "symbol": "SOXL" })')
+      if (!env.DB) return toolError('DB binding is not configured')
+      // /dashboard/charts/symbol/json ルート (index.ts) と同じ手順:
+      // effective rule (global default → role preset → per-symbol override) を
+      // buildSymbolRules で解決し、SSR / JSON export とチャート内容を揃える。
+      // 変更時は index.ts 側と同期すること (#dashboard-json-api)。
+      const [universe, global] = await Promise.all([
+        loadSymbolUniverse(env),
+        loadGlobalConfigFrom(env, requestId),
+      ])
+      const defaultEntryRule: SymbolRule = strategyParamsFromGlobal(global)
+      const entryRule = buildSymbolRules(defaultEntryRule, universe)[symbol] ?? defaultEntryRule
+      const rules: SymbolChartRules = {
+        pullbackMax: entryRule.pullbackMax,
+        pullbackMin: entryRule.pullbackMin,
+        stopPct: entryRule.stopPct,
+        takeProfitPct: entryRule.takeProfitPct,
+        timeStopDays: entryRule.timeStopDays,
+      }
+      const chart = await loadSymbolChart(env, symbol, rules)
+      // 判定履歴の load 失敗 (migration 未適用等) はチャート本体を巻き込まず
+      // 空配列に落とす (/charts/symbol/json と同挙動)。
+      const decisionRows = await loadDecisionRows(createDb(env.DB), { symbol, limit: 30 }).catch(
+        () => [],
+      )
+      return toolOk(buildSymbolChartPacket(chart, decisionRows))
+    }
+  }
+}
+
+export const mcp = new Hono<AppBindings>()
+  // read-only + Access 保護済みだが、dashboard と同じ read 系 soft cap
+  // (60 req / 60s) を適用しておく — LLM の tool 連打で D1/DO を焼かない保険。
+  .use('*', rateLimit('DASHBOARD'))
+  // SSE stream (GET) は MCP spec 上 optional — 本サーバーは server→client の
+  // push を持たないので非対応を 405 で明示する。
+  .get('/', (c) =>
+    c.json({ error: 'method_not_allowed', message: 'SSE is not supported; POST JSON-RPC to /mcp' }, 405),
+  )
+  // session 管理を持たない stateless サーバーなので DELETE (session 終了) も 405。
+  .delete('/', (c) =>
+    c.json({ error: 'method_not_allowed', message: 'sessions are not supported' }, 405),
+  )
+  .post('/', async (c) => {
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json(rpcError(null, -32700, 'Parse error'))
+    }
+    // batch (array) は非対応 — 単発 object のみ受ける (POC 最小実装)。
+    if (Array.isArray(body)) {
+      return c.json(rpcError(null, -32600, 'Batch requests are not supported'))
+    }
+    if (!isRecord(body)) {
+      return c.json(rpcError(null, -32600, 'Invalid Request'))
+    }
+    const idRaw = body.id
+    if (body.jsonrpc !== '2.0' || typeof body.method !== 'string') {
+      return c.json(
+        rpcError(typeof idRaw === 'string' || typeof idRaw === 'number' ? idRaw : null, -32600, 'Invalid Request'),
+      )
+    }
+    // id なし = notification (notifications/initialized 等)。応答 body 不要、
+    // spec 通り 202 Accepted の空応答を返す。
+    if (idRaw === undefined || idRaw === null) {
+      return c.body(null, 202)
+    }
+    if (typeof idRaw !== 'string' && typeof idRaw !== 'number') {
+      return c.json(rpcError(null, -32600, 'Invalid Request: id must be a string or number'))
+    }
+    const id: JsonRpcId = idRaw
+
+    switch (body.method) {
+      case 'initialize': {
+        const params = isRecord(body.params) ? body.params : {}
+        // client の protocolVersion をそのまま echo する (バージョン交渉を
+        // 実装しない最単純形 — 本サーバーの応答形はどの版でも互換)。
+        const protocolVersion =
+          typeof params.protocolVersion === 'string'
+            ? params.protocolVersion
+            : MCP_PROTOCOL_VERSION
+        return c.json(
+          rpcResult(id, {
+            protocolVersion,
+            capabilities: { tools: {} },
+            serverInfo: SERVER_INFO,
+          }),
+        )
+      }
+      // ping は MCP spec の必須 keep-alive (クライアントが定期送信してくる)。
+      case 'ping':
+        return c.json(rpcResult(id, {}))
+      case 'tools/list':
+        return c.json(rpcResult(id, { tools: TOOLS }))
+      case 'tools/call': {
+        const params = isRecord(body.params) ? body.params : {}
+        const name = typeof params.name === 'string' ? params.name : ''
+        const tool = TOOLS.find((t) => t.name === name)
+        // 未知 tool は spec 通り JSON-RPC error (-32602 Invalid params)。
+        if (!tool) {
+          return c.json(rpcError(id, -32602, `Unknown tool: ${name || '(missing name)'}`))
+        }
+        const args = isRecord(params.arguments) ? params.arguments : {}
+        let result: ToolResult
+        try {
+          result = await callTool(c.env, c.get('requestId'), tool.name, args)
+        } catch (err) {
+          // loader の想定外 throw も 500 にせず isError で返す (fail-graceful)。
+          result = toolError(messageOf(err))
+        }
+        return c.json(rpcResult(id, result))
+      }
+      default:
+        return c.json(rpcError(id, -32601, `Method not found: ${body.method}`))
+    }
+  })

--- a/test/routes/mcp.test.ts
+++ b/test/routes/mcp.test.ts
@@ -1,0 +1,259 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp } from '../../src/app'
+import { loadSymbolUniverse } from '../../src/infrastructure/db/symbolUniverse'
+import { createDb } from '../../src/infrastructure/db/tradeJournalRepo'
+import { makeSymbolUniverse } from '../helpers/configFixtures'
+
+vi.mock('../../src/infrastructure/db/symbolUniverse', () => ({
+  loadSymbolUniverse: vi.fn(),
+}))
+vi.mock('../../src/infrastructure/db/tradeJournalRepo', async () => {
+  const actual = await vi.importActual<typeof import('../../src/infrastructure/db/tradeJournalRepo')>(
+    '../../src/infrastructure/db/tradeJournalRepo',
+  )
+  return { ...actual, createDb: vi.fn() }
+})
+
+const baseEnv = { ACCESS_DEV_BYPASS_USER: 'admin' }
+
+/** POST /mcp に JSON-RPC message を送る helper。 */
+async function rpc(env: Record<string, unknown>, body: unknown): Promise<Response> {
+  const app = createApp()
+  return app.request(
+    '/mcp',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+    env,
+  )
+}
+
+function toolCall(name: string, args: Record<string, unknown> = {}) {
+  return { jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name, arguments: args } }
+}
+
+/** dashboardJsonApi.test.ts と同じ SymbolStateDO の fake namespace。 */
+function fakeSymbolStateNamespace() {
+  const stub = {
+    async getState(symbol: string) {
+      return {
+        symbol,
+        position: { qty: 10, avgPrice: 100, openedAt: '2026-06-20T00:00:00.000Z' },
+        pendingOrder: null,
+        lastSignalAt: null,
+        cooldownUntil: null,
+        settledCash: 0,
+        pendingSettlement: [],
+        lastExecutedPrice: null,
+        lastQuote: { price: 105, asOf: '2026-07-01T00:00:00Z', fetchedAt: '2026-07-01T00:00:00Z', source: 'yahoo' },
+        updatedAt: '2026-07-01T00:00:00.000Z',
+      }
+    },
+  }
+  return {
+    idFromName: (_name: string) => 'id',
+    get: (_id: string) => stub,
+  } as unknown
+}
+
+/** loadDecisionRows (select→from→leftJoin→where→orderBy→limit) 用の fake chain。 */
+function fakeCronDb(rows: unknown[]) {
+  const query = {
+    from: vi.fn(() => query),
+    leftJoin: vi.fn(() => query),
+    where: vi.fn(() => query),
+    orderBy: vi.fn(() => query),
+    limit: vi.fn(async () => rows),
+  }
+  return {
+    select: vi.fn(() => query),
+  }
+}
+
+describe('read-only MCP server (#553)', () => {
+  beforeEach(() => {
+    vi.mocked(loadSymbolUniverse).mockResolvedValue(
+      makeSymbolUniverse({
+        allowedSymbols: ['SOXL'],
+        inactiveSymbols: [],
+        symbolCurrency: { SOXL: 'USD' },
+        symbolName: { SOXL: 'Direxion Semiconductor Bull 3X' },
+      }),
+    )
+  })
+  afterEach(() => vi.resetAllMocks())
+
+  describe('auth (Cloudflare Access)', () => {
+    it('rejects requests without Access JWT / dev bypass', async () => {
+      // bypass なし env → accessJwtMiddleware の既存挙動 (fail-closed 401)
+      const res = await rpc({}, { jsonrpc: '2.0', id: 1, method: 'tools/list' })
+      expect(res.status).toBe(401)
+    })
+  })
+
+  describe('JSON-RPC framing', () => {
+    it('responds to initialize echoing the client protocolVersion', async () => {
+      const res = await rpc(baseEnv, {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-06-18',
+          capabilities: {},
+          clientInfo: { name: 'test-client', version: '0.0.0' },
+        },
+      })
+      expect(res.status).toBe(200)
+      const json = (await res.json()) as Record<string, any>
+      expect(json.jsonrpc).toBe('2.0')
+      expect(json.id).toBe(1)
+      expect(json.result.protocolVersion).toBe('2025-06-18')
+      expect(json.result.capabilities).toEqual({ tools: {} })
+      expect(json.result.serverInfo).toEqual({ name: 'webull-trading-dashboard', version: '0.1.0' })
+    })
+
+    it('accepts notifications/initialized with an empty 202', async () => {
+      const res = await rpc(baseEnv, { jsonrpc: '2.0', method: 'notifications/initialized' })
+      expect(res.status).toBe(202)
+      expect(await res.text()).toBe('')
+    })
+
+    it('returns -32601 for unknown methods', async () => {
+      const res = await rpc(baseEnv, { jsonrpc: '2.0', id: 7, method: 'resources/list' })
+      const json = (await res.json()) as Record<string, any>
+      expect(json.id).toBe(7)
+      expect(json.error.code).toBe(-32601)
+    })
+
+    it('returns -32600 for batch (array) requests', async () => {
+      const res = await rpc(baseEnv, [{ jsonrpc: '2.0', id: 1, method: 'tools/list' }])
+      const json = (await res.json()) as Record<string, any>
+      expect(json.error.code).toBe(-32600)
+    })
+
+    it('returns -32700 for unparseable bodies', async () => {
+      const app = createApp()
+      const res = await app.request(
+        '/mcp',
+        { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{not json' },
+        baseEnv,
+      )
+      const json = (await res.json()) as Record<string, any>
+      expect(json.error.code).toBe(-32700)
+    })
+
+    it('rejects GET /mcp with 405 (SSE not supported)', async () => {
+      const app = createApp()
+      const res = await app.request('/mcp', {}, baseEnv)
+      expect(res.status).toBe(405)
+    })
+  })
+
+  describe('tools/list', () => {
+    it('lists the 5 read-only dashboard tools', async () => {
+      const res = await rpc(baseEnv, { jsonrpc: '2.0', id: 2, method: 'tools/list' })
+      const json = (await res.json()) as Record<string, any>
+      const names = json.result.tools.map((t: { name: string }) => t.name)
+      expect(names).toEqual([
+        'get_positions',
+        'get_trades',
+        'get_cron_decisions',
+        'get_equity',
+        'get_symbol_chart',
+      ])
+      // 全 tool が inputSchema (JSON Schema) を持つ
+      for (const tool of json.result.tools) {
+        expect(tool.inputSchema.type).toBe('object')
+        expect(typeof tool.description).toBe('string')
+      }
+    })
+  })
+
+  describe('tools/call', () => {
+    it('get_positions returns the dashboard_positions_export.v1 packet as text', async () => {
+      const env = {
+        ...baseEnv,
+        DB: {} as D1Database,
+        SYMBOL_STATE: fakeSymbolStateNamespace(),
+      }
+      const res = await rpc(env, toolCall('get_positions'))
+      expect(res.status).toBe(200)
+      const json = (await res.json()) as Record<string, any>
+      expect(json.result.isError).toBeUndefined()
+      expect(json.result.content).toHaveLength(1)
+      expect(json.result.content[0].type).toBe('text')
+      const packet = JSON.parse(json.result.content[0].text) as Record<string, any>
+      // /dashboard/positions/json と同じ packet builder → 同じ schema 契約
+      expect(packet.schema).toBe('dashboard_positions_export.v1')
+      expect(packet.rowCount).toBe(1)
+      expect(packet.positions[0].symbol).toBe('SOXL')
+      expect(packet.positions[0].qty).toBe(10)
+      expect(packet.positions[0].avgPrice).toBe(100)
+      expect(packet.positions[0].unrealizedPnlPct).toBe(5)
+    })
+
+    it('get_cron_decisions with symbol filter reuses the shared cron export', async () => {
+      vi.mocked(createDb).mockReturnValue(
+        fakeCronDb([
+          {
+            id: 42,
+            timestamp: '2026-07-01T00:00:00.000Z',
+            requestId: 'req-9',
+            symbol: 'SOXL',
+            decision: 'SKIP',
+            reason: 'pullback -0.01 > -0.03 (not deep enough)',
+            price: 30,
+            indicatorsJson: '{"price":30}',
+            clientOrderId: null,
+            traceJson: null,
+            filledPrice: null,
+            filledQty: null,
+            realizedPnl: null,
+            brokerStatus: null,
+          },
+        ]) as never,
+      )
+      const res = await rpc(
+        { ...baseEnv, DB: {} as D1Database },
+        toolCall('get_cron_decisions', { symbol: 'soxl', limit: 10 }),
+      )
+      const json = (await res.json()) as Record<string, any>
+      expect(json.result.isError).toBeUndefined()
+      const packet = JSON.parse(json.result.content[0].text) as Record<string, any>
+      expect(packet.schema).toBe('dashboard_cron_export.v1')
+      expect(packet.symbol).toBe('SOXL')
+      expect(packet.limit).toBe(10)
+      expect(packet.rowCount).toBe(1)
+      expect(packet.decisions[0].id).toBe(42)
+      expect(packet.decisions[0].requestId).toBe('req-9')
+      // route と同じ cronDecisionJson 経由 → indicators は parse 済み object
+      expect(packet.decisions[0].indicators).toEqual({ price: 30 })
+    })
+
+    it('get_symbol_chart without symbol returns isError (not a 500)', async () => {
+      const res = await rpc({ ...baseEnv, DB: {} as D1Database }, toolCall('get_symbol_chart'))
+      expect(res.status).toBe(200)
+      const json = (await res.json()) as Record<string, any>
+      expect(json.result.isError).toBe(true)
+      expect(json.result.content[0].text).toContain('symbol')
+    })
+
+    it('returns isError when DB is not bound (fail-graceful, not a 500)', async () => {
+      for (const name of ['get_positions', 'get_trades', 'get_cron_decisions', 'get_equity']) {
+        const res = await rpc(baseEnv, toolCall(name))
+        expect(res.status).toBe(200)
+        const json = (await res.json()) as Record<string, any>
+        expect(json.result.isError).toBe(true)
+        expect(json.result.content[0].text).toContain('not configured')
+      }
+    })
+
+    it('returns -32602 for unknown tool names', async () => {
+      const res = await rpc(baseEnv, toolCall('place_order', { symbol: 'SOXL' }))
+      const json = (await res.json()) as Record<string, any>
+      expect(json.error.code).toBe(-32602)
+    })
+  })
+})


### PR DESCRIPTION
## 概要

#553 の実装。Claude (Claude Code / claude.ai) からダッシュボードを開かずに判定・約定・ポジション・資産推移を照会して会話できる read-only MCP サーバを追加する。

## 設計 (#553 の推奨案どおり)

- **`POST /mcp`** — streamable HTTP MCP。SDK 依存を増やさず JSON-RPC 2.0 を素の Hono handler で処理 (GET/DELETE は 405、batch 非対応 -32600、未知 method -32601)
- **認証: Cloudflare Access service token** — 既存 `accessJwtMiddleware()` を `/mcp` に適用するだけ。新しい認証機構なし。`rateLimit('DASHBOARD')` (read 系) 適用
- **書き込み tool なし (fail-closed)**。DB/DO 未バインド・引数不正・loader 例外はすべて `isError: true` の text で返し HTTP 500 にしない

## Tools (5 本)

| tool | 引数 | 出力 schema |
|---|---|---|
| `get_positions` | — | `dashboard_positions_export.v1` |
| `get_trades` | view / symbol / clientOrderId / limit | `dashboard_trades_export.v1` |
| `get_cron_decisions` | requestId / decisionId / symbol / limit | `dashboard_cron_export.v1` |
| `get_equity` | — | `dashboard_equity_export.v1` (新規: points + 期間別 + 月次) |
| `get_symbol_chart` | symbol (必須) | `dashboard_chart_symbol_export.v1` |

packet builder (#557) を Worker 内で直接呼ぶため、**「画面で見る内容 = /json = MCP tool 出力」が単一関数由来**。`/cron/json` はロジックを `runCronJsonExport()` に移設して共用 (payload は移設前とバイト同一、既存テストで担保)。

## テスト

`pnpm typecheck` / `pnpm test` — **116 files / 1692 tests green** (新規 12: 認証 401 / initialize / tools一覧 / -32601 / -32600 / happy path / isError 系)。

## merge 後に必要な操作 (operator 側)

1. Zero Trust → Access → Service Auth で service token を発行
2. `/mcp` を含む Access application の policy に Service Auth を許可
3. `claude mcp add -s user -t http webull-dashboard https://<worker-domain>/mcp --header "CF-Access-Client-Id: <id>.access" --header "CF-Access-Client-Secret: <secret>"`

Closes #553

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * MCP 経由でダッシュボード関連データを取得できる読み取り専用エンドポイントを追加しました。
  * 位置情報、取引履歴、実績推移、銘柄チャートなどをツールとして呼び出せるようになりました。

* **改善**
  * 日次・月次の実績データをまとめて取得しやすくしました。
  * 監査用の出力を共通化し、表示内容の整合性を向上しました。

* **バグ修正**
  * 不正な入力や対象データ不足時に、適切なエラー応答を返すようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->