### PR TITLE
feat: subtract an estimated trade cost from realized PnL

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Retail auto-trading system on Cloudflare Workers + Hono + TypeScript, speaking W
 | `total_capital_usd` / `_jpy` | `NULL` | NAV (NULL なら exposure check skip) |
 | `max_portfolio_exposure_pct` | `0.6` | total_capital × これを超える open 合計を禁止 |
 | `spread_limit_pct_{us,jp}` | `0.0025` / `0.006` | spread guard |
+| `fee_pct_of_notional` | `0` | 売買コスト見積りの料率。realized PnL を net 化する (#trade-cost) |
+| `fee_fixed_per_order` | `0` | 同、1 注文あたりの固定費 (銘柄通貨建て) |
 | `gap_reject_pct` | `0.03` | gap 判定 |
 
 **Pullback 戦略の default rule (#118、#124):**

--- a/drizzle/0039_add_trade_cost_config.sql
+++ b/drizzle/0039_add_trade_cost_config.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `global_config` ADD `fee_pct_of_notional` real DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE `global_config` ADD `fee_fixed_per_order` real DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE `trade_journal` ADD `estimated_cost` real;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1785000214011,
       "tag": "0038_add_max_stop_to_tp_ratio",
       "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "6",
+      "when": 1785000435697,
+      "tag": "0039_add_trade_cost_config",
+      "breakpoints": true
     }
   ]
 }

