### PR TITLE
fix: verify /mcp against dedicated Access application AUD

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -121,3 +121,8 @@ WEBULL_ACCESS_TOKEN=
 # BAR_SOURCE (#475): 'webull' で daily/intraday bars を Webull Market Data API に
 # 切替。^VIX / JP 銘柄 / Webull 障害時は Yahoo に自動 fallback。未設定 = yahoo。
 # BAR_SOURCE=webull
+
+# --- MCP (#553) ---
+# CF_ACCESS_MCP_AUD: /mcp 専用 Access application (path 限定 + Service Auth policy)
+# の AUD tag。未設定なら CF_ACCESS_AUD に fallback。設定は wrangler secret:
+#   wrangler secret put CF_ACCESS_MCP_AUD --env=production

--- a/src/app.ts
+++ b/src/app.ts
@@ -58,8 +58,8 @@ export function createApp() {
   // Read-only MCP server (#553 append)。/dashboard と同じ Access JWT 検証を
   // 通す (service token も同じ検証を通過する)。ワイルドカード `/mcp/*` は
   // `/mcp` 単一 path に効かない router があるため base path にも明示的に張る。
-  app.use('/mcp', accessJwtMiddleware())
-  app.use('/mcp/*', accessJwtMiddleware())
+  app.use('/mcp', accessJwtMiddleware({ audience: 'mcp' }))
+  app.use('/mcp/*', accessJwtMiddleware({ audience: 'mcp' }))
   app.route('/mcp', mcp)
   app.onError(errorHandler)
   return app

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -393,9 +393,13 @@ export interface Env {
 //   未設定 AND `Cf-Access-Jwt-Assertion` ヘッダ無しの時のみ、この文字列を actor として
 //   stamp する。**deployed env では絶対に設定禁止** (上記 gate で実質無効化されるが、
 //   設定自体しない方が誤爆リスクが少ない)。
+// - CF_ACCESS_MCP_AUD: /mcp 専用 Access application (path 限定 + Service Auth
+//   policy) の AUD tag (#553)。未設定時は CF_ACCESS_AUD に fallback。専用 app を
+//   分ける理由は service token の権限を read-only な /mcp に限定するため。
 export interface Env {
   CF_ACCESS_TEAM_DOMAIN?: string
   CF_ACCESS_AUD?: string
+  CF_ACCESS_MCP_AUD?: string
   ACCESS_DEV_BYPASS_USER?: string
 }
 

--- a/src/middleware/accessJwt.ts
+++ b/src/middleware/accessJwt.ts
@@ -69,13 +69,24 @@ function pickActor(payload: AccessClaims): string {
   return 'unknown'
 }
 
-export function accessJwtMiddleware(): MiddlewareHandler<{
+/**
+ * `audience: 'mcp'` は /mcp 専用の Access application (path 限定 + Service Auth
+ * policy) の AUD (`CF_ACCESS_MCP_AUD`) を検証する。専用 app を分けるのは、
+ * service token の届く範囲を read-only な /mcp に限定するため (メインの
+ * trading app に Service Auth を足すと token で /admin の書き込み系まで
+ * 通ってしまう)。`CF_ACCESS_MCP_AUD` 未設定時は `CF_ACCESS_AUD` に fallback
+ * (メイン app に Service Auth policy を足す運用も許容する)。
+ */
+export function accessJwtMiddleware(opts?: { audience?: 'default' | 'mcp' }): MiddlewareHandler<{
   Bindings: Env
   Variables: AccessJwtVariables
 }> {
   return async (c, next) => {
     const teamDomain = c.env.CF_ACCESS_TEAM_DOMAIN?.trim()
-    const audience = c.env.CF_ACCESS_AUD?.trim()
+    const audience =
+      opts?.audience === 'mcp'
+        ? c.env.CF_ACCESS_MCP_AUD?.trim() || c.env.CF_ACCESS_AUD?.trim()
+        : c.env.CF_ACCESS_AUD?.trim()
     const devBypassUser = c.env.ACCESS_DEV_BYPASS_USER?.trim()
 
     const jwt = c.req.header('Cf-Access-Jwt-Assertion')

--- a/test/middleware/accessJwt.test.ts
+++ b/test/middleware/accessJwt.test.ts
@@ -272,3 +272,75 @@ describe('accessJwtMiddleware (#29)', () => {
     })
   })
 })
+
+describe('accessJwtMiddleware audience: mcp (#553)', () => {
+  const MCP_AUD = 'aud-tag-mcp'
+  let key: SetupResult
+
+  beforeEach(async () => {
+    _resetJwksCacheForTests()
+    key = await setupKey()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  function buildMcpApp(captured: CapturedActor) {
+    const app = new Hono<{ Bindings: Env; Variables: AccessJwtVariables }>()
+    app.use('/mcp/*', accessJwtMiddleware({ audience: 'mcp' }))
+    app.get('/mcp/x', (c) => {
+      captured.actor = c.get('actor')
+      return c.text('ok')
+    })
+    return app
+  }
+
+  it('CF_ACCESS_MCP_AUD の JWT (service token) を受理する', async () => {
+    stubJwksFetch(key.jwk)
+    const captured: CapturedActor = { actor: undefined }
+    const app = buildMcpApp(captured)
+    const jwt = await signToken(key, { aud: MCP_AUD, commonName: 'webull-mcp-prod' })
+
+    const res = await app.request(
+      '/mcp/x',
+      { headers: { 'Cf-Access-Jwt-Assertion': jwt } },
+      { CF_ACCESS_TEAM_DOMAIN: TEAM_DOMAIN, CF_ACCESS_AUD: AUD, CF_ACCESS_MCP_AUD: MCP_AUD } as Env,
+    )
+
+    expect(res.status).toBe(200)
+    expect(captured.actor).toBe('webull-mcp-prod')
+  })
+
+  it('CF_ACCESS_MCP_AUD 設定時、メイン app の AUD は /mcp では 401 (専用 app に限定)', async () => {
+    stubJwksFetch(key.jwk)
+    const captured: CapturedActor = { actor: undefined }
+    const app = buildMcpApp(captured)
+    const jwt = await signToken(key, { aud: AUD, email: 'alice@example.com' })
+
+    const res = await app.request(
+      '/mcp/x',
+      { headers: { 'Cf-Access-Jwt-Assertion': jwt } },
+      { CF_ACCESS_TEAM_DOMAIN: TEAM_DOMAIN, CF_ACCESS_AUD: AUD, CF_ACCESS_MCP_AUD: MCP_AUD } as Env,
+    )
+
+    expect(res.status).toBe(401)
+  })
+
+  it('CF_ACCESS_MCP_AUD 未設定なら CF_ACCESS_AUD に fallback (メイン app 運用も許容)', async () => {
+    stubJwksFetch(key.jwk)
+    const captured: CapturedActor = { actor: undefined }
+    const app = buildMcpApp(captured)
+    const jwt = await signToken(key, { aud: AUD, commonName: 'webull-mcp-prod' })
+
+    const res = await app.request(
+      '/mcp/x',
+      { headers: { 'Cf-Access-Jwt-Assertion': jwt } },
+      { CF_ACCESS_TEAM_DOMAIN: TEAM_DOMAIN, CF_ACCESS_AUD: AUD } as Env,
+    )
+
+    expect(res.status).toBe(200)
+    expect(captured.actor).toBe('webull-mcp-prod')
+  })
+})


### PR DESCRIPTION
## 概要

#566 の follow-up。/mcp 用に path 限定の Access application (Service Auth policy) を分ける構成にしたが、その app が発行する JWT は **AUD タグがメイン app (`CF_ACCESS_AUD`) と異なる**ため、middleware の audience 検証で 401 になっていた (実機の service token 疎通で発覚: `{"error":"unauthorized"}`)。

## 変更点

- `accessJwtMiddleware({ audience: 'mcp' })` を追加し、/mcp のみ **`CF_ACCESS_MCP_AUD`** (新 env、未設定時は `CF_ACCESS_AUD` に fallback) で検証
- メイン AUD を /mcp に足すのではなく専用 env に分離する理由: service token の JWT を /admin 等の書き込み系ルートで有効にしないため (専用 app 構成の least-privilege を Worker 側でも守る)
- fallback は「メイン app に Service Auth policy を足す運用」も許容するため

## テスト

`pnpm typecheck` / `pnpm test` — **1684 tests green** (新規 3: MCP AUD 受理 / メイン AUD は /mcp で 401 / 未設定時 fallback)。

## merge 後の operator 設定

```
wrangler secret put CF_ACCESS_MCP_AUD   # staging / production それぞれ
```
値は Zero Trust → Access → アプリケーション → /mcp 用 app の概要にある **Application Audience (AUD) タグ**。設定後に curl で tools/list が返れば疎通完了。

関連: #553 / #566

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `/mcp` 向けの認証設定に対応し、専用のアクセス設定を使えるようになりました。
* **Bug Fixes**
  * `/mcp` の認証チェックで、専用設定があれば優先し、未設定時は既存設定へ安全にフォールバックするようになりました。
  * 認証情報の判定がより安定するよう、入力値の扱いを改善しました。
* **Documentation**
  * 開発・本番環境での設定手順を追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->