### PR TITLE
feat: allow the ATR baseline to exclude the window it is compared against

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Retail auto-trading system on Cloudflare Workers + Hono + TypeScript, speaking W
 | `spread_limit_pct_{us,jp}` | `0.0025` / `0.006` | spread guard |
 | `fee_pct_of_notional` | `0` | 売買コスト見積りの料率。realized PnL を net 化する (#trade-cost) |
 | `fee_fixed_per_order` | `0` | 同、1 注文あたりの固定費 (銘柄通貨建て) |
+| `atr_baseline_exclude_recent` | `0` | baseline ATR から直近 20 本を除外する (#atr-baseline-window)。`1` にすると `atr20/baseline` が素直な比率になるが、過熱ガード / atr-floor の閾値は再校正が必要 |
 | `gap_reject_pct` | `0.03` | gap 判定 |
 
 **Pullback 戦略の default rule (#118、#124):**

--- a/drizzle/0040_add_atr_baseline_exclude_recent.sql
+++ b/drizzle/0040_add_atr_baseline_exclude_recent.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `global_config` ADD `atr_baseline_exclude_recent` integer DEFAULT false NOT NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1785000435697,
       "tag": "0039_add_trade_cost_config",
       "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "6",
+      "when": 1785000927225,
+      "tag": "0040_add_atr_baseline_exclude_recent",
+      "breakpoints": true
     }
   ]
 }

