### PR TITLE
fix(ci): put the version in the release PR title

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -16,7 +16,7 @@ reviews:
       - "release: promote main to production"
       - "🚀リリース"
       # release-please が作る release PR も本文自動生成なのでレビュー不要
-      - "chore(main): release"
+      - "chore: release"
 
   path_filters:
     - "!.local/**"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,18 +8,54 @@
     }
   },
   "changelog-sections": [
-    { "type": "feat", "section": "Features" },
-    { "type": "fix", "section": "Bug Fixes" },
-    { "type": "perf", "section": "Performance" },
-    { "type": "refactor", "section": "Refactors" },
-    { "type": "deps", "section": "Dependencies" },
-    { "type": "chore", "section": "Chores", "hidden": true },
-    { "type": "docs", "section": "Docs", "hidden": true },
-    { "type": "test", "section": "Tests", "hidden": true },
-    { "type": "ci", "section": "CI", "hidden": true },
-    { "type": "style", "section": "Style", "hidden": true }
+    {
+      "type": "feat",
+      "section": "Features"
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes"
+    },
+    {
+      "type": "perf",
+      "section": "Performance"
+    },
+    {
+      "type": "refactor",
+      "section": "Refactors"
+    },
+    {
+      "type": "deps",
+      "section": "Dependencies"
+    },
+    {
+      "type": "chore",
+      "section": "Chores",
+      "hidden": true
+    },
+    {
+      "type": "docs",
+      "section": "Docs",
+      "hidden": true
+    },
+    {
+      "type": "test",
+      "section": "Tests",
+      "hidden": true
+    },
+    {
+      "type": "ci",
+      "section": "CI",
+      "hidden": true
+    },
+    {
+      "type": "style",
+      "section": "Style",
+      "hidden": true
+    }
   ],
   "bootstrap-sha": "d8adae22c0ee694f1609502afe1cbdf701923a1a",
   "separate-pull-requests": false,
-  "include-component-in-tag": false
+  "include-component-in-tag": false,
+  "pull-request-title-pattern": "chore: release ${version}"
 }


### PR DESCRIPTION
release-please の初回動作を実測した結果の微修正です。

生成された release PR (#605) のタイトルが **`chore: release main`** で、切ろうとしている版数 (1.0.1) がタイトルから読めませんでした。加えて #602 で `.coderabbit.yaml` に入れた skip キーワード `chore(main): release` が実際のタイトルと一致していませんでした。

- `pull-request-title-pattern` を `chore: release ${version}` に指定 → `chore: release 1.0.1`
- skip キーワードを `chore: release` に修正

中身 (CHANGELOG / version bump) は期待どおり動いており、この PR はタイトル表記だけの修正です。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * リリース関連のプルリクエストタイトル形式を統一しました。
  * リリース用プルリクエストが自動レビューの対象外として正しく扱われるよう、判定ルールを更新しました。
  * 変更履歴の分類設定を整理し、リリース情報の生成を安定化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->