### PR TITLE
fix: align session-filter pagination with visible rows on cron page

### DIFF
--- a/src/routes/dashboard/cron.ts
+++ b/src/routes/dashboard/cron.ts
@@ -856,6 +856,60 @@ export function isDecisionRowInSession(timestampIso: string, symbol: string): bo
   return isWithinStrategyWindow(ts, inferTradingMarket(symbol), 0)
 }
 
+/** loadDecisionRowsInSession の 1 バッチのフェッチ幅 (URL limit 上限と同じ)。 */
+const SESSION_FILTER_BATCH_SIZE = 200
+
+/** カーソルを進めながら走査する最大バッチ数 (D1 保護、200 × 5 = 1,000 行)。 */
+const SESSION_FILTER_MAX_BATCHES = 5
+
+/**
+ * 開場中の判定行を limit 件そろえるページローダー (#cron-session-filter)。
+ *
+ * 「limit+1 件フェッチして表示側で間引く」だけだとページの表示件数が不定に
+ * なり、次ページカーソルもフェッチ窓基準で表示と一致しない。ここでは表示行が
+ * limit+1 件 (hasMore 判定込み) そろうまでカーソルを進めながら追加フェッチし、
+ * 次ページの before は「最後に表示した行の id」で切れ目なく続くようにする。
+ *
+ * 走査は最大 SESSION_FILTER_MAX_BATCHES バッチで打ち切る (休場行が延々続く
+ * 病的データで D1 を舐め尽くさないため)。打ち切り時は hasMore=true とし、
+ * lastScannedId (表示 0 件時のカーソル代替) で次ページへ進めるようにする。
+ */
+export async function loadDecisionRowsInSession(
+  db: ReturnType<typeof createDb>,
+  opts: { symbol?: string; clientOrderId?: string; limit: number; before?: number },
+): Promise<{ rows: DecisionRow[]; hasMore: boolean; lastScannedId?: number }> {
+  const target = opts.limit + 1
+  const visible: DecisionRow[] = []
+  let before = opts.before
+  let lastScannedId: number | undefined
+  let truncated = false
+  for (let i = 0; i < SESSION_FILTER_MAX_BATCHES; i++) {
+    const batch = await loadDecisionRows(db, {
+      symbol: opts.symbol,
+      clientOrderId: opts.clientOrderId,
+      limit: SESSION_FILTER_BATCH_SIZE,
+      before,
+    })
+    for (const r of batch) {
+      lastScannedId = r.id
+      if (isDecisionRowInSession(r.timestamp, r.symbol)) visible.push(r)
+      if (visible.length >= target) break
+    }
+    if (visible.length >= target) break
+    if (batch.length < SESSION_FILTER_BATCH_SIZE) break // データ末尾に到達
+    const minId = batch[batch.length - 1]!.id
+    // カーソルが前進しない場合は打ち切る (テスト用 fake db や重複 id の保護)
+    if (before !== undefined && minId >= before) break
+    before = minId
+    if (i === SESSION_FILTER_MAX_BATCHES - 1) truncated = true
+  }
+  return {
+    rows: visible.slice(0, opts.limit),
+    hasMore: visible.length > opts.limit || truncated,
+    lastScannedId,
+  }
+}
+
 /** now (実時刻) の JST 暦日 YYYY-MM-DD。 */
 function jstYmdOf(now: Date): string {
   return new Date(now.getTime() + 9 * 3_600_000).toISOString().slice(0, 10)

--- a/src/routes/dashboard/index.ts
+++ b/src/routes/dashboard/index.ts
@@ -704,9 +704,13 @@ export const dashboard = new Hono<DashboardBindings>()
             page.hasMore,
             clientOrderIdFilter,
             sessionFilter,
-            // 次ページカーソル: 表示した最後の行を優先 (表示と切れ目なく続く)。
-            // 表示 0 件 (走査打ち切り) 時のみ走査末尾で前進させる。
-            page.rows.length > 0 ? page.rows[page.rows.length - 1]!.id : page.lastScannedId,
+            // 次ページカーソル: ページが limit 件で埋まったときは表示末尾
+            // (表示と切れ目なく続く)。埋まらなかったとき (走査打ち切り / データ
+            // 末尾) は走査末尾 — 走査済み窓内の開場行は全て表示済みなので、
+            // 表示末尾から再走査すると同じ休場行を舐め直して空ページを挟むだけ。
+            page.rows.length >= limit
+              ? page.rows[page.rows.length - 1]!.id
+              : page.lastScannedId,
           ),
           cronSubnav,
         ),

