### PR TITLE
feat: block whipsaw re-entry after any exit (cooldown + last-exit price floor)

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -359,6 +359,10 @@ export const admin = new Hono<AppBindings>()
         global.pullbackDefaultMaxAtrRatio,
         { mustBePositive: true },
       ),
+      // #reentry: 再エントリー価格ガード。backtest preview は per-symbol の
+      // lastExit 状態を持たないので実際には fail-open (この rule 上は既定値だけ保持)。
+      reentryMinAtrBelowLastExit: 1.0,
+      reentryGuardBusinessDays: 3,
     }
 
     // Need at least 50 warmup bars before `from` for SMA50; estimate generous
@@ -1933,6 +1937,9 @@ export const admin = new Hono<AppBindings>()
       kAtr: global.pullbackDefaultKAtr,
       maxSma50DeviationPct: global.pullbackDefaultMaxSma50DeviationPct,
       maxAtrRatio: global.pullbackDefaultMaxAtrRatio,
+      // #reentry: cron の runStrategyCron 既定と一致 (global_config 列化はまだ)。
+      reentryMinAtrBelowLastExit: 1.0,
+      reentryGuardBusinessDays: 3,
     }
     const rules = buildSymbolRules(defaultRule, universe)
     const barClient = await selectBarClient(c.env)

