### PR TITLE
feat: cap the ATR-linked stop at a multiple of take-profit

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Retail auto-trading system on Cloudflare Workers + Hono + TypeScript, speaking W
 | `pullback_default_k_atr` | `2.0` | ATR 倍率。`stopDistance = max(k_atr × atr20, pct stop)` |
 | `pullback_default_max_sma50_deviation_pct` | `0.6` | sma50 からの上方乖離が大きすぎる時は entry 見送り |
 | `pullback_default_max_atr_ratio` | `1.5` | ATR 拡大 (ボラ急騰) 時の entry 見送り閾値 |
+| `pullback_default_max_stop_to_tp_ratio` | `2.0` | stop 幅の上限 = `take_profit_pct × これ`。ATR 連動 stop が利確幅に対して広がりすぎるのを止め R:R に下限を作る (2.0 = R:R 0.5 以上)。`0` で無効 |
 
 **Risk gate の動的パラメタ (#23 Lane 2-3):**
 

--- a/drizzle/0038_add_max_stop_to_tp_ratio.sql
+++ b/drizzle/0038_add_max_stop_to_tp_ratio.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `global_config` ADD `pullback_default_max_stop_to_tp_ratio` real DEFAULT 2 NOT NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -267,6 +267,13 @@
       "when": 1783088190965,
       "tag": "0037_decision_skip_reject_taxonomy",
       "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "6",
+      "when": 1785000214011,
+      "tag": "0038_add_max_stop_to_tp_ratio",
+      "breakpoints": true
     }
   ]
 }

