### PR TITLE
fix(ci): make dependency updates produce a release

### DIFF
--- a/docs/production-cd.md
+++ b/docs/production-cd.md
@@ -113,4 +113,5 @@ Required checks:
 
 - 採番は Conventional Commits 由来 (`feat:` → minor / `fix:` → patch / `!` or `BREAKING CHANGE` → major)
 - CHANGELOG に出るのは `feat` / `fix` / `perf` / `refactor` / `deps`。`chore` / `docs` / `test` / `ci` / `style` は hidden
+- **hidden な type だけの変更はリリースを生まない** (実測: `chore(deps)` のみを merge しても release PR は出なかった)。依存更新が production に永久に出ない乖離を避けるため、Renovate は `renovate.json` の packageRules で `fix(deps):` を使わせている
 - ロールバックの参照点は tag。`git checkout vX.Y.Z` した tree を `production` に流し直せば戻せる

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,13 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "description": "依存更新を release-please が採番できる形にする。既定の `chore(deps):` は changelog-sections で hidden にしている = リリース対象にならず、staging には入るのに production へ永久に出ないという乖離が起きるため、patch bump になる `fix(deps):` を使う。",
+      "matchPackageNames": ["*"],
+      "semanticCommitType": "fix",
+      "semanticCommitScope": "deps"
+    }
   ]
 }


### PR DESCRIPTION
#602 で入れた release-please のフローを実測した結果、**依存更新だけでは production に永久に出ない**ことが分かったので塞ぎます。

## 実測した挙動

`chore(deps): update dependency @cloudflare/workers-types` (#599) を main に merge

→ `release please` workflow は success で終わるが **release PR は生成されない**

`chore` を `changelog-sections` で `hidden: true` にしているため、release-please が「リリース対象の変更なし」と判断します。

## なぜ問題か

- 依存更新は main push で **staging には即入る** (Workers Builds)
- しかし release が切られないので **production には出ない**
- 無関係な `feat:` / `fix:` が入るまで staging と production の依存が乖離し続ける
- hono / wrangler のようにランタイムに乗るものが含まれるので、実マネー環境では放置できない

## 変更

`renovate.json` の packageRules で、Renovate の commit prefix を `chore(deps):` → **`fix(deps):`** にします。`fix` は patch bump の対象なので、依存更新だけでも release PR が出るようになります。

`deps:` 単独の prefix も候補でしたが (release-please native の Dependencies セクションに載る)、hidden セクションと同じくリリース対象外になるリスクがあるため、bump が保証される `fix` を選びました。

## 副作用

初回の CHANGELOG で依存更新が "Bug Fixes" に並ぶ可能性があります (release-please が scope `deps` を Dependencies セクションに寄せるかは実測待ち)。並び方が気になるようなら `changelog-sections` を調整します。

## 検証

コード変更なし (`renovate.json` と docs のみ)。実際の効果は次の Renovate PR が `fix(deps):` の title で出るか、それを merge して release PR が出るかで確認します。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * 依存関係の更新を含むリリースの扱いについて、バージョニングの説明を追記しました。

* **改善**
  * 依存関係の更新が本番環境へ確実に反映されるよう、更新コミットの形式を調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->