### PR TITLE
fix(ci): let the release PR carry its component so tagging is automatic

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -16,7 +16,7 @@ reviews:
       - "release: promote main to production"
       - "🚀リリース"
       # release-please が作る release PR も本文自動生成なのでレビュー不要
-      - "chore: release"
+      - "chore(main): release"
 
   path_filters:
     - "!.local/**"

--- a/docs/production-cd.md
+++ b/docs/production-cd.md
@@ -113,7 +113,8 @@ Required checks:
 
 - **GitHub Release が 1 つも無いと、merged release PR にタグを打てず `untagged, merged release PRs outstanding - aborting` で止まる**。ベースラインの Release (`v1.0.0`) を手で 1 本作る必要がある
 - `packages` に `package-name` を書くと component 扱いになり、grouped release PR (component 無し) と一致せず `PR component: undefined does not match configured component` でタグ生成が skip される。単一パッケージでは書かない
-- combined PR のタイトルは `pull-request-title-pattern` ではなく `group-pull-request-title-pattern` から作られる (既定は `chore: release ${branch}` なので版数が出ない)
+- **`separate-pull-requests: false` を明示すると Merge プラグインが有効になり、component を持たない grouped PR が作られる**。その PR は merge 後に `PR component: undefined does not match configured component` でタグ生成が skip される。単一パッケージでは書かない (書かない場合の PR title は `chore(main): release x.y.z`)
+- grouped PR を使う場合、タイトルは `pull-request-title-pattern` ではなく `group-pull-request-title-pattern` から作られる (既定は `chore: release ${branch}` なので版数が出ない)
 - `pull-request-title-pattern` から `${scope}` / `${component}` を落とすと既存 release PR を逆パースできず、PR の更新が丸ごと skip される
 
 `release-please-config.json` / `.release-please-manifest.json` が正。`release-type: node` なので `package.json` の `version` も追随する。

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -53,8 +53,6 @@
       "hidden": true
     }
   ],
-  "separate-pull-requests": false,
   "include-component-in-tag": false,
-  "pull-request-title-pattern": "chore${scope}: release${component} ${version}",
-  "group-pull-request-title-pattern": "chore: release ${version}"
+  "pull-request-title-pattern": "chore${scope}: release${component} ${version}"
 }


### PR DESCRIPTION
#610 でも直りきらなかった自動タグ生成を塞ぎます。

## 何が起きていたか

`separate-pull-requests: false` を明示していたため Merge プラグインが有効になり、**component を持たない grouped release PR** が作られていました。merge 後に release-please が自分の PR を認識できず:

```
⚠ PR component: undefined does not match configured component: webull-trading
⚠ There are untagged, merged release PRs outstanding - aborting
```

`package-name` を消しても、node strategy は `package.json` の `name` を component として使うため解決しませんでした。**grouping をやめるのが正解**です (単一パッケージなので元々不要)。

## 変更

- `separate-pull-requests` / `group-pull-request-title-pattern` を削除 → release PR は `chore(main): release x.y.z` (component 付き) になり、merge するとタグと Release が自動で作られる
- `.coderabbit.yaml` の skip キーワードを `chore(main): release` に戻す
- `docs/production-cd.md` の罠リストを更新

## 現状の後始末

1.0.1 は詰まったままだったので、タグと Release を手動で作って流しました。その publish で **昇格 PR #611「🚀リリース v1.0.1 → production」が自動生成されることは確認済み**です (`production release PR` workflow が `release` イベントで success)。

つまり **Release → 昇格 PR の連鎖は動いており**、残っていたのは「merged release PR → Release」の自動化だけです。この PR 以降のリリースで手動作業は不要になります。

## 検証

次のリリース PR が `chore(main): release 1.0.2` の形で出ること、それを merge したらタグ・Release・昇格 PR が自動で連鎖することを確認します。