--- a/src/infrastructure/db/globalConfigRepo.ts
+++ b/src/infrastructure/db/globalConfigRepo.ts
@@ -41,6 +41,8 @@ export interface GlobalConfigSnapshot {
   pullbackDefaultMaxSma50DeviationPct: number
   /** ボラ過熱ガード: atr20/baselineAtr20 がこの比率超で BUY 見送り。 */
   pullbackDefaultMaxAtrRatio: number
+  /** Stop 幅の上限 = |価格 * takeProfitPct| * これ (#stop-rr-cap)。0 で無効。 */
+  pullbackDefaultMaxStopToTpRatio: number
   /** Base risk fraction per trade (0.4% default)。#23 Lane 2。 */
   riskBasePerTradePct: number
   /** drawdown がこの閾値 (負) 未満で size を 0.5× に (-0.05 default)。 */
@@ -104,6 +106,7 @@ export const GLOBAL_CONFIG_DEFAULTS: GlobalConfigSnapshot = Object.freeze({
   pullbackDefaultKAtr: 2.0,
   pullbackDefaultMaxSma50DeviationPct: 0.6,
   pullbackDefaultMaxAtrRatio: 1.5,
+  pullbackDefaultMaxStopToTpRatio: 2.0,
   riskBasePerTradePct: 0.004,
   riskDdHalfThreshold: -0.05,
   riskDdHaltThreshold: -0.10,
@@ -308,6 +311,7 @@ export async function loadGlobalConfig(
             pullbackDefaultKAtr: globalConfig.pullbackDefaultKAtr,
             pullbackDefaultMaxSma50DeviationPct: globalConfig.pullbackDefaultMaxSma50DeviationPct,
             pullbackDefaultMaxAtrRatio: globalConfig.pullbackDefaultMaxAtrRatio,
+            pullbackDefaultMaxStopToTpRatio: globalConfig.pullbackDefaultMaxStopToTpRatio,
             riskBasePerTradePct: globalConfig.riskBasePerTradePct,
             riskDdHalfThreshold: globalConfig.riskDdHalfThreshold,
             riskDdHaltThreshold: globalConfig.riskDdHaltThreshold,
@@ -342,6 +346,8 @@ export async function loadGlobalConfig(
             pullbackDefaultKAtr: legacyRow.pullbackDefaultKAtr,
             pullbackDefaultMaxSma50DeviationPct: legacyRow.pullbackDefaultMaxSma50DeviationPct,
             pullbackDefaultMaxAtrRatio: legacyRow.pullbackDefaultMaxAtrRatio,
+            // 0038 追加列 (#stop-rr-cap)。legacy path は default。
+            pullbackDefaultMaxStopToTpRatio: GLOBAL_CONFIG_DEFAULTS.pullbackDefaultMaxStopToTpRatio,
             riskBasePerTradePct: legacyRow.riskBasePerTradePct,
             riskDdHalfThreshold: legacyRow.riskDdHalfThreshold,
             riskDdHaltThreshold: legacyRow.riskDdHaltThreshold,
@@ -404,6 +410,7 @@ export async function loadGlobalConfig(
     pullbackDefaultKAtr: row.pullbackDefaultKAtr,
     pullbackDefaultMaxSma50DeviationPct: row.pullbackDefaultMaxSma50DeviationPct,
     pullbackDefaultMaxAtrRatio: row.pullbackDefaultMaxAtrRatio,
+    pullbackDefaultMaxStopToTpRatio: row.pullbackDefaultMaxStopToTpRatio,
     riskBasePerTradePct: row.riskBasePerTradePct,
     riskDdHalfThreshold: row.riskDdHalfThreshold,
     riskDdHaltThreshold: row.riskDdHaltThreshold,

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -328,6 +328,14 @@ export const globalConfig = sqliteTable(
      */
     pullbackDefaultMaxAtrRatio: real('pullback_default_max_atr_ratio').notNull().default(1.5),
     /**
+     * Stop 幅の上限 = |avgPrice * take_profit_pct| * これ (#stop-rr-cap)。ATR 連動
+     * stop が利確幅に対して一方的に広がるのを止め、R:R に下限を作る (2.0 なら
+     * R:R >= 0.5)。0 で無効 = ATR 連動そのまま (従来挙動)。
+     */
+    pullbackDefaultMaxStopToTpRatio: real('pullback_default_max_stop_to_tp_ratio')
+      .notNull()
+      .default(2.0),
+    /**
      * Base risk fraction per trade (0.4% default)。drawdown scale を掛けた値が
      * pullbackSizing に渡る。#23 Lane 2。
      */

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -359,6 +359,12 @@ export const admin = new Hono<AppBindings>()
         global.pullbackDefaultMaxAtrRatio,
         { mustBePositive: true },
       ),
+      maxStopToTpRatio: readOptionalNumber(
+        c.req.query('maxStopToTpRatio'),
+        'maxStopToTpRatio',
+        global.pullbackDefaultMaxStopToTpRatio,
+        {},
+      ),
       // #reentry: 再エントリー価格ガード。backtest preview は per-symbol の
       // lastExit 状態を持たないので実際には fail-open (この rule 上は既定値だけ保持)。
       reentryMinAtrBelowLastExit: 1.0,
@@ -1937,6 +1943,7 @@ export const admin = new Hono<AppBindings>()
       kAtr: global.pullbackDefaultKAtr,
       maxSma50DeviationPct: global.pullbackDefaultMaxSma50DeviationPct,
       maxAtrRatio: global.pullbackDefaultMaxAtrRatio,
+      maxStopToTpRatio: global.pullbackDefaultMaxStopToTpRatio,
       // #reentry: cron の runStrategyCron 既定と一致 (global_config 列化はまだ)。
       reentryMinAtrBelowLastExit: 1.0,
       reentryGuardBusinessDays: 3,

--- a/src/routes/dashboard/charts/shared.ts
+++ b/src/routes/dashboard/charts/shared.ts
@@ -83,6 +83,8 @@ export interface StrategyParamsSnapshot {
   reentryMinAtrBelowLastExit: number
   /** #reentry: 再エントリー価格ガードの有効窓 (営業日)。 */
   reentryGuardBusinessDays: number
+  /** #stop-rr-cap: stop 幅の上限 = |価格 * takeProfitPct| * これ。0 で無効。 */
+  maxStopToTpRatio: number
 }
 
 /**
@@ -104,6 +106,7 @@ export function strategyParamsFromGlobal(global: LoadedGlobalConfig): StrategyPa
     kAtr: global.pullbackDefaultKAtr,
     maxSma50DeviationPct: global.pullbackDefaultMaxSma50DeviationPct,
     maxAtrRatio: global.pullbackDefaultMaxAtrRatio,
+    maxStopToTpRatio: global.pullbackDefaultMaxStopToTpRatio,
     // #reentry: cron の runStrategyCron 既定と一致 (まだ global_config 列なし)。
     reentryMinAtrBelowLastExit: 1.0,
     reentryGuardBusinessDays: 3,

--- a/src/routes/dashboard/charts/symbol.ts
+++ b/src/routes/dashboard/charts/symbol.ts
@@ -1399,6 +1399,7 @@ export const STRATEGY_DEFAULTS: StrategyParamsSnapshot = {
   kAtr: 2.0,
   maxSma50DeviationPct: 0.6,
   maxAtrRatio: 1.5,
+  maxStopToTpRatio: 2.0,
   reentryMinAtrBelowLastExit: 1.0,
   reentryGuardBusinessDays: 3,
 }

--- a/src/routes/dashboard/cron.ts
+++ b/src/routes/dashboard/cron.ts
@@ -54,7 +54,8 @@ export function localizeReason(en: string | null | undefined): string {
     (_m, p, t) => `利食い: 利確目標到達 (含み損益 ${fmtPct(p)} ≥ 目標 ${fmtPct(t)})`,
   )
   s = s.replace(
-    /^stop-loss hit: pnl (\S+) <= (\S+)$/,
+    // #stop-rr-cap: reason 末尾に `(atr, dist 9.06)` 等の内訳が付く形式も受ける。
+    /^stop-loss hit: pnl (\S+) <= (\S+)(?:\s+\(.*\))?$/,
     (_m, p, t) => `損切り: 損切りライン到達 (含み損益 ${fmtPct(p)} ≤ ライン ${fmtPct(t)})`,
   )
   s = s.replace(

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -897,6 +897,9 @@ export async function runPullbackScheduler(
               riskPerTradePct: options.riskPerTradePct,
               lotSize: resolvedLotSize,
               kAtr: rule.kAtr,
+              // #stop-rr-cap: sizing と exit で同じ stop 幅を使う。
+              takeProfitPct: rule.takeProfitPct,
+              maxStopToTpRatio: rule.maxStopToTpRatio,
               budgetAllocPct: options.symbolBudgetAllocPctMap?.[upper],
               budgetBasisJpy: options.budgetBasisJpy,
               fxJpyPerSymbolCcy: options.fxJpyPerSymbolCcy,

--- a/src/trading/strategy/pullbackSizing.ts
+++ b/src/trading/strategy/pullbackSizing.ts
@@ -1,3 +1,5 @@
+import { resolveStopDistance } from './stopDistance'
+
 export interface PullbackSizingInput {
   equity: number
   entryPrice: number
@@ -44,6 +46,14 @@ export interface PullbackSizingInput {
    * Required; invalid (<=0 or non-finite) throws.
    */
   kAtr: number
+  /**
+   * Stop 幅の上限 = |entryPrice * takeProfitPct| * これ (#stop-rr-cap)。exit 側と
+   * **同じ式**で距離を出さないと「サイズを決めた stop」と「実際に切る stop」が
+   * ズレるので、strategy と共有の `resolveStopDistance` を使う。0 / 未指定で無効。
+   */
+  maxStopToTpRatio?: number
+  /** cap の基準となる利確幅 (正値)。未指定なら cap 無効。 */
+  takeProfitPct?: number
 }
 
 export interface PullbackSizingResult {
@@ -132,10 +142,16 @@ export function computePullbackSizing(input: PullbackSizingInput): PullbackSizin
     quantity = Math.floor(target / input.entryPrice)
   } else {
     // === 従来の risk-% sizing ===
-    const pctStop = Math.abs(input.entryPrice * input.stopPct)
-    // vol-adaptive: kAtr * atr20。atr20=0 (post-halt/gap) は pct stop が floor。
-    const atrStop = input.atr20 > 0 ? input.kAtr * input.atr20 : 0
-    stopDistance = atrStop > pctStop ? atrStop : pctStop
+    // vol-adaptive: kAtr * atr20 (atr20=0 は pct stop が floor)、さらに
+    // R:R cap (#stop-rr-cap)。exit 判定と同一関数で算出する。
+    stopDistance = resolveStopDistance({
+      price: input.entryPrice,
+      stopPct: input.stopPct,
+      takeProfitPct: input.takeProfitPct ?? 0,
+      atr20: input.atr20,
+      kAtr: input.kAtr,
+      maxStopToTpRatio: input.maxStopToTpRatio ?? 0,
+    }).distance
 
     if (!Number.isFinite(stopDistance) || stopDistance <= 0) {
       return { quantity: 0, notional: 0, capped: true, capReason: 'invalid-stop', stopDistance }

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -134,6 +134,7 @@ export interface StrategyCronAnalysis {
       kAtr: number
       maxSma50DeviationPct: number
       maxAtrRatio: number
+      maxStopToTpRatio: number
     }
     risk: {
       basePerTradePct: number
@@ -297,6 +298,7 @@ export async function runStrategyCron(
     kAtr: global.pullbackDefaultKAtr,
     maxSma50DeviationPct: global.pullbackDefaultMaxSma50DeviationPct,
     maxAtrRatio: global.pullbackDefaultMaxAtrRatio,
+    maxStopToTpRatio: global.pullbackDefaultMaxStopToTpRatio,
     // #reentry: 再エントリー価格ガード。まだ global_config 列を持たせていないので
     // 定数 (前回売値 −1ATR / 3 営業日窓)。チューニングが要れば列/override 化。
     reentryMinAtrBelowLastExit: 1.0,

--- a/src/trading/strategy/stopDistance.ts
+++ b/src/trading/strategy/stopDistance.ts
@@ -1,0 +1,68 @@
+/**
+ * Stop 幅の単一の決定点 (#stop-rr-cap)。
+ *
+ * 従来は「pct stop と ATR stop の広い方」を strategy / momentum / sizing の
+ * 3 箇所で個別に計算していた。ATR 連動は高ボラ銘柄のノイズ stop-out を防ぐ
+ * ためのものだが、**利確側は固定 % のまま**なので、ATR が大きい銘柄ほど
+ * リワード:リスクが一方的に潰れる:
+ *
+ *   SOXL: atr20/price = 22% → kAtr 2.0 で stop -44% に対し TP は +7% (R:R 0.16)
+ *
+ * そこで「stop は TP の何倍まで許すか」(`maxStopToTpRatio`) で上限を掛ける。
+ * TP を基準にすることで銘柄ごとに R:R の下限が自動的に決まる (ratio 2.0 なら
+ * どの銘柄でも R:R >= 0.5)。pct stop は従来どおり **floor** で、cap が pct を
+ * 下回る場合は pct が勝つ (名目 stop より狭くはしない)。
+ *
+ * ratio <= 0 / 非有限、または takeProfitPct <= 0 のときは cap 無効 = 従来挙動。
+ */
+export interface StopDistanceInput {
+  /** 基準価格。entry 時は発注価格、保有中は avgPrice。 */
+  price: number
+  /** 名目 stop (負値、例 -0.04)。絶対値が距離の floor になる。 */
+  stopPct: number
+  /** 利確幅 (正値)。cap の基準。 */
+  takeProfitPct: number
+  atr20: number
+  kAtr: number
+  /** stop 幅の上限 = |price * takeProfitPct| * これ。0 / 非有限で無効。 */
+  maxStopToTpRatio: number
+}
+
+export interface StopDistanceResult {
+  /** 価格単位の stop 幅 (正値)。 */
+  distance: number
+  /** avgPrice に対する実効 stop (負値)。 */
+  effectiveStopPct: number
+  /** どの制約が最終的に効いたか (ログ / reason 表示用)。 */
+  dominant: 'pct' | 'atr' | 'tp-cap'
+}
+
+export function resolveStopDistance(input: StopDistanceInput): StopDistanceResult {
+  const price = Number.isFinite(input.price) && input.price > 0 ? input.price : 0
+  const pctDistance = Math.abs(price * input.stopPct)
+  const atrDistance =
+    Number.isFinite(input.atr20) && input.atr20 > 0 && Number.isFinite(input.kAtr) && input.kAtr > 0
+      ? input.kAtr * input.atr20
+      : 0
+
+  let distance = Math.max(pctDistance, atrDistance)
+  let dominant: StopDistanceResult['dominant'] = atrDistance > pctDistance ? 'atr' : 'pct'
+
+  const capEnabled =
+    Number.isFinite(input.maxStopToTpRatio) &&
+    input.maxStopToTpRatio > 0 &&
+    Number.isFinite(input.takeProfitPct) &&
+    input.takeProfitPct > 0 &&
+    price > 0
+  if (capEnabled) {
+    const cap = Math.abs(price * input.takeProfitPct) * input.maxStopToTpRatio
+    if (distance > cap) {
+      // pct stop は floor。cap が pct を下回るなら pct を採る。
+      distance = Math.max(cap, pctDistance)
+      dominant = distance > cap ? 'pct' : 'tp-cap'
+    }
+  }
+
+  const effectiveStopPct = price > 0 ? -distance / price : input.stopPct
+  return { distance, effectiveStopPct, dominant }
+}

--- a/src/trading/strategy/strategies/BreakoutMomentumStrategy.ts
+++ b/src/trading/strategy/strategies/BreakoutMomentumStrategy.ts
@@ -1,6 +1,7 @@
 import type { DecisionTraceStep, Signal } from '../../domain/Signal'
 import type { PendingOrderLock, PositionState } from '../../state/types'
 import type { PullbackIndicatorSnapshot } from '../indicators'
+import { resolveStopDistance } from '../stopDistance'
 
 /**
  * ブレイクアウト/モメンタム entry 戦略 (#momentum)。
@@ -37,6 +38,11 @@ export interface MomentumRule {
   maxSma50DeviationPct: number
   /** `price > sma50` を要求するか。 */
   requireAboveSma50: boolean
+  /**
+   * Stop 幅の上限 = |avgPrice * takeProfitPct| * これ (#stop-rr-cap)。押し目側と
+   * 同じ意味。0 で無効。
+   */
+  maxStopToTpRatio: number
 }
 
 /** backtest / unit test 用のデフォルト (全数値 backtest 未検証の初期推定)。 */
@@ -49,6 +55,7 @@ export const TEST_DEFAULT_MOMENTUM_RULE: MomentumRule = Object.freeze({
   breakoutBuffer: 0.005,
   maxSma50DeviationPct: 0.6,
   requireAboveSma50: true,
+  maxStopToTpRatio: 2.0,
 })
 
 export interface MomentumInput {
@@ -153,21 +160,34 @@ function exitDecision(
     return sell(input, position, `take-profit hit: pnl ${pnlPct.toFixed(4)} >= ${rule.takeProfitPct}`, trace)
   }
 
-  const pctStopDistance = Math.abs(position.avgPrice * rule.stopPct)
-  const atrStopDistance =
-    Number.isFinite(input.indicators.atr20) && input.indicators.atr20 > 0 ? rule.kAtr * input.indicators.atr20 : 0
-  const stopDistance = Math.max(pctStopDistance, atrStopDistance)
-  const effectiveStopPct = position.avgPrice > 0 ? -stopDistance / position.avgPrice : rule.stopPct
+  const stop = resolveStopDistance({
+    price: position.avgPrice,
+    stopPct: rule.stopPct,
+    takeProfitPct: rule.takeProfitPct,
+    atr20: input.indicators.atr20,
+    kAtr: rule.kAtr,
+    maxStopToTpRatio: rule.maxStopToTpRatio,
+  })
+  const effectiveStopPct = stop.effectiveStopPct
   if (pnlPct <= effectiveStopPct) {
     trace.push(step('exit.stop_loss', true, pnlPct, '<=', effectiveStopPct))
-    return sell(input, position, `stop-loss hit: pnl ${pnlPct.toFixed(4)} <= ${effectiveStopPct.toFixed(4)}`, trace)
+    return sell(
+      input,
+      position,
+      `stop-loss hit: pnl ${pnlPct.toFixed(4)} <= ${effectiveStopPct.toFixed(4)} (${stop.dominant}, dist ${stop.distance.toFixed(2)})`,
+      trace,
+    )
   }
 
   if (input.holdBusinessDays >= rule.timeStopDays) {
     trace.push(step('exit.time_stop', true, input.holdBusinessDays, '>=', rule.timeStopDays))
     return sell(input, position, `time-stop hit: held ${input.holdBusinessDays}d >= ${rule.timeStopDays}d`, trace)
   }
-  return hold(input, `holding: pnl ${pnlPct.toFixed(4)} within (${rule.stopPct}, ${rule.takeProfitPct})`, trace)
+  return hold(
+    input,
+    `holding: pnl ${pnlPct.toFixed(4)} within (${effectiveStopPct.toFixed(4)}, ${rule.takeProfitPct})`,
+    trace,
+  )
 }
 
 function hold(input: MomentumInput, reason: string, trace: DecisionTraceStep[]): Signal {

--- a/src/trading/strategy/strategies/PullbackUptrendStrategy.ts
+++ b/src/trading/strategy/strategies/PullbackUptrendStrategy.ts
@@ -1,5 +1,6 @@
 import type { DecisionTraceStep, Signal } from '../../domain/Signal'
 import type { PendingOrderLock, PositionState } from '../../state/types'
+import { resolveStopDistance } from '../stopDistance'
 
 export interface PullbackIndicators {
   price: number
@@ -77,6 +78,13 @@ export interface SymbolRule {
    * 0 で無効。既定 3。
    */
   reentryGuardBusinessDays: number
+  /**
+   * Stop 幅の上限 = |avgPrice * takeProfitPct| * これ (#stop-rr-cap)。ATR 連動
+   * stop が利確幅に対して一方的に広がるのを止め、銘柄ごとの R:R に下限を作る
+   * (2.0 なら R:R >= 0.5)。0 で無効 (= ATR 連動そのまま)。pct stop は floor
+   * なので、cap が名目 stop より狭くなる場合は名目が勝つ。
+   */
+  maxStopToTpRatio: number
 }
 
 /**
@@ -97,6 +105,7 @@ export const TEST_DEFAULT_RULE: SymbolRule = Object.freeze({
   maxAtrRatio: 1.5,
   reentryMinAtrBelowLastExit: 1.0,
   reentryGuardBusinessDays: 3,
+  maxStopToTpRatio: 2.0,
 })
 
 export interface PullbackInput {
@@ -172,24 +181,23 @@ export class PullbackUptrendStrategy {
     }
     trace.push(step('exit.take_profit', false, pnlPct, '>=', rule.takeProfitPct))
 
-    // ATR 連動 stop (#exit-atr): 固定 pct stop だけだと高ボラ銘柄 (3x レバ ETF 等) で
-    // 通常変動/寄りギャップに叩かれる。sizing と同式の距離ベースにして「pct stop か
-    // ATR stop の広い方」を採り、ボラに応じて stop 幅を自動で広げる (ノイズ stop-out
-    // 抑制)。atr20<=0/非有限は pct のみに fallback (defensive)。stopPct は最低 stop 幅の floor。
-    const pctStopDistance = Math.abs(position.avgPrice * rule.stopPct)
-    const atrStopDistance =
-      Number.isFinite(input.indicators.atr20) && input.indicators.atr20 > 0
-        ? rule.kAtr * input.indicators.atr20
-        : 0
-    const stopDistance = Math.max(pctStopDistance, atrStopDistance)
-    const effectiveStopPct = position.avgPrice > 0 ? -stopDistance / position.avgPrice : rule.stopPct
-    const stopDominant = atrStopDistance > pctStopDistance ? 'atr' : 'pct'
+    // ATR 連動 stop (#exit-atr) + R:R cap (#stop-rr-cap)。距離の決定は
+    // `resolveStopDistance` に一本化 (sizing と同式)。
+    const stop = resolveStopDistance({
+      price: position.avgPrice,
+      stopPct: rule.stopPct,
+      takeProfitPct: rule.takeProfitPct,
+      atr20: input.indicators.atr20,
+      kAtr: rule.kAtr,
+      maxStopToTpRatio: rule.maxStopToTpRatio,
+    })
+    const effectiveStopPct = stop.effectiveStopPct
     if (pnlPct <= effectiveStopPct) {
       trace.push(step('exit.stop_loss', true, pnlPct, '<=', effectiveStopPct))
       return sell(
         input,
         position,
-        `stop-loss hit: pnl ${pnlPct.toFixed(4)} <= ${effectiveStopPct.toFixed(4)} (${stopDominant}, dist ${stopDistance.toFixed(2)} = max(pct ${pctStopDistance.toFixed(2)}, atr ${atrStopDistance.toFixed(2)}))`,
+        `stop-loss hit: pnl ${pnlPct.toFixed(4)} <= ${effectiveStopPct.toFixed(4)} (${stop.dominant}, dist ${stop.distance.toFixed(2)})`,
         trace,
       )
     }
@@ -205,8 +213,17 @@ export class PullbackUptrendStrategy {
       )
     }
     trace.push(step('exit.time_stop', false, input.holdBusinessDays, '>=', rule.timeStopDays))
-    trace.push(step('exit.hold_position', true, pnlPct, 'between', [rule.stopPct, rule.takeProfitPct]))
-    return hold(input, `holding: pnl ${pnlPct.toFixed(4)} within (${rule.stopPct}, ${rule.takeProfitPct})`, trace)
+    // #stop-rr-cap: 表示する下限は名目 `stopPct` ではなく **実効 stop**。
+    // ATR / cap で動く値なので、名目を出すと operator が「-8% で切れる」と
+    // 誤読する (実際は -10.7% だった等)。
+    trace.push(
+      step('exit.hold_position', true, pnlPct, 'between', [effectiveStopPct, rule.takeProfitPct]),
+    )
+    return hold(
+      input,
+      `holding: pnl ${pnlPct.toFixed(4)} within (${effectiveStopPct.toFixed(4)}, ${rule.takeProfitPct})`,
+      trace,
+    )
   }
 
   private entryDecision(input: PullbackInput, rule: SymbolRule, trace: DecisionTraceStep[]): Signal {

--- a/test/helpers/configFixtures.ts
+++ b/test/helpers/configFixtures.ts
@@ -35,6 +35,7 @@ export function makeGlobalConfigSnapshot(
     pullbackDefaultKAtr: 2.0,
     pullbackDefaultMaxSma50DeviationPct: 0.6,
     pullbackDefaultMaxAtrRatio: 1.5,
+    pullbackDefaultMaxStopToTpRatio: 2.0,
     riskBasePerTradePct: 0.004,
     riskDdHalfThreshold: -0.05,
     riskDdHaltThreshold: -0.10,

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -1078,6 +1078,7 @@ const DEFAULT_PARAMS: StrategyParamsSnapshot = {
   kAtr: 2.0,
   maxSma50DeviationPct: 0.6,
   maxAtrRatio: 1.5,
+  maxStopToTpRatio: 2.0,
   reentryMinAtrBelowLastExit: 1.0,
   reentryGuardBusinessDays: 3,
 }
@@ -2024,6 +2025,7 @@ describe('renderSymbolTab — 判定点 scatter + click-to-trace の配線', () 
     pullbackMax: -0.03, pullbackMin: -0.15, minReturn50d: 0,
     requireAboveSma50: true, kAtr: 2,
     maxSma50DeviationPct: 0.6, maxAtrRatio: 1.5,
+    maxStopToTpRatio: 2.0,
     reentryMinAtrBelowLastExit: 1.0, reentryGuardBusinessDays: 3,
   }
   function symbolArgs(

--- a/test/routes/dashboardChartMarkers.test.ts
+++ b/test/routes/dashboardChartMarkers.test.ts
@@ -213,6 +213,7 @@ describe('renderSymbolTab — fill 詳細パネル + 保有区間 markArea の�
     pullbackMax: -0.03, pullbackMin: -0.15, minReturn50d: 0,
     requireAboveSma50: true, kAtr: 2,
     maxSma50DeviationPct: 0.6, maxAtrRatio: 1.5,
+    maxStopToTpRatio: 2.0,
     reentryMinAtrBelowLastExit: 1.0, reentryGuardBusinessDays: 3,
   }
   function args(): ChartsBodySymbol {

--- a/test/strategy/pullbackUptrendStrategy.test.ts
+++ b/test/strategy/pullbackUptrendStrategy.test.ts
@@ -22,6 +22,7 @@ const LEVERAGED_RULE: SymbolRule = {
   maxSma50DeviationPct: 100,
   maxAtrRatio: 100,
   // 再エントリーガードも既存ケースでは無効化 (0)。検証は専用 describe で実施。
+  maxStopToTpRatio: 2.0,
   reentryMinAtrBelowLastExit: 0,
   reentryGuardBusinessDays: 0,
 }
@@ -273,6 +274,29 @@ describe('PullbackUptrendStrategy exit ATR-linked stop (#exit-atr)', () => {
     const signal = strategy.decide(buildExit(96, 0)) // pnl -4% <= -3% pct
     expect(signal.action).toBe('SELL')
     expect(signal.reason).toMatch(/stop-loss/)
+  })
+
+  // #stop-rr-cap: LEVERAGED_RULE は TP +5% / ratio 2.0 → stop 上限は -10%。
+  // 高 ATR 銘柄で stop が TP の何倍にも広がる (SOXL 実測 -44% vs TP +7%) のを止める。
+  it('caps the ATR stop at takeProfitPct * maxStopToTpRatio', () => {
+    // atr20=10, kAtr 2.5 → atrStopDist=25 (=-25%) だが cap は 5*2=10 (=-10%)。
+    // pnl -12% は cap 後の -10% を割るので SELL。cap 無しなら HOLD だった。
+    const signal = strategy.decide(buildExit(88, 10))
+    expect(signal.action).toBe('SELL')
+    expect(signal.reason).toMatch(/tp-cap/)
+  })
+
+  it('does not fire above the capped stop', () => {
+    // pnl -8% は cap 後の -10% に届かない → HOLD。
+    expect(strategy.decide(buildExit(92, 10)).action).toBe('HOLD')
+  })
+
+  // dashboard の「損切り -X%」表示は HOLD reason から作られるので、名目ではなく
+  // 実効 stop を出す (名目 -3% と実効 -5% がズレたまま表示されていた)。
+  it('HOLD reason reports the effective stop, not the nominal stopPct', () => {
+    const signal = strategy.decide(buildExit(99, 2)) // 実効 stop -5%
+    expect(signal.action).toBe('HOLD')
+    expect(signal.reason).toContain('within (-0.0500')
   })
 })
 

--- a/test/trading/strategy/pullbackScheduler.test.ts
+++ b/test/trading/strategy/pullbackScheduler.test.ts
@@ -1541,6 +1541,7 @@ describe('runPullbackScheduler per-symbol rule override (#316)', () => {
     maxSma50DeviationPct: 100,
     maxAtrRatio: 100,
     // 再エントリーガードも既存 scheduler テストでは無効化 (0)。plumbing 検証は専用ケース。
+    maxStopToTpRatio: 2.0,
     reentryMinAtrBelowLastExit: 0,
     reentryGuardBusinessDays: 0,
   }

--- a/test/trading/strategy/stopDistance.test.ts
+++ b/test/trading/strategy/stopDistance.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import { resolveStopDistance } from '../../../src/trading/strategy/stopDistance'
+
+const base = {
+  price: 100,
+  stopPct: -0.04,
+  takeProfitPct: 0.07,
+  atr20: 1,
+  kAtr: 2,
+  maxStopToTpRatio: 2,
+}
+
+describe('resolveStopDistance', () => {
+  it('pct stop が floor になる (ATR が小さい)', () => {
+    // atr 1 * kAtr 2 = 2 < pct 4 → pct が勝つ
+    const r = resolveStopDistance({ ...base, atr20: 1 })
+    expect(r.distance).toBe(4)
+    expect(r.effectiveStopPct).toBeCloseTo(-0.04)
+    expect(r.dominant).toBe('pct')
+  })
+
+  it('ATR stop が pct を上回れば ATR を採る (cap 内)', () => {
+    // atr 3 * 2 = 6 > pct 4、cap = 7 * 2 = 14 なので素通り
+    const r = resolveStopDistance({ ...base, atr20: 3 })
+    expect(r.distance).toBe(6)
+    expect(r.dominant).toBe('atr')
+  })
+
+  it('ATR stop が TP の倍数上限を超えたら cap する', () => {
+    // atr 15 * 2 = 30 → cap = |100 * 0.07| * 2 = 14
+    const r = resolveStopDistance({ ...base, atr20: 15 })
+    expect(r.distance).toBeCloseTo(14, 10)
+    expect(r.effectiveStopPct).toBeCloseTo(-0.14)
+    expect(r.dominant).toBe('tp-cap')
+  })
+
+  it('cap が名目 pct stop より狭い場合は pct stop が勝つ (stop を狭めない)', () => {
+    // TP 1% * ratio 2 = cap 2 < pct stop 4 → pct
+    const r = resolveStopDistance({ ...base, takeProfitPct: 0.01, atr20: 15 })
+    expect(r.distance).toBe(4)
+    expect(r.dominant).toBe('pct')
+  })
+
+  it('ratio 0 で cap 無効 (従来の ATR 連動そのまま)', () => {
+    const r = resolveStopDistance({ ...base, atr20: 15, maxStopToTpRatio: 0 })
+    expect(r.distance).toBe(30)
+    expect(r.dominant).toBe('atr')
+  })
+
+  it('takeProfitPct が 0 / 未設定相当なら cap 無効', () => {
+    const r = resolveStopDistance({ ...base, atr20: 15, takeProfitPct: 0 })
+    expect(r.distance).toBe(30)
+  })
+
+  it('atr20 が非有限 / 0 でも pct stop に落ちる', () => {
+    expect(resolveStopDistance({ ...base, atr20: Number.NaN }).distance).toBe(4)
+    expect(resolveStopDistance({ ...base, atr20: 0 }).distance).toBe(4)
+  })
+
+  it('price が不正なら距離 0 + 名目 stopPct を返す (呼び出し側が invalid-stop で弾く)', () => {
+    const r = resolveStopDistance({ ...base, price: 0, atr20: 0 })
+    expect(r.distance).toBe(0)
+    expect(r.effectiveStopPct).toBe(-0.04)
+  })
+
+  // 本番実測 (SOXL): atr20/price = 22% → kAtr 2.0 で stop -44%、TP は +7%。
+  // R:R 0.16 という壊れた比率が cap で 0.5 に矯正されることを固定する。
+  it('SOXL 実測パラメタで R:R が 0.5 以上になる', () => {
+    const r = resolveStopDistance({
+      price: 136.81,
+      stopPct: -0.04,
+      takeProfitPct: 0.07,
+      atr20: 30.39,
+      kAtr: 2,
+      maxStopToTpRatio: 2,
+    })
+    const rr = 0.07 / Math.abs(r.effectiveStopPct)
+    expect(rr).toBeGreaterThanOrEqual(0.5)
+    expect(r.dominant).toBe('tp-cap')
+  })
+})


### PR DESCRIPTION
戦略判定モデルのレビューで挙げた課題 **2/5 と 3/5** (同じコードパスなのでまとめました)。

## 問題

`stopDistance = max(kAtr × atr20, |entry × stopPct|)` で **損切りだけが ATR に連動**し、利確は固定 % のままでした。ATR が大きい銘柄ほどリワード:リスクが一方的に潰れます。

| 銘柄 | atr20/価格 | 実効 stop (kAtr 2.0) | TP | R:R |
|---|---|---|---|---|
| SOXL | 22.2% | **-44%** | +7% | 0.16 |
| SQQQ | 5.2% | -10.7% | +4% | 0.37 |
| DFEN | 5.9% | -11.9% | +7% | 0.59 |
| VUG | 1.7% | -5% (pct 側が勝つ) | +6% | 1.2 |

実績も同じ形で、最大損失 -12.72 (DFEN 1 トレードで -14.4%) に対し勝ちは +2.21〜+10.83 です。

あわせて、HOLD の reason は **名目 `stopPct`** を出していたため、dashboard の「損切り -8.00%」表示が実効 stop (-10.7%) と食い違っていました。

## 変更

### stop 幅の決定を 1 箇所に集約

`src/trading/strategy/stopDistance.ts` の `resolveStopDistance()` を新設し、押し目戦略の exit / モメンタム戦略の exit / sizing の 3 箇所に散っていた `max(pct, atr)` を置き換えました。**サイズを決めた stop と実際に切る stop がズレない**ことが保証されます。

### R:R cap

`stop 幅 <= |価格 × takeProfitPct| × maxStopToTpRatio` を追加。TP 基準なので銘柄ごとに R:R の下限が自動的に決まります (ratio 2.0 → R:R >= 0.5)。

- pct stop は従来どおり **floor**。cap が名目 stop より狭くなる場合は名目が勝ちます (stop を勝手に狭めない)
- `0` で無効 = 従来の ATR 連動そのまま

### 設定

`global_config.pullback_default_max_stop_to_tp_ratio` (migration `0038`、**既定 2.0**) で runtime 変更できます。

```sql
-- もっと締める (R:R 0.67 以上)
UPDATE global_config SET pullback_default_max_stop_to_tp_ratio = 1.5 WHERE id = 'default';
-- 無効化 (従来挙動に戻す)
UPDATE global_config SET pullback_default_max_stop_to_tp_ratio = 0 WHERE id = 'default';
```

### 表示の修正 (課題 3)

HOLD reason と trace の下限を実効 stop に変更。dashboard の localizer は stop-loss reason 末尾の内訳 `(tp-cap, dist 14.00)` も受けるよう正規表現を更新しました。

## 影響 (現行パラメタでの実効 stop)

| 銘柄 | 変更前 | 変更後 |
|---|---|---|
| SOXL | -44% | **-14%** (TP 7% × 2) |
| SQQQ | -10.7% | **-8%** (pct floor が勝つ) |
| DFEN | -11.9% | -11.9% (TP 7% × 2 = 14% 以内) |
| VUG | -5% | -5% |

**トレードオフ**: stop が狭くなる分ノイズ stop-out は増えます。ATR 連動を入れた元の意図 (3x ETF が通常変動で切られるのを防ぐ) とは逆方向なので、実際の stop-out 頻度を見て ratio を調整してください。

## 検証

- `pnpm run typecheck` clean / `pnpm test` 115 files・1710 tests pass
- `resolveStopDistance` の単体テストを新規追加 (pct floor / ATR 優先 / cap 発動 / cap < pct の逆転 / 無効化 / 非有限ガード / SOXL 実測値で R:R >= 0.5)
- 戦略側に cap 発動・非発動・HOLD reason が実効 stop を出すケースを追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * プルバック戦略の損切り幅に、テイクプロフィット幅に対する上限比率を追加しました。
  * ATR連動で損切り幅が広がりすぎる場合も、設定した比率内に制限します。
  * 比率を「0」にすると制限を無効化できます。
  * バックテスト、シミュレーション、ダッシュボード表示に新設定を反映しました。

* **改善**
  * 損切り判定の理由表示を拡張し、追加情報を含む形式にも対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->