### PR TITLE
docs: pin the merge method per branch so it is not a choice

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@
 ## 非自明な慣習 (package.json / tsconfig.json 見れば分かる話は省略)
 
 - ブランチ名: `dev/<topic>` (例: `dev/poc-phase-2-trading`)。 `main` 直接編集禁止
+- **merge 方式は ruleset で強制済み — 選ぶ必要はない**: `main` は **merge commit のみ** (`gh pr merge --merge`)、`production` は **squash のみ** (`gh pr merge --squash`)。他方を指定すると GitHub 側で reject される
 - worktree: `git gtr new dev/<topic>` で作成、`git gtr rm` で削除
 - PR title: Conventional Commits 形式 (POC 期は `POC Phase N: <概要> (issue #<n>)` を使っていた)
 - リリース: `chore(main): release x.y.z` PR を merge して tag を切る → 生成された Release が production 昇格 PR を作る (詳細は `docs/production-cd.md`)

--- a/docs/production-cd.md
+++ b/docs/production-cd.md
@@ -107,6 +107,17 @@ Required checks:
 
 `workflow_dispatch` で `production release PR` を手動実行すると、最新の Release に対して昇格 PR を作り直せる。
 
+## Merge 方式
+
+ブランチごとに ruleset の `pull_request.allowed_merge_methods` で**強制**している。手で選ばない (選べない)。
+
+| 対象 | 方式 | 理由 |
+|---|---|---|
+| `main` | **merge commit のみ** | フィーチャーブランチの履歴を残す (squash は並列開発でコンフリクト解決や revert の手掛かりを失う) |
+| `production` | **squash のみ** | `release/production` は機械生成の単一コミットブランチ。1 リリース = production の 1 コミットを保ち、ロールバック先を一意にする。`required_linear_history` とも整合 |
+
+`main` が merge commit になったことで、**CHANGELOG の粒度が「PR 単位」から「コミット単位」に変わる**。release-please は releasable unit (`feat` / `fix` / `deps`) をコミット単位で拾うため、ブランチ内の細かいコミットもそのままリリースノートに並ぶ。粒度を保ちたい PR は push 前にローカルで畳む。
+
 ## Versioning
 
 導入時に踏んだ罠 (再導入・移設時の注意):


### PR DESCRIPTION
「どっちで merge するか毎回忘れる」を、覚えなくていい形にしました。

## やったこと (設定)

ruleset の `pull_request.allowed_merge_methods` でブランチごとに**強制**しました。GitHub の UI / `gh` の両方で、許可された方式以外は reject されます。

| 対象 | 変更前 | 変更後 |
|---|---|---|
| `main` | merge / squash / rebase すべて許可 | **merge commit のみ** |
| `production` | squash のみ (元から) | 変更なし |

`production` は元から `["squash"]` + `required_linear_history` で固定されていたので、実質 `main` 側だけの変更です。

## なぜこの割り当てか

- `main` = **merge commit**: 並列開発でフィーチャーブランチの履歴を潰さない (今回の依頼の主旨)
- `production` = **squash**: `release/production` は機械生成の単一コミットブランチで、1 リリース = production の 1 コミットを保つとロールバック先が一意になる。merge commit にしても得るものが無い

## 副作用: CHANGELOG の粒度

`main` が merge commit になるので、release-please が拾う releasable unit が **PR 単位 → コミット単位**に変わります。ブランチ内の細かい `fix:` もそのままリリースノートに並ぶので、粒度を保ちたい PR は push 前にローカルで畳んでください。この点は `docs/production-cd.md` に明記しました。

## 検証

この PR 自体を squash で merge しようとして reject されること、merge commit なら通ることで確認します。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **ドキュメント**
  - ブランチごとのマージ方式に関する運用ルールを明文化しました。
  - `main` ではマージコミット、`production` ではスカッシュマージのみを使用します。
  - リリースノート生成時の変更単位や、必要に応じて事前にコミットを整理する手順を追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->