--- a/src/routes/dashboard/index.ts
+++ b/src/routes/dashboard/index.ts
@@ -63,7 +63,7 @@ import { buildPositionsPacket, loadLatestStrategyPrices, loadPositionsPageData, 
 import { parseEquityRange, portfolioBody, safeLoadPortfolioSnapshots } from './portfolio'
 import { buildTradesPacket, loadTradeJournalRows, parseTradesQuery, tradesBody } from './trades'
 import { configBody } from './config'
-import { aggregateReasonTrend, buildDecisionMatrix, cronBody, decisionMatrixBody, isDecisionRowInSession, loadDecisionMatrix, loadDecisionRows, runCronJsonExport } from './cron'
+import { aggregateReasonTrend, buildDecisionMatrix, cronBody, decisionMatrixBody, loadDecisionMatrix, loadDecisionRows, loadDecisionRowsInSession, runCronJsonExport } from './cron'
 import { alertsBody, clampAlertLimit, parseAlertsQuery, parseEventTypeFilter, parseSeverityFilter } from './alerts'
 import { auditBody, clampAuditLimit, parseAuditDateFilter, trimQuery } from './audit'
 import { type StrategyParamsSnapshot, computeZoomRange, parseChartsTab, parseIsoTimestamp, strategyParamsFromGlobal } from './charts/shared'
@@ -674,39 +674,39 @@ export const dashboard = new Hono<DashboardBindings>()
     }
     // 休場時間帯の行 (手動 run 等) は既定で隠す (#cron-session-filter)。
     // `?session=all` で全時間帯表示。SQL では時刻×市場×祝日の判定が書けない
