### PR TITLE
feat: keep evaluating exits while a risk halt blocks new entries

### DIFF
--- a/.agents/skills/coderabbit-policy/SKILL.md
+++ b/.agents/skills/coderabbit-policy/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: coderabbit-policy
+description: Use this skill when processing CodeRabbit CLI or PR-level findings — to decide which suggestions to apply and which to skip with a documented reason. Keeps POC reviews from scope-creeping.
+---
+
+# CodeRabbit Policy
+
+CodeRabbit の指摘は全件反映するのではなく、**POC スコープ + 安全性**の観点でフィルタする。採用基準と却下基準をここに集約。
+
+## 採用する指摘 (apply)
+
+- **セキュリティ**: secret の timing-safe 比較、credential の leak、XSS / injection、auth bypass
+- **correctness バグ**: `typeof arr === 'object'` 誤判定、負値 / NaN / Infinity の通過、DRY_RUN が無視される分岐
+- **入力 validation**: 空文字 / ゼロ / 非数値を弾く
+- **型の厳格化**: loose string → literal union + runtime guard
+- **実際に壊れている挙動**: audit log が status を誤記録、認証通さず 200 が返る、等
+
+## スキップする指摘 (skip with reason)
+
+PR body もしくはコメントで明示的に却下理由を書く。「無言で無視」はしない。
+
+| パターン | 却下理由テンプレ |
+|---|---|
+| 他 Phase に属する機能要求 | `Phase N scope (#issue)` |
+| 意図された TODO 実装要求 (e.g. `bridge/grpc/client.ts`) | `Intentional TODO per issue #5 scope` |
+| 早期最適化 (middleware closure cache 等) | `Premature optimization for POC` |
+| 未使用 optional フィールドの追加 | `Dead interface — no caller populates these fields` |
+| DI / factory の前倒し | `Premature abstraction for POC` |
+| 過剰な境界テスト / exhaustive coverage | `POC coverage is adequate (1 pass + 1 fail case)` |
+| Workers 制約を bridge に誤適用 | `Stale finding: bridge runs in Node, not Workers` |
+| 既に対応済 / 前提を誤解 | `Stale finding: <具体的な状況>` |
+
+## フロー
+
+1. `coderabbit review --agent` の findings JSON を読む
+2. 各 finding について:
+   - セキュリティ or correctness?
+     - YES → apply
+     - NO → 下へ
+   - Phase scope 内?
+     - YES → apply (trivial / minor でも入れてよい)
+     - NO → skip + テンプレ適用
+3. apply リストを 1 commit に束ねる (commit message で CodeRabbit 参照)
+4. skip リストを PR body に表形式で記載:
+   - `# | finding | 却下理由`
+
+## コマンド
+
+### ローカル実行
+
+```bash
+# worktree 内で:
+coderabbit review --agent > .local/coderabbit-findings.log
+```
+
+### codex 経由での実行
+
+codex sandbox は network と `~/.coderabbit/` への書き込みをデフォルトでブロックする。両方を明示的に許可する:
+
+```bash
+codex exec --full-auto \
+  -c 'sandbox_workspace_write.network_access=true' \
+  -c 'sandbox_workspace_write.writable_roots=["$HOME/.coderabbit"]' \
+  - < prompt.md
+```
+
+### 認証の渡し方
+
+**推奨: OAuth 保存トークン** (`coderabbit auth login --agent` を事前に1回実行済み)
+- `~/.coderabbit/` 内に保存されるため、上記 `writable_roots` を設定すれば codex 内でも読める
+- プロンプトでは `coderabbit review --agent` をそのまま呼ぶ (`--api-key` 不要)
+
+**`--api-key` 経由** (有料 Hoppy CLI アドオン必須、通常プランでは "User API keys are not supported" / "No CLI addon found" と弾かれる):
+1. 1P の Agentic API key (User API key ではない) を `op://Personal/CODERABBIT_API_KEY/credential` に保存
+2. 親シェルで解決して env var で渡す (codex sandbox は 1P デスクトップアプリの IPC socket に到達できないので `op run -- ...` を codex 内から直接呼ぶのは失敗する):
+
+```bash
+CODERABBIT_API_KEY="$(op read 'op://Personal/CODERABBIT_API_KEY/credential')" \
+  codex exec --full-auto \
+    -c 'sandbox_workspace_write.network_access=true' \
+    -c 'sandbox_workspace_write.writable_roots=["$HOME/.coderabbit"]' \
+    - < prompt.md
+```
+
+3. codex 内では `coderabbit review --agent --api-key "$CODERABBIT_API_KEY"` と呼ぶ (env var 単体では CLI は honor しないので flag 渡しが必須)
+
+### よくあるエラーと原因
+
+| エラー | 原因 |
+|---|---|
+| `Authentication required` | `~/.coderabbit/` が読めない or `--api-key` 未指定。sandbox 設定か OAuth ログインを確認 |
+| `Invalid or expired API key` | 1P に保存された key が古い。再発行して更新 |
+| `User API keys are not supported for the CLI` | User API key を渡した。**Agentic API key** をダッシュボードで発行 |
+| `No CLI addon found` | 通常プランでは API key 経由 CLI が使えない。OAuth 保存トークン経由に戻す |
+| `ConnectionRefused` to `posthog.com` | codex sandbox の network_access を有効化していない |
+| `EPERM unlink ~/.coderabbit/logs/...` | `writable_roots` に `~/.coderabbit` を含めていない |
+
+### findings の整形
+
+```bash
+grep '"type":"finding"' .local/coderabbit-findings.log | python3 -c '
+import json, sys
+for i, line in enumerate(sys.stdin, 1):
+    f = json.loads(line)
+    print(f"{i}. [{f[\"severity\"]}] {f[\"fileName\"]}")
+    print(f"   {f[\"codegenInstructions\"].split(chr(10)+chr(10), 1)[-1][:200]}")'
+```
+
+## CodeRabbit への事前シグナル
+
+`.coderabbit.yaml` の `path_instructions` で Phase scope ルールをプリロードしてある。自動レビュー時の誤爆を減らすためのガードレール。`AGENTS.md` と同じ方針をレビュア視点で書く。
+
+## 迷ったときの原則
+
+- **安全側 (採用) に倒すのは correctness / security のみ**
+- **抽象化 / 網羅性は却下側に倒す**
+- 判断に悩むものは PR 本文に明示して human review に渡す

