### PR TITLE
feat: distinguish market-closed cells in decision matrix

### DIFF
--- a/src/routes/dashboard/cron.ts
+++ b/src/routes/dashboard/cron.ts
@@ -6,6 +6,10 @@ import { LOG_COPY_ALL_BTN, clampLimit, currencyOfSymbol, displaySymbol, esc, fmt
 // ECHARTS_CDN のみ利用。charts/shared 側の `import type { DecisionRow }` は
 // type-only なので runtime 循環にはならない。
 import { ECHARTS_CDN } from './charts/shared'
+// マトリクスの休場セル判定 (#matrix-closed)。domain 層の純粋関数を表示時に
+// 評価する — 休場 tick は strategy_decision_log に行が残らない設計 (skip 早期
+// return) のため、記録側でなく表示側で暦から区別する。
+import { type TradingMarket, inferTradingMarket, isTradingDay } from '../../trading/domain/tradingCalendar'
 
 /**
  * Strategy / sizing が出力する英語 reason を **初心者にも分かる日本語** に翻訳
@@ -793,8 +797,59 @@ export interface DecisionMatrixCell {
 export interface DecisionMatrix {
   /** JST 日付 (昇順) */
   dates: string[]
-  /** 銘柄昇順。cells は日付キー (判定が無い日はキーなし) */
-  rows: Array<{ symbol: string; cells: Record<string, DecisionMatrixCell> }>
+  /**
+   * 銘柄昇順。cells は日付キー (判定が無い日はキーなし)。
+   * closedDates はその銘柄の市場が休場 (週末/祝日) の日付 — 「休場だから
+   * 判定なし」と「開場していたのにログなし (cron 停止等)」を区別する
+   * (#matrix-closed、opts 付き buildDecisionMatrix でのみ算出)。
+   */
+  rows: Array<{ symbol: string; cells: Record<string, DecisionMatrixCell>; closedDates?: string[] }>
+}
+
+/**
+ * JST 日付 X に「その市場のセッション由来の判定ログが乗り得ない」= 休場か。
+ *
+ * マトリクスの日付キーは JST だが、US セッション (ET 09:30-16:00) は JST では
+ * 同日 22:30〜翌日 06:00 にまたがる。つまり JST 日 X には ET 日 X の前半と
+ * ET 日 X-1 の後半が乗る → US は X と X-1 の両方が非営業日のときだけ休場。
+ * JP はセッションが JST 日内に収まるので暦日そのまま。
+ * `isTradingDay` は UTC 暦日基準なので T12:00:00Z 固定で ymd を評価する
+ * (DST の影響を受けない)。
+ */
+export function isJstDateClosedForMarket(jstYmd: string, market: TradingMarket): boolean {
+  const noon = new Date(`${jstYmd}T12:00:00Z`)
+  if (market === 'JP') return !isTradingDay(noon, 'JP')
+  const prev = new Date(noon.getTime() - 86_400_000)
+  return !isTradingDay(noon, 'US') && !isTradingDay(prev, 'US')
+}
+
+/** now (実時刻) の JST 暦日 YYYY-MM-DD。 */
+function jstYmdOf(now: Date): string {
+  return new Date(now.getTime() + 9 * 3_600_000).toISOString().slice(0, 10)
+}
+
+/**
+ * マトリクスの列日付 (#matrix-closed): 直近 days 日の全 JST 暦日から、
+ * 「全銘柄が休場でデータも無い」列 (JST 日曜など) を落とした昇順リスト。
+ * ログがある日は休場判定に関わらず必ず残す (臨時セッションや過去データの保全)。
+ */
+export function buildMatrixDates(
+  dataDates: ReadonlySet<string>,
+  markets: readonly TradingMarket[],
+  days: number,
+  now: Date,
+): string[] {
+  const out = new Set<string>()
+  const todayNoonUtc = new Date(`${jstYmdOf(now)}T12:00:00Z`).getTime()
+  for (let i = days - 1; i >= 0; i--) {
+    const ymd = new Date(todayNoonUtc - i * 86_400_000).toISOString().slice(0, 10)
+    const anyOpen = markets.some((m) => !isJstDateClosedForMarket(ymd, m))
+    if (dataDates.has(ymd) || anyOpen) out.add(ymd)
+  }
+  // 範囲外のログ日も必ず残す (loadDecisionMatrix 側の窓とずれても列が消えて
+  // データが見えなくなる事故を防ぐ)。
+  for (const d of dataDates) out.add(d)
+  return [...out].sort()
 }
 
 /**
@@ -802,8 +857,16 @@ export interface DecisionMatrix {
  * 代表判定は MATRIX_DECISION_PRIORITY 順。想定外 decision (将来追加など) は
  * ERROR 相当の優先度で扱い、表示から漏れないようにする (quality.ts の
  * aggregateDecisionRows と同思想)。
+ *
+ * opts 指定時 (#matrix-closed): 列を「ログがあった日」でなく直近 days 日の
+ * 全 JST 暦日 (全休列は除去) に広げ、各行に closedDates (休場でログが乗り得ない
+ * 日付) を付ける。opts 省略時は従来どおりログのあった日だけを列にする
+ * (後方互換、now を持たない呼び出し向け)。
  */