--- a/src/infrastructure/db/globalConfigRepo.ts
+++ b/src/infrastructure/db/globalConfigRepo.ts
@@ -47,6 +47,8 @@ export interface GlobalConfigSnapshot {
   feePctOfNotional: number
   /** 売買コスト見積りの 1 注文固定費 (銘柄通貨建て)。 */
   feeFixedPerOrder: number
+  /** baseline ATR から直近 20 本を除外するか (#atr-baseline-window)。 */
+  atrBaselineExcludeRecent: boolean
   /** Base risk fraction per trade (0.4% default)。#23 Lane 2。 */
   riskBasePerTradePct: number
   /** drawdown がこの閾値 (負) 未満で size を 0.5× に (-0.05 default)。 */
@@ -113,6 +115,7 @@ export const GLOBAL_CONFIG_DEFAULTS: GlobalConfigSnapshot = Object.freeze({
   pullbackDefaultMaxStopToTpRatio: 2.0,
   feePctOfNotional: 0,
   feeFixedPerOrder: 0,
+  atrBaselineExcludeRecent: false,
   riskBasePerTradePct: 0.004,
   riskDdHalfThreshold: -0.05,
   riskDdHaltThreshold: -0.10,
@@ -320,6 +323,7 @@ export async function loadGlobalConfig(
             pullbackDefaultMaxStopToTpRatio: globalConfig.pullbackDefaultMaxStopToTpRatio,
             feePctOfNotional: globalConfig.feePctOfNotional,
             feeFixedPerOrder: globalConfig.feeFixedPerOrder,
+            atrBaselineExcludeRecent: globalConfig.atrBaselineExcludeRecent,
             riskBasePerTradePct: globalConfig.riskBasePerTradePct,
             riskDdHalfThreshold: globalConfig.riskDdHalfThreshold,
             riskDdHaltThreshold: globalConfig.riskDdHaltThreshold,
@@ -359,6 +363,8 @@ export async function loadGlobalConfig(
             // 0039 追加列 (#trade-cost)。legacy path は default (= gross PnL)。
             feePctOfNotional: GLOBAL_CONFIG_DEFAULTS.feePctOfNotional,
             feeFixedPerOrder: GLOBAL_CONFIG_DEFAULTS.feeFixedPerOrder,
+            // 0040 追加列 (#atr-baseline-window)。legacy path は default (従来窓)。
+            atrBaselineExcludeRecent: GLOBAL_CONFIG_DEFAULTS.atrBaselineExcludeRecent,
             riskBasePerTradePct: legacyRow.riskBasePerTradePct,
             riskDdHalfThreshold: legacyRow.riskDdHalfThreshold,
             riskDdHaltThreshold: legacyRow.riskDdHaltThreshold,
@@ -424,6 +430,7 @@ export async function loadGlobalConfig(
     pullbackDefaultMaxStopToTpRatio: row.pullbackDefaultMaxStopToTpRatio,
     feePctOfNotional: row.feePctOfNotional,
     feeFixedPerOrder: row.feeFixedPerOrder,
+    atrBaselineExcludeRecent: row.atrBaselineExcludeRecent,
     riskBasePerTradePct: row.riskBasePerTradePct,
     riskDdHalfThreshold: row.riskDdHalfThreshold,
     riskDdHaltThreshold: row.riskDdHaltThreshold,

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -350,6 +350,14 @@ export const globalConfig = sqliteTable(
     /** 1 注文あたりの固定費 (銘柄通貨建て)。0 で無効。 */
     feeFixedPerOrder: real('fee_fixed_per_order').notNull().default(0),
     /**
+     * baseline ATR から直近 20 本 (atr20 の窓) を除外するか (#atr-baseline-window)。
+     * **既定 false = 従来の重複窓**。true にすると比率が素直になる代わりに
+     * 過熱ガード / atr-floor の閾値を測り直す必要がある。
+     */
+    atrBaselineExcludeRecent: integer('atr_baseline_exclude_recent', { mode: 'boolean' })
+      .notNull()
+      .default(false),
+    /**
      * Base risk fraction per trade (0.4% default)。drawdown scale を掛けた値が
      * pullbackSizing に渡る。#23 Lane 2。
      */

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -399,6 +399,13 @@ export const admin = new Hono<AppBindings>()
       to,
       initialCash,
       rule,
+      // #atr-baseline-window: `?atrBaselineExcludeRecent=1` で baseline から
+      // 直近 20 本を除いた場合の成績を測れる。既定は global_config の値
+      // (= 本番と同じ条件) なので、閾値の再校正はこの 2 通りを比べて行う。
+      atrBaselineExcludeRecent:
+        c.req.query('atrBaselineExcludeRecent') === undefined
+          ? global.atrBaselineExcludeRecent
+          : c.req.query('atrBaselineExcludeRecent') === '1',
     }
     const result = await runBacktest(sliced, params)
     return c.json(result)

--- a/src/routes/dashboard/config.ts
+++ b/src/routes/dashboard/config.ts
@@ -177,15 +177,15 @@ export const CONFIG_KEY_META: Record<string, ConfigKeyMeta> = {
   },
   pullback_default_pullback_max: {
     label: '押し目上限 (比率、負)',
-    detail: '押し目買いを狙う「浅い側」の下落率閾値。-0.03 なら「-3% 以上下げた銘柄を候補に」。緩めると機会↑、騙し↑。',
+    detail: '押し目買いを狙う「浅い側」の下落率閾値。**直近 10 営業日の高値**から -0.03 なら「-3% 以上下げた銘柄を候補に」。緩めると機会↑、騙し↑。',
   },
   pullback_default_pullback_min: {
     label: '押し目下限 (比率、負)',
-    detail: '押し目買いを狙う「深い側」の下落率閾値。-0.06 なら「-6% より深い下げは敬遠」。深すぎる下げは反発せず転換の可能性。',
+    detail: '押し目買いを狙う「深い側」の下落率閾値。**直近 10 営業日の高値**から -0.06 なら「-6% より深い下げは敬遠」。深すぎる下げは反発せず転換の可能性。',
   },
   pullback_default_min_return_50d: {
-    label: '50日最低騰落率 (比率)',
-    detail: '過去 50 日の騰落率がこの値以上の銘柄だけ押し目買い対象。0.08 = +8%。上昇トレンド銘柄を絞るフィルター。',
+    label: '20日最低騰落率 (比率)',
+    detail: '過去 **20 営業日** の騰落率がこの値以上の銘柄だけ押し目買い対象。0.08 = +8%。上昇トレンド銘柄を絞るフィルター。列名の `50d` は #318 で lookback を 50→20 日に短縮した際の名残 (storage 互換のため据え置き)。',
   },
   pullback_default_require_above_sma50: {
     label: 'SMA50 超必須 (bool)',
@@ -201,7 +201,7 @@ export const CONFIG_KEY_META: Record<string, ConfigKeyMeta> = {
   },
   pullback_default_max_atr_ratio: {
     label: '過熱ガード: ATR比上限 (倍)',
-    detail: '直近 ATR が baseline (長期平均) のこの倍率を超える高ボラ局面では押し目買いを見送る。1.5 = baseline の 1.5 倍。ボラ・レジーム破綻時の entry を抑制。',
+    detail: '直近 ATR が baseline (**直近 20 日を除いた**長期平均) のこの倍率を超える高ボラ局面では押し目買いを見送る。1.5 = baseline の 1.5 倍。ボラ・レジーム破綻時の entry を抑制。',
   },
   risk_base_per_trade_pct: {
     label: '基本リスク率 (比率)',

--- a/src/trading/backtest/runBacktest.ts
+++ b/src/trading/backtest/runBacktest.ts
@@ -59,6 +59,11 @@ export interface BacktestParams {
    * PullbackUptrendStrategy を構築。BreakoutMomentumStrategy 等を渡せる。
    */
   strategy?: BacktestStrategy
+  /**
+   * baseline ATR から直近 20 本を除外して評価するか (#atr-baseline-window)。
+   * 閾値 (maxAtrRatio / atr-floor) の再校正はここで測る。既定 false = 本番同等。
+   */
+  atrBaselineExcludeRecent?: boolean
 }
 
 export type ExitReason = 'TP' | 'STOP' | 'TIME_STOP' | 'END_OF_DATA'
@@ -154,7 +159,9 @@ export async function runBacktest(
     // and execution fill (T+0). Realistic enough for daily-bar offline eval;
     // intra-day slippage is out of scope.
     const window = bars.slice(Math.max(0, i + 1 - 60), i + 1)
-    const indicators = computePullbackIndicators(window, null)
+    const indicators = computePullbackIndicators(window, null, {
+      excludeRecentFromBaseline: params.atrBaselineExcludeRecent === true,
+    })
     const today = bars[i]!
     if (!indicators) {
       // Should not happen given warmup>=50, but bail safely.

--- a/src/trading/strategy/indicators.ts
+++ b/src/trading/strategy/indicators.ts
@@ -12,6 +12,11 @@ export interface DailyBar {
   close: number
 }
 
+/** baseline ATR から除外する直近本数 (= atr20 の窓)。 */
+const BASELINE_EXCLUDE_RECENT = 20
+/** baseline ATR に使う最大サンプル数 (≈ 3 か月)。 */
+const BASELINE_MAX_SAMPLES = 60
+
 export interface PullbackIndicatorSnapshot {
   price: number
   sma50: number
@@ -38,6 +43,12 @@ export interface PullbackIndicatorSnapshot {
    */
   low20d: number
   atr20: number
+  /**
+   * 長期 ATR baseline。既定は直近 60 本平均 (atr20 の窓を**含む**)。
+   * `excludeRecentFromBaseline` を立てると直近 20 本を除外した平均になり
+   * (#atr-baseline-window)、`atr20 / baselineAtr20` が「直近 vs それ以前」の
+   * 素直な比率になる。閾値の再校正が要るので既定は従来のまま。
+   */
   baselineAtr20: number
   /**
    * ブレイクアウト基準 = **当日を除く** 直近 20 営業日の終値高値 (#momentum)。
@@ -63,9 +74,23 @@ export interface PullbackIndicatorSnapshot {
  * reference high lookback を 10d に短縮。フィールド名 (`return50d` /
  * `high20d`) は storage / dashboard 互換のため据え置き。
  */
+export interface PullbackIndicatorOptions {
+  /**
+   * baseline ATR から直近 20 本 (= atr20 の窓) を除外するか (#atr-baseline-window)。
+   *
+   * **既定 false = 従来の重複窓**。true にすると `atr20 / baselineAtr20` は
+   * 「直近 vs それ以前」の素直な比率になるが、**過熱ガード (maxAtrRatio) と
+   * sizing の atr-floor の閾値は旧 baseline 前提で校正されている**ため、
+   * 同じ閾値のままだと押し目 entry (= 直近 ATR が上がった局面) がほぼ全て
+   * blocked になる。切り替えるときは backtest で閾値を測り直すこと。
+   */
+  excludeRecentFromBaseline?: boolean
+}
+
 export function computePullbackIndicators(
   bars: DailyBar[],
   intradayPrice?: number | null,
+  options?: PullbackIndicatorOptions,
 ): PullbackIndicatorSnapshot | null {
   // SMA50 が 50 bars を必要とするので最小要件は 50。return/high の lookback が
   // 短くなっても warmup 要件は SMA50 に律速されたまま。
@@ -93,9 +118,22 @@ export function computePullbackIndicators(
   const trueRanges = computeTrueRanges(bars)
   if (trueRanges.length < 20) return null
   const atr20 = average(trueRanges.slice(-20))
-  // Baseline ATR = longer-window average that `computePullbackSizing` compares
-  // against to decide whether to floor the size. 60 bars ≈ ~3 months daily.
-  const baselineAtr20 = average(trueRanges.slice(-Math.min(trueRanges.length, 60)))
+  // Baseline ATR (#atr-baseline-window)。60 本平均の中に atr20 の窓が丸ごと
+  // 入っているので、直近ボラが跳ねると baseline も一緒に上がり比率が鈍る
+  // (窓が重なる限り比率は理論上 3 倍で頭打ち)。`excludeRecentFromBaseline` で
+  // 直近 20 本を除外した「直近 vs それ以前」の比率に切り替えられる。
+  //
+  // **既定は従来のまま**: 過熱ガード (maxAtrRatio 1.5) と sizing の atr-floor
+  // (0.5) は重複窓前提で校正されており、除外に切り替えると押し目 entry が
+  // ほぼ全滅する (テスト fixture で BUY 64 ケースが blocked になった)。
+  // 切り替えは backtest で閾値を測り直してから。
+  // bars >= 50 を上で保証しているので TR は 49 本以上あり、直近 20 本を除いても
+  // 29 本以上残る (= サンプル不足の分岐は起き得ない)。
+  const baselineSource =
+    options?.excludeRecentFromBaseline === true
+      ? trueRanges.slice(0, -BASELINE_EXCLUDE_RECENT).slice(-BASELINE_MAX_SAMPLES)
+      : trueRanges.slice(-Math.min(trueRanges.length, BASELINE_MAX_SAMPLES))
+  const baselineAtr20 = average(baselineSource)
 
   // intradayPrice がきちんと正値の有限数なら採用、そうでなければ daily close。
   // `> 0` で 0 / 負値もはじき、Number.isFinite で NaN / Infinity をはじく。

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -207,6 +207,11 @@ export interface PullbackSchedulerOptions {
    */
   tradeCost?: TradeCostConfig
   /**
+   * baseline ATR から直近 20 本を除外するか (#atr-baseline-window)。未注入は
+   * false = 従来窓。閾値の再校正が要るので production は global_config 経由。
+   */
+  atrBaselineExcludeRecent?: boolean
+  /**
    * ペアレジーム layer (#472)。mode='observe' は zone/score を trace に残すだけ
    * (gate しない)、'enforce' は zone が許可しない側の BUY を SKIP し、保有と
    * 反対 zone への flip で SELL (regime_flip) を出す。未注入 = 従来挙動。
@@ -555,7 +560,9 @@ export async function runPullbackScheduler(
       continue
     }
 
-    const indicators = computePullbackIndicators(bars, intradayPrice)
+    const indicators = computePullbackIndicators(bars, intradayPrice, {
+      excludeRecentFromBaseline: options.atrBaselineExcludeRecent === true,
+    })
     if (!indicators) {
       summary.rejected.push({ symbol: upper, reason: 'insufficient bars for indicators' })
       await emitDecision({ symbol: upper, decision: 'SKIP', reason: 'insufficient bars for indicators' })

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -743,6 +743,7 @@ export async function runStrategyCron(
       defaultRule,
       rulesMap,
       entrySuppressedSymbols: effectiveEntrySuppressed,
+      atrBaselineExcludeRecent: global.atrBaselineExcludeRecent,
       // #trade-cost: 通知の realized を reconcile と同じ net にする。
       tradeCost: {
         feePctOfNotional: global.feePctOfNotional,

--- a/test/helpers/configFixtures.ts
+++ b/test/helpers/configFixtures.ts
@@ -38,6 +38,7 @@ export function makeGlobalConfigSnapshot(
     pullbackDefaultMaxStopToTpRatio: 2.0,
     feePctOfNotional: 0,
     feeFixedPerOrder: 0,
+    atrBaselineExcludeRecent: false,
     riskBasePerTradePct: 0.004,
     riskDdHalfThreshold: -0.05,
     riskDdHaltThreshold: -0.10,

--- a/test/trading/strategy/indicators.test.ts
+++ b/test/trading/strategy/indicators.test.ts
@@ -123,3 +123,48 @@ describe('computeHoldBusinessDays', () => {
     expect(computeHoldBusinessDays('not-a-date', new Date(), 'US')).toBe(0)
   })
 })
+
+// #atr-baseline-window: baseline は既定で直近 20 本 (atr20 の窓) を内包する。
+// opt-in で除外でき、その場合だけ「直近 vs それ以前」の素直な比率になる。
+describe('computePullbackIndicators baseline ATR window', () => {
+  /** 前半 40 本は静穏 (幅 1%)、直近 20 本だけボラを 5 倍にした系列。 */
+  function volSpikeBars(): DailyBar[] {
+    return Array.from({ length: 61 }, (_, i) => {
+      const close = 100
+      const spread = i >= 41 ? 0.05 : 0.01
+      const iso = new Date(Date.UTC(2026, 0, 1 + i)).toISOString().slice(0, 10)
+      return {
+        date: iso,
+        open: close,
+        high: close * (1 + spread),
+        low: close * (1 - spread),
+        close,
+      }
+    })
+  }
+
+  it('既定では baseline に直近の急騰分が混ざり、比率が鈍る', () => {
+    const r = computePullbackIndicators(volSpikeBars())!
+    const ratio = r.atr20 / r.baselineAtr20
+    // 実際のボラ差は 5 倍だが、baseline が直近を含むので比率は大幅に縮む。
+    expect(ratio).toBeLessThan(3)
+  })
+
+  it('excludeRecentFromBaseline で実際のボラ差 (5 倍) に近い比率になる', () => {
+    const r = computePullbackIndicators(volSpikeBars(), null, {
+      excludeRecentFromBaseline: true,
+    })!
+    const ratio = r.atr20 / r.baselineAtr20
+    expect(ratio).toBeGreaterThan(4)
+  })
+
+  it('最小 bar 数 (50) でも除外後に十分なサンプルが残る', () => {
+    const closes = Array.from({ length: 50 }, (_, i) => 100 + i)
+    const excluded = computePullbackIndicators(makeBars(closes), null, {
+      excludeRecentFromBaseline: true,
+    })!
+    // TR 49 本 − 直近 20 本 = 29 本。0 除算や空平均にならないことを固定する。
+    expect(excluded.baselineAtr20).toBeGreaterThan(0)
+    expect(Number.isFinite(excluded.atr20 / excluded.baselineAtr20)).toBe(true)
+  })
+})


### PR DESCRIPTION
戦略判定モデルのレビューで挙げた課題 5/5。

## 問題

`baselineAtr20` は直近 60 本の平均で、**その中に `atr20` の窓 (直近 20 本) が丸ごと入っていました**。直近ボラが跳ねると baseline も一緒に上がるので `atr20 / baselineAtr20` は鈍り、窓が重なる限り比率は理論上 3 倍で頭打ちになります。

この比率は 2 か所で閾値判定に使われています:

- 過熱ガード `maxAtrRatio` (1.5) — 高ボラ局面の entry 見送り
- sizing の atr-floor (0.5) — 低ボラ時のサイズ半減

どちらも「名目の閾値より鈍く効く」状態でした。

## 変更と、既定を変えなかった理由

`computePullbackIndicators` に `excludeRecentFromBaseline` を追加し、baseline から直近 20 本を除外できるようにしました。**既定は従来のまま (重複窓)** です。

無条件に切り替えたところ、**scheduler のテストで BUY が 64 ケース全滅**しました。押し目 entry は定義上「直近下げてボラが上がった」局面なので、比率が素直になると `maxAtrRatio 1.5` にほぼ必ず引っかかります。閾値は旧 baseline 前提で校正されているため、分母の意味だけ変えると戦略が実質停止します。

そこで:

- `global_config.atr_baseline_exclude_recent` (migration `0040`、既定 `0`) で切り替え
- **`GET /admin/backtest?atrBaselineExcludeRecent=1`** で新旧を比較でき、閾値を測り直せる (`runBacktest` の `BacktestParams` にも追加)

```sql
-- backtest で maxAtrRatio を測り直してから
UPDATE global_config SET atr_baseline_exclude_recent = 1 WHERE id = 'default';
```

## 併せて修正: 設定画面の誤ったラベル

`/dashboard/config` が `pullback_default_min_return_50d` を **「50日最低騰落率」** と表示していました。実体は #318 以降 **20 営業日**です。この画面は operator が閾値を触る場所なので、50 日のつもりで +8% を設定すると全く違う条件になります。

- ラベルを「20日最低騰落率」に修正し、列名の `50d` が名残であることを detail に明記
- 押し目上限/下限の detail に「直近 **10 営業日**の高値から」の基準を追記 (これも #318 で 20→10 日)
- ATR 比上限の detail に baseline の定義を追記

フィールド名 (`return50d` / `high20d` / `minReturn50d`) 自体の rename は、`strategy_decision_log.indicators_json` の既存行・dashboard・MCP 出力すべてに波及するため見送りました。誤設定の実害があるのは画面のラベルなので、そちらを先に潰しています。

## 検証

- `pnpm run typecheck` clean / `pnpm test` 116 files・1721 tests pass
- 「静穏 40 本 + 直近 20 本だけボラ 5 倍」の系列で、既定は比率 < 3 に潰れ、除外指定では > 4 になることを固定
- 最小 bar 数 (50) でも除外後 29 サンプル残ることを確認 (0 除算しない)。到達不能な fallback 分岐は入れずに削除

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ATR baseline の計算時に、直近20本を除外する設定を追加しました。
  * 管理画面のバックテストと通常の戦略実行で、この設定を切り替えられるようになりました。
  * 設定は既定で無効です。

* **ドキュメント**
  * ATR baseline、過熱ガード、`atr-floor` 閾値に関する説明を更新しました。
  * 押し目買い設定の参照期間を明確化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->