### PR TITLE
fix(ci): keep every placeholder in the release PR title pattern

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -57,5 +57,5 @@
   "bootstrap-sha": "d8adae22c0ee694f1609502afe1cbdf701923a1a",
   "separate-pull-requests": false,
   "include-component-in-tag": false,
-  "pull-request-title-pattern": "chore: release ${version}"
+  "pull-request-title-pattern": "chore${scope}: release${component} ${version}"
 }


### PR DESCRIPTION
#606 で入れた `pull-request-title-pattern: "chore: release \${version}"` が逆効果だったので直します。

## 実測した障害

#606 merge 後の `release please` run のログ:

```
⚠ No latest release pull request found.
❯ pull request title pattern: chore: release ${version}
⚠ pullRequestTitlePattern miss the part of '${scope}'
⚠ pullRequestTitlePattern miss the part of '${component}'
✔ Found existing pull request ... Skipping creating a new pull request.
```

release-please は **自分が作った release PR のタイトルを逆パースして状態を復元**します。パターンから `${scope}` / `${component}` を落とすとパースできず、既存 release PR (#605) を「無い」と判断 → **タイトルも本文も版数も更新されなくなりました** (1.0.1 のまま、#606 の分が反映されない)。

## 変更

`chore${scope}: release${component} ${version}` に変更。全プレースホルダを残しつつ版数がタイトルに出ます。

## merge 後の手順

現在の #605 は旧タイトルのままでパース対象外なので、**close して再生成**させます (`workflow_dispatch` で `release please` を再実行)。