### PR TITLE
fix(ci): title the grouped release PR with the version

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -57,5 +57,6 @@
   "bootstrap-sha": "d8adae22c0ee694f1609502afe1cbdf701923a1a",
   "separate-pull-requests": false,
   "include-component-in-tag": false,
-  "pull-request-title-pattern": "chore${scope}: release${component} ${version}"
+  "pull-request-title-pattern": "chore${scope}: release${component} ${version}",
+  "group-pull-request-title-pattern": "chore: release ${version}"
 }


### PR DESCRIPTION
manifest モードの combined release PR のタイトルは `pull-request-title-pattern` ではなく **`group-pull-request-title-pattern`** から作られます (既定 `chore: release ${branch}`)。#606 / #607 で前者をいじっても "chore: release main" のままだったのはこのためです。

後者を `chore: release ${version}` に設定します。merge 後に `release please` を再実行し、タイトルに版数が出ること・既存 PR が重複せず更新されることを確認します。