-    // (DST もある) ので、ページ分の行を取ってから表示側で間引く。
+    // (DST もある) ので、開場行が limit 件そろうまでカーソルを進めながら
+    // フェッチする (loadDecisionRowsInSession) — ページの表示件数と次ページ
+    // カーソルを表示行に一致させる。
     const sessionFilter = c.req.query('session') === 'all' ? ('all' as const) : ('open' as const)
     const db = createDb(c.env.DB)
     try {
-      const [rows, universe] = await Promise.all([
-        loadDecisionRows(db, {
-          symbol: symbolFilter,
-          clientOrderId: clientOrderIdFilter,
-          limit: limit + 1,
-          before,
-        }),
+      const queryOpts = { symbol: symbolFilter, clientOrderId: clientOrderIdFilter, before }
+      const [page, universe] = await Promise.all([
+        sessionFilter === 'open'
+          ? loadDecisionRowsInSession(db, { ...queryOpts, limit })
+          : loadDecisionRows(db, { ...queryOpts, limit: limit + 1 }).then((rows) => {
+              const hasMore = rows.length > limit
+              if (hasMore) rows.pop()
+              return { rows, hasMore, lastScannedId: rows[rows.length - 1]?.id }
+            }),
         loadSymbolUniverse(c.env).catch(() => null),
       ])
-      const hasMore = rows.length > limit
-      if (hasMore) rows.pop()
-      const visibleRows =
-        sessionFilter === 'open'
-          ? rows.filter((r) => isDecisionRowInSession(r.timestamp, r.symbol))
-          : rows
       return c.html(
         renderLayout(
           c,
           '戦略判定',
           cronBody(
-            visibleRows,
+            page.rows,
             limit,
             symbolFilter,
             universe,
             before,
-            hasMore,
+            page.hasMore,
             clientOrderIdFilter,
             sessionFilter,
-            rows.length > 0 ? rows[rows.length - 1]!.id : undefined,
+            // 次ページカーソル: 表示した最後の行を優先 (表示と切れ目なく続く)。
+            // 表示 0 件 (走査打ち切り) 時のみ走査末尾で前進させる。
+            page.rows.length > 0 ? page.rows[page.rows.length - 1]!.id : page.lastScannedId,
           ),
           cronSubnav,
         ),

--- a/test/routes/dashboardTradesAlertsUi.test.ts
+++ b/test/routes/dashboardTradesAlertsUi.test.ts
@@ -438,3 +438,99 @@ describe('/dashboard/cron セッションフィルタ (#cron-session-filter)', (
     expect(isDecisionRowInSession('not-a-date', 'SOXL')).toBe(true)
   })
 })
+
+describe('loadDecisionRowsInSession のページ整合 (#cron-session-filter paging)', () => {
+  const IN_TS = '2026-06-05T14:30:00.000Z' // ET 10:30 金曜 = US 場中
+  const OUT_TS = '2026-06-06T00:00:00.000Z' // ET 金曜 20:00 = 閉場後
+  const mkRow = (id: number, inSession: boolean) => ({
+    id,
+    timestamp: inSession ? IN_TS : OUT_TS,
+    requestId: 'run-1',
+    symbol: 'SOXL',
+    decision: 'HOLD',
+    reason: null,
+    price: 30.5,
+    indicatorsJson: null,
+    clientOrderId: null,
+    traceJson: null,
+    filledPrice: null,
+    filledQty: null,
+    realizedPnl: null,
+    brokerStatus: null,
+  })
+  /**
+   * limit() 呼び出しごとに次のバッチを返す stateful fake (カーソル前進を模擬)。
+   * 判定クエリは leftJoin を通るので、それ以外のクエリ (kill switch の
+   * global_config 読みなど) には空を返して queue を消費させない。
+   */
+  function batchedDb(batches: unknown[][]) {
+    const queue = [...batches]
+    return {
+      select() {
+        let isDecisionQuery = false
+        const chain = {
+          leftJoin: () => {
+            isDecisionQuery = true
+            return chain
+          },
+          where: () => chain,
+          orderBy: () => chain,
+          limit: async () => (isDecisionQuery ? (queue.shift() ?? []) : []),
+        }
+        return { from: () => chain }
+      },
+    } as never
+  }
+
+  it('休場行 200 件を跨いで次バッチから開場行を limit 件そろえる', async () => {
+    const batch1 = Array.from({ length: 200 }, (_, i) => mkRow(400 - i, false))
+    const batch2 = [mkRow(200, true), mkRow(199, true)]
+    vi.mocked(createDb).mockReturnValue(batchedDb([batch1, batch2]))
+    const { loadDecisionRowsInSession } = await import('../../src/routes/dashboard/cron')
+    const page = await loadDecisionRowsInSession(createDb({} as D1Database), { limit: 1 })
+    expect(page.rows.map((r) => r.id)).toEqual([200])
+    expect(page.hasMore).toBe(true) // 開場行が limit+1 件見つかった
+  })
+
+  it('データ末尾に到達したら hasMore=false (フェッチ窓でなく表示行基準)', async () => {
+    vi.mocked(createDb).mockReturnValue(
+      batchedDb([[mkRow(5, true), mkRow(4, false), mkRow(3, true)]]),
+    )
+    const { loadDecisionRowsInSession } = await import('../../src/routes/dashboard/cron')
+    const page = await loadDecisionRowsInSession(createDb({} as D1Database), { limit: 50 })
+    expect(page.rows.map((r) => r.id)).toEqual([5, 3])
+    expect(page.hasMore).toBe(false)
+  })
+
+  it('走査上限 (5 バッチ) で打ち切り、hasMore=true + lastScannedId で前進できる', async () => {
+    const batches = Array.from({ length: 6 }, (_, b) =>
+      Array.from({ length: 200 }, (_, i) => mkRow(2000 - b * 200 - i, false)),
+    )
+    vi.mocked(createDb).mockReturnValue(batchedDb(batches))
+    const { loadDecisionRowsInSession } = await import('../../src/routes/dashboard/cron')
+    const page = await loadDecisionRowsInSession(createDb({} as D1Database), { limit: 50 })
+    expect(page.rows).toEqual([])
+    expect(page.hasMore).toBe(true)
+    expect(page.lastScannedId).toBe(2000 - 5 * 200 + 1) // 5 バッチ分の末尾
+  })
+
+  it('route: 次ページカーソルは「最後に表示した行」の id になる', async () => {
+    // 開場 [5,3,1] / 休場 [4,2]。limit=2 → 表示 [5,3]、次カーソルは 3
+    vi.mocked(createDb).mockReturnValue(
+      batchedDb([[mkRow(5, true), mkRow(4, false), mkRow(3, true), mkRow(2, false), mkRow(1, true)]]),
+    )
+    const app = createApp()
+    const res = await app.request(
+      '/dashboard/cron?limit=2',
+      { headers: {} },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    expect(body).toContain('data-id="5"')
+    expect(body).toContain('data-id="3"')
+    expect(body).not.toContain('data-id="4"')
+    expect(body).not.toContain('data-id="1"') // limit=2 で切れる
+    expect(body).toContain('before=3') // 表示末尾がカーソル
+  })
+})

--- a/test/routes/dashboardTradesAlertsUi.test.ts
+++ b/test/routes/dashboardTradesAlertsUi.test.ts
@@ -533,4 +533,25 @@ describe('loadDecisionRowsInSession のページ整合 (#cron-session-filter pag
     expect(body).not.toContain('data-id="1"') // limit=2 で切れる
     expect(body).toContain('before=3') // 表示末尾がカーソル
   })
+
+  it('route: 走査打ち切りでページが埋まらなかったら、カーソルは走査末尾へ進む', async () => {
+    // batch1 の先頭 2 行だけ開場、以降 5 バッチ分 (走査上限) すべて休場行。
+    // 走査済み窓内の開場行は表示済みなので、表示末尾 (1199) でなく走査末尾
+    // (201) から次ページを始める — 同じ休場行の舐め直しと空ページを防ぐ。
+    const batches = Array.from({ length: 5 }, (_, b) =>
+      Array.from({ length: 200 }, (_, i) => mkRow(1200 - b * 200 - i, b === 0 && i < 2)),
+    )
+    vi.mocked(createDb).mockReturnValue(batchedDb(batches))
+    const app = createApp()
+    const res = await app.request(
+      '/dashboard/cron?limit=50',
+      { headers: {} },
+      { ...baseEnv, DB: {} as D1Database },
+    )
+    const body = await res.text()
+    expect(body).toContain('data-id="1200"')
+    expect(body).toContain('data-id="1199"')
+    expect(body).toContain('before=201')
+    expect(body).not.toContain('before=1199')
+  })
 })


