### PR TITLE
feat: hide off-session decision rows by default on cron page

### DIFF
--- a/src/routes/dashboard/cron.ts
+++ b/src/routes/dashboard/cron.ts
@@ -9,7 +9,7 @@ import { ECHARTS_CDN } from './charts/shared'
 // マトリクスの休場セル判定 (#matrix-closed)。domain 層の純粋関数を表示時に
 // 評価する — 休場 tick は strategy_decision_log に行が残らない設計 (skip 早期
 // return) のため、記録側でなく表示側で暦から区別する。
-import { type TradingMarket, inferTradingMarket, isTradingDay } from '../../trading/domain/tradingCalendar'
+import { type TradingMarket, inferTradingMarket, isTradingDay, isWithinStrategyWindow } from '../../trading/domain/tradingCalendar'
 
 /**
  * Strategy / sizing が出力する英語 reason を **初心者にも分かる日本語** に翻訳
@@ -276,13 +276,23 @@ export function cronBody(
   before?: number,
   hasMore = false,
   clientOrderIdFilter?: string,
+  sessionFilter: 'open' | 'all' = 'open',
+  /**
+   * ページ送りカーソル用の「フィルタ前の末尾 id」。session フィルタで rows が
+   * 間引かれてもカーソルはフェッチした範囲の末尾で進める (全行が休場時間帯で
+   * 非表示のページでも次ページへ辿れる)。
+   */
+  pageLastId?: number,
 ): string {
   const copyAllBtn = rows.length > 0 ? LOG_COPY_ALL_BTN : ''
+  // session=all のみ URL に載せる (open が既定)。pill 切替・ページネーションの
+  // 双方に伝搬させ、ページ送りでフィルタが外れないようにする。
+  const sessionQs = sessionFilter === 'all' ? '&session=all' : ''
   const baseHref = clientOrderIdFilter
-    ? `/dashboard/cron?clientOrderId=${encodeURIComponent(clientOrderIdFilter)}&limit=${limit}`
+    ? `/dashboard/cron?clientOrderId=${encodeURIComponent(clientOrderIdFilter)}&limit=${limit}${sessionQs}`
     : symbolFilter
-      ? `/dashboard/cron?symbol=${encodeURIComponent(symbolFilter)}&limit=${limit}`
-      : `/dashboard/cron?limit=${limit}`
+      ? `/dashboard/cron?symbol=${encodeURIComponent(symbolFilter)}&limit=${limit}${sessionQs}`
+      : `/dashboard/cron?limit=${limit}${sessionQs}`
   const header = clientOrderIdFilter
     ? `<p class="filter-banner">注文 <code>${esc(clientOrderIdFilter)}</code> の判定のみ表示。<a href="/dashboard/trades?clientOrderId=${encodeURIComponent(clientOrderIdFilter)}">約定を見る</a> / <a href="/dashboard/cron">全件へ戻る</a> ${copyAllBtn}</p>`
     : symbolFilter
@@ -291,14 +301,24 @@ export function cronBody(
   const pagination = renderPaginationNav({
     baseHref,
     before,
-    lastId: rows.length > 0 ? rows[rows.length - 1]!.id : undefined,
+    lastId: pageLastId ?? (rows.length > 0 ? rows[rows.length - 1]!.id : undefined),
     hasMore,
   })
   const rail = renderCronSymbolRail(universe, symbolFilter, limit)
-  const viewPills = renderCronViewPills('list', limit, symbolFilter)
+  // 開場中のみ / 全時間帯 の切替 (#cron-session-filter)。休場時間帯の行
+  // (手動 run 等) は既定で隠す。
+  const stripSession = baseHref.replace('&session=all', '')
+  const sessionPills = `<span class="muted" style="font-size:12px;margin-left:8px">時間帯:</span>
+    <a href="${stripSession}" class="chip${sessionFilter === 'open' ? ' active' : ''}">開場中のみ</a>
+    <a href="${stripSession}&session=all" class="chip${sessionFilter === 'all' ? ' active' : ''}" title="休場時間帯に書かれた行 (手動 run 等) も表示する">全時間帯</a>`
+  const viewPills = renderCronViewPills('list', limit, symbolFilter).replace('</nav>', `${sessionPills}</nav>`)
   const main =
     rows.length === 0
-      ? `${viewPills}${header}<p class="muted">判定ログがまだありません。</p>${pagination}`
+      ? `${viewPills}${header}<p class="muted">${
+          sessionFilter === 'open' && pageLastId !== undefined
+            ? 'このページの判定はすべて休場時間帯 (手動 run 等) のため非表示です。'
+            : '判定ログがまだありません。'
+        }</p>${pagination}`
       : `${viewPills}${header}
   ${renderDecisionTable(rows, universe, {
     copyVarName: '__cronCopy',
@@ -821,6 +841,19 @@ export function isJstDateClosedForMarket(jstYmd: string, market: TradingMarket):
   if (market === 'JP') return !isTradingDay(noon, 'JP')
   const prev = new Date(noon.getTime() - 86_400_000)
   return !isTradingDay(noon, 'US') && !isTradingDay(prev, 'US')
+}
+
+/**
+ * 判定行がその銘柄の市場の**開場時間中**に書かれたものか (#cron-session-filter)。
+ * 通常の cron はセッション外で行を書かない (skip 早期 return) が、手動 run
+ * (/admin/strategy/run) や過去仕様の行が休場時間帯に残ることがあり、一覧では
+ * 既定で隠す (operator は開場中の判定だけ読みたい)。不正 timestamp は
+ * 隠さない側に倒す (フィルタで情報が消える事故の防止)。
+ */
+export function isDecisionRowInSession(timestampIso: string, symbol: string): boolean {
+  const ts = new Date(timestampIso)
+  if (!Number.isFinite(ts.getTime())) return true
+  return isWithinStrategyWindow(ts, inferTradingMarket(symbol), 0)
 }
 
 /** now (実時刻) の JST 暦日 YYYY-MM-DD。 */

--- a/src/routes/dashboard/index.ts
+++ b/src/routes/dashboard/index.ts
@@ -63,7 +63,7 @@ import { buildPositionsPacket, loadLatestStrategyPrices, loadPositionsPageData, 
 import { parseEquityRange, portfolioBody, safeLoadPortfolioSnapshots } from './portfolio'
 import { buildTradesPacket, loadTradeJournalRows, parseTradesQuery, tradesBody } from './trades'
 import { configBody } from './config'
-import { aggregateReasonTrend, buildDecisionMatrix, cronBody, decisionMatrixBody, loadDecisionMatrix, loadDecisionRows, runCronJsonExport } from './cron'
+import { aggregateReasonTrend, buildDecisionMatrix, cronBody, decisionMatrixBody, isDecisionRowInSession, loadDecisionMatrix, loadDecisionRows, runCronJsonExport } from './cron'
 import { alertsBody, clampAlertLimit, parseAlertsQuery, parseEventTypeFilter, parseSeverityFilter } from './alerts'
 import { auditBody, clampAuditLimit, parseAuditDateFilter, trimQuery } from './audit'
 import { type StrategyParamsSnapshot, computeZoomRange, parseChartsTab, parseIsoTimestamp, strategyParamsFromGlobal } from './charts/shared'
@@ -672,6 +672,10 @@ export const dashboard = new Hono<DashboardBindings>()
         return c.html(renderLayout(c, '戦略判定', unavailable(messageOf(err)), cronSubnav))
       }
     }
+    // 休場時間帯の行 (手動 run 等) は既定で隠す (#cron-session-filter)。
+    // `?session=all` で全時間帯表示。SQL では時刻×市場×祝日の判定が書けない
+    // (DST もある) ので、ページ分の行を取ってから表示側で間引く。
+    const sessionFilter = c.req.query('session') === 'all' ? ('all' as const) : ('open' as const)
     const db = createDb(c.env.DB)
     try {
       const [rows, universe] = await Promise.all([
@@ -685,11 +689,25 @@ export const dashboard = new Hono<DashboardBindings>()
       ])
       const hasMore = rows.length > limit
       if (hasMore) rows.pop()
+      const visibleRows =
+        sessionFilter === 'open'
+          ? rows.filter((r) => isDecisionRowInSession(r.timestamp, r.symbol))
+          : rows
       return c.html(
         renderLayout(
           c,
           '戦略判定',
-          cronBody(rows, limit, symbolFilter, universe, before, hasMore, clientOrderIdFilter),
+          cronBody(
+            visibleRows,
+            limit,
+            symbolFilter,
+            universe,
+            before,
+            hasMore,
+            clientOrderIdFilter,
+            sessionFilter,
+            rows.length > 0 ? rows[rows.length - 1]!.id : undefined,
+          ),
           cronSubnav,
         ),
       )

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -494,7 +494,7 @@ describe('dashboard', () => {
       fakeCronDb([
         {
           id: 200,
-          timestamp: '2026-06-06T00:00:00.000Z',
+          timestamp: '2026-06-05T14:30:00.000Z', // ET 10:30 (場中) — session フィルタ既定 open を通す
           requestId: 'req-tr',
           symbol: 'TQQQ',
           decision: 'SKIP',
@@ -540,7 +540,7 @@ describe('dashboard', () => {
       fakeCronDb([
         {
           id: 201,
-          timestamp: '2026-06-06T00:00:00.000Z',
+          timestamp: '2026-06-05T14:30:00.000Z', // ET 10:30 (場中) — session フィルタ既定 open を通す
           requestId: 'req-old',
           symbol: 'TQQQ',
           decision: 'HOLD',

--- a/test/routes/dashboardTradesAlertsUi.test.ts
+++ b/test/routes/dashboardTradesAlertsUi.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp } from '../../src/app'
+import { isDecisionRowInSession } from '../../src/routes/dashboard/cron'
 import { loadRecentAlerts } from '../../src/infrastructure/notification/notificationEmitLog'
 import { createDb } from '../../src/infrastructure/db/tradeJournalRepo'
 
@@ -365,5 +366,75 @@ describe('/dashboard/cron 銘柄レール (#decisions-chart-unify)', () => {
     expect(body).toContain('href="/dashboard/cron?symbol=SOXS')
     // inactive 銘柄もレールに出る (grayed)
     expect(body).toContain('href="/dashboard/cron?symbol=SPY')
+  })
+})
+
+describe('/dashboard/cron セッションフィルタ (#cron-session-filter)', () => {
+  function cronDb(rows: unknown[]) {
+    return {
+      select() {
+        return {
+          from() {
+            const chain = {
+              leftJoin: () => chain,
+              where: () => chain,
+              orderBy: () => chain,
+              limit: async () => rows,
+            }
+            return chain
+          },
+        }
+      },
+    } as never
+  }
+  const inSession = {
+    id: 1,
+    timestamp: '2026-06-05T14:30:00.000Z', // ET 10:30 金曜 = US 場中
+    requestId: 'run-1',
+    symbol: 'SOXL',
+    decision: 'HOLD',
+    reason: 'holding: pnl 0.01 within (-0.05, 0.08)',
+    price: 30.5,
+    indicatorsJson: null,
+    clientOrderId: null,
+    traceJson: null,
+    filledPrice: null,
+    filledQty: null,
+    realizedPnl: null,
+    brokerStatus: null,
+  }
+  const outOfSession = {
+    ...inSession,
+    id: 2,
+    timestamp: '2026-06-06T00:00:00.000Z', // ET 金曜 20:00 = 閉場後 (手動 run 相当)
+    reason: 'manual run after close',
+  }
+
+  it('既定 (開場中のみ) は休場時間帯の行を隠し、切替 pill を出す', async () => {
+    vi.mocked(createDb).mockReturnValue(cronDb([inSession, outOfSession]))
+    const app = createApp()
+    const res = await app.request('/dashboard/cron', { headers: {} }, { ...baseEnv, DB: {} as D1Database })
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    expect(body).toContain('data-id="1"')
+    expect(body).not.toContain('data-id="2"')
+    expect(body).toContain('開場中のみ')
+    expect(body).toContain('session=all')
+  })
+
+  it('?session=all は全時間帯の行を表示する', async () => {
+    vi.mocked(createDb).mockReturnValue(cronDb([inSession, outOfSession]))
+    const app = createApp()
+    const res = await app.request('/dashboard/cron?session=all', { headers: {} }, { ...baseEnv, DB: {} as D1Database })
+    const body = await res.text()
+    expect(body).toContain('data-id="1"')
+    expect(body).toContain('data-id="2"')
+  })
+
+  it('isDecisionRowInSession: JP は JST 場中のみ true、不正 timestamp は true (隠さない)', () => {
+    expect(isDecisionRowInSession('2026-06-05T01:00:00.000Z', '1357')).toBe(true) // JST 10:00 金曜
+    expect(isDecisionRowInSession('2026-06-05T11:00:00.000Z', '1357')).toBe(false) // JST 20:00
+    expect(isDecisionRowInSession('2026-06-05T11:00:00.000Z', 'SOXL')).toBe(false) // ET 07:00 寄り前
+    expect(isDecisionRowInSession('not-a-date', 'SOXL')).toBe(true)
   })
 })


### PR DESCRIPTION
## 概要

「戦略判定もフィルタできると嬉しい。休場時なんて基本ログほしくない」への対応。戦略判定一覧に**時間帯フィルタ**を追加し、休場時間帯に書かれた行 (手動 `/admin/strategy/run`・旧仕様データ等。通常の cron はセッション外に行を書かない) を**既定で非表示**にする。

> **base は #570 (dev/matrix-market-closed)。#570 merge 後に base が自動で切り替わります。**

## 変更点

- 一覧上部の pill に「時間帯: **開場中のみ** (既定) / 全時間帯」を追加。`?session=all` で切替、ページネーション・絞り込みと共存
- 判定は表示側で `isWithinStrategyWindow` (domain 取引カレンダー、祝日・半日取引対応) を銘柄の市場 (`inferTradingMarket`) に対して評価。SQL では時刻×市場×祝日 (+DST) の判定が書けないため表示側で間引く
- **ページ送りの安全策**: カーソルはフィルタ前の末尾 id で進めるため、ページ内が全行非表示でも次ページへ辿れる (専用メッセージ表示)
- 不正 timestamp の行は隠さない (フィルタで情報が消える事故の防止、fail-open は表示のみ)

## テスト

`pnpm typecheck` / `pnpm test` — **1693 tests green** (新規 3: 既定で隠す + pill / session=all で表示 / pure 関数の JP・US・不正 timestamp)。既存 fixture 2 箇所の timestamp を場中時刻へ更新 (場外時刻はこの機能で正しく隠されるようになったため)。

関連: #570 (マトリクス休場セル) の後続 — 休場 UX の対