--- a/src/routes/dashboard/charts/shared.ts
+++ b/src/routes/dashboard/charts/shared.ts
@@ -79,6 +79,10 @@ export interface StrategyParamsSnapshot {
   maxSma50DeviationPct: number
   /** ボラ過熱ガード閾値 `atr20/baselineAtr20` 上限。 */
   maxAtrRatio: number
+  /** #reentry: 再エントリー価格ガード 前回売値からの最小 ATR 下方距離。 */
+  reentryMinAtrBelowLastExit: number
+  /** #reentry: 再エントリー価格ガードの有効窓 (営業日)。 */
+  reentryGuardBusinessDays: number
 }
 
 /**
@@ -100,6 +104,9 @@ export function strategyParamsFromGlobal(global: LoadedGlobalConfig): StrategyPa
     kAtr: global.pullbackDefaultKAtr,
     maxSma50DeviationPct: global.pullbackDefaultMaxSma50DeviationPct,
     maxAtrRatio: global.pullbackDefaultMaxAtrRatio,
+    // #reentry: cron の runStrategyCron 既定と一致 (まだ global_config 列なし)。
+    reentryMinAtrBelowLastExit: 1.0,
+    reentryGuardBusinessDays: 3,
   }
 }
 

--- a/src/routes/dashboard/charts/symbol.ts
+++ b/src/routes/dashboard/charts/symbol.ts
@@ -1399,6 +1399,8 @@ export const STRATEGY_DEFAULTS: StrategyParamsSnapshot = {
   kAtr: 2.0,
   maxSma50DeviationPct: 0.6,
   maxAtrRatio: 1.5,
+  reentryMinAtrBelowLastExit: 1.0,
+  reentryGuardBusinessDays: 3,
 }
 
 /**

--- a/src/trading/reconciliation/reconcileFills.ts
+++ b/src/trading/reconciliation/reconcileFills.ts
@@ -1122,11 +1122,13 @@ async function applyFillToState(args: {
     }
   }
 
-  // Stop-out cooldown: a losing exit parks the symbol until the next trading
-  // day so a whipsaw re-entry cannot compound the loss. Ported from the
-  // removed TradeEventHandler — pullbackScheduler reads `state.cooldownUntil`
-  // for its signal decision, so without this write the strategy never
-  // backs off after a losing sell.
+  // Exit cooldown: **any** completed SELL parks the symbol until the next
+  // trading day so a same-day / next-tick re-entry cannot whipsaw. #reentry:
+  // 以前は損失決済 (realizedPnl < 0) のみ cooldown を張っていたが、**良い利確の
+  // 直後に同一銘柄を即買い戻して往復で削る** ケース (SQQQ 実例: +4% TP → 6h 後に
+  // 売値超で買い直し → 含み損) を止められなかった。TP / time-stop / 損切りを問わず
+  // 全 SELL で cooldown を張り、時間軸で買い直しを 1 営業日ブロックする
+  // (価格軸のガードは PullbackUptrendStrategy 側 = 前回売値 −1ATR)。
   //
   // Cooldown failures are intentionally NON-fatal (caught + logged) because
   // the position itself has already been correctly recorded, and a missed
@@ -1136,8 +1138,6 @@ async function applyFillToState(args: {
   // applied.
   if (
     side === 'SELL' &&
-    realizedPnl !== null &&
-    realizedPnl < 0 &&
     env.SYMBOL_STATE &&
     (symbolApplied || portfolioApplied)
   ) {

--- a/src/trading/state/SymbolStateDO.ts
+++ b/src/trading/state/SymbolStateDO.ts
@@ -176,10 +176,13 @@ export class SymbolStateDO extends DurableObject<object> {
   }
 
   private normalize(state: SymbolState): SymbolState {
-    if (!('appliedClientOrderIds' in state) ||
-      !Array.isArray((state as { appliedClientOrderIds?: unknown }).appliedClientOrderIds)) {
-      return { ...state, appliedClientOrderIds: [] }
-    }
-    return state
+    const appliedClientOrderIds =
+      'appliedClientOrderIds' in state &&
+      Array.isArray((state as { appliedClientOrderIds?: unknown }).appliedClientOrderIds)
+        ? state.appliedClientOrderIds
+        : []
+    // #reentry: lastExitAt は後付けフィールド。旧 state には欠落しているので
+    // 読み込み時に null へ正規化し、永続データを型 (string | null) と揃える。
+    return { ...state, appliedClientOrderIds, lastExitAt: state.lastExitAt ?? null }
   }
 }

--- a/src/trading/state/stateTransitions.ts
+++ b/src/trading/state/stateTransitions.ts
@@ -61,12 +61,18 @@ export function recordFill(
   }
 
   const position = applyFillToPosition(state.position, fill, ctx.now)
+  const iso = ctx.now().toISOString()
+  // 建玉を閉じた SELL (position が null に落ちた) のときだけ lastExitAt を刻む。
+  // #reentry の価格ガードが「前回手仕舞いからの経過営業日」を測る起点。
+  // 部分 SELL / BUY では更新しない (position !== null)。
+  const closedByExit = fill.side === 'SELL' && position === null
   return {
     ...state,
     position,
     pendingOrder: null,
     lastExecutedPrice: fill.price,
-    updatedAt: ctx.now().toISOString(),
+    ...(closedByExit ? { lastExitAt: iso } : {}),
+    updatedAt: iso,
   }
 }
 

--- a/src/trading/state/types.ts
+++ b/src/trading/state/types.ts
@@ -36,6 +36,13 @@ export interface SymbolState {
   settledCash: number
   pendingSettlement: PendingSettlement[]
   lastExecutedPrice: number | null
+  /**
+   * 建玉を閉じた最後の SELL fill の時刻 (ISO 8601)。#reentry の再エントリー
+   * 価格ガードが「前回手仕舞いから何営業日経過したか」の recency 判定に使う。
+   * flat 時の `lastExecutedPrice` (= 前回売値) と対で読む。close 以外の fill
+   * (BUY / 部分 SELL) では更新しない。旧 state には無い → undefined は null 相当。
+   */
+  lastExitAt: string | null
   lastQuote: QuoteSnapshot | null
   updatedAt: string
 }