-export function buildDecisionMatrix(rows: DecisionMatrixSourceRow[]): DecisionMatrix {
+export function buildDecisionMatrix(
+  rows: DecisionMatrixSourceRow[],
+  opts?: { days: number; now: Date },
+): DecisionMatrix {
   const dateSet = new Set<string>()
   const bySymbol = new Map<string, Map<string, DecisionMatrixSourceRow[]>>()
   for (const r of rows) {
@@ -821,7 +884,17 @@ export function buildDecisionMatrix(rows: DecisionMatrixSourceRow[]): DecisionMa
     const i = (MATRIX_DECISION_PRIORITY as readonly string[]).indexOf(decision)
     return i === -1 ? MATRIX_DECISION_PRIORITY.indexOf('ERROR') : i
   }
-  const outRows = [...bySymbol.keys()].sort().map((symbol) => {
+  const symbols = [...bySymbol.keys()].sort()
+  // 列: opts 付きは全 JST 暦日 (全休列は除去)、無しは従来のログがあった日のみ。
+  const dates = opts
+    ? buildMatrixDates(
+        dateSet,
+        [...new Set(symbols.map((s) => inferTradingMarket(s)))],
+        opts.days,
+        opts.now,
+      )
+    : [...dateSet].sort()
+  const outRows = symbols.map((symbol) => {
     const cells: Record<string, DecisionMatrixCell> = {}
     for (const [day, group] of bySymbol.get(symbol)!) {
       let best = group[0]!
@@ -839,9 +912,12 @@ export function buildDecisionMatrix(rows: DecisionMatrixSourceRow[]): DecisionMa
       }
       cells[day] = { decision: best.decision, reason: rep.reason, count, total }
     }
-    return { symbol, cells }
+    if (!opts) return { symbol, cells }
+    const market = inferTradingMarket(symbol)
+    const closedDates = dates.filter((d) => !cells[d] && isJstDateClosedForMarket(d, market))
+    return { symbol, cells, closedDates }
   })
-  return { dates: [...dateSet].sort(), rows: outRows }
+  return { dates, rows: outRows }
 }
 
 /**
@@ -996,6 +1072,7 @@ export function decisionMatrixBody(
   .mx-pill.mx-warn{background:#b25000}
   .mx-pill.mx-err{background:#c22}
   .mx-pill.mx-muted{background:#e8e8ed;color:#86868b}
+  .mx-closed{display:inline-block;min-width:20px;padding:1px 5px;border-radius:9px;font-size:11px;background:#f3f3f5;color:#b6b6bd}
   .mx-legend{margin-top:8px;font-size:11px;color:#86868b;display:flex;flex-wrap:wrap;gap:10px}
   </style>`
   const headCells = matrix.dates
@@ -1006,10 +1083,15 @@ export function decisionMatrixBody(
       const inactive = isSymbolInactive(row.symbol, universe)
       const titleAttr = inactive ? ` title="${esc(inactiveTooltip(row.symbol, universe))}"` : ''
       const symCell = `<td class="mx-sym"><a href="/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(row.symbol)}"${titleAttr}><strong${inactive ? ' class="symbol-disabled"' : ''}>${esc(displaySymbol(row.symbol, universe))}</strong></a></td>`
+      const closed = new Set(row.closedDates ?? [])
       const cells = matrix.dates
         .map((d) => {
           const cell = row.cells[d]
-          if (!cell) return '<td><span class="muted">·</span></td>'
+          if (!cell && closed.has(d)) {
+            // 休場 (週末/祝日) — 「判定なし」と区別する (#matrix-closed)
+            return `<td><span class="mx-closed" title="${esc(d)} 休場 (週末/祝日)">休</span></td>`
+          }
+          if (!cell) return '<td><span class="muted" title="開場日だが判定ログなし (cron 停止・銘柄追加前など)">·</span></td>'
           const label = MATRIX_DECISION_LABELS[cell.decision] ?? { short: '?', ja: cell.decision, cls: 'mx-err' }
           const title = `${d} ${cell.decision} (${label.ja}、${cell.count}/${cell.total}件): ${localizeReason(cell.reason)}`
           return `<td><a class="mx-pill ${label.cls}" href="/dashboard/cron?symbol=${encodeURIComponent(row.symbol)}" title="${esc(title)}">${esc(label.short)}</a></td>`
@@ -1020,7 +1102,7 @@ export function decisionMatrixBody(
     .join('')
   const legend = `<div class="mx-legend">${Object.entries(MATRIX_DECISION_LABELS)
     .map(([key, v]) => `<span><span class="mx-pill ${v.cls}">${esc(v.short)}</span> ${esc(key)} (${esc(v.ja)})</span>`)
-    .join('')}<span>· = 判定なし</span></div>`
+    .join('')}<span><span class="mx-closed">休</span> 休場 (週末/祝日)</span><span>· = 開場だが判定ログなし (cron 停止・銘柄追加前など)</span></div>`
   return `${pills}${header}
   <div class="mx-wrap">
     <table class="mx-table">

--- a/src/routes/dashboard/index.ts
+++ b/src/routes/dashboard/index.ts
@@ -623,7 +623,7 @@ export const dashboard = new Hono<DashboardBindings>()
     try {
       const days = 30
       const rows = await loadDecisionMatrix(c.env.DB, days)
-      const matrix = buildDecisionMatrix(rows)
+      const matrix = buildDecisionMatrix(rows, { days, now: new Date() })
       return jsonPretty({
         schema: 'dashboard_cron_matrix_export.v1',
         exportedAt: new Date().toISOString(),
@@ -660,7 +660,7 @@ export const dashboard = new Hono<DashboardBindings>()
             c,
             '戦略判定',
             decisionMatrixBody(
-              buildDecisionMatrix(matrixRows),
+              buildDecisionMatrix(matrixRows, { days, now: new Date() }),
               aggregateReasonTrend(matrixRows),
               universe,
               { days, limit, symbolFilter },

--- a/test/routes/dashboardDecisionMatrix.test.ts
+++ b/test/routes/dashboardDecisionMatrix.test.ts
@@ -5,7 +5,9 @@ import {
   REASON_CATEGORIES,
   aggregateReasonTrend,
   buildDecisionMatrix,
+  buildMatrixDates,
   categorizeReason,
+  isJstDateClosedForMarket,
   type DecisionMatrixSourceRow,
 } from '../../src/routes/dashboard/cron'
 
@@ -277,9 +279,16 @@ describe('GET /dashboard/cron/matrix/json', () => {
     expect(json.days).toBe(30)
     expect(json.rowCount).toBe(1)
     expect(typeof json.exportedAt).toBe('string')
-    const matrix = json.matrix as { dates: string[]; rows: Array<{ symbol: string }> }
-    expect(matrix.dates).toEqual(['2026-07-01'])
+    const matrix = json.matrix as {
+      dates: string[]
+      rows: Array<{ symbol: string; closedDates?: string[] }>
+    }
+    // #matrix-closed: 列はログ日だけでなく直近 30 日の開場暦日ベースになった
+    expect(matrix.dates).toContain('2026-07-01')
+    expect(matrix.dates.length).toBeGreaterThan(1)
     expect(matrix.rows[0]!.symbol).toBe('SOXL')
+    // 休場日は closedDates として additive に載る (schema は v1 のまま)
+    expect(Array.isArray(matrix.rows[0]!.closedDates)).toBe(true)
   })
 
   it('DB 未 bind は 503 の error envelope', async () => {
@@ -288,5 +297,67 @@ describe('GET /dashboard/cron/matrix/json', () => {
     expect(res.status).toBe(503)
     const json = (await res.json()) as Record<string, unknown>
     expect(json.error).toBe('db_not_bound')
+  })
+})
+
+describe('休場セルの区別 (#matrix-closed, pure)', () => {
+  it('isJstDateClosedForMarket: JP は暦日そのまま (元日/土曜=休、平日=開)', () => {
+    expect(isJstDateClosedForMarket('2026-01-01', 'JP')).toBe(true) // 元日 (木)
+    expect(isJstDateClosedForMarket('2026-07-03', 'JP')).toBe(false) // 金曜
+    expect(isJstDateClosedForMarket('2026-07-04', 'JP')).toBe(true) // 土曜
+  })
+
+  it('isJstDateClosedForMarket: US は JST 日 X と X-1 の両方が非営業日のときだけ休', () => {
+    // JST 土曜の早朝には ET 金曜セッションの後半が乗る → 開扱い
+    expect(isJstDateClosedForMarket('2026-06-27', 'US')).toBe(false) // 土 (前日 金 6/26 が営業日)
+    expect(isJstDateClosedForMarket('2026-06-28', 'US')).toBe(true) // 日 (土日とも非営業)
+    // 2026-07-03 (金) は独立記念日 7/4 (土) の振替休場 → JST 7/3 は前日 7/2(木) 営業で開、
+    // JST 7/4 (土) は 7/3 振替休場 + 7/4 土曜でどちらも非営業 → 休
+    expect(isJstDateClosedForMarket('2026-07-03', 'US')).toBe(false)
+    expect(isJstDateClosedForMarket('2026-07-04', 'US')).toBe(true)
+    expect(isJstDateClosedForMarket('2026-07-05', 'US')).toBe(true) // 日 (前日 土)
+  })
+
+  it('buildMatrixDates: 全休列 (JST 日曜) は落ち、ログのある日と開場日は残る', () => {
+    const now = new Date('2026-07-01T00:00:00Z') // JST 7/1 09:00
+    const dates = buildMatrixDates(new Set(['2026-06-28']), ['US', 'JP'], 7, now)
+    // 範囲: 6/25(木)〜7/1(水)。6/28(日) は全休だがログがあるので残る
+    expect(dates).toContain('2026-06-28')
+    // 6/27(土) は JP 休だが US が開扱い (ET 金曜後半) なので残る
+    expect(dates).toContain('2026-06-27')
+    expect(dates).toContain('2026-06-25')
+    expect(dates).toContain('2026-07-01')
+    expect(dates).toEqual([...dates].sort())
+  })
+
+  it('buildMatrixDates: US 銘柄が無ければ JST 土日列は落ちる', () => {
+    const now = new Date('2026-07-01T00:00:00Z')
+    const dates = buildMatrixDates(new Set<string>(), ['JP'], 7, now)
+    expect(dates).not.toContain('2026-06-27') // 土
+    expect(dates).not.toContain('2026-06-28') // 日
+    expect(dates).toContain('2026-06-26') // 金
+  })
+
+  it('buildDecisionMatrix (opts 付き): 列が全暦日ベースになり closedDates が付く', () => {
+    const rows = [
+      srcRow({ day: '2026-06-26', symbol: 'SOXL', decision: 'HOLD' }),
+      srcRow({ day: '2026-06-26', symbol: '1357', decision: 'HOLD' }),
+    ]
+    const matrix = buildDecisionMatrix(rows, { days: 7, now: new Date('2026-07-01T00:00:00Z') })
+    // ログの無い平日 (6/29 月) も列に入る
+    expect(matrix.dates).toContain('2026-06-29')
+    const jp = matrix.rows.find((r) => r.symbol === '1357')!
+    const us = matrix.rows.find((r) => r.symbol === 'SOXL')!
+    // JST 土曜 6/27: JP は休、US は開 (ログ無し = 判定なし側)
+    expect(jp.closedDates).toContain('2026-06-27')
+    expect(us.closedDates).not.toContain('2026-06-27')
+    // ログがある日は closedDates に入らない
+    expect(jp.closedDates).not.toContain('2026-06-26')
+  })
+
+  it('buildDecisionMatrix (opts なし): 従来どおりログのあった日のみ (後方互換)', () => {
+    const matrix = buildDecisionMatrix([srcRow({ day: '2026-06-26' })])
+    expect(matrix.dates).toEqual(['2026-06-26'])
+    expect(matrix.rows[0]!.closedDates).toBeUndefined()
   })
 })


### PR DESCRIPTION
## 概要

「休場による判定変わらずと、開場中の判定変わらずを分けられるか?」への対応。判定マトリクス (`/dashboard/cron?view=matrix`) のセルを 3 状態に分ける:

| 表示 | 意味 |
|---|---|
| 判定 pill (BUY/SELL/HOLD/…) | 開場中に評価された (従来どおり) |
| **休** (新規・グレー) | その銘柄の市場が休場 (週末/祝日) |
| **·** | 開場していたはずなのに判定ログなし — cron 停止・deploy 空白・銘柄追加前の手がかり |

## 設計

- **記録は変えない**: 休場 tick は `strategy_decision_log` に行が残らない設計 (skip 早期 return) のまま、表示時に domain 層のカレンダー純粋関数 (`isTradingDay` / `inferTradingMarket`、PR #548) で判定。休場ごとに SKIP 行を書く案はログ爆発のため不採用
- **タイムゾーンの核心**: マトリクスの日付キーは JST だが、US セッション (ET) は JST 2 日にまたがる。`isJstDateClosedForMarket` は US について「JST 日 X と X-1 の両方が ET 非営業日」のときだけ休 (JST 土曜の早朝には金曜セッション後半が乗るため、JST 土曜は US 銘柄では開扱い)
- **列の拡張**: 「ログがあった日」だけ → 直近 30 日の全 JST 暦日。ただし全銘柄が休のみの列 (JST 日曜など) は除去、ログのある日は範囲外でも必ず残す
- **JSON**: `dashboard_cron_matrix_export.v1` に row ごとの `closedDates` を additive 追加 (schema version は据え置き)

## テスト

`pnpm typecheck` / `pnpm test` — **1690 tests green** (新規 6: JP/US の休場判定・振替休日 7/3・JST 土曜の US 開扱い・列生成・closedDates・opts なし後方互換)。既存アサーション更新は matrix/json の dates 期待値 1 箇所のみ (列拡張に伴う正当な更新)。

## 確認方法 (staging 反映後)

`/dashboard/cron?view=matrix` で 7/3 (US 振替休場) の列は US 銘柄が「休」・JP 銘柄が pill、7/4 (土) は JP が「休」で US は判定 pill (金曜セッション後半)、JST 日曜列は消えていること。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ダッシュボードのマトリクス表示で、休場日を「休」として明確に区別して表示するようになりました。
  * 凡例が更新され、休場日と判定ログなしのセルの違いが分かりやすくなりました。
* **改善**
  * 判定ログが載らない日でも、開場日と休場日を見分けやすくなり、一覧の見通しが向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->