### PR DESCRIPTION
## 概要

#571 の follow-up。「フィルタが単純でページングと一致していない」指摘への対応。

旧実装は「limit+1 件フェッチ → 表示だけ間引く」だったため、(a) ページの表示件数がフィルタ結果次第で不定 (limit=50 なのに 12 件だけ等)、(b) 次ページカーソルがフェッチ窓の末尾基準で、表示した行と連続しない、という不整合があった。

## 変更点

- **`loadDecisionRowsInSession`**: 開場行が limit+1 件 (hasMore 判定込み) そろうまでカーソルを進めながら追加フェッチするページローダー。ページは常に limit 件フルで埋まる
- **次ページカーソル = 最後に表示した行の id** — 表示と切れ目なく連続する
- **D1 保護**: 走査は最大 5 バッチ × 200 行で打ち切り。打ち切り時は hasMore=true + 走査末尾 id で前進できる (休場行が延々続く病的データでも詰まらない)
- `?session=all` は従来どおり単純ページング (挙動不変)

## テスト

`pnpm typecheck` / `pnpm test` — **1697 tests green** (新規 4: バッチ跨ぎで limit 件収集 / データ末尾で hasMore=false / 走査上限打ち切り + lastScannedId / route のカーソルが表示末尾に一致)。

関連: #570 / #571 (休場 UX) の follow-up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ダッシュボードの cron 一覧で、営業中（開場中）の行だけを表示するセッションフィルタの取得・ページングを強化しました。  
  * 表示件数に応じて必要分を取得し、次ページへのつながりを改善しました。  
* **Bug Fixes**
  * データ末尾・大量データ・走査打ち切り時でも、表示件数と次ページ位置のずれを起こしにくくしました。  
* **Tests**
  * セッションフィルタ付きページングのカーソル挙動を確認する統合テストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->