--- a/src/infrastructure/db/globalConfigRepo.ts
+++ b/src/infrastructure/db/globalConfigRepo.ts
@@ -43,6 +43,10 @@ export interface GlobalConfigSnapshot {
   pullbackDefaultMaxAtrRatio: number
   /** Stop 幅の上限 = |価格 * takeProfitPct| * これ (#stop-rr-cap)。0 で無効。 */
   pullbackDefaultMaxStopToTpRatio: number
+  /** 売買コスト見積りの料率 (#trade-cost)。0 で従来どおり gross PnL。 */
+  feePctOfNotional: number
+  /** 売買コスト見積りの 1 注文固定費 (銘柄通貨建て)。 */
+  feeFixedPerOrder: number
   /** Base risk fraction per trade (0.4% default)。#23 Lane 2。 */
   riskBasePerTradePct: number
   /** drawdown がこの閾値 (負) 未満で size を 0.5× に (-0.05 default)。 */
@@ -107,6 +111,8 @@ export const GLOBAL_CONFIG_DEFAULTS: GlobalConfigSnapshot = Object.freeze({
   pullbackDefaultMaxSma50DeviationPct: 0.6,
   pullbackDefaultMaxAtrRatio: 1.5,
   pullbackDefaultMaxStopToTpRatio: 2.0,
+  feePctOfNotional: 0,
+  feeFixedPerOrder: 0,
   riskBasePerTradePct: 0.004,
   riskDdHalfThreshold: -0.05,
   riskDdHaltThreshold: -0.10,
@@ -312,6 +318,8 @@ export async function loadGlobalConfig(
             pullbackDefaultMaxSma50DeviationPct: globalConfig.pullbackDefaultMaxSma50DeviationPct,
             pullbackDefaultMaxAtrRatio: globalConfig.pullbackDefaultMaxAtrRatio,
             pullbackDefaultMaxStopToTpRatio: globalConfig.pullbackDefaultMaxStopToTpRatio,
+            feePctOfNotional: globalConfig.feePctOfNotional,
+            feeFixedPerOrder: globalConfig.feeFixedPerOrder,
             riskBasePerTradePct: globalConfig.riskBasePerTradePct,
             riskDdHalfThreshold: globalConfig.riskDdHalfThreshold,
             riskDdHaltThreshold: globalConfig.riskDdHaltThreshold,
@@ -348,6 +356,9 @@ export async function loadGlobalConfig(
             pullbackDefaultMaxAtrRatio: legacyRow.pullbackDefaultMaxAtrRatio,
             // 0038 追加列 (#stop-rr-cap)。legacy path は default。
             pullbackDefaultMaxStopToTpRatio: GLOBAL_CONFIG_DEFAULTS.pullbackDefaultMaxStopToTpRatio,
+            // 0039 追加列 (#trade-cost)。legacy path は default (= gross PnL)。
+            feePctOfNotional: GLOBAL_CONFIG_DEFAULTS.feePctOfNotional,
+            feeFixedPerOrder: GLOBAL_CONFIG_DEFAULTS.feeFixedPerOrder,
             riskBasePerTradePct: legacyRow.riskBasePerTradePct,
             riskDdHalfThreshold: legacyRow.riskDdHalfThreshold,
             riskDdHaltThreshold: legacyRow.riskDdHaltThreshold,
@@ -411,6 +422,8 @@ export async function loadGlobalConfig(
     pullbackDefaultMaxSma50DeviationPct: row.pullbackDefaultMaxSma50DeviationPct,
     pullbackDefaultMaxAtrRatio: row.pullbackDefaultMaxAtrRatio,
     pullbackDefaultMaxStopToTpRatio: row.pullbackDefaultMaxStopToTpRatio,
+    feePctOfNotional: row.feePctOfNotional,
+    feeFixedPerOrder: row.feeFixedPerOrder,
     riskBasePerTradePct: row.riskBasePerTradePct,
     riskDdHalfThreshold: row.riskDdHalfThreshold,
     riskDdHaltThreshold: row.riskDdHaltThreshold,

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -40,6 +40,13 @@ export const tradeJournal = sqliteTable('trade_journal', {
   filledQty: real('filled_qty'),
   filledPrice: real('filled_price'),
   realizedPnl: real('realized_pnl'),
+  /**
+   * 売買コストの見積り (#trade-cost)。SELL 行に往復分 (entry + exit) を入れる。
+   * `realized_pnl` は **この額を引いた net**。broker が実費を返さないので
+   * `global_config.fee_pct_of_notional` / `fee_fixed_per_order` からの推定値。
+   * NULL = コスト未設定 (= realized_pnl は gross) か、旧データ。
+   */
+  estimatedCost: real('estimated_cost'),
   holdDays: real('hold_days'),
   exitReason: text('exit_reason'),
   errorClass: text('error_class'),
@@ -335,6 +342,13 @@ export const globalConfig = sqliteTable(
     pullbackDefaultMaxStopToTpRatio: real('pullback_default_max_stop_to_tp_ratio')
       .notNull()
       .default(2.0),
+    /**
+     * 売買コスト見積り (#trade-cost)。約定代金に対する料率。realized PnL を
+     * net 化するのに使う。0 = 従来どおり gross。
+     */
+    feePctOfNotional: real('fee_pct_of_notional').notNull().default(0),
+    /** 1 注文あたりの固定費 (銘柄通貨建て)。0 で無効。 */
+    feeFixedPerOrder: real('fee_fixed_per_order').notNull().default(0),
     /**
      * Base risk fraction per trade (0.4% default)。drawdown scale を掛けた値が
      * pullbackSizing に渡る。#23 Lane 2。

--- a/src/trading/domain/tradingCost.ts
+++ b/src/trading/domain/tradingCost.ts
@@ -1,0 +1,70 @@
+/**
+ * 売買コストの見積り (#trade-cost)。
+ *
+ * これまで realized PnL は `(exit - avg) * qty` の **gross** で、手数料も為替
+ * スプレッドも一切入っていなかった。1 トレードの notional が $50–350 の規模だと
+ * 往復コストは勝ち幅と同じオーダーになり得るため、gross のまま equity curve /
+ * drawdown kill を回すと「勝っているのに減っている」状態を検知できない。
+ *
+ * broker の order detail は手数料を返さない (`WebullOrderDetailDto` に該当
+ * フィールドなし) ので、**設定値からの見積り**を差し引く。実費が取れるように
+ * なったらこの module を実測ベースに差し替える。
+ *
+ * 既定は 0 (= 従来どおり gross)。口座の手数料体系を確認してから
+ * `global_config.fee_pct_of_notional` / `fee_fixed_per_order` を設定する。
+ */
+export interface TradeCostConfig {
+  /** 約定代金に対する料率 (0.0022 = 0.22%)。0 で無効。 */
+  feePctOfNotional: number
+  /** 1 注文あたりの固定費 (銘柄通貨建て)。0 で無効。 */
+  feeFixedPerOrder: number
+}
+
+export const NO_TRADE_COST: TradeCostConfig = Object.freeze({
+  feePctOfNotional: 0,
+  feeFixedPerOrder: 0,
+})
+
+function sanitize(value: number | null | undefined): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) return 0
+  return value
+}
+
+/** 片道 (1 注文) のコスト見積り。notional が不正なら固定費のみ。 */
+export function estimateOrderCost(notional: number, config: TradeCostConfig): number {
+  const pct = sanitize(config.feePctOfNotional)
+  const fixed = sanitize(config.feeFixedPerOrder)
+  const base = Number.isFinite(notional) && notional > 0 ? notional : 0
+  return base * pct + fixed
+}
+
+/**
+ * 往復コスト見積り。exit 時にしか realized PnL を出さないので、entry 側の
+ * コストもここでまとめて引く (entry notional は avgPrice × qty で近似)。
+ */
+export function estimateRoundTripCost(
+  entryNotional: number,
+  exitNotional: number,
+  config: TradeCostConfig,
+): number {
+  return estimateOrderCost(entryNotional, config) + estimateOrderCost(exitNotional, config)
+}
+
+/**
+ * gross realized PnL から往復コストを引いた net を返す。コスト未設定なら
+ * gross をそのまま返す (数値としても完全に一致する)。
+ */
+export function netRealizedPnl(input: {
+  avgPrice: number
+  exitPrice: number
+  quantity: number
+  config: TradeCostConfig
+}): { gross: number; cost: number; net: number } {
+  const gross = (input.exitPrice - input.avgPrice) * input.quantity
+  const cost = estimateRoundTripCost(
+    input.avgPrice * input.quantity,
+    input.exitPrice * input.quantity,
+    input.config,
+  )
+  return { gross, cost, net: gross - cost }
+}

--- a/src/trading/reconciliation/reconcileFills.ts
+++ b/src/trading/reconciliation/reconcileFills.ts
@@ -10,6 +10,8 @@ import type { WebullOrderDetailDto } from '../../infrastructure/webull/dto'
 import { inferWebullMarket } from '../../infrastructure/webull/mapper'
 import { inferTradingMarket, nextTradingDay } from '../domain/tradingCalendar'
 import { loadSymbolUniverse } from '../../infrastructure/db/symbolUniverse'
+import { loadGlobalConfig } from '../../infrastructure/db/globalConfigRepo'
+import { netRealizedPnl, type TradeCostConfig } from '../domain/tradingCost'
 import type { SymbolCurrency } from '../../infrastructure/db/symbolConfigRepo'
 import { PortfolioStateClient } from '../state/PortfolioStateClient'
 import { SymbolStateClient } from '../state/SymbolStateClient'
@@ -286,6 +288,27 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
   }
 
   const db = createDb(options.env.DB)
+
+  // #trade-cost: realized PnL を net 化するためのコスト設定。**既存の db handle
+  // を使い回す** (createDb を増やすと呼び出し順に依存した test fixture が壊れる)。
+  // 読み出し失敗は 0 (= gross) に倒す — ここで止めると fill の反映自体が止まり、
+  // DO と broker の split-brain が伸びる方が害が大きい。
+  let tradeCost: TradeCostConfig = { feePctOfNotional: 0, feeFixedPerOrder: 0 }
+  try {
+    const globalConfigSnapshot = await loadGlobalConfig(db, options.requestId)
+    tradeCost = {
+      feePctOfNotional: globalConfigSnapshot.feePctOfNotional,
+      feeFixedPerOrder: globalConfigSnapshot.feeFixedPerOrder,
+    }
+  } catch (error) {
+    console.warn(
+      JSON.stringify({
+        event: 'reconcile_trade_cost_config_error',
+        requestId: options.requestId,
+        message: error instanceof Error ? error.message : String(error),
+      }),
+    )
+  }
   // Two cohorts in one query:
   //   (a) `broker_status IS NULL` — never-reconciled, the original case.
   //   (b) `broker_status='FILLED' AND state_applied_at IS NULL` — D1 says
@@ -644,6 +667,8 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
     const resolvedSide = resolveJournalSide(detail.side, journalSide)
     const symbol = row.symbol ?? detail.symbol ?? null
     let realizedPnl: number | null = null
+    // #trade-cost: 往復コストの見積り。SELL 行にだけ入る (entry 分もここで引く)。
+    let estimatedCost: number | null = null
     if (
       status === 'FILLED' &&
       resolvedSide === 'SELL' &&
@@ -656,7 +681,17 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
         const priorState = await new SymbolStateClient(options.env.SYMBOL_STATE).getState(symbol)
         const avg = priorState.position?.avgPrice
         if (typeof avg === 'number' && Number.isFinite(avg) && avg > 0) {
-          realizedPnl = (filledPrice - avg) * filledQty
+          // #trade-cost: broker が実費を返さないので設定値から往復コストを
+          // 見積り、**net** を realized として記録する。未設定 (既定 0) なら
+          // gross と完全に一致する。
+          const pnl = netRealizedPnl({
+            avgPrice: avg,
+            exitPrice: filledPrice,
+            quantity: filledQty,
+            config: tradeCost,
+          })
+          realizedPnl = pnl.net
+          estimatedCost = pnl.cost > 0 ? pnl.cost : null
         }
       } catch (error) {
         // Not fatal — just means we can't pre-compute realized. Log + continue.
@@ -680,6 +715,7 @@ export async function reconcileFills(options: ReconcileOptions): Promise<Reconci
           filledQty,
           filledPrice,
           realizedPnl,
+          ...(estimatedCost !== null ? { estimatedCost } : {}),
         })
         .where(eq(tradeJournal.id, row.id))
       summary.updated.push({ clientOrderId: coid, status, ...(realizedPnl !== null ? { realizedPnl } : {}) })

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -6,6 +6,7 @@ import { BrokerRequestError, isSellQtyExceedError, isTickerDenyError } from '../
 import type { DecisionTraceStep } from '../domain/Signal'
 import type { StrategyDecision } from '../domain/StrategyDecision'
 import { inferTradingMarket, isWithinUsCloseWindow } from '../domain/tradingCalendar'
+import { NO_TRADE_COST, netRealizedPnl, type TradeCostConfig } from '../domain/tradingCost'
 import type { Execution } from '../execution/Execution'
 import type { PositionStore } from '../state/PositionStore'
 import type { SymbolState } from '../state/types'
@@ -199,6 +200,12 @@ export interface PullbackSchedulerOptions {
    * (`runStrategyCron`) は `buildEntrySuppressedSymbols` の結果を渡す。
    */
   entrySuppressedSymbols?: Record<string, string>
+  /**
+   * 売買コスト見積り (#trade-cost)。TRADE 通知の realized PnL を net 化する。
+   * 未注入なら 0 (= gross)。永続化される realized は `reconcileFills` 側が
+   * 同じ設定で計算する。
+   */
+  tradeCost?: TradeCostConfig
   /**
    * ペアレジーム layer (#472)。mode='observe' は zone/score を trace に残すだけ
    * (gate しない)、'enforce' は zone が許可しない側の BUY を SKIP し、保有と
@@ -1456,9 +1463,16 @@ export async function runPullbackScheduler(
     // が無い SELL は不正経路 (上で reject 済) なので発生しないはずだが defensive。
     // fallback で qty が変わった場合も executedIntent.quantity を使うので
     // realized PnL は実 SELL 数量分のみ。
+    // #trade-cost: 通知に出す realized も reconcile と同じ net にする
+    // (片方 gross・片方 net だと突き合わせできない)。
     const realizedPnl =
       executedIntent.side === 'SELL' && state.position && Number.isFinite(state.position.avgPrice)
-        ? (executedIntent.price - state.position.avgPrice) * executedIntent.quantity
+        ? netRealizedPnl({
+            avgPrice: state.position.avgPrice,
+            exitPrice: executedIntent.price,
+            quantity: executedIntent.quantity,
+            config: options.tradeCost ?? NO_TRADE_COST,
+          }).net
         : undefined
     emitNotify({
       type: 'TRADE',

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -743,6 +743,11 @@ export async function runStrategyCron(
       defaultRule,
       rulesMap,
       entrySuppressedSymbols: effectiveEntrySuppressed,
+      // #trade-cost: 通知の realized を reconcile と同じ net にする。
+      tradeCost: {
+        feePctOfNotional: global.feePctOfNotional,
+        feeFixedPerOrder: global.feeFixedPerOrder,
+      },
       halfEntrySymbols,
       momentumSymbols,
       ...(momentumStrategy ? { momentumStrategy } : {}),

--- a/test/helpers/configFixtures.ts
+++ b/test/helpers/configFixtures.ts
@@ -36,6 +36,8 @@ export function makeGlobalConfigSnapshot(
     pullbackDefaultMaxSma50DeviationPct: 0.6,
     pullbackDefaultMaxAtrRatio: 1.5,
     pullbackDefaultMaxStopToTpRatio: 2.0,
+    feePctOfNotional: 0,
+    feeFixedPerOrder: 0,
     riskBasePerTradePct: 0.004,
     riskDdHalfThreshold: -0.05,
     riskDdHaltThreshold: -0.10,

--- a/test/trading/domain/tradingCost.test.ts
+++ b/test/trading/domain/tradingCost.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import {
+  NO_TRADE_COST,
+  estimateOrderCost,
+  estimateRoundTripCost,
+  netRealizedPnl,
+} from '../../../src/trading/domain/tradingCost'
+
+describe('estimateOrderCost', () => {
+  it('料率と固定費を足す', () => {
+    expect(estimateOrderCost(1000, { feePctOfNotional: 0.002, feeFixedPerOrder: 1 })).toBeCloseTo(3)
+  })
+
+  it('未設定 (既定) なら 0', () => {
+    expect(estimateOrderCost(1000, NO_TRADE_COST)).toBe(0)
+  })
+
+  it('notional が不正でも固定費だけは残る (料率は 0 扱い)', () => {
+    const cfg = { feePctOfNotional: 0.002, feeFixedPerOrder: 1 }
+    expect(estimateOrderCost(Number.NaN, cfg)).toBe(1)
+    expect(estimateOrderCost(-100, cfg)).toBe(1)
+  })
+
+  it('負値 / 非有限の設定は 0 に倒す (コストを負にして PnL を水増ししない)', () => {
+    expect(estimateOrderCost(1000, { feePctOfNotional: -0.5, feeFixedPerOrder: -10 })).toBe(0)
+    expect(
+      estimateOrderCost(1000, { feePctOfNotional: Number.NaN, feeFixedPerOrder: Number.NaN }),
+    ).toBe(0)
+  })
+})
+
+describe('estimateRoundTripCost', () => {
+  it('entry と exit の両脚を足す', () => {
+    const cfg = { feePctOfNotional: 0.001, feeFixedPerOrder: 0.5 }
+    // 1000*0.001+0.5 + 1100*0.001+0.5 = 1.5 + 1.6
+    expect(estimateRoundTripCost(1000, 1100, cfg)).toBeCloseTo(3.1)
+  })
+})
+
+describe('netRealizedPnl', () => {
+  it('コスト未設定なら gross と一致する (既存挙動の回帰保証)', () => {
+    const r = netRealizedPnl({
+      avgPrice: 40,
+      exitPrice: 43,
+      quantity: 5,
+      config: NO_TRADE_COST,
+    })
+    expect(r.gross).toBe(15)
+    expect(r.cost).toBe(0)
+    expect(r.net).toBe(15)
+  })
+
+  // 本番実測 (SQQQ 5 株 @40.775 → 42.9401、gross +10.83)。往復 0.22% だと
+  // コストは約 0.92 で、勝ち幅の 8% 相当が消える。
+  it('実測トレードで gross から往復コストを引く', () => {
+    const r = netRealizedPnl({
+      avgPrice: 40.775,
+      exitPrice: 42.9401,
+      quantity: 5,
+      config: { feePctOfNotional: 0.0022, feeFixedPerOrder: 0 },
+    })
+    expect(r.gross).toBeCloseTo(10.83, 2)
+    expect(r.cost).toBeCloseTo(0.92, 2)
+    expect(r.net).toBeCloseTo(9.9, 1)
+  })
+
+  it('小さい勝ちはコストで負けに転じ得る', () => {
+    const r = netRealizedPnl({
+      avgPrice: 100,
+      exitPrice: 100.5,
+      quantity: 1,
+      config: { feePctOfNotional: 0, feeFixedPerOrder: 1 },
+    })
+    expect(r.gross).toBeCloseTo(0.5)
+    expect(r.net).toBeCloseTo(-1.5)
+  })
+})


### PR DESCRIPTION
戦略判定モデルのレビューで挙げた課題 4/5。

## 問題

`realizedPnl = (exit - avg) * qty` で、**手数料も為替スプレッドも一切入っていません**でした (`src/` 内に手数料モデルは存在しない)。

1 トレードの notional が $50–350 の規模なので、往復コストは勝ち幅と同じオーダーになり得ます。実測トレード (SQQQ 5 株、gross +10.83) は往復 0.22% なら約 0.92 が消え、勝ち幅の 8% 相当です。gross のまま以下が回っていました:

- エクイティカーブ / 期間リターン (dashboard・MCP)
- `dailyRealizedPnl` → **drawdown kill の判定**
- 「勝っているのに口座は減っている」状態を検知できない

## 変更

`src/trading/domain/tradingCost.ts` を新設し、設定値からの見積りコストを realized から引きます。

- `estimateOrderCost(notional, config)` = `notional × feePct + feeFixed`
- `netRealizedPnl()` が exit 時に **往復分** (entry notional は `avgPrice × qty` で近似) を引く
- 適用先は `reconcileFills` (= 永続化される realized、DO の `dailyRealizedPnl`、エクイティカーブ) と scheduler の TRADE 通知。**両方が同じ計算**を使うので突き合わせできます
- `trade_journal.estimated_cost` (migration `0039`) に見積り額を残し、gross に戻して読めるようにしています

### 設定

`global_config.fee_pct_of_notional` / `fee_fixed_per_order` (いずれも **既定 0 = 従来どおり gross**)。

```sql
-- 例: 往復 0.22% を見積もる
UPDATE global_config SET fee_pct_of_notional = 0.0022 WHERE id = 'default';
```

**既定を 0 にした理由**: broker の order detail は手数料を返さず (`WebullOrderDetailDto` に該当フィールドなし)、実際の手数料体系をコード側で確定できません。推測値を焼き込んで実績を歪めるより、口座の条件を確認して設定してもらう方が安全と判断しました。実費が API から取れるようになればこの module を実測ベースに差し替えます。

## 実装上の注意

- コスト設定の読み出しは **`reconcileFills` が既に持っている `db` handle を使い回し**ています。`createDb` を追加で呼ぶと、呼び出し順に依存した既存 fixture が壊れるためです
- 設定の読み出しに失敗したらコスト 0 に倒します。ここで止めると fill の反映自体が止まり、DO と broker の split-brain が伸びる方が害が大きいためです
- 負値 / 非有限の設定値は 0 に丸めます (コストを負にして PnL を水増ししない)

## 検証

- `pnpm run typecheck` clean / `pnpm test` 116 files・1718 tests pass
- `tradingCost` の単体テストを追加 (料率+固定費 / 未設定は gross と完全一致 / 不正値の丸め / 実測トレードでの net / 小さい勝ちがコストで負けに転じるケース)

## 未対応

為替スプレッド (JPY 口座で USD 銘柄を売買する際のコスト) は別モデルが要るのでこの PR では扱っていません。当面は `fee_pct_of_notional` に上乗せして近似できます。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 売買の料率・注文固定費を設定できるようになりました。
  - 手数料などを考慮した実現損益（net）を通知・記録します。
  - 取引ごとの推定コストをジャーナルに保存します。
  - 未設定時は従来どおり、コスト0として動作します。

- **ドキュメント**
  - 安全性設定の通貨別上限・予算テーブルに、売買コスト設定項目を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->