@@ -51,6 +58,7 @@ export function emptySymbolState(symbol: string, now: () => Date = () => new Dat
     settledCash: 0,
     pendingSettlement: [],
     lastExecutedPrice: null,
+    lastExitAt: null,
     lastQuote: null,
     updatedAt: now().toISOString(),
   }

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -578,6 +578,14 @@ export async function runPullbackScheduler(
     // execution は通常 BUY/SELL と全く同じ経路を通る (= 通常ロールと同じ動き)。
     const useMomentum = !!(options.momentumStrategy && options.momentumSymbols?.has(upper))
     const decider = useMomentum ? options.momentumStrategy! : strategy
+    // #reentry: flat のときだけ前回手仕舞い情報を渡す (position 保有中は
+    // lastExecutedPrice = 直近 BUY 価格になり得るので再エントリーガードに使わない)。
+    // flat 時は建玉を閉じた SELL が最後の fill なので lastExecutedPrice = 前回売値。
+    const reentryLastExitPrice = state.position === null ? state.lastExecutedPrice : null
+    const reentryBusinessDaysSinceExit =
+      state.position === null && state.lastExitAt
+        ? computeHoldBusinessDays(state.lastExitAt, now(), market)
+        : null
     let signal = decider.decide({
       symbol: upper,
       indicators,
@@ -585,6 +593,8 @@ export async function runPullbackScheduler(
       pendingOrder: state.pendingOrder,
       cooldownUntil: state.cooldownUntil,
       holdBusinessDays,
+      lastExitPrice: reentryLastExitPrice,
+      businessDaysSinceExit: reentryBusinessDaysSinceExit,
       now: now(),
     })
 

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -280,6 +280,10 @@ export async function runStrategyCron(
     kAtr: global.pullbackDefaultKAtr,
     maxSma50DeviationPct: global.pullbackDefaultMaxSma50DeviationPct,
     maxAtrRatio: global.pullbackDefaultMaxAtrRatio,
+    // #reentry: 再エントリー価格ガード。まだ global_config 列を持たせていないので
+    // 定数 (前回売値 −1ATR / 3 営業日窓)。チューニングが要れば列/override 化。
+    reentryMinAtrBelowLastExit: 1.0,
+    reentryGuardBusinessDays: 3,
   }
   // Per-symbol rule map (#316 / #exit-atr / #452)。global default → role preset
   // → per-symbol override の順に重ねる。詳細と回帰保証は symbolRuleResolution.ts。

--- a/src/trading/strategy/strategies/BreakoutMomentumStrategy.ts
+++ b/src/trading/strategy/strategies/BreakoutMomentumStrategy.ts
@@ -58,6 +58,13 @@ export interface MomentumInput {
   pendingOrder: PendingOrderLock | null
   cooldownUntil: string | null
   holdBusinessDays: number
+  /**
+   * #reentry: pullback 戦略の再エントリー価格ガード用フィールド。momentum は
+   * 使わないが、scheduler が両戦略へ同一 input オブジェクトを渡すため (union の
+   * excess property check を通すため) optional で受けておく。
+   */
+  lastExitPrice?: number | null
+  businessDaysSinceExit?: number | null
   now: Date
 }
 

--- a/src/trading/strategy/strategies/PullbackUptrendStrategy.ts
+++ b/src/trading/strategy/strategies/PullbackUptrendStrategy.ts
@@ -62,6 +62,21 @@ export interface SymbolRule {
    * 既存の atr-floor (低ボラで size 半減) と対になる高ボラ側の上限。
    */
   maxAtrRatio: number
+  /**
+   * 再エントリー価格ガード (#reentry)。直前に手仕舞いした価格 (flat 時の
+   * `lastExecutedPrice` = 前回売値) より、この倍率 × atr20 以上 **安く** ない限り
+   * 同一銘柄を買い直さない。「良い利確の直後に同水準/上で買い戻して往復で削る」
+   * whipsaw を価格軸で防ぐ (時間軸の cooldown = reconcileFills が全 exit で翌
+   * 営業日まで、と対)。0 で無効。既定 1.0 (= 前回売値 −1ATR)。
+   */
+  reentryMinAtrBelowLastExit: number
+  /**
+   * 再エントリー価格ガードの有効窓 (営業日)。前回手仕舞いからこの日数**未満**の
+   * 間だけ上のガードを適用し、それを過ぎたら無効化して通常のトレンド再 entry を
+   * 妨げない (前回売値より高い新レグでの押し目買いを永久に塞がないため)。
+   * 0 で無効。既定 3。
+   */
+  reentryGuardBusinessDays: number
 }
 
 /**
@@ -80,6 +95,8 @@ export const TEST_DEFAULT_RULE: SymbolRule = Object.freeze({
   kAtr: 2.0,
   maxSma50DeviationPct: 0.6,
   maxAtrRatio: 1.5,
+  reentryMinAtrBelowLastExit: 1.0,
+  reentryGuardBusinessDays: 3,
 })
 
 export interface PullbackInput {
@@ -90,6 +107,16 @@ export interface PullbackInput {
   cooldownUntil: string | null
   /** Business days elapsed since position.openedAt. 0 when position is null. */
   holdBusinessDays: number
+  /**
+   * 前回手仕舞い価格 (#reentry)。flat 時の `SymbolState.lastExecutedPrice`
+   * (= 建玉を閉じた SELL の約定価格) を渡す。null / 未設定なら価格ガード素通り。
+   */
+  lastExitPrice?: number | null
+  /**
+   * 前回手仕舞いからの経過営業日 (#reentry)。scheduler が `lastExitAt` から
+   * market 別に算出して渡す。null なら価格ガード素通り (recency 判定不能)。
+   */
+  businessDaysSinceExit?: number | null
   now: Date
 }
 
@@ -184,6 +211,39 @@ export class PullbackUptrendStrategy {
 
   private entryDecision(input: PullbackInput, rule: SymbolRule, trace: DecisionTraceStep[]): Signal {
     const ind = input.indicators
+
+    // 再エントリー価格ガード (#reentry): 前回手仕舞い (前回売値) から
+    // reentryGuardBusinessDays 営業日以内は、前回売値より reentryMinAtrBelowLastExit
+    // × atr20 以上 安い水準でなければ BUY を見送る。良い利確直後の同水準/高値
+    // 買い戻し (往復で削る whipsaw) を価格軸で止める。窓を過ぎる or 情報欠落
+    // (前回売値 / 経過日数 / atr 不明) は fail-open (通常のトレンド再 entry を妨げない)。
+    const lastExitPrice = input.lastExitPrice ?? null
+    const bdSinceExit = input.businessDaysSinceExit ?? null
+    const reentryGuardActive =
+      rule.reentryMinAtrBelowLastExit > 0 &&
+      rule.reentryGuardBusinessDays > 0 &&
+      lastExitPrice !== null &&
+      Number.isFinite(lastExitPrice) &&
+      lastExitPrice > 0 &&
+      bdSinceExit !== null &&
+      bdSinceExit < rule.reentryGuardBusinessDays &&
+      Number.isFinite(ind.atr20) &&
+      ind.atr20 > 0
+    if (reentryGuardActive) {
+      const reentryCeiling = lastExitPrice! - rule.reentryMinAtrBelowLastExit * ind.atr20
+      if (ind.price > reentryCeiling) {
+        trace.push(step('entry.reentry_below_last_exit', false, ind.price, '<=', reentryCeiling, `within ${bdSinceExit}bd of last exit ${lastExitPrice}`))
+        return hold(
+          input,
+          `re-entry guard: price ${ind.price} > last exit ${lastExitPrice} - ${rule.reentryMinAtrBelowLastExit}*ATR(${ind.atr20.toFixed(2)}) = ${reentryCeiling.toFixed(2)} (${bdSinceExit}bd since exit)`,
+          trace,
+        )
+      }
+      trace.push(step('entry.reentry_below_last_exit', true, ind.price, '<=', reentryCeiling))
+    } else {
+      trace.push(step('entry.reentry_below_last_exit', true, ind.price, '<=', ind.price, 'guard inactive'))
+    }
+
     if (ind.return50d <= rule.minReturn50d) {
       trace.push(step('entry.trend_50d_return', false, ind.return50d, '>', rule.minReturn50d))
       // #318: lookback は 20 営業日 (フィールド名は historical)。reason は人間
@@ -314,6 +374,7 @@ const TRACE_LABEL_JA: Record<string, string> = {
   'guard.pending_order_absent': '未約定注文がない',
   'guard.cooldown_inactive': 'クールダウン中ではない',
   'route.position_open': '建玉を保有中',
+  'entry.reentry_below_last_exit': '前回売値からの再エントリー間隔・値幅が十分',
   // #318: trace 識別子 (`entry.trend_50d_return` / `entry.high20d_valid`) は
   // 既存 decision_log と互換維持のため据え置き。**表示文字列のみ実 lookback に
   // 合わせて 20日 / 10日 と表記**。

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -1078,6 +1078,8 @@ const DEFAULT_PARAMS: StrategyParamsSnapshot = {
   kAtr: 2.0,
   maxSma50DeviationPct: 0.6,
   maxAtrRatio: 1.5,
+  reentryMinAtrBelowLastExit: 1.0,
+  reentryGuardBusinessDays: 3,
 }
 
 /** Count cells flagged as 変更済 (title attr ベースで識別、凡例 ⚠ と分離)。 */
@@ -2022,6 +2024,7 @@ describe('renderSymbolTab — 判定点 scatter + click-to-trace の配線', () 
     pullbackMax: -0.03, pullbackMin: -0.15, minReturn50d: 0,
     requireAboveSma50: true, kAtr: 2,
     maxSma50DeviationPct: 0.6, maxAtrRatio: 1.5,
+    reentryMinAtrBelowLastExit: 1.0, reentryGuardBusinessDays: 3,
   }
   function symbolArgs(
     decisions: SymbolChartDecision[],

--- a/test/routes/dashboardChartMarkers.test.ts
+++ b/test/routes/dashboardChartMarkers.test.ts
@@ -213,6 +213,7 @@ describe('renderSymbolTab — fill 詳細パネル + 保有区間 markArea の�
     pullbackMax: -0.03, pullbackMin: -0.15, minReturn50d: 0,
     requireAboveSma50: true, kAtr: 2,
     maxSma50DeviationPct: 0.6, maxAtrRatio: 1.5,
+    reentryMinAtrBelowLastExit: 1.0, reentryGuardBusinessDays: 3,
   }
   function args(): ChartsBodySymbol {
     return {

--- a/test/strategy/pullbackUptrendStrategy.test.ts
+++ b/test/strategy/pullbackUptrendStrategy.test.ts
@@ -21,6 +21,9 @@ const LEVERAGED_RULE: SymbolRule = {
   // 過熱ガードは既存ケースでは無効化 (大きい値)。ガード検証は専用 describe で実施。
   maxSma50DeviationPct: 100,
   maxAtrRatio: 100,
+  // 再エントリーガードも既存ケースでは無効化 (0)。検証は専用 describe で実施。
+  reentryMinAtrBelowLastExit: 0,
+  reentryGuardBusinessDays: 0,
 }
 
 /** Build a valid BUY-triggering input; individual tests mutate one field. */
@@ -60,6 +63,7 @@ describe('PullbackUptrendStrategy entry', () => {
       ['guard.pending_order_absent', true],
       ['guard.cooldown_inactive', true],
       ['route.position_open', false],
+      ['entry.reentry_below_last_exit', true],
       ['entry.trend_50d_return', true],
       ['entry.above_sma50', true],
       ['entry.not_overextended', true],
@@ -142,6 +146,53 @@ describe('PullbackUptrendStrategy entry', () => {
     const input = goodEntryInput()
     input.cooldownUntil = new Date(now.getTime() + 60_000).toISOString()
     expect(strategy.decide(input).reason).toMatch(/cooldown/)
+  })
+})
+
+// #reentry: 前回売値からの再エントリー価格ガード。窓内 (既定 3 営業日) は前回売値
+// −1ATR 以上安くないと買い直さない。窓外 / 情報欠落は素通り (fail-open)。
+describe('PullbackUptrendStrategy re-entry price guard', () => {
+  const strategy = new PullbackUptrendStrategy(TEST_DEFAULT_RULE)
+
+  it('HOLDs when re-buying within the window at/above (last exit - 1 ATR)', () => {
+    const input = goodEntryInput() // price 96, atr20 1.5
+    input.lastExitPrice = 96 // ceiling = 96 - 1*1.5 = 94.5; price 96 > 94.5 → block
+    input.businessDaysSinceExit = 1
+    const signal = strategy.decide(input)
+    expect(signal.action).toBe('HOLD')
+    expect(signal.reason).toMatch(/re-entry guard/)
+    expect(signal.trace?.at(-1)).toMatchObject({
+      label: 'entry.reentry_below_last_exit',
+      passed: false,
+    })
+  })
+
+  it('BUYs when re-entry price is sufficiently below last exit within the window', () => {
+    const input = goodEntryInput() // price 96
+    input.lastExitPrice = 100 // ceiling = 100 - 1.5 = 98.5; price 96 <= 98.5 → pass
+    input.businessDaysSinceExit = 1
+    expect(strategy.decide(input).action).toBe('BUY')
+  })
+
+  it('BUYs once the guard window has elapsed even at/above last exit', () => {
+    const input = goodEntryInput()
+    input.lastExitPrice = 96
+    input.businessDaysSinceExit = 3 // >= reentryGuardBusinessDays → guard inactive
+    expect(strategy.decide(input).action).toBe('BUY')
+  })
+
+  it('is fail-open when lastExitPrice is unknown', () => {
+    const input = goodEntryInput()
+    input.lastExitPrice = null
+    input.businessDaysSinceExit = 1
+    expect(strategy.decide(input).action).toBe('BUY')
+  })
+
+  it('is fail-open when businessDaysSinceExit is unknown', () => {
+    const input = goodEntryInput()
+    input.lastExitPrice = 96
+    input.businessDaysSinceExit = null
+    expect(strategy.decide(input).action).toBe('BUY')
   })
 })
 

--- a/test/trading/reconciliation/reconcileFills.test.ts
+++ b/test/trading/reconciliation/reconcileFills.test.ts
@@ -710,7 +710,7 @@ describe('reconcileFills state-apply marker (issue #142)', () => {
     expect(updates[0]!.set.stateAppliedAt).toBeUndefined()
   })
 
-  it('SELL fill: applies portfolio realized PnL and stamps marker', async () => {
+  it('SELL fill: applies portfolio realized PnL, stamps marker, and parks cooldown even on a profit', async () => {
     const row: CandidateRow = {
       id: 15,
       clientOrderId: 'coid-sell-1',
@@ -772,6 +772,9 @@ describe('reconcileFills state-apply marker (issue #142)', () => {
     expect(portfolioStub.applyRealizedPnlOnce).toHaveBeenCalledWith('coid-sell-1', 40)
     expect(summary.stateApplied).toBe(1)
     expect(updates.at(-1)!.set.stateAppliedAt).toBe('2026-04-25T12:00:00.000Z')
+    // #reentry (Change A): 損益符号を問わず全 SELL で cooldown を張る。+40 の
+    // 利確でも翌営業日まで park し、同日/次tick の買い戻し whipsaw を止める。
+    expect(symbolStub.setCooldown).toHaveBeenCalledTimes(1)
   })
 
   it('repair retry after marker update failure does not double-apply DO state', async () => {

--- a/test/trading/reconciliation/syncHoldings.test.ts
+++ b/test/trading/reconciliation/syncHoldings.test.ts
@@ -19,6 +19,7 @@ function stateWith(symbol: string, position: PositionState | null, updatedAt = '
     settledCash: 0,
     pendingSettlement: [],
     lastExecutedPrice: null,
+    lastExitAt: null,
     lastQuote: null,
     updatedAt,
   }

--- a/test/trading/state/stateTransitions.test.ts
+++ b/test/trading/state/stateTransitions.test.ts
@@ -93,6 +93,8 @@ describe('recordFill', () => {
     })
     expect(next.pendingOrder).toBeNull()
     expect(next.lastExecutedPrice).toBe(9)
+    // #reentry: BUY は手仕舞いではないので lastExitAt を刻まない。
+    expect(next.lastExitAt).toBeNull()
   })
 
   it('averages the fill price on a subsequent BUY', () => {
@@ -111,6 +113,18 @@ describe('recordFill', () => {
 
     expect(state.position).toBeNull()
     expect(state.lastExecutedPrice).toBe(12)
+    // #reentry: 建玉を閉じた SELL は lastExitAt を fill 時刻で刻む。
+    expect(state.lastExitAt).toBe('2026-04-18T11:00:00.000Z')
+  })
+
+  it('does not stamp lastExitAt on a partial SELL that leaves a position open', () => {
+    let state = emptySymbolState('SOXL', fixedNow('2026-04-18T10:00:00.000Z'))
+    state = recordFill(state, { side: 'BUY', qty: 3, price: 9 }, { now: fixedNow('2026-04-18T10:05:00.000Z') })
+    state = recordFill(state, { side: 'SELL', qty: 1, price: 12 }, { now: fixedNow('2026-04-18T11:00:00.000Z') })
+
+    // 部分 SELL は position が残る (2 株) → 手仕舞い扱いしない。
+    expect(state.position?.qty).toBe(2)
+    expect(state.lastExitAt).toBeNull()
   })
 
   it('keeps the opened_at timestamp when scaling in', () => {

--- a/test/trading/strategy/pullbackScheduler.test.ts
+++ b/test/trading/strategy/pullbackScheduler.test.ts
@@ -175,6 +175,59 @@ describe('runPullbackScheduler', () => {
     expect(summary.decisions[0]?.trace?.find((step) => step.label === 'broker.submit')?.label_ja).toBe('証券会社への発注送信')
   })
 
+  // #reentry: flat な state に前回手仕舞い (lastExecutedPrice + lastExitAt) が
+  // 残っていると、scheduler がそれを strategy に plumb し、窓内 & 値幅不足なら
+  // BUY を price 軸ガードで止める (uptrendBars は本来 BUY する fixture)。
+  it('blocks a would-be BUY when re-entry price guard is active (recent exit near price)', async () => {
+    const recentlyExited: SymbolState = {
+      ...emptySymbolState('SOXL', () => now),
+      // 直近 BUY fixture の last close = 117.5。前回売値をそこに置くと
+      // ceiling = 117.5 - 1*ATR < 117.5 なので必ずガードに掛かる。
+      lastExecutedPrice: 117.5,
+      // now (2026-04-20 Mon) の 1 営業日前 (Fri) → businessDaysSinceExit = 1 < 3。
+      lastExitAt: '2026-04-17T14:30:00.000Z',
+    }
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['SOXL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({ SOXL: recentlyExited }),
+      execution,
+      now: () => now,
+    })
+
+    expect(summary.buys).toBe(0)
+    expect(execution.calls).toHaveLength(0)
+    const decision = summary.decisions.find((d) => d.symbol === 'SOXL')
+    expect(decision?.decision).toBe('HOLD')
+    expect(decision?.reason).toMatch(/re-entry guard/)
+    expect(decision?.trace?.map((s) => s.label)).toContain('entry.reentry_below_last_exit')
+    expect(decision?.trace?.map((s) => s.label)).not.toContain('entry.adopt_buy')
+  })
+
+  it('allows the BUY once the re-entry guard window has elapsed', async () => {
+    const staleExit: SymbolState = {
+      ...emptySymbolState('SOXL', () => now),
+      lastExecutedPrice: 117.5,
+      // ~6 営業日前 → businessDaysSinceExit >= 3 → ガード無効化。
+      lastExitAt: '2026-04-10T14:30:00.000Z',
+    }
+    const execution = mockExecution()
+    const summary = await runPullbackScheduler({
+      symbols: ['SOXL'],
+      equity: 100_000,
+      barClient: mockBarClient(uptrendBars()),
+      positionStore: makeStore({ SOXL: staleExit }),
+      execution,
+      now: () => now,
+    })
+
+    expect(summary.buys).toBe(1)
+    expect(execution.calls).toHaveLength(1)
+    expect(summary.decisions.find((d) => d.symbol === 'SOXL')?.decision).toBe('BUY')
+  })
+
   it('HOLDs (and does not submit) when bars are too short for indicators', async () => {
     const store = makeStore({})
     const execution = mockExecution()
@@ -1487,6 +1540,9 @@ describe('runPullbackScheduler per-symbol rule override (#316)', () => {
     // ガード自体の検証は pullbackUptrendStrategy.test.ts の専用ケースで行う。
     maxSma50DeviationPct: 100,
     maxAtrRatio: 100,
+    // 再エントリーガードも既存 scheduler テストでは無効化 (0)。plumbing 検証は専用ケース。
+    reentryMinAtrBelowLastExit: 0,
+    reentryGuardBusinessDays: 0,
   }
 
   it('applies timeStopDays override to the matching symbol and falls through for others', async () => {


### PR DESCRIPTION
## 背景

良い利確の直後に同一銘柄を即買い戻して往復で削る **whipsaw 再エントリー** が実玉で発生していた。

**SQQQ 実例（dashboard の trade_journal より）:**
- 7/02 BUY 5 @ 39.297 → 7/07 14:45 SELL 5 @ 40.935（**+4% TP, +\$8.19** の良い売り）
- 7/07 20:45（同日6時間後）BUY 5 @ **41.10** ← 売値より **+0.4% 高値**で買い直し
- 現在 −6.4% 含み損

原因は2つ:
1. exit cooldown が **損失決済のときだけ**発動していた（`reconcileFills`）→ 利確は素通りで即買い直せた
2. 「前回売値より安くないと買わない」ガードが**存在しなかった** → 売値超えの買い直しを弾けなかった

## 変更

**A. 全 exit で cooldown（時間軸）** — `reconcileFills.ts`
- 損益符号を問わず **全 SELL** で翌営業日まで cooldown。同日/次tick の買い戻しをブロック。

**B. 前回売値ガード（価格軸）** — `PullbackUptrendStrategy` + state 層
- 建玉を閉じた SELL 時刻を `SymbolState.lastExitAt` に記録（DO migration 不要 = 旧 state は fail-open）
- エントリー時、**前回手仕舞いから3営業日以内**は「前回売値 −1ATR」より安くない限り BUY を見送る
- 窓を過ぎれば無効化し、通常のトレンド再エントリーは妨げない（fail-open）

パラメータ（3営業日 / −1ATR）は運用者の戦略分析の値を採用。cooldown は day-1 完全ブロック、day 2–3 は価格条件付き（本物の深押しは拾える折衷）。dashboard のパラメータ表にも反映。

## 注意点

- 既存の SQQQ 建玉は**遡及対象外**（前向きガード）。既存 time-stop / stop で処理される
- backtest preview はガードを再現しない（per-symbol の手仕舞い状態を持たないため fail-open）。ライブ cron のみ有効

## テスト

- `pullbackUptrendStrategy`: ガードの block / 値幅十分で BUY / 窓経過で BUY / lastExit 不明で fail-open
- `stateTransitions`: 建玉を閉じた SELL のみ `lastExitAt` を刻む（BUY / 部分 SELL は刻まない）
- `reconcileFills`: 利確(+40)でも cooldown を張る
- `pullbackScheduler`: state → strategy の plumbing 統合（直近手仕舞いで BUY 阻止 / 窓経過で BUY）
- 全 1575 tests green / typecheck 通過

すべて fail-safe 方向（発注が減る側）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 再エントリーを抑制する価格ガード（直近退出価格とATR）と経過営業日条件を追加し、手仕舞い直後の再入を抑えられるようになりました。
  * ダッシュボード/管理画面の既定ルールに再エントリー関連パラメータを反映し、表示・シミュレーションの挙動を揃えました。
* **バグ修正**
  * 利確・損切りを含む売却全般でクールダウン判定が一貫して適用されるよう改善しました。
  * 全量クローズ時の最終退出時刻を正しく記録します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->