### PR TITLE
chore: align .dev.vars.example with the env vars the code actually reads

### DIFF
--- a/.agents/skills/coderabbit-policy/SKILL.md
+++ b/.agents/skills/coderabbit-policy/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: coderabbit-policy
+description: Use this skill when processing CodeRabbit CLI or PR-level findings — to decide which suggestions to apply and which to skip with a documented reason. Keeps POC reviews from scope-creeping.
+---
+
+# CodeRabbit Policy
+
+CodeRabbit の指摘は全件反映するのではなく、**POC スコープ + 安全性**の観点でフィルタする。採用基準と却下基準をここに集約。
+
+## 採用する指摘 (apply)
+
+- **セキュリティ**: secret の timing-safe 比較、credential の leak、XSS / injection、auth bypass
+- **correctness バグ**: `typeof arr === 'object'` 誤判定、負値 / NaN / Infinity の通過、DRY_RUN が無視される分岐
+- **入力 validation**: 空文字 / ゼロ / 非数値を弾く
+- **型の厳格化**: loose string → literal union + runtime guard
+- **実際に壊れている挙動**: audit log が status を誤記録、認証通さず 200 が返る、等
+
+## スキップする指摘 (skip with reason)
+
+PR body もしくはコメントで明示的に却下理由を書く。「無言で無視」はしない。
+
+| パターン | 却下理由テンプレ |
+|---|---|
+| 他 Phase に属する機能要求 | `Phase N scope (#issue)` |
+| 意図された TODO 実装要求 (e.g. `bridge/grpc/client.ts`) | `Intentional TODO per issue #5 scope` |
+| 早期最適化 (middleware closure cache 等) | `Premature optimization for POC` |
+| 未使用 optional フィールドの追加 | `Dead interface — no caller populates these fields` |
+| DI / factory の前倒し | `Premature abstraction for POC` |
+| 過剰な境界テスト / exhaustive coverage | `POC coverage is adequate (1 pass + 1 fail case)` |
+| Workers 制約を bridge に誤適用 | `Stale finding: bridge runs in Node, not Workers` |
+| 既に対応済 / 前提を誤解 | `Stale finding: <具体的な状況>` |
+
+## フロー
+
+1. `coderabbit review --agent` の findings JSON を読む
+2. 各 finding について:
+   - セキュリティ or correctness?
+     - YES → apply
+     - NO → 下へ
+   - Phase scope 内?
+     - YES → apply (trivial / minor でも入れてよい)
+     - NO → skip + テンプレ適用
+3. apply リストを 1 commit に束ねる (commit message で CodeRabbit 参照)
+4. skip リストを PR body に表形式で記載:
+   - `# | finding | 却下理由`
+
+## コマンド
+
+### ローカル実行
+
+```bash
+# worktree 内で:
+coderabbit review --agent > .local/coderabbit-findings.log
+```
+
+### codex 経由での実行
+
+codex sandbox は network と `~/.coderabbit/` への書き込みをデフォルトでブロックする。両方を明示的に許可する:
+
+```bash
+codex exec --full-auto \
+  -c 'sandbox_workspace_write.network_access=true' \
+  -c 'sandbox_workspace_write.writable_roots=["$HOME/.coderabbit"]' \
+  - < prompt.md
+```
+
+### 認証の渡し方
+
+**推奨: OAuth 保存トークン** (`coderabbit auth login --agent` を事前に1回実行済み)
+- `~/.coderabbit/` 内に保存されるため、上記 `writable_roots` を設定すれば codex 内でも読める
+- プロンプトでは `coderabbit review --agent` をそのまま呼ぶ (`--api-key` 不要)
+
+**`--api-key` 経由** (有料 Hoppy CLI アドオン必須、通常プランでは "User API keys are not supported" / "No CLI addon found" と弾かれる):
+1. 1P の Agentic API key (User API key ではない) を `op://Personal/CODERABBIT_API_KEY/credential` に保存
+2. 親シェルで解決して env var で渡す (codex sandbox は 1P デスクトップアプリの IPC socket に到達できないので `op run -- ...` を codex 内から直接呼ぶのは失敗する):
+
+```bash
+CODERABBIT_API_KEY="$(op read 'op://Personal/CODERABBIT_API_KEY/credential')" \
+  codex exec --full-auto \
+    -c 'sandbox_workspace_write.network_access=true' \
+    -c 'sandbox_workspace_write.writable_roots=["$HOME/.coderabbit"]' \
+    - < prompt.md
+```
+
+3. codex 内では `coderabbit review --agent --api-key "$CODERABBIT_API_KEY"` と呼ぶ (env var 単体では CLI は honor しないので flag 渡しが必須)
+
+### よくあるエラーと原因
+
+| エラー | 原因 |
+|---|---|
+| `Authentication required` | `~/.coderabbit/` が読めない or `--api-key` 未指定。sandbox 設定か OAuth ログインを確認 |
+| `Invalid or expired API key` | 1P に保存された key が古い。再発行して更新 |
+| `User API keys are not supported for the CLI` | User API key を渡した。**Agentic API key** をダッシュボードで発行 |
+| `No CLI addon found` | 通常プランでは API key 経由 CLI が使えない。OAuth 保存トークン経由に戻す |
+| `ConnectionRefused` to `posthog.com` | codex sandbox の network_access を有効化していない |
+| `EPERM unlink ~/.coderabbit/logs/...` | `writable_roots` に `~/.coderabbit` を含めていない |
+
+### findings の整形
+
+```bash
+grep '"type":"finding"' .local/coderabbit-findings.log | python3 -c '
+import json, sys
+for i, line in enumerate(sys.stdin, 1):
+    f = json.loads(line)
+    print(f"{i}. [{f[\"severity\"]}] {f[\"fileName\"]}")
+    print(f"   {f[\"codegenInstructions\"].split(chr(10)+chr(10), 1)[-1][:200]}")'
+```
+
+## CodeRabbit への事前シグナル
+
+`.coderabbit.yaml` の `path_instructions` で Phase scope ルールをプリロードしてある。自動レビュー時の誤爆を減らすためのガードレール。`AGENTS.md` と同じ方針をレビュア視点で書く。
+
+## 迷ったときの原則
+
+- **安全側 (採用) に倒すのは correctness / security のみ**
+- **抽象化 / 網羅性は却下側に倒す**
+- 判断に悩むものは PR 本文に明示して human review に渡す

--- a/.agents/skills/phase-scope/SKILL.md
+++ b/.agents/skills/phase-scope/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: phase-scope
+description: Use this skill before opening a PR, before accepting a CodeRabbit suggestion, or when planning changes — to verify that work stays inside the current PR's Phase scope and to route out-of-scope items to the correct Phase issue.
+---
+
+# Phase Scope
+
+POC は **Phase 単位の PR** で進める。Phase 跨ぎの変更要求は必ず該当 issue に回し、この PR では対応しない。
+
+## Phase → Issue
+
+| Phase | Issue | 概要 |
+|---|---|---|
+| 1 | — (PR #2 merged) | Scaffold |
+| 2 | [#3](https://github.com/ochanuco/webull-trading/issues/3) | Trading core (Strategy / Risk / MockExecution) |
+| 3 | [#4](https://github.com/ochanuco/webull-trading/issues/4) | Webull HTTP |
+| 4 | [#5](https://github.com/ochanuco/webull-trading/issues/5) | gRPC trade events |
+| 5 | [#6](https://github.com/ochanuco/webull-trading/issues/6) | retry / audit 強化 / symbol config |
+
+owned ファイル / acceptance / in-out scope の詳細は **各 issue** を参照 (`gh issue view <N>`)。
+
+## 判定フロー
+
+1. 現 PR の Phase を branch 名 / title から特定
+2. 変更対象が当該 Phase の owned ファイル? (issue の scope 表で確認)
+   - YES → 進める
+3. 共有ファイル (`src/app.ts` / `src/config/env.ts` / `.dev.vars.example`) への **末尾 append**?
+   - YES → 進める (後発 PR が rebase で union 解決)
+4. 他 Phase の owned ファイルへの変更 or 機能追加か?
+   - **却下**。該当 issue への参照でスキップ理由を書く
+
+## スキップ理由テンプレ
+
+- `Phase N scope (#issue)` — 他 Phase に属する機能/ハードニング要求
+- `Not in scope for this POC` — HFT / ML / multi-broker / Queue / DO
+- `Stale finding` — 既対応 or 前提誤認
+- `Premature abstraction for POC` — DI / factory / 設定間接化
+- `Intentional TODO per issue` — scope 明記の placeholder
+- `POC coverage is adequate` — exhaustive 境界テスト要求
+
+## 例外 (Phase 不問で採用)
+
+- セキュリティ (timing-safe、credential leak、auth bypass)
+- 入力 validation (negative / NaN / empty / zero)
+- 明確なバグ (型判定の誤り、status の誤記録等)
+- 型の厳格化 (literal union + runtime guard)
+
+## 迷ったら
+
+PR 本文に判断を書いて human review に委ねる。一人で抱え込まない。

--- a/.agents/skills/trading-developer/SKILL.md
+++ b/.agents/skills/trading-developer/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: trading-developer
+description: Use this skill when editing, reviewing, or planning code under `src/trading/`, `src/infrastructure/webull/`, `bridge/`, or any file that touches orders / positions / market data / broker calls. Applies retail auto-trading domain knowledge and safety invariants.
+---
+
+# Trading Developer
+
+このリポジトリで**取引系コード**を触るときのドメイン姿勢。
+
+## 前提
+
+- 対象は **retail (個人) の POC auto-trader**。Webull OpenAPI (SDK 非依存) に直接 HTTP / gRPC で接続する Cloudflare Workers アプリ。
+- **実マネーが流れる前提**で書く。遅さは直せるが誤発注は直せない。
+- HFT / sub-second latency は対象外。数秒〜分オーダーでよい。
+
+## Safety invariants (絶対に壊さない)
+
+- **発注経路は Strategy → Risk → Execution** の順。Risk で止まるフローを壊すリファクタ提案は却下。
+- Safety defaults は **fail-closed**: `DRY_RUN=true` / `TRADING_ENABLED=false` が初期値。`DRY_RUN=true` のとき **broker 実通信を一切行わない**。
+- Risk checks: symbol whitelist / max order notional / tradingEnabled / market hours (Phase 5) は OR ではなく **すべて AND で評価**。
+- Webull raw JSON / proto は infrastructure 層に閉じ込める。application / domain には **正規化後のドメイン型だけ** 流す。
+- secret / token の比較は **timing-safe** (単純な `!==` は不可)。
+- 各 request / event に `requestId` を付け、結果を構造化 JSON で audit log に残す。
+
+## ドメイン用語 (混同しない)
+
+| 用語 | 意味 | 備考 |
+|---|---|---|
+| **order** | 発注指示 | market / limit / stop / stop-limit。現状 POC は limit / market のみ想定 |
+| **position** | 保有数 | long = +、short = -。POC は long のみ |
+| **notional** | 金額ベースの建玉 | `price * quantity`。Risk の上限チェックに使う |
+| **filled_qty** | 約定済み数量 | 非負整数。部分約定で ≤ 発注数量 |
+| **bid / ask** | 買指値 / 売指値 | spread = ask - bid |
+| **Dry Run** | 実発注せず mock 応答 | `DRY_RUN=true` 時の動作 |
+| **Paper trading** | Webull 側の仮想口座 | POC では扱わない (Dry Run で代替) |
+
+## 書き方のクセ
+
+- Order 関連の数値型 (`price`, `quantity`, `notional`, `filledQty`) は **必ず `> 0` / `>= 0` を入力時に確認**。negative / NaN / Infinity は domain の手前で弾く。
+- Symbol は大文字で正規化 (`"soxl"` 受けても `"SOXL"` で比較)。ティッカーは case-insensitive が暗黙慣習。
+- 時刻は必ず **UTC の ISO 8601** で保存 (`new Date().toISOString()`)。US market 時間変換は表示側で。
+- 通貨は POC では USD のみ。multi-currency の抽象は前倒しで入れない。
+- `rawPayload` は audit 用に保持するが、**domain ロジックから参照しない**。
+
+## Webull / Cloudflare Workers 特有の制約
+
+- Workers は長時間 TCP 保持不可 → gRPC stream は `bridge/` (Node runtime) で受け、HTTP POST で Worker に ingest する設計。
+- Workers の `fetch` は request timeout が実質無制限ではない → broker 呼び出しには **明示タイムアウト** を入れる (Phase 5 で retry 付き強化)。
+- `crypto.randomUUID()` / `crypto.subtle` は Workers で利用可。Node だけの API は Worker 側では使わない。
+- 秘密は `.dev.vars` / Worker secrets 経由。ログに出さない (secret値を含む body は監査ログから除外 or masked)。
+
+## よくある間違い (レビューで弾く)
+
+- **DRY_RUN なのに broker に request 飛ばす分岐** → 即 reject
+- **Risk チェックを bypass する "便利" helper** → 即 reject
+- **string 比較での secret check** (`env.SECRET !== header`) → timing-safe に直す
+- **allowedSymbols が env で上書き可能な開発用バックドア** → 本番 / POC 問わず入れない
+- **filledQty に負値 / NaN を許容する parser** → 非負 finite で弾く
+- **order 数量 0 を "何もしない" として扱う** → 入力として却下 (400)
+- **Market hours を確認せず発注** → Phase 5 で入れるまでは `tradingEnabled` で代用 (hard toggle)
+
+## 迷ったら
+
+- **安全側に倒す** (実発注しない / エラー返す / ログだけ残す)。fallback で "とりあえず発注" は絶対やらない
+- POC scope 外の議論 (multi-broker / HFT / ML) は **別 issue にして打ち切る**
+- 判断に悩むなら Issue #1 (POC 設計書) の §11 安全設計 / §13 エラー分類を参照

--- a/.claude/agents/trading-strategist.md
+++ b/.claude/agents/trading-strategist.md
@@ -50,8 +50,8 @@ tools: Read, Grep, Glob, WebSearch, WebFetch
 
 - 執行可能な broker は **Webull のみ** (POC 段階)
 - 執行頻度は **日次〜分足スケール**。tick-by-tick は不可
-- 保有銘柄は `ALLOWED_SYMBOLS` に制限 (現状 SOXL / SOXS 等の 3x ETF が主想定 — 設計書参照)
-- 1トレードの上限 notional は `MAX_ORDER_NOTIONAL` (env 既定 = $100)
+- 保有銘柄は D1 `symbol_config` (`active = 1`) に制限 (レバレッジ ETF + テーマ ETF が主想定)
+- 1トレードの上限 notional は `global_config.max_order_notional_usd` / `_jpy` (既定 = $2000 / ¥100000)
 - long only、現物のみ (オプション / 先物 / margin なし)
 
 ## コードが必要と言われたとき

--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,20 +1,24 @@
 # Local dev secrets for `wrangler dev`. Copy to `.dev.vars` and fill in.
 #
-# Split:
-# - Operational flags (not sensitive): DRY_RUN / TRADING_ENABLED / MARKET_HOURS_CHECK
-#   → live in wrangler.jsonc::vars and wrangler.jsonc::env.<target>.vars.
-#   Override locally by uncommenting the block at the bottom.
-# - Sensitive (personal strategy / credentials / non-public endpoint):
-#   ALLOWED_SYMBOLS / MAX_ORDER_NOTIONAL / SYMBOL_MAX_NOTIONAL /
-#   WEBULL_TRADE_API_BASE / WEBULL_QUOTES_API_BASE / WEBULL_EVENTS_API_BASE /
-#   BASIC_AUTH_* / EVENT_INGEST_SECRET / WEBULL_APP_* / WEBULL_ACCOUNT_ID
-#   → set below for local dev, use `wrangler secret put` for deployed envs.
+# 前提 (#118 以降):
+# - 運用パラメタ (dry_run / trading_enabled / market_hours_check / stale_quote_ms /
+#   gap_reject_pct / 銘柄 universe / notional cap / 戦略 rule など) は **D1 の
+#   `global_config` / `symbol_config`** が真値。env var では持たない。
+#   → `wrangler d1 execute ... "UPDATE global_config SET ..."` で runtime 即反映。
+# - ここに書くのは **credential / 非公開 endpoint / deploy gate** のみ。
+# - deployed env は `wrangler secret put <KEY> --env=<dev|staging|production>`。
+#   production の credential は staging/dev と必ず分ける (誤爆防止)。
+# - 並列 PR での conflict を避けるため、**新しい var は末尾に append** する。
 
+# --- Webull credential (必須) ---
 WEBULL_APP_KEY=
 WEBULL_APP_SECRET=
-# Run `pnpm run accounts` after setting the two above to fetch account_id.
-WEBULL_ACCOUNT_ID=
-# Webull JP host (#21)。env 未設定なら JP **prod** default に fallback:
+# 口座 ID。JP_CASH 単一口座に集約済 (#109)。上 2 つを入れて `pnpm run accounts`
+# を叩くと取得できる (Webull sandbox は dashboard から確認できないため)。
+WEBULL_ACCOUNT_ID_JP_CASH=
+
+# --- Webull JP host (optional) ---
+# env 未設定なら JP **prod** default に fallback:
 #   WEBULL_TRADE_API_BASE  default = https://api.webull.co.jp
 #   WEBULL_QUOTES_API_BASE default = https://data-api.webull.co.jp
 #   WEBULL_EVENTS_API_BASE default = https://events-api.webull.co.jp  (consumer 未実装)
@@ -26,69 +30,10 @@ WEBULL_ACCOUNT_ID=
 # WEBULL_QUOTES_API_BASE=https://jp-openapi-alb.uat.webullbroker.com
 # WEBULL_EVENTS_API_BASE=https://jp-openapi-alb.uat.webullbroker.com
 
-ALLOWED_SYMBOLS=SOXL,SOXS
-MAX_ORDER_NOTIONAL=100
-SYMBOL_MAX_NOTIONAL={"SOXL":200,"SOXS":150}
-
-# Local overrides for operational flags (optional):
-# DRY_RUN=true
-# TRADING_ENABLED=false
-# MARKET_HOURS_CHECK=false
-
-# #38-C risk knobs (optional, both default to sane values):
-# STALE_QUOTE_MS=900000
-# GAP_REJECT_PCT=0.03
-
-# Notification webhooks (#199, optional). 未設定なら通知 no-op。
-# Slack incoming webhook と Discord webhook はそれぞれ単独 / 両方設定可能。
-SLACK_WEBHOOK_URL=
-DISCORD_WEBHOOK_URL=
-# dashboard 通知 link の base URL (例: https://webull-trading.example.workers.dev)。
-DASHBOARD_BASE_URL=
-
-# #257: trade/account endpoint path 上書き (optional、append at end 規約)。
-# default は旧 path (/openapi/account/*)。staging で新 path に切替えるとき
-# 設定する。値は `/` で始まる絶対パスのみ受理、空 / whitespace / 相対 URL
-# は default fallback (broken request 投げない / WEBULL_TRADE_API_BASE bypass 防止)。
-# WEBULL_PATH_POSITIONS=/openapi/assets/positions
-# WEBULL_PATH_ORDERS_HISTORY=/openapi/trade/order/history
-# WEBULL_PATH_ORDERS_PLACE=/openapi/trade/order/place
-
-# #258: trade/account routes の x-version ヘッダ override (optional、append
-# 規約)。default 'v1' (= 現行)。新 docs では v2 推奨だが旧 path でも v1 alias
-# で受理されるので staging で 'v2' 切替え検証してから default 化する。
-# 受理値は 'v1' / 'v2' のみ、それ以外 (空 / whitespace / 任意文字列) は 'v1'
-# fallback (auth signing が壊れるのを防ぐ strict 受理)。
-# WEBULL_TRADE_VERSION=v2
-
-# #256: Place Order body schema version (optional、append 規約)。default 'v1'
-# (現挙動)、'v2' で新 docs 形式 (combo_type=NORMAL / session=CORE / MARKET
-# は limit_price 不要 / account_id を body)。受理値は 'v1' / 'v2' のみ、
-# それ以外 (空 / whitespace / 任意文字列) は 'v1' fallback。
-# WEBULL_PLACE_ORDER_SCHEMA=v2
-
-# #276: runtime kill-switch の deploy-gate override (optional、append 規約)。
-# prod は D1 `global_config.trading_enabled` が真値だが、env を 'false' に
-# すると DB が ON でも強制 OFF (= より制限的が勝つ)。preview / staging で
-# 「DB を間違って ON にしてもこの環境では絶対に発注しない」保険。
-# 受理値: unset / 'true' → DB 尊重、'false' → 強制 OFF、それ以外 → 強制 OFF。
-# TRADING_ENABLED=false
-
-# #277: per-env secrets. `.dev.vars` is local only. For deployed envs use
-# `wrangler secret put <KEY> --env=<dev|staging|production>`. Examples:
-#   wrangler secret put BASIC_AUTH_USER --env=dev
-#   wrangler secret put BASIC_AUTH_PASSWORD --env=dev
-#   wrangler secret put EVENT_INGEST_SECRET --env=dev
-#   wrangler secret put WEBULL_APP_KEY --env=dev
-#   wrangler secret put WEBULL_APP_SECRET --env=dev
-#   wrangler secret put WEBULL_ACCOUNT_ID --env=dev
-# Repeat for --env=staging (sandbox key) and --env=production (live key).
-# Production credentials MUST be distinct from staging/dev to avoid 誤爆.
-
-# #29: Cloudflare Access auth (append 規約)。本 PR で BASIC_AUTH_USER /
-# BASIC_AUTH_PASSWORD / EVENT_INGEST_SECRET は廃止 (上記 #277 ブロック内の
-# 例示はファイル append-only 規約のため残しているが、これらの secret は実体
-# として存在しない。代わりに以下を投入する)。
+# --- 認証 (#29: Cloudflare Access) ---
+# 旧 BASIC_AUTH_USER / BASIC_AUTH_PASSWORD / EVENT_INGEST_SECRET は廃止済 (実体
+# として存在しない)。残っている deployed env があれば
+# `wrangler secret delete <KEY> --env=<env>` で除去する。
 # - Local dev (wrangler dev): ACCESS_DEV_BYPASS_USER のみ設定。middleware が
 #   この文字列を actor として stamp する。**deployed env では絶対に設定禁止**。
 # - dev / staging / production: CF_ACCESS_TEAM_DOMAIN (full URL、例:
@@ -96,33 +41,68 @@ DASHBOARD_BASE_URL=
 #   application AUD tag) を `wrangler secret put --env=<env>` で投入。
 #   CF_ACCESS_TEAM_DOMAIN が設定されていると middleware は ACCESS_DEV_BYPASS_USER
 #   を無視するので、deployed env で誤って bypass var を入れても prod-safe。
-#   投入例:
-#     wrangler secret put CF_ACCESS_TEAM_DOMAIN --env=production
-#     wrangler secret put CF_ACCESS_AUD --env=production
-# 旧 BASIC_AUTH_* / EVENT_INGEST_SECRET は wrangler secret delete --env=<env> で除去。
 ACCESS_DEV_BYPASS_USER=dev@local
 # CF_ACCESS_TEAM_DOMAIN=
 # CF_ACCESS_AUD=
+# /mcp 専用 Access application (path 限定 + Service Auth policy) の AUD tag (#553)。
+# 未設定なら CF_ACCESS_AUD に fallback。
+# CF_ACCESS_MCP_AUD=
 
-# Webull `x-access-token` (#21、append 規約)。token flow 別の supplemental auth:
-#   1. operator が Webull 公式ツールで token 発行 (PENDING 初期 status)
+# --- Webull `x-access-token` (#21) ---
+# signature とは直交する supplemental auth。通常運用の真値は WEBULL_TOKEN_STATE DO
+# 側で、`0 22 * * *` cron が expires 残り 7 days で自動 refresh する。この env は
+# DO seed 前の bootstrap fallback。
+#   1. `pnpm run issue-token` で PENDING token を発行
 #   2. Webull モバイルアプリで 2FA SMS verify (5 min 以内) → NORMAL 化
-#   3. その token 値を投入 (`wrangler secret put WEBULL_ACCESS_TOKEN --env=...`)
-#   4. 15 days inactivity で INVALID → 期限切れ監視 / 再投入は別 issue
-# テスト環境は 2FA 不要で auto-NORMAL、staging では未設定でも動くケース有り。
-# prod では設定漏れ → 401 で発覚させる方針 (= fail-closed ではなく throw しない)。
+#   3. `POST /admin/webull-token/seed` (または /dashboard/webull-token) で DO に投入
+# 15 days inactivity で INVALID 化する。
 WEBULL_ACCESS_TOKEN=
 
-# QUOTE_SOURCE (#475): 'webull' で quote を Webull Market Data API (bid/ask 付き、
-# trade host + v2) に切替。JP 銘柄と Webull 障害時は Yahoo に自動 fallback。
-# 未設定 = yahoo (現行 default)。
-# QUOTE_SOURCE=webull
+# --- 通知 (#199, optional) ---
+# 未設定なら通知 no-op。Slack / Discord はそれぞれ単独 / 両方設定可能。
+SLACK_WEBHOOK_URL=
+DISCORD_WEBHOOK_URL=
+# dashboard 通知 link の base URL (例: https://webull-trading.example.workers.dev)。
+DASHBOARD_BASE_URL=
 
-# BAR_SOURCE (#475): 'webull' で daily/intraday bars を Webull Market Data API に
-# 切替。^VIX / JP 銘柄 / Webull 障害時は Yahoo に自動 fallback。未設定 = yahoo。
+# --- deploy gate (#276, optional) ---
+# prod の kill-switch 真値は D1 `global_config.trading_enabled` だが、env を
+# 'false' にすると DB が ON でも強制 OFF (= より制限的が勝つ)。preview / staging で
+# 「DB を間違って ON にしてもこの環境では絶対に発注しない」保険。
+# 受理値: unset / 'true' → DB 尊重、'false' → 強制 OFF、それ以外 → 強制 OFF。
+# TRADING_ENABLED=false
+
+# --- Webull endpoint path / schema override (optional) ---
+# #257: trade/account endpoint path。default は旧 path (/openapi/account/*)。
+# 値は `/` で始まる絶対パスのみ受理、空 / whitespace / 相対 URL は default fallback
+# (broken request を投げない / WEBULL_TRADE_API_BASE bypass 防止)。
+# WEBULL_PATH_POSITIONS=/openapi/assets/positions
+# WEBULL_PATH_ORDERS_HISTORY=/openapi/trade/order/history
+# WEBULL_PATH_ORDERS_PLACE=/openapi/trade/order/place
+# #415: Account Balance (買付余力 pre-trade ゲート用)。default は v1
+# `/openapi/account/balance`。WEBULL_TRADE_VERSION=v2 運用なら下記を指定。
+# WEBULL_PATH_ACCOUNT_BALANCE=/openapi/assets/balance
+# quote snapshot path の override (UAT 差異吸収用)。
+# WEBULL_QUOTE_PATH=
+# #258: trade/account routes の x-version ヘッダ。受理値は 'v1' / 'v2' のみ、
+# それ以外は 'v1' fallback (auth signing が壊れるのを防ぐ strict 受理)。
+# WEBULL_TRADE_VERSION=v2
+# #256: Place Order body schema version。'v2' で新 docs 形式 (combo_type=NORMAL /
+# session=CORE / MARKET は limit_price 不要 / account_id を body)。同じく strict。
+# WEBULL_PLACE_ORDER_SCHEMA=v2
+
+# --- market data source (#475, optional) ---
+# QUOTE_SOURCE: 'webull' で quote を Webull Market Data API (bid/ask 付き、
+# trade host + v2) に切替。JP 銘柄と Webull 障害時は Yahoo に自動 fallback。
+# BAR_SOURCE: 'webull' で daily/intraday bars を同 API に切替。^VIX / JP 銘柄 /
+# 障害時は Yahoo に自動 fallback。いずれも未設定 = yahoo。
+# QUOTE_SOURCE=webull
 # BAR_SOURCE=webull
 
-# --- MCP (#553) ---
-# CF_ACCESS_MCP_AUD: /mcp 専用 Access application (path 限定 + Service Auth policy)
-# の AUD tag。未設定なら CF_ACCESS_AUD に fallback。設定は wrangler secret:
-#   wrangler secret put CF_ACCESS_MCP_AUD --env=production
+# --- production readiness の閾値 (#376 / #379, optional) ---
+# `GET /admin/production-readiness` の preflight を締める値。取引 gate そのものでは
+# なく、本番 gate を外す前の fail-closed チェックの上限。
+# FIRST_LIVE_MAX_ACTIVE_SYMBOLS=
+# FIRST_LIVE_MAX_ORDER_NOTIONAL_USD=
+# FIRST_LIVE_MAX_ORDER_NOTIONAL_JPY=
+# ROLLBACK_REHEARSAL_MAX_AGE_HOURS=

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,21 @@
+{
+  "mcpServers": {
+    "webull": {
+      "command": "op",
+      "args": [
+        "run",
+        "--env-file=.dev.vars",
+        "--",
+        "uvx",
+        "webull-openapi-mcp",
+        "serve"
+      ],
+      "env": {
+        "WEBULL_ENVIRONMENT": "prod",
+        "WEBULL_REGION_ID": "jp",
+        "WEBULL_TOOLSETS": "account,market-data,instrument",
+        "WEBULL_TOKEN_DIR": ".local/webull-mcp/conf"
+      }
+    }
+  }
+}

--- a/docs/db-operations.md
+++ b/docs/db-operations.md
@@ -85,7 +85,7 @@ VALUES ('GLD', 'SPDR Gold Shares', 'US', 1, 5000, strftime('%Y-%m-%dT%H:%M:%fZ',
 INSERT INTO symbol_config (symbol, name, market, active, max_notional, updated_at)
 VALUES ('7203', 'トヨタ自動車', 'JP', 1, 100000, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'));
 
--- 一時停止 (ALLOWED_SYMBOLS から外れる / 次 cron から反映)
+-- 一時停止 (universe から外れる / 次 cron から反映)
 UPDATE symbol_config SET active = 0, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
 WHERE symbol = 'SOXS';
 

--- a/docs/env-separation.md
+++ b/docs/env-separation.md
@@ -56,12 +56,12 @@ pnpm wrangler d1 migrations apply webull-trading-production --env=production --r
 
 ### 3. Secret を env ごとに投入
 
-`wrangler secret put <KEY> --env=<dev|staging|production>` で投入する。`.dev.vars.example` 末尾に key 一覧と例コマンドがある。
+`wrangler secret put <KEY> --env=<dev|staging|production>` で投入する。key の一覧と用途は `.dev.vars.example` にある。
 
 最小必須:
 
 - `CF_ACCESS_TEAM_DOMAIN` / `CF_ACCESS_AUD` (#29 Access auth)
-- `WEBULL_APP_KEY` / `WEBULL_APP_SECRET` / `WEBULL_ACCOUNT_ID`
+- `WEBULL_APP_KEY` / `WEBULL_APP_SECRET` / `WEBULL_ACCOUNT_ID_JP_CASH`
 
 `BASIC_AUTH_USER` / `BASIC_AUTH_PASSWORD` / `EVENT_INGEST_SECRET` は #29 で
 廃止。既存 deploy は `wrangler secret delete <key> --env=<env>` で除去する。

--- a/scripts/list-webull-accounts.ts
+++ b/scripts/list-webull-accounts.ts
@@ -9,7 +9,7 @@
  *     WEBULL_TRADE_API_BASE=https://jp-openapi-alb.uat.webullbroker.com \
  *     pnpm run accounts
  *
- * Copy the account_id into `.dev.vars` as WEBULL_ACCOUNT_ID.
+ * Copy the account_id into `.dev.vars` as WEBULL_ACCOUNT_ID_JP_CASH.
  */
 
 import { createWebullReadClient } from '../src/infrastructure/webull/WebullReadClient'


### PR DESCRIPTION
## なぜ

`.dev.vars.example` をコピーしてもローカル dev がまともに動かない状態だった。

- `WEBULL_ACCOUNT_ID` のまま (コードが読むのは `WEBULL_ACCOUNT_ID_JP_CASH`、PR #109 の単一口座化以降)
- `ALLOWED_SYMBOLS` / `MAX_ORDER_NOTIONAL` / `SYMBOL_MAX_NOTIONAL` / `STALE_QUOTE_MS` / `GAP_REJECT_PCT` / `DRY_RUN` / `MARKET_HOURS_CHECK` を現役の設定として提示 — いずれも `src/` に参照ゼロ (D1 `global_config` / `symbol_config` に移行済)
- 逆に、実際に必要な `ACCESS_DEV_BYPASS_USER` 以外の Access 系や `FIRST_LIVE_*` などが分散・欠落
- 冒頭の「Operational flags は wrangler.jsonc::vars にある」も不正確 (現在 `vars` にあるのは `ENVIRONMENT` / `QUOTE_SOURCE` / `BAR_SOURCE` のみ)

## やったこと

- `src/config/env.ts` の `Env` 宣言と突き合わせ、**実際に読まれる var だけ**を用途別セクション (credential / host / 認証 / token / 通知 / deploy gate / path・schema override / market data source / production readiness) に再編
- `WEBULL_ACCOUNT_ID` → `WEBULL_ACCOUNT_ID_JP_CASH`
- 死んだ var を削除し、冒頭に「運用パラメタの真値は D1、ここは credential と gate のみ」を明記
- 旧 `BASIC_AUTH_*` / `EVENT_INGEST_SECRET` は「廃止済 + `wrangler secret delete` で除去」の 1 ブロックに集約 (#277 の例示ブロックは実体のない secret を投入例として並べていたので削除)
- 「新 var は末尾に append」の並列 PR 規約は冒頭に明記して維持
- 併せて同じ rename が漏れていた箇所を修正: `docs/env-separation.md` / `scripts/list-webull-accounts.ts` の doc comment、`docs/db-operations.md` と `.claude/agents/trading-strategist.md` の `ALLOWED_SYMBOLS` / `MAX_ORDER_NOTIONAL` 前提

## 検証

- `pnpm test` (117 files / 1724 tests) pass。コード変更は doc comment 1 行のみで挙動に影響なし
- var の取捨は `src/config/env.ts` の `Env` interface と `grep` による参照カウントで確認

## 残件 (別 issue 向け)

- `src/config/env.ts` の `parseSymbolRulesMap` / `parseSymbolNotionalMap` / `parseInversePairs` / `parseDrawdownKillThreshold` は env.ts 外から参照されておらず dead code (テストのみ)
- `docs/review-queries.md` に削除済の `/dashboard/charts?tab=grid` への参照が残っている

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * CodeRabbit の指摘を安全性・正確性・Phase スコープで判断する運用ガイドを追加しました。
  * トレード開発時の安全ルール、Workers 制約、レビュー基準を文書化しました。
  * Phase スコープ判定とスキップ理由の手順を追加しました。
  * データベース操作、環境分離、Webull アカウント設定の説明を更新しました。

* **設定**
  * Webull の日本キャッシュ口座設定、Cloudflare Access、通知、取引ゲート、市場データ切り替えの設定例を整理しました。
  * Webull MCP サーバー設定を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->