--- a/.agents/skills/phase-scope/SKILL.md
+++ b/.agents/skills/phase-scope/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: phase-scope
+description: Use this skill before opening a PR, before accepting a CodeRabbit suggestion, or when planning changes — to verify that work stays inside the current PR's Phase scope and to route out-of-scope items to the correct Phase issue.
+---
+
+# Phase Scope
+
+POC は **Phase 単位の PR** で進める。Phase 跨ぎの変更要求は必ず該当 issue に回し、この PR では対応しない。
+
+## Phase → Issue
+
+| Phase | Issue | 概要 |
+|---|---|---|
+| 1 | — (PR #2 merged) | Scaffold |
+| 2 | [#3](https://github.com/ochanuco/webull-trading/issues/3) | Trading core (Strategy / Risk / MockExecution) |
+| 3 | [#4](https://github.com/ochanuco/webull-trading/issues/4) | Webull HTTP |
+| 4 | [#5](https://github.com/ochanuco/webull-trading/issues/5) | gRPC trade events |
+| 5 | [#6](https://github.com/ochanuco/webull-trading/issues/6) | retry / audit 強化 / symbol config |
+
+owned ファイル / acceptance / in-out scope の詳細は **各 issue** を参照 (`gh issue view <N>`)。
+
+## 判定フロー
+
+1. 現 PR の Phase を branch 名 / title から特定
+2. 変更対象が当該 Phase の owned ファイル? (issue の scope 表で確認)
+   - YES → 進める
+3. 共有ファイル (`src/app.ts` / `src/config/env.ts` / `.dev.vars.example`) への **末尾 append**?
+   - YES → 進める (後発 PR が rebase で union 解決)
+4. 他 Phase の owned ファイルへの変更 or 機能追加か?
+   - **却下**。該当 issue への参照でスキップ理由を書く
+
+## スキップ理由テンプレ
+
+- `Phase N scope (#issue)` — 他 Phase に属する機能/ハードニング要求
+- `Not in scope for this POC` — HFT / ML / multi-broker / Queue / DO
+- `Stale finding` — 既対応 or 前提誤認
+- `Premature abstraction for POC` — DI / factory / 設定間接化
+- `Intentional TODO per issue` — scope 明記の placeholder
+- `POC coverage is adequate` — exhaustive 境界テスト要求
+
+## 例外 (Phase 不問で採用)
+
+- セキュリティ (timing-safe、credential leak、auth bypass)
+- 入力 validation (negative / NaN / empty / zero)
+- 明確なバグ (型判定の誤り、status の誤記録等)
+- 型の厳格化 (literal union + runtime guard)
+
+## 迷ったら
+
+PR 本文に判断を書いて human review に委ねる。一人で抱え込まない。

--- a/.agents/skills/trading-developer/SKILL.md
+++ b/.agents/skills/trading-developer/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: trading-developer
+description: Use this skill when editing, reviewing, or planning code under `src/trading/`, `src/infrastructure/webull/`, `bridge/`, or any file that touches orders / positions / market data / broker calls. Applies retail auto-trading domain knowledge and safety invariants.
+---
+
+# Trading Developer
+
+このリポジトリで**取引系コード**を触るときのドメイン姿勢。
+
+## 前提
+
+- 対象は **retail (個人) の POC auto-trader**。Webull OpenAPI (SDK 非依存) に直接 HTTP / gRPC で接続する Cloudflare Workers アプリ。
+- **実マネーが流れる前提**で書く。遅さは直せるが誤発注は直せない。
+- HFT / sub-second latency は対象外。数秒〜分オーダーでよい。
+
+## Safety invariants (絶対に壊さない)
+
+- **発注経路は Strategy → Risk → Execution** の順。Risk で止まるフローを壊すリファクタ提案は却下。
+- Safety defaults は **fail-closed**: `DRY_RUN=true` / `TRADING_ENABLED=false` が初期値。`DRY_RUN=true` のとき **broker 実通信を一切行わない**。
+- Risk checks: symbol whitelist / max order notional / tradingEnabled / market hours (Phase 5) は OR ではなく **すべて AND で評価**。
+- Webull raw JSON / proto は infrastructure 層に閉じ込める。application / domain には **正規化後のドメイン型だけ** 流す。
+- secret / token の比較は **timing-safe** (単純な `!==` は不可)。
+- 各 request / event に `requestId` を付け、結果を構造化 JSON で audit log に残す。
+
+## ドメイン用語 (混同しない)
+
+| 用語 | 意味 | 備考 |
+|---|---|---|
+| **order** | 発注指示 | market / limit / stop / stop-limit。現状 POC は limit / market のみ想定 |
+| **position** | 保有数 | long = +、short = -。POC は long のみ |
+| **notional** | 金額ベースの建玉 | `price * quantity`。Risk の上限チェックに使う |
+| **filled_qty** | 約定済み数量 | 非負整数。部分約定で ≤ 発注数量 |
+| **bid / ask** | 買指値 / 売指値 | spread = ask - bid |
+| **Dry Run** | 実発注せず mock 応答 | `DRY_RUN=true` 時の動作 |
+| **Paper trading** | Webull 側の仮想口座 | POC では扱わない (Dry Run で代替) |
+
+## 書き方のクセ
+
+- Order 関連の数値型 (`price`, `quantity`, `notional`, `filledQty`) は **必ず `> 0` / `>= 0` を入力時に確認**。negative / NaN / Infinity は domain の手前で弾く。
+- Symbol は大文字で正規化 (`"soxl"` 受けても `"SOXL"` で比較)。ティッカーは case-insensitive が暗黙慣習。
+- 時刻は必ず **UTC の ISO 8601** で保存 (`new Date().toISOString()`)。US market 時間変換は表示側で。
+- 通貨は POC では USD のみ。multi-currency の抽象は前倒しで入れない。
+- `rawPayload` は audit 用に保持するが、**domain ロジックから参照しない**。
+
+## Webull / Cloudflare Workers 特有の制約
+
+- Workers は長時間 TCP 保持不可 → gRPC stream は `bridge/` (Node runtime) で受け、HTTP POST で Worker に ingest する設計。
+- Workers の `fetch` は request timeout が実質無制限ではない → broker 呼び出しには **明示タイムアウト** を入れる (Phase 5 で retry 付き強化)。
+- `crypto.randomUUID()` / `crypto.subtle` は Workers で利用可。Node だけの API は Worker 側では使わない。
+- 秘密は `.dev.vars` / Worker secrets 経由。ログに出さない (secret値を含む body は監査ログから除外 or masked)。
+
+## よくある間違い (レビューで弾く)
+
+- **DRY_RUN なのに broker に request 飛ばす分岐** → 即 reject
+- **Risk チェックを bypass する "便利" helper** → 即 reject
+- **string 比較での secret check** (`env.SECRET !== header`) → timing-safe に直す
+- **allowedSymbols が env で上書き可能な開発用バックドア** → 本番 / POC 問わず入れない
+- **filledQty に負値 / NaN を許容する parser** → 非負 finite で弾く
+- **order 数量 0 を "何もしない" として扱う** → 入力として却下 (400)
+- **Market hours を確認せず発注** → Phase 5 で入れるまでは `tradingEnabled` で代用 (hard toggle)
+
+## 迷ったら
+
+- **安全側に倒す** (実発注しない / エラー返す / ログだけ残す)。fallback で "とりあえず発注" は絶対やらない
+- POC scope 外の議論 (multi-broker / HFT / ML) は **別 issue にして打ち切る**
+- 判断に悩むなら Issue #1 (POC 設計書) の §11 安全設計 / §13 エラー分類を参照

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,21 @@
+{
+  "mcpServers": {
+    "webull": {
+      "command": "op",
+      "args": [
+        "run",
+        "--env-file=.dev.vars",
+        "--",
+        "uvx",
+        "webull-openapi-mcp",
+        "serve"
+      ],
+      "env": {
+        "WEBULL_ENVIRONMENT": "prod",
+        "WEBULL_REGION_ID": "jp",
+        "WEBULL_TOOLSETS": "account,market-data,instrument",
+        "WEBULL_TOKEN_DIR": ".local/webull-mcp/conf"
+      }
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -218,6 +218,9 @@ export default {
                 requestId,
                 symbols: result.symbols,
                 skipReason: result.skipReason,
+                // #exit-only-halt: run 全体は走っているが新規 entry だけ止めた場合。
+                // skipReason とは排他で、こちらが出ている tick は exit 判定済み。
+                entryHaltReason: result.entryHaltReason ?? null,
                 summary,
                 analysis: result.analysis,
               }),

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -95,6 +95,11 @@ export interface StrategyCronResult {
    * Webull payloads, only config/risk context and per-symbol decisions.
    */
   analysis: StrategyCronAnalysis
+  /**
+   * run 全体を評価せず抜けた理由。`portfolio_halted` / `drawdown_kill` は
+   * #exit-only-halt 以降 **この経路では出ない** (entry のみ停止に変更)。
+   * 既存の decision log / dashboard filter との互換のため union には残す。
+   */
   skipReason?:
     | 'trading_disabled'
     | 'no_tradable_symbols'
@@ -103,6 +108,12 @@ export interface StrategyCronResult {
     | 'no_bridge_state'
     | 'portfolio_halted'
     | 'drawdown_kill'
+  /**
+   * #exit-only-halt: risk halt により **新規 entry のみ**停止した理由。
+   * `skipReason` (= run 全体を skip) とは排他で、こちらが立っている run は
+   * 建玉の exit 判定を通常どおり実行している。
+   */
+  entryHaltReason?: string
 }
 
 export interface StrategyCronAnalysis {
@@ -149,6 +160,12 @@ export interface StrategyCronAnalysis {
     scale: number
     drawdown: number
   }
+  /**
+   * #exit-only-halt: risk 由来の halt で **新規 entry だけ**を止めている状態。
+   * 全銘柄が BUY 抑止され、exit (stop / TP / time-stop) は通常どおり評価される。
+   * 未設定なら通常運転。
+   */
+  entryHalt?: { reason: string }
   /**
    * VIX regime decision (issue #196 3/3)。`^VIX` の最新値から導出。
    * cron tick で一度だけ算出し、両 currency run に同じ decision を渡す。
@@ -405,24 +422,31 @@ export async function runStrategyCron(
     }
   }
 
-  // Portfolio-level pre-flight (fail-closed):
-  // - PORTFOLIO_STATE binding 不在 → halt (drawdown kill を評価する術が無い)
-  // - getPortfolio 例外 → halt
-  // - tradingDisabledUntil が truthy だが parse 不能 → halt (silent pass 防止)
-  // - tradingDisabledUntil が有効 & 未来 → halt
-  // - drawdown 閾値超過 → halt
-  if (!env.PORTFOLIO_STATE) {
-    emitSkipReasonNotify(notifier, 'portfolio_halted', options.requestId, 'critical', 'PORTFOLIO_STATE binding missing')
-    return {
-      summary: emptySummary(),
-      symbols: universe.allowedSymbols,
-      analysis: analysisBase(),
-      skipReason: 'portfolio_halted',
-    }
-  }
-  const portfolioStore = new PortfolioStateClient(env.PORTFOLIO_STATE)
-  let portfolioSnapshot: Awaited<ReturnType<typeof portfolioStore.getPortfolio>>
+  // Portfolio-level pre-flight。**exit-only halt** (#exit-only-halt):
+  // - PORTFOLIO_STATE binding 不在 → entry 停止
+  // - getPortfolio 例外 → entry 停止
+  // - tradingDisabledUntil が truthy だが parse 不能 → entry 停止 (silent pass 防止)
+  // - tradingDisabledUntil が有効 & 未来 → entry 停止
+  // - drawdown 閾値超過 → entry 停止
+  //
+  // いずれも **新規 BUY だけを止め、保有建玉の exit (stop / TP / time-stop) は
+  // 評価し続ける**。stop はブローカー側の逆指値ではなく cron が毎 tick 評価する
+  // ソフト stop なので、ここで全停止すると「一番荒れている時に建玉の唯一の
+  // 保護が消える」ことになる。特に drawdown kill は **実現損益**基準 = stop が
+  // 効いた直後に発火するため、その順序が起きやすい。
+  //
+  // 全停止のままにするのは operator の明示停止 (`trading_enabled` / env
+  // TRADING_ENABLED) と `no_bridge_state` (SYMBOL_STATE 不在 = 建玉状態が
+  // そもそも読めない) だけ。
+  let entryHaltReason: string | null = null
+  const portfolioStore = env.PORTFOLIO_STATE ? new PortfolioStateClient(env.PORTFOLIO_STATE) : null
+  let portfolioSnapshot: Awaited<ReturnType<PortfolioStateClient['getPortfolio']>> | null = null
   let analysis = analysisBase()
+  if (!portfolioStore) {
+    entryHaltReason = 'portfolio_halted: PORTFOLIO_STATE binding missing'
+    emitSkipReasonNotify(notifier, 'portfolio_halted', options.requestId, 'critical', 'PORTFOLIO_STATE binding missing')
+  }
+  if (portfolioStore) {
   try {
     portfolioSnapshot = await portfolioStore.getPortfolio()
     // `lastRolledAt` は #140 で追加した forward-compat フィールド。古い DO row
@@ -454,15 +478,10 @@ export async function runStrategyCron(
           'critical',
           `tradingDisabledUntil=${portfolioSnapshot.tradingDisabledUntil}`,
         )
-        return {
-          summary: emptySummary(),
-          symbols: universe.allowedSymbols,
-          analysis,
-          skipReason: 'portfolio_halted',
-        }
+        entryHaltReason = `portfolio_halted: tradingDisabledUntil=${portfolioSnapshot.tradingDisabledUntil}`
       }
     }
-    if (portfolioSnapshot.dailyStartEquity > 0) {
+    if (entryHaltReason === null && portfolioSnapshot.dailyStartEquity > 0) {
       const ratio = portfolioSnapshot.dailyRealizedPnl / portfolioSnapshot.dailyStartEquity
       if (ratio <= global.drawdownKillThreshold) {
         emitSkipReasonNotify(
@@ -472,36 +491,31 @@ export async function runStrategyCron(
           'critical',
           `ratio=${ratio.toFixed(4)} <= threshold=${global.drawdownKillThreshold}`,
         )
-        return {
-          summary: emptySummary(),
-          symbols: universe.allowedSymbols,
-          analysis,
-          skipReason: 'drawdown_kill',
-        }
+        entryHaltReason = `drawdown_kill: ratio=${ratio.toFixed(4)} <= threshold=${global.drawdownKillThreshold}`
       }
     }
   } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
     emitSkipReasonNotify(
       notifier,
       'portfolio_halted',
       options.requestId,
       'critical',
-      `getPortfolio threw: ${error instanceof Error ? error.message : String(error)}`,
+      `getPortfolio threw: ${message}`,
     )
-    return {
-      summary: emptySummary(),
-      symbols: universe.allowedSymbols,
-      analysis,
-      skipReason: 'portfolio_halted',
-    }
+    entryHaltReason = `portfolio_halted: getPortfolio threw: ${message}`
+  }
   }
 
   // Drawdown-scaled risk: derate sizing for the rest of the trading day
   // when realized PnL is underwater but not yet at drawdown_kill threshold.
   // Emits a journal-visible log so the operator can tell a quiet day from
   // a halved one.
+  // portfolio が読めなかった場合 (exit-only halt 中) は 0/0 を渡す。この経路では
+  // entry が全銘柄抑止されているので sizing 結果は使われないが、後続の型と
+  // ログ形状を素通しにするために neutral な値を入れる。
   const { portfolio: portfolioForScale, usedFallback } = resolvePortfolioForRiskScale(
-    portfolioSnapshot,
+    portfolioSnapshot ?? { dailyStartEquity: 0, dailyRealizedPnl: 0 },
     global.totalCapitalUsd,
   )
   if (usedFallback) {
@@ -619,6 +633,29 @@ export async function runStrategyCron(
   // VIX regime decision を summary にも載せる (CodeRabbit #216 4th):
   // sub-run ごとに独立した summary が `vix` を持つので、aggregate もそれと
   // 揃えておく。`emptySummary()` は `vix` を埋めないので明示的に上書きする。
+  // #exit-only-halt: risk 由来の halt 中は **全銘柄の BUY を抑止**し、SELL /
+  // exit だけを通す。role 由来の抑止理由が既にある銘柄はそちらを優先して残す
+  // (より具体的な理由の方が decision log で有用)。
+  const effectiveEntrySuppressed: Record<string, string> =
+    entryHaltReason === null
+      ? entrySuppressedSymbols
+      : {
+          ...Object.fromEntries(
+            universe.allowedSymbols.map((symbol) => [symbol.toUpperCase(), entryHaltReason]),
+          ),
+          ...entrySuppressedSymbols,
+        }
+  if (entryHaltReason !== null) {
+    console.log(
+      JSON.stringify({
+        event: 'entry_halt_exit_only',
+        requestId: options.requestId,
+        reason: entryHaltReason,
+        symbols: universe.allowedSymbols.length,
+      }),
+    )
+    analysis = { ...analysis, entryHalt: { reason: entryHaltReason } }
+  }
   const summary: PullbackRunSummary = { ...emptySummary(), vix: vixDecision }
   // run は `activeCurrencies` (= 銘柄あり ∧ (gate off ∨ 窓内)) のみ構築する。
   // gate off の時は両 currency が active なので従来挙動と一致する (#session-window-gate)。
@@ -703,7 +740,7 @@ export async function runStrategyCron(
       intradayOnlySymbols: new Set(Object.keys(universe.symbolIntradayOnly)),
       defaultRule,
       rulesMap,
-      entrySuppressedSymbols,
+      entrySuppressedSymbols: effectiveEntrySuppressed,
       halfEntrySymbols,
       momentumSymbols,
       ...(momentumStrategy ? { momentumStrategy } : {}),
@@ -821,7 +858,10 @@ export async function runStrategyCron(
   })
   analysis.allocation = { view: allocationView, ordersEnabled: global.cashFallbackOrdersEnabled }
 
-  if (global.cashFallbackOrdersEnabled && budgetBasisJpy !== undefined) {
+  // #exit-only-halt: cash rebalance pass 2 は entrySuppressedSymbols を渡さない
+  // 唯一の BUY 経路なので、halt 中はここで丸ごと止める (退避先への自動 BUY も
+  // 「新規 entry」として扱う)。
+  if (global.cashFallbackOrdersEnabled && budgetBasisJpy !== undefined && entryHaltReason === null) {
     const plan = buildCashRebalancePlan({
       allocation: allocationView,
       snapshots: summary.entrySnapshots,
@@ -892,7 +932,12 @@ export async function runStrategyCron(
     }
   }
 
-  return { summary, symbols: universe.allowedSymbols, analysis }
+  return {
+    summary,
+    symbols: universe.allowedSymbols,
+    analysis,
+    ...(entryHaltReason !== null ? { entryHaltReason } : {}),
+  }
 }
 
 function sanitizeEquity(value: number | null | undefined, fallback: number): number {

--- a/test/trading/strategy/runStrategyCron.test.ts
+++ b/test/trading/strategy/runStrategyCron.test.ts
@@ -6,7 +6,26 @@ import {
   resolvePortfolioForRiskScale,
   runStrategyCron,
 } from '../../../src/trading/strategy/runStrategyCron'
+import { runPullbackScheduler } from '../../../src/trading/strategy/pullbackScheduler'
 import { makeGlobalConfigSnapshot, makeSymbolUniverse } from '../../helpers/configFixtures'
+
+const emptySchedulerSummary = () => ({
+  evaluated: 0,
+  buys: 0,
+  sells: 0,
+  holds: 0,
+  rejected: [],
+  errors: [],
+  decisions: [],
+  entrySnapshots: {},
+})
+
+/** 直近の runPullbackScheduler 呼び出しに渡された options。 */
+function lastSchedulerOptions(): Parameters<typeof runPullbackScheduler>[0] {
+  const calls = vi.mocked(runPullbackScheduler).mock.calls
+  expect(calls.length).toBeGreaterThan(0)
+  return calls[calls.length - 1]![0]
+}
 
 vi.mock('../../../src/infrastructure/db/globalConfigLoader', () => ({
   loadGlobalConfigFrom: vi.fn(),
@@ -14,6 +33,14 @@ vi.mock('../../../src/infrastructure/db/globalConfigLoader', () => ({
 vi.mock('../../../src/infrastructure/db/symbolUniverse', () => ({
   loadSymbolUniverse: vi.fn(),
 }))
+// #exit-only-halt: risk halt でも scheduler まで進む (entry だけ抑止) ようになった
+// ので、DO / bar client を叩かずに「何が渡されたか」を検証できるよう scheduler を
+// mock する。scheduler 自身の gate 挙動は pullbackScheduler.test.ts が担保する。
+vi.mock('../../../src/trading/strategy/pullbackScheduler', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../src/trading/strategy/pullbackScheduler')>()
+  return { ...actual, runPullbackScheduler: vi.fn() }
+})
 
 const env = {
   DB: {} as D1Database,
@@ -28,6 +55,7 @@ describe('runStrategyCron', () => {
   beforeEach(() => {
     vi.mocked(loadGlobalConfigFrom).mockResolvedValue(makeGlobalConfigSnapshot())
     vi.mocked(loadSymbolUniverse).mockResolvedValue(makeSymbolUniverse())
+    vi.mocked(runPullbackScheduler).mockResolvedValue(emptySchedulerSummary())
     warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
   })
 
@@ -97,7 +125,14 @@ describe('runStrategyCron', () => {
       },
     } as unknown as Parameters<typeof runStrategyCron>[0]
     const result = await runStrategyCron(envWithPortfolio)
-    expect(result.skipReason).toBe('portfolio_halted')
+    // #exit-only-halt: run 全体は skip せず、entry だけ止めて exit 判定は続ける。
+    expect(result.skipReason).toBeUndefined()
+    expect(result.entryHaltReason).toMatch(/^portfolio_halted: tradingDisabledUntil=/)
+    expect(result.analysis.entryHalt?.reason).toBe(result.entryHaltReason)
+    // 全銘柄が BUY 抑止として scheduler に渡る (SELL は素通り = scheduler 側の契約)。
+    const suppressed = lastSchedulerOptions().entrySuppressedSymbols ?? {}
+    expect(Object.keys(suppressed).sort()).toEqual(['SOXL', 'SOXS'])
+    expect(suppressed.SOXL).toBe(result.entryHaltReason)
   })
 
   it('skips with drawdown_kill when realized drawdown exceeds threshold', async () => {
@@ -119,7 +154,36 @@ describe('runStrategyCron', () => {
       },
     } as unknown as Parameters<typeof runStrategyCron>[0]
     const result = await runStrategyCron(envWithPortfolio)
-    expect(result.skipReason).toBe('drawdown_kill')
+    // drawdown kill は **実現損益**基準 = stop が効いた直後に発火する。ここで
+    // 全停止すると残りの建玉の stop が消えるので、entry だけを止める。
+    expect(result.skipReason).toBeUndefined()
+    expect(result.entryHaltReason).toMatch(/^drawdown_kill: ratio=/)
+    const suppressed = lastSchedulerOptions().entrySuppressedSymbols ?? {}
+    expect(suppressed.SOXL).toBe(result.entryHaltReason)
+    expect(suppressed.SOXS).toBe(result.entryHaltReason)
+  })
+
+  it('exit-only halt でも scheduler は全銘柄を評価対象として受け取る (exit を止めない)', async () => {
+    const envWithPortfolio = {
+      ...env,
+      PORTFOLIO_STATE: {
+        idFromName: () => ({}),
+        get: () => ({
+          getPortfolio: vi.fn().mockResolvedValue({
+            dailyStartEquity: 10_000,
+            dailyRealizedPnl: -250,
+            tradingDisabledUntil: null,
+            updatedAt: new Date().toISOString(),
+          }),
+        }),
+      },
+    } as unknown as Parameters<typeof runStrategyCron>[0]
+    vi.mocked(loadGlobalConfigFrom).mockResolvedValue(
+      makeGlobalConfigSnapshot({ drawdownKillThreshold: -0.02 }),
+    )
+    await runStrategyCron(envWithPortfolio)
+    // symbols を間引くと建玉が orphan になる (exit 判定が走らない) ので全銘柄渡す。
+    expect(lastSchedulerOptions().symbols).toEqual(['SOXL', 'SOXS'])
   })
 
   it('fail-closes to portfolio_halted when PORTFOLIO_STATE binding is missing', async () => {
@@ -128,8 +192,10 @@ describe('runStrategyCron', () => {
       SYMBOL_STATE: {} as DurableObjectNamespace<never>,
     } as unknown as Parameters<typeof runStrategyCron>[0]
     const result = await runStrategyCron(envWithoutPortfolio)
-    expect(result.skipReason).toBe('portfolio_halted')
+    expect(result.skipReason).toBeUndefined()
+    expect(result.entryHaltReason).toBe('portfolio_halted: PORTFOLIO_STATE binding missing')
     expect(result.analysis.universe.symbols).toEqual(['SOXL', 'SOXS'])
+    expect(lastSchedulerOptions().entrySuppressedSymbols?.SOXL).toBe(result.entryHaltReason)
   })
 
   // dashboard が disabled (active=0) を表示するために `inactiveSymbols` を
@@ -172,7 +238,10 @@ describe('runStrategyCron', () => {
       },
     } as unknown as Parameters<typeof runStrategyCron>[0]
     const result = await runStrategyCron(envBadTimestamp)
-    expect(result.skipReason).toBe('portfolio_halted')
+    expect(result.skipReason).toBeUndefined()
+    expect(result.entryHaltReason).toBe(
+      'portfolio_halted: tradingDisabledUntil=not-an-iso-timestamp',
+    )
   })
 
   it('fail-closes to portfolio_halted when getPortfolio throws', async () => {
@@ -186,7 +255,8 @@ describe('runStrategyCron', () => {
       },
     } as unknown as Parameters<typeof runStrategyCron>[0]
     const result = await runStrategyCron(envWithBrokenPortfolio)
-    expect(result.skipReason).toBe('portfolio_halted')
+    expect(result.skipReason).toBeUndefined()
+    expect(result.entryHaltReason).toBe('portfolio_halted: getPortfolio threw: DO unreachable')
   })
 
   // CodeRabbit #196 review: 0013 未 migrate な D1 で earnings gate を有効化すると
@@ -312,7 +382,7 @@ describe('runStrategyCron', () => {
         },
       } as unknown as Parameters<typeof runStrategyCron>[0]
       const result = await runStrategyCron(envWithBrokenPortfolio, { requestId: 'req-x' })
-      expect(result.skipReason).toBe('portfolio_halted')
+      expect(result.entryHaltReason).toBe('portfolio_halted: getPortfolio threw: DO unreachable')
       // notify は fire-and-forget なので microtask flush 待ち
       await new Promise((r) => setTimeout(r, 0))
       expect(fetchSpy).toHaveBeenCalled()
@@ -349,10 +419,10 @@ describe('runStrategyCron', () => {
       vi.useFakeTimers()
       vi.setSystemTime(new Date(T_US_OUT))
       // default config は sessionWindowGateEnabled=false。窓外でも gate を通り、
-      // PORTFOLIO_STATE 未 bind で portfolio_halted まで進む (= gate で止まっていない)。
+      // PORTFOLIO_STATE 未 bind の exit-only halt まで進む (= gate で止まっていない)。
       const result = await runStrategyCron(env)
-      expect(result.skipReason).not.toBe('outside_session_window')
-      expect(result.skipReason).toBe('portfolio_halted')
+      expect(result.skipReason).toBeUndefined()
+      expect(result.entryHaltReason).toBe('portfolio_halted: PORTFOLIO_STATE binding missing')
     })
 
     it('flag on + 全市場窓外 → outside_session_window で即 skip', async () => {
@@ -375,7 +445,9 @@ describe('runStrategyCron', () => {
       const result = await runStrategyCron(env)
       // gate 通過 → 後段 (PORTFOLIO_STATE 未 bind) で portfolio_halted。
       expect(result.skipReason).not.toBe('outside_session_window')
-      expect(result.skipReason).toBe('portfolio_halted')
+      // #exit-only-halt: gate 通過の証拠は「run 全体を skip していない」+ 後段の
+      // exit-only halt に到達していること。
+      expect(result.entryHaltReason).toBe('portfolio_halted: PORTFOLIO_STATE binding missing')
     })
 
     it('per-market: JPY 銘柄は US 窓内でも JP 窓外なら skip', async () => {
@@ -398,7 +470,9 @@ describe('runStrategyCron', () => {
       vi.mocked(loadSymbolUniverse).mockResolvedValue(jpyUniverse())
       const result = await runStrategyCron(env)
       expect(result.skipReason).not.toBe('outside_session_window')
-      expect(result.skipReason).toBe('portfolio_halted')
+      // #exit-only-halt: gate 通過の証拠は「run 全体を skip していない」+ 後段の
+      // exit-only halt に到達していること。
+      expect(result.entryHaltReason).toBe('portfolio_halted: PORTFOLIO_STATE binding missing')
     })
 
     // 2026-07-03 は Independence Day 振替休場 (7/4=土)。13:00 ET は通常なら窓内の
@@ -422,7 +496,9 @@ describe('runStrategyCron', () => {
       vi.setSystemTime(new Date(T_US_HOLIDAY))
       const result = await runStrategyCron(env)
       expect(result.skipReason).not.toBe('market_holiday')
-      expect(result.skipReason).toBe('portfolio_halted')
+      // #exit-only-halt: gate 通過の証拠は「run 全体を skip していない」+ 後段の
+      // exit-only halt に到達していること。
+      expect(result.entryHaltReason).toBe('portfolio_halted: PORTFOLIO_STATE binding missing')
     })
 
     it('休場と窓外が混在する場合は outside_session_window に倒す', async () => {
@@ -463,7 +539,9 @@ describe('runStrategyCron', () => {
       )
       const result = await runStrategyCron(env)
       expect(result.skipReason).not.toBe('outside_session_window')
-      expect(result.skipReason).toBe('portfolio_halted')
+      // #exit-only-halt: gate 通過の証拠は「run 全体を skip していない」+ 後段の
+      // exit-only halt に到達していること。
+      expect(result.entryHaltReason).toBe('portfolio_halted: PORTFOLIO_STATE binding missing')
     })
   })
 


### PR DESCRIPTION
戦略判定モデルのレビューで挙げた課題 1/5。

## 問題

stop はブローカー側の逆指値ではなく **cron が毎 tick 評価するソフト stop** です。ところが risk halt 経路 (`runStrategyCron`) は銘柄ループの前に `return` していたため、halt した瞬間に建玉の stop / TP / time-stop がすべて評価されなくなっていました。

特に `drawdown_kill` は **実現損益**基準 (`dailyRealizedPnl / dailyStartEquity`) なので、「stop が効いて損失が実現した直後」に発火します。つまり **一番荒れている時に、残りの建玉の唯一の保護が消える** 順序になっていました。

## 変更

risk 由来の halt を **exit-only halt** にしました。新規 BUY だけを止め、exit 判定はそのまま走ります。

| 停止理由 | 変更前 | 変更後 |
|---|---|---|
| `drawdown_kill` | run 全体 skip | **entry のみ停止** |
| `portfolio_halted` (binding 不在 / getPortfolio throw / tradingDisabledUntil) | run 全体 skip | **entry のみ停止** |
| `trading_disabled` (`trading_enabled` / env `TRADING_ENABLED`) | run 全体 skip | 変更なし (operator の明示停止) |
| `no_bridge_state` (`SYMBOL_STATE` 不在) | run 全体 skip | 変更なし (建玉状態が読めない) |
| `outside_session_window` / `market_holiday` | run 全体 skip | 変更なし |

実装は既存の `entrySuppressedSymbols` (BUY だけを SKIP し SELL を通す #452 の機構) に相乗りし、halt 中は全銘柄をこのマップに載せます。role 由来の抑止理由がある銘柄はそちらを優先して残します。

- 退避先への自動 BUY (`cash_fallback_orders_enabled` の pass 2) は `entrySuppressedSymbols` を通らない唯一の BUY 経路なので、halt 中は丸ごと止めています
- `StrategyCronResult.entryHaltReason` と `analysis.entryHalt` を追加。cron の構造化ログにも出るので dashboard / MCP から追えます
- `skipReason` の union から `portfolio_halted` / `drawdown_kill` は消していません (既存 decision log との互換)。この経路では出なくなった旨をコメントで明記

## 検証

- `pnpm run typecheck` clean / `pnpm test` 114 files・1698 tests pass
- 既存の halt テスト 6 本を新契約 (`entryHaltReason` + 全銘柄が `entrySuppressedSymbols` に載る) に更新
- 「halt 中でも scheduler が全銘柄を評価対象として受け取る」テストを追加 (銘柄を間引くと建玉が orphan になるため)
- session window gate のテストは「後段の halt に到達したこと」を gate 通過の証拠にしていたので、同じ意図のまま `entryHaltReason` で見るよう修正

## 注意

この PR は **halt 中に SELL が発注され得る** ようになります。意図した変更ですが、本番反映後の最初の halt 発生時はログ (`event: entry_halt_exit_only`) と約定履歴を確認してください。全面停止したい場合は従来どおり `trading_enabled = 0` を使います。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 取引戦略の実行時、保有ポジションの決済処理を継続しながら、新規エントリーのみを安全に停止できるようになりました。
  * エントリー停止の理由が実行結果やログに表示されるようになりました。
  * Webull MCP サーバーのローカル起動設定を追加しました。

* **ドキュメント**
  * CodeRabbit の指摘対応、Phase スコープ、取引系機能の安全ルールに関する運用ガイドを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->