### PR TITLE
fix(ci): retitle the promotion PR when a newer release supersedes it

### DIFF
--- a/.github/workflows/production-release-pr.yml
+++ b/.github/workflows/production-release-pr.yml
@@ -193,11 +193,14 @@ jobs:
             --json number \
             --jq '.[0].number // empty')"
 
+          # PR がすでに開いている間に次の Release が出ることがある (昇格前に
+          # もう 1 本切った等)。body だけ更新すると **タイトルが古い版を指したまま**
+          # になり、承認する側が別物を見て merge しかねないので title も揃える。
+          title="🚀リリース $RELEASE_TAG → production"
           if [ -n "$existing" ]; then
-            gh pr edit "$existing" --body-file release-pr-body.md
+            gh pr edit "$existing" --title "$title" --body-file release-pr-body.md
             echo "Updated PR #$existing"
           else
-            title="🚀リリース $RELEASE_TAG → production"
             gh pr create --base production --head release/production --title "$title" --body-file release-pr-body.md
           fi
 


### PR DESCRIPTION
実測で見つかった最後の綻びです。

昇格 PR #611 のタイトルが `🚀リリース v1.0.1 → production` のままなのに、body と実際の tree は `v1.0.2` になっていました。既存 PR の更新時に body しか差し替えていなかったためです。

昇格前にもう 1 本リリースを切ると必ず起きます。**承認する側がタイトルの版数を見て merge する**ので、中身と食い違うのは危険です。

## 変更

既存 PR を更新する際に `--title` も渡すようにしました。

## 検証

`js-yaml` でパース確認。挙動は次に「昇格前に新しい Release が出た」ケースで確認できます。