### PR TITLE
fix(ci): stop release-please skipping its own merged release PR

### DIFF
--- a/docs/production-cd.md
+++ b/docs/production-cd.md
@@ -109,6 +109,13 @@ Required checks:
 
 ## Versioning
 
+導入時に踏んだ罠 (再導入・移設時の注意):
+
+- **GitHub Release が 1 つも無いと、merged release PR にタグを打てず `untagged, merged release PRs outstanding - aborting` で止まる**。ベースラインの Release (`v1.0.0`) を手で 1 本作る必要がある
+- `packages` に `package-name` を書くと component 扱いになり、grouped release PR (component 無し) と一致せず `PR component: undefined does not match configured component` でタグ生成が skip される。単一パッケージでは書かない
+- combined PR のタイトルは `pull-request-title-pattern` ではなく `group-pull-request-title-pattern` から作られる (既定は `chore: release ${branch}` なので版数が出ない)
+- `pull-request-title-pattern` から `${scope}` / `${component}` を落とすと既存 release PR を逆パースできず、PR の更新が丸ごと skip される
+
 `release-please-config.json` / `.release-please-manifest.json` が正。`release-type: node` なので `package.json` の `version` も追随する。
 
 - 採番は Conventional Commits 由来 (`feat:` → minor / `fix:` → patch / `!` or `BREAKING CHANGE` → major)

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,6 @@
   "release-type": "node",
   "packages": {
     ".": {
-      "package-name": "webull-trading",
       "changelog-path": "CHANGELOG.md"
     }
   },
@@ -54,7 +53,6 @@
       "hidden": true
     }
   ],
-  "bootstrap-sha": "d8adae22c0ee694f1609502afe1cbdf701923a1a",
   "separate-pull-requests": false,
   "include-component-in-tag": false,
   "pull-request-title-pattern": "chore${scope}: release${component} ${version}",


### PR DESCRIPTION
リリースを 1 本切って (#608 merge) 連鎖を実測したところ、**タグも Release も作られませんでした**。原因が特定できたので直します。

## 症状

```
⚠ PR component: undefined does not match configured component: webull-trading
⚠ Expected 1 releases, only found 0
⚠ There are untagged, merged release PRs outstanding - aborting
```

merged release PR #608 は `autorelease: pending` ラベルのまま、タグ無しで放置されていました。

## 原因と修正

1. **`package-name: "webull-trading"`** を書いたため component 扱いになり、component を持たない grouped release PR と一致せず、リリース生成が skip されていた → **削除** (単一パッケージなので component は空でよい)
2. **GitHub Release が 1 つも無い**状態では merged release PR にタグを打てない → ベースラインとして `v1.0.0` を手動作成済み (bootstrap-sha の commit を指す)
3. baseline ができたので **`bootstrap-sha` を削除** (残すと毎回 bootstrapping 経路に入る)

導入時に踏んだ罠は `docs/production-cd.md` の Versioning 節にまとめました (タイトルパターン 2 種の使い分け含む)。

## merge 後

`release please` を再実行し、#608 に対して `v1.0.1` のタグと Release が作られること、その publish で production 昇格 PR が出ることを確認します。