### PR TITLE
feat(news): add attention observation store and GDELT producer

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -106,3 +106,12 @@ DASHBOARD_BASE_URL=
 # FIRST_LIVE_MAX_ORDER_NOTIONAL_USD=
 # FIRST_LIVE_MAX_ORDER_NOTIONAL_JPY=
 # ROLLBACK_REHEARSAL_MAX_AGE_HOURS=
+
+# --- news attention producer (newsShockGate PR 1, optional) ---
+# NEWS_ATTENTION_ENABLED: 'true' のときだけ GDELT DOC 2.0 API を叩いて報道量 /
+# トーンを attention_observation に蓄積する (5 分 cron)。未設定 = 無効。
+# 取引経路からは参照されない observation 専用の producer。
+# GDELT_API_BASE: GDELT のベース URL override (テスト / モック用)。未設定なら
+# https://api.gdeltproject.org を使う。
+# NEWS_ATTENTION_ENABLED=true
+# GDELT_API_BASE=

--- a/drizzle/0041_add_attention_observation.sql
+++ b/drizzle/0041_add_attention_observation.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `attention_observation` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`source` text NOT NULL,
+	`probe_key` text NOT NULL,
+	`metric` text NOT NULL,
+	`bucket_at` text NOT NULL,
+	`value` real NOT NULL,
+	`fetched_at` text NOT NULL,
+	`request_id` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `attention_observation_source_probe_metric_bucket_unique` ON `attention_observation` (`source`,`probe_key`,`metric`,`bucket_at`);

--- a/drizzle/meta/0041_snapshot.json
+++ b/drizzle/meta/0041_snapshot.json
@@ -1,0 +1,1705 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "98e748fb-778d-4abd-baf7-e57bda13481b",
+  "prevId": "d4e0629e-0c13-4962-97bd-84b87308bd76",
+  "tables": {
+    "attention_observation": {
+      "name": "attention_observation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "probe_key": {
+          "name": "probe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bucket_at": {
+          "name": "bucket_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "attention_observation_source_probe_metric_bucket_unique": {
+          "name": "attention_observation_source_probe_metric_bucket_unique",
+          "columns": [
+            "source",
+            "probe_key",
+            "metric",
+            "bucket_at"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "config_audit_log": {
+      "name": "config_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before_json": {
+          "name": "before_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "after_json": {
+          "name": "after_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "config_audit_log_timestamp_id_idx": {
+          "name": "config_audit_log_timestamp_id_idx",
+          "columns": [
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "config_audit_log_actor_timestamp_id_idx": {
+          "name": "config_audit_log_actor_timestamp_id_idx",
+          "columns": [
+            "actor",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "config_audit_log_endpoint_timestamp_id_idx": {
+          "name": "config_audit_log_endpoint_timestamp_id_idx",
+          "columns": [
+            "endpoint",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "config_state_snapshot": {
+      "name": "config_state_snapshot",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "earnings_calendar": {
+      "name": "earnings_calendar",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "earnings_date": {
+          "name": "earnings_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "earnings_calendar_symbol_date_unique": {
+          "name": "earnings_calendar_symbol_date_unique",
+          "columns": [
+            "symbol",
+            "earnings_date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "global_config": {
+      "name": "global_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "trading_enabled": {
+          "name": "trading_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "market_hours_check": {
+          "name": "market_hours_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "session_window_gate_enabled": {
+          "name": "session_window_gate_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "max_order_notional": {
+          "name": "max_order_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "max_order_notional_usd": {
+          "name": "max_order_notional_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2000
+        },
+        "max_order_notional_jpy": {
+          "name": "max_order_notional_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100000
+        },
+        "total_capital_usd": {
+          "name": "total_capital_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_capital_jpy": {
+          "name": "total_capital_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_portfolio_exposure_pct": {
+          "name": "max_portfolio_exposure_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.6
+        },
+        "drawdown_kill_threshold": {
+          "name": "drawdown_kill_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.02
+        },
+        "stale_quote_ms": {
+          "name": "stale_quote_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 900000
+        },
+        "gap_reject_pct": {
+          "name": "gap_reject_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.03
+        },
+        "spread_limit_pct_us": {
+          "name": "spread_limit_pct_us",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.0025
+        },
+        "spread_limit_pct_jp": {
+          "name": "spread_limit_pct_jp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.006
+        },
+        "pullback_default_stop_pct": {
+          "name": "pullback_default_stop_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.04
+        },
+        "pullback_default_take_profit_pct": {
+          "name": "pullback_default_take_profit_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.07
+        },
+        "pullback_default_time_stop_days": {
+          "name": "pullback_default_time_stop_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "pullback_default_pullback_max": {
+          "name": "pullback_default_pullback_max",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.03
+        },
+        "pullback_default_pullback_min": {
+          "name": "pullback_default_pullback_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.06
+        },
+        "pullback_default_min_return_50d": {
+          "name": "pullback_default_min_return_50d",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.08
+        },
+        "pullback_default_require_above_sma50": {
+          "name": "pullback_default_require_above_sma50",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "pullback_default_k_atr": {
+          "name": "pullback_default_k_atr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "pullback_default_max_sma50_deviation_pct": {
+          "name": "pullback_default_max_sma50_deviation_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.6
+        },
+        "pullback_default_max_atr_ratio": {
+          "name": "pullback_default_max_atr_ratio",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1.5
+        },
+        "pullback_default_max_stop_to_tp_ratio": {
+          "name": "pullback_default_max_stop_to_tp_ratio",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "fee_pct_of_notional": {
+          "name": "fee_pct_of_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "fee_fixed_per_order": {
+          "name": "fee_fixed_per_order",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "atr_baseline_exclude_recent": {
+          "name": "atr_baseline_exclude_recent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "risk_base_per_trade_pct": {
+          "name": "risk_base_per_trade_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.004
+        },
+        "risk_dd_half_threshold": {
+          "name": "risk_dd_half_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.05
+        },
+        "risk_dd_halt_threshold": {
+          "name": "risk_dd_halt_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.1
+        },
+        "vix_warning_threshold": {
+          "name": "vix_warning_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 25
+        },
+        "vix_critical_threshold": {
+          "name": "vix_critical_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "vix_warning_size_scale": {
+          "name": "vix_warning_size_scale",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.5
+        },
+        "pair_regime_mode": {
+          "name": "pair_regime_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'off'"
+        },
+        "pair_regime_theta_bull_enter": {
+          "name": "pair_regime_theta_bull_enter",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.03
+        },
+        "pair_regime_theta_bull_exit": {
+          "name": "pair_regime_theta_bull_exit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.01
+        },
+        "pair_regime_theta_bear_enter": {
+          "name": "pair_regime_theta_bear_enter",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.04
+        },
+        "pair_regime_theta_bear_exit": {
+          "name": "pair_regime_theta_bear_exit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -0.015
+        },
+        "overview_panels": {
+          "name": "overview_panels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'kpi,equity,composition,recent'"
+        },
+        "cash_fallback_orders_enabled": {
+          "name": "cash_fallback_orders_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "global_config_max_order_notional_range": {
+          "name": "global_config_max_order_notional_range",
+          "value": "\"global_config\".\"max_order_notional\" > 0 AND \"global_config\".\"max_order_notional\" <= 10000000"
+        },
+        "global_config_max_order_notional_usd_range": {
+          "name": "global_config_max_order_notional_usd_range",
+          "value": "\"global_config\".\"max_order_notional_usd\" > 0 AND \"global_config\".\"max_order_notional_usd\" <= 1000000"
+        },
+        "global_config_max_order_notional_jpy_range": {
+          "name": "global_config_max_order_notional_jpy_range",
+          "value": "\"global_config\".\"max_order_notional_jpy\" > 0 AND \"global_config\".\"max_order_notional_jpy\" <= 100000000"
+        },
+        "global_config_total_capital_usd_range": {
+          "name": "global_config_total_capital_usd_range",
+          "value": "\"global_config\".\"total_capital_usd\" IS NULL OR \"global_config\".\"total_capital_usd\" > 0"
+        },
+        "global_config_total_capital_jpy_range": {
+          "name": "global_config_total_capital_jpy_range",
+          "value": "\"global_config\".\"total_capital_jpy\" IS NULL OR \"global_config\".\"total_capital_jpy\" > 0"
+        },
+        "global_config_max_portfolio_exposure_pct_range": {
+          "name": "global_config_max_portfolio_exposure_pct_range",
+          "value": "\"global_config\".\"max_portfolio_exposure_pct\" > 0 AND \"global_config\".\"max_portfolio_exposure_pct\" <= 1"
+        },
+        "global_config_drawdown_kill_threshold_range": {
+          "name": "global_config_drawdown_kill_threshold_range",
+          "value": "\"global_config\".\"drawdown_kill_threshold\" >= -1 AND \"global_config\".\"drawdown_kill_threshold\" <= 0"
+        },
+        "global_config_stale_quote_ms_range": {
+          "name": "global_config_stale_quote_ms_range",
+          "value": "\"global_config\".\"stale_quote_ms\" >= 0"
+        },
+        "global_config_gap_reject_pct_range": {
+          "name": "global_config_gap_reject_pct_range",
+          "value": "\"global_config\".\"gap_reject_pct\" >= 0 AND \"global_config\".\"gap_reject_pct\" <= 1"
+        },
+        "global_config_spread_limit_pct_us_range": {
+          "name": "global_config_spread_limit_pct_us_range",
+          "value": "\"global_config\".\"spread_limit_pct_us\" >= 0 AND \"global_config\".\"spread_limit_pct_us\" <= 1"
+        },
+        "global_config_spread_limit_pct_jp_range": {
+          "name": "global_config_spread_limit_pct_jp_range",
+          "value": "\"global_config\".\"spread_limit_pct_jp\" >= 0 AND \"global_config\".\"spread_limit_pct_jp\" <= 1"
+        },
+        "global_config_pullback_default_stop_pct_range": {
+          "name": "global_config_pullback_default_stop_pct_range",
+          "value": "\"global_config\".\"pullback_default_stop_pct\" < 0 AND \"global_config\".\"pullback_default_stop_pct\" >= -1"
+        },
+        "global_config_pullback_default_take_profit_pct_range": {
+          "name": "global_config_pullback_default_take_profit_pct_range",
+          "value": "\"global_config\".\"pullback_default_take_profit_pct\" > 0 AND \"global_config\".\"pullback_default_take_profit_pct\" <= 1"
+        },
+        "global_config_pullback_default_time_stop_days_range": {
+          "name": "global_config_pullback_default_time_stop_days_range",
+          "value": "\"global_config\".\"pullback_default_time_stop_days\" > 0 AND \"global_config\".\"pullback_default_time_stop_days\" <= ?"
+        },
+        "global_config_pullback_default_pullback_max_range": {
+          "name": "global_config_pullback_default_pullback_max_range",
+          "value": "\"global_config\".\"pullback_default_pullback_max\" <= 0 AND \"global_config\".\"pullback_default_pullback_max\" >= -1"
+        },
+        "global_config_pullback_default_pullback_min_range": {
+          "name": "global_config_pullback_default_pullback_min_range",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= 0 AND \"global_config\".\"pullback_default_pullback_min\" >= -1"
+        },
+        "global_config_pullback_default_min_return_50d_range": {
+          "name": "global_config_pullback_default_min_return_50d_range",
+          "value": "\"global_config\".\"pullback_default_min_return_50d\" >= -1 AND \"global_config\".\"pullback_default_min_return_50d\" <= 10"
+        },
+        "global_config_pullback_default_k_atr_range": {
+          "name": "global_config_pullback_default_k_atr_range",
+          "value": "\"global_config\".\"pullback_default_k_atr\" > 0 AND \"global_config\".\"pullback_default_k_atr\" <= 10"
+        },
+        "global_config_pullback_default_pullback_window_order": {
+          "name": "global_config_pullback_default_pullback_window_order",
+          "value": "\"global_config\".\"pullback_default_pullback_min\" <= \"global_config\".\"pullback_default_pullback_max\""
+        },
+        "global_config_risk_base_per_trade_pct_range": {
+          "name": "global_config_risk_base_per_trade_pct_range",
+          "value": "\"global_config\".\"risk_base_per_trade_pct\" > 0 AND \"global_config\".\"risk_base_per_trade_pct\" <= 1"
+        },
+        "global_config_risk_dd_half_threshold_range": {
+          "name": "global_config_risk_dd_half_threshold_range",
+          "value": "\"global_config\".\"risk_dd_half_threshold\" < 0 AND \"global_config\".\"risk_dd_half_threshold\" >= -1"
+        },
+        "global_config_risk_dd_halt_threshold_range": {
+          "name": "global_config_risk_dd_halt_threshold_range",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" < 0 AND \"global_config\".\"risk_dd_halt_threshold\" >= -1"
+        },
+        "global_config_risk_dd_threshold_order": {
+          "name": "global_config_risk_dd_threshold_order",
+          "value": "\"global_config\".\"risk_dd_halt_threshold\" <= \"global_config\".\"risk_dd_half_threshold\""
+        },
+        "global_config_vix_warning_threshold_range": {
+          "name": "global_config_vix_warning_threshold_range",
+          "value": "\"global_config\".\"vix_warning_threshold\" > 0 AND \"global_config\".\"vix_warning_threshold\" <= 200"
+        },
+        "global_config_vix_critical_threshold_range": {
+          "name": "global_config_vix_critical_threshold_range",
+          "value": "\"global_config\".\"vix_critical_threshold\" > 0 AND \"global_config\".\"vix_critical_threshold\" <= 200"
+        },
+        "global_config_vix_threshold_order": {
+          "name": "global_config_vix_threshold_order",
+          "value": "\"global_config\".\"vix_warning_threshold\" <= \"global_config\".\"vix_critical_threshold\""
+        },
+        "global_config_vix_warning_size_scale_range": {
+          "name": "global_config_vix_warning_size_scale_range",
+          "value": "\"global_config\".\"vix_warning_size_scale\" >= 0 AND \"global_config\".\"vix_warning_size_scale\" <= 1"
+        }
+      }
+    },
+    "inverse_pairs": {
+      "name": "inverse_pairs",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inverse": {
+          "name": "inverse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "regime_enabled": {
+          "name": "regime_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "regime_proxy_symbol": {
+          "name": "regime_proxy_symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "regime_bull_symbol": {
+          "name": "regime_bull_symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "macro_event_calendar": {
+      "name": "macro_event_calendar",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_time": {
+          "name": "event_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "macro_event_calendar_type_date_unique": {
+          "name": "macro_event_calendar_type_date_unique",
+          "columns": [
+            "event_type",
+            "event_date"
+          ],
+          "isUnique": true
+        },
+        "macro_event_calendar_date_idx": {
+          "name": "macro_event_calendar_date_idx",
+          "columns": [
+            "event_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_emit_log": {
+      "name": "notification_emit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cause": {
+          "name": "cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notification_emit_log_timestamp_id_idx": {
+          "name": "notification_emit_log_timestamp_id_idx",
+          "columns": [
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "notification_emit_log_severity_timestamp_id_idx": {
+          "name": "notification_emit_log_severity_timestamp_id_idx",
+          "columns": [
+            "severity",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "notification_emit_log_event_type_timestamp_id_idx": {
+          "name": "notification_emit_log_event_type_timestamp_id_idx",
+          "columns": [
+            "event_type",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "portfolio_equity_snapshot": {
+      "name": "portfolio_equity_snapshot",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "daily_start_equity_usd": {
+          "name": "daily_start_equity_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_start_equity_jpy": {
+          "name": "daily_start_equity_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_realized_pnl_usd": {
+          "name": "daily_realized_pnl_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_realized_pnl_jpy": {
+          "name": "daily_realized_pnl_jpy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "drawdown_pct": {
+          "name": "drawdown_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "portfolio_equity_snapshot_at_idx": {
+          "name": "portfolio_equity_snapshot_at_idx",
+          "columns": [
+            "snapshot_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "strategy_decision_log": {
+      "name": "strategy_decision_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indicators_json": {
+          "name": "indicators_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trace_json": {
+          "name": "trace_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "strategy_decision_log_symbol_id_idx": {
+          "name": "strategy_decision_log_symbol_id_idx",
+          "columns": [
+            "symbol",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "strategy_decision_log_coid_idx": {
+          "name": "strategy_decision_log_coid_idx",
+          "columns": [
+            "client_order_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "symbol_config": {
+      "name": "symbol_config",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "market": {
+          "name": "market",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_notional": {
+          "name": "max_notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_stop_days_override": {
+          "name": "time_stop_days_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "k_atr_override": {
+          "name": "k_atr_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "budget_alloc_pct": {
+          "name": "budget_alloc_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lot_size": {
+          "name": "lot_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stop_pct_override": {
+          "name": "stop_pct_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "take_profit_pct_override": {
+          "name": "take_profit_pct_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "intraday_only": {
+          "name": "intraday_only",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pullback_max_override": {
+          "name": "pullback_max_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pullback_min_override": {
+          "name": "pullback_min_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "min_return_50d_override": {
+          "name": "min_return_50d_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_atr_ratio_override": {
+          "name": "max_atr_ratio_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_sma50_deviation_pct_override": {
+          "name": "max_sma50_deviation_pct_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "require_above_sma50_override": {
+          "name": "require_above_sma50_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_required": {
+          "name": "entry_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "always_active": {
+          "name": "always_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cash_fallback_symbols": {
+          "name": "cash_fallback_symbols",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "symbol_config_currency_enum": {
+          "name": "symbol_config_currency_enum",
+          "value": "\"symbol_config\".\"currency\" IN ('USD', 'JPY')"
+        },
+        "symbol_config_time_stop_days_override_range": {
+          "name": "symbol_config_time_stop_days_override_range",
+          "value": "\"symbol_config\".\"time_stop_days_override\" IS NULL OR (\"symbol_config\".\"time_stop_days_override\" >= 1 AND \"symbol_config\".\"time_stop_days_override\" <= ?)"
+        },
+        "symbol_config_k_atr_override_range": {
+          "name": "symbol_config_k_atr_override_range",
+          "value": "\"symbol_config\".\"k_atr_override\" IS NULL OR (\"symbol_config\".\"k_atr_override\" >= 0.5 AND \"symbol_config\".\"k_atr_override\" <= 5.0)"
+        }
+      }
+    },
+    "tradable_instrument": {
+      "name": "tradable_instrument",
+      "columns": {
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exchange_code": {
+          "name": "exchange_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currently_tradable": {
+          "name": "currently_tradable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tradable_instrument_currently_idx": {
+          "name": "tradable_instrument_currently_idx",
+          "columns": [
+            "currently_tradable"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trade_journal": {
+      "name": "trade_journal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trade_event_type": {
+          "name": "trade_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_order_id": {
+          "name": "client_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "strategy_name": {
+          "name": "strategy_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_action": {
+          "name": "signal_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_reason": {
+          "name": "signal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_allowed": {
+          "name": "risk_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_reasons": {
+          "name": "risk_reasons",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "limit_price": {
+          "name": "limit_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notional": {
+          "name": "notional",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "broker_status": {
+          "name": "broker_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "submitted": {
+          "name": "submitted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_qty": {
+          "name": "filled_qty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filled_price": {
+          "name": "filled_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "realized_pnl": {
+          "name": "realized_pnl",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "estimated_cost": {
+          "name": "estimated_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hold_days": {
+          "name": "hold_days",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_reason": {
+          "name": "exit_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_applied_at": {
+          "name": "state_applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_error": {
+          "name": "state_apply_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_apply_attempts": {
+          "name": "state_apply_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trading_toggle_history": {
+      "name": "trading_toggle_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before": {
+          "name": "before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "after": {
+          "name": "after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -288,6 +288,13 @@
       "when": 1785000927225,
       "tag": "0040_add_atr_baseline_exclude_recent",
       "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "6",
+      "when": 1785164158928,
+      "tag": "0041_add_attention_observation",
+      "breakpoints": true
     }
   ]
 }

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -262,3 +262,16 @@ export interface Env {
 export interface Env {
   BAR_SOURCE?: string
 }
+
+
+// news attention producer (issue #196 follow-up、newsShockGate PR 1)。
+// NEWS_ATTENTION_ENABLED: `newsScheduler` の opt-in flag。値が 'true'
+// (大小文字問わず、前後空白 trim) のときだけ GDELT を叩く。未設定 / それ以外は
+// 無効 — この repo の「未設定は安全側 default、明示 opt-in」規約 (QUOTE_SOURCE /
+// BAR_SOURCE と同じ判定パターン)。
+// GDELT_API_BASE: GDELT DOC 2.0 API のベース URL override (テスト用)。未設定なら
+// 本番 URL (`https://api.gdeltproject.org`) を使う。
+export interface Env {
+  NEWS_ATTENTION_ENABLED?: string
+  GDELT_API_BASE?: string
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { createNotifier } from './infrastructure/notification/createNotifier'
 import { checkMarketDataHealth } from './infrastructure/webull/checkMarketDataHealth'
 import { refreshTradableAllowlist } from './infrastructure/webull/refreshTradableAllowlist'
 import { refreshWebullToken } from './infrastructure/webull/refreshWebullToken'
+import { runNewsScheduler } from './trading/news/newsScheduler'
 import { runPortfolioRoll } from './trading/portfolio/runPortfolioRoll'
 import { runQuoteFeed } from './trading/quotes/quoteScheduler'
 import { reconcileFills } from './trading/reconciliation/reconcileFills'
@@ -386,6 +387,28 @@ export default {
           )
         },
       ),
+    )
+    // News attention producer (issue #196 follow-up、newsShockGate PR 1)。
+    // quote/reconcile とは完全に独立 — GDELT 障害・レート制限が取引経路に
+    // 伝播しないことを物理的に保証する配線 (runNewsScheduler 自体も内部で
+    // fetch/DB 失敗を throw せず握りつぶすが、ここでも二重に .catch する)。
+    ctx.waitUntil(
+      runNewsScheduler({ env, requestId })
+        .then((summary) => {
+          if (!summary.ran) return
+          console.log(
+            JSON.stringify({
+              event: 'news_scheduler_run',
+              requestId,
+              probeKey: summary.probeKey,
+              metric: summary.metric,
+              fetched: summary.fetched,
+              inserted: summary.inserted,
+              skipped: summary.skipped,
+            }),
+          )
+        })
+        .catch(() => undefined),
     )
   },
 }

--- a/src/infrastructure/calendar/earningsCalendarRepo.ts
+++ b/src/infrastructure/calendar/earningsCalendarRepo.ts
@@ -79,10 +79,14 @@ export function createEarningsCalendarRepo(db: EarningsCalendarDb): EarningsCale
       // で multi-row INSERT (chunk) にまとめ、`onConflictDoNothing()` で UNIQUE
       // 違反 row のみ skip する挙動は維持。drizzle d1 driver は VALUES (?,?), (?,?), ...
       // の prepared statement を 1 statement で送るため、chunk あたり 1 subrequest。
+      //
+      // CHUNK は D1 の bound parameter 上限 (1 クエリ 100 個) から逆算する。
+      // multi-row INSERT の bind 数は `列数 × 行数` なので、3 列 → 100 / 3 = 33 行。
+      // 以前の 50 は 150 bind になり、34 件以上を一度に seed すると失敗していた。
       let inserted = 0
       let skipped = 0
       if (records.length === 0) return { inserted, skipped }
-      const CHUNK = 50
+      const CHUNK = 33
       for (let i = 0; i < records.length; i += CHUNK) {
         const chunk = records.slice(i, i + CHUNK)
         const values = chunk.map((r) => ({

--- a/src/infrastructure/calendar/macroEventCalendarRepo.ts
+++ b/src/infrastructure/calendar/macroEventCalendarRepo.ts
@@ -100,10 +100,14 @@ export function createMacroEventCalendarRepo(
       // CodeRabbit #196 review: 1 row 1 INSERT は D1 subrequest を浪費するため
       // chunk multi-row INSERT (`.values([...])`) にまとめる。`.onConflictDoNothing()`
       // で UNIQUE (event_type, event_date) 違反 row のみ skip。
+      //
+      // CHUNK は D1 の bound parameter 上限 (1 クエリ 100 個) から逆算する。
+      // multi-row INSERT の bind 数は `列数 × 行数` なので、4 列 → 100 / 4 = 25 行。
+      // 以前の 50 は 200 bind になり、26 件以上を一度に seed すると失敗していた。
       let inserted = 0
       let skipped = 0
       if (records.length === 0) return { inserted, skipped }
-      const CHUNK = 50
+      const CHUNK = 25
       for (let i = 0; i < records.length; i += CHUNK) {
         const chunk = records.slice(i, i + CHUNK)
         const values = chunk.map((r) => ({

--- a/src/infrastructure/db/attentionObservationRepo.ts
+++ b/src/infrastructure/db/attentionObservationRepo.ts
@@ -1,0 +1,118 @@
+/**
+ * `attention_observation` テーブルへの薄い repo (news/crowd attention producer,
+ * PR 1)。
+ *
+ * - `bulkInsertIgnore` は producer (`newsScheduler`, 将来の crowdScheduler) から
+ *   の write。CHUNK=50 の multi-row INSERT + `.onConflictDoNothing()` で D1
+ *   subrequest 制限を避ける (`macroEventCalendarRepo.bulkUpsert` と同パターン)。
+ *   `UNIQUE (source, probe_key, metric, bucket_at)` 違反行は静かに skip される
+ *   — GDELT `timespan=1d` は毎 tick 全点 (~96) を返すので、これが冪等
+ *   backfill の実体になる。
+ * - `fetchRecent` は将来の risk gate (newsShockGate 等) からの read。
+ * - `purgeOlderThan` は retention purge (将来 PR で 5 分毎 cron に同梱予定) 用。
+ *
+ * このリポジトリ自体はこの PR ではどこからも read されない (取引経路の変更
+ * ゼロ — gate 本体は後続 PR)。テストと将来実装の土台として先に用意する。
+ */
+import { and, asc, eq, gte, lt, type SQL } from 'drizzle-orm'
+import { drizzle, type DrizzleD1Database } from 'drizzle-orm/d1'
+import { attentionObservation, type AttentionObservationRow } from './schema'
+
+export type AttentionObservationDb = DrizzleD1Database
+
+export interface AttentionObservationRecord {
+  source: string
+  probeKey: string
+  metric: string
+  bucketAt: string
+  value: number
+  fetchedAt: string
+  requestId?: string | null
+}
+
+export interface AttentionObservationRepo {
+  /**
+   * Chunk insert (CHUNK=50) + `.onConflictDoNothing()`。既に存在する
+   * `(source, probe_key, metric, bucket_at)` は skip としてカウントする。
+   */
+  bulkInsertIgnore(
+    records: AttentionObservationRecord[],
+  ): Promise<{ inserted: number; skipped: number }>
+  /** `(source, probeKey, metric)` を絞り込み、`bucketAt >= sinceIso` を bucketAt asc で返す。 */
+  fetchRecent(filter: {
+    source: string
+    probeKey: string
+    metric: string
+    sinceIso: string
+  }): Promise<AttentionObservationRow[]>
+  /** `bucketAt < iso` の行を削除し、削除件数を返す。 */
+  purgeOlderThan(iso: string): Promise<number>
+}
+
+/** Wraps a Worker `env.DB` into a drizzle-typed client (other repos と同形式)。 */
+export function createAttentionObservationDb(d1: D1Database): AttentionObservationDb {
+  return drizzle(d1)
+}
+
+export function createAttentionObservationRepo(
+  db: AttentionObservationDb,
+): AttentionObservationRepo {
+  return {
+    async bulkInsertIgnore(records) {
+      let inserted = 0
+      let skipped = 0
+      if (records.length === 0) return { inserted, skipped }
+      const CHUNK = 50
+      for (let i = 0; i < records.length; i += CHUNK) {
+        const chunk = records.slice(i, i + CHUNK)
+        const values = chunk.map((r) => ({
+          source: r.source,
+          probeKey: r.probeKey,
+          metric: r.metric,
+          bucketAt: r.bucketAt,
+          value: r.value,
+          fetchedAt: r.fetchedAt,
+          requestId: r.requestId ?? null,
+        }))
+        const result = await db
+          .insert(attentionObservation)
+          .values(values)
+          .onConflictDoNothing({
+            target: [
+              attentionObservation.source,
+              attentionObservation.probeKey,
+              attentionObservation.metric,
+              attentionObservation.bucketAt,
+            ],
+          })
+          .returning({ id: attentionObservation.id })
+        const insertedInChunk = result.length
+        inserted += insertedInChunk
+        skipped += chunk.length - insertedInChunk
+      }
+      return { inserted, skipped }
+    },
+
+    async fetchRecent(filter) {
+      const conditions: SQL[] = [
+        eq(attentionObservation.source, filter.source),
+        eq(attentionObservation.probeKey, filter.probeKey),
+        eq(attentionObservation.metric, filter.metric),
+        gte(attentionObservation.bucketAt, filter.sinceIso),
+      ]
+      return db
+        .select()
+        .from(attentionObservation)
+        .where(and(...conditions))
+        .orderBy(asc(attentionObservation.bucketAt))
+    },
+
+    async purgeOlderThan(iso) {
+      const result = await db
+        .delete(attentionObservation)
+        .where(lt(attentionObservation.bucketAt, iso))
+        .returning({ id: attentionObservation.id })
+      return result.length
+    },
+  }
+}

--- a/src/infrastructure/db/attentionObservationRepo.ts
+++ b/src/infrastructure/db/attentionObservationRepo.ts
@@ -62,7 +62,11 @@ export function createAttentionObservationRepo(
       let inserted = 0
       let skipped = 0
       if (records.length === 0) return { inserted, skipped }
-      const CHUNK = 50
+      // D1 は 1 クエリあたり bound parameter 100 個が上限。multi-row INSERT の
+      // bind 数は `列数 × 行数` なので、7 列 → 100 / 7 = 14 行が安全な最大値。
+      // (CHUNK=50 だと 350 bind になり、GDELT の 1d timeline ~66 点を入れた
+      // 時点で必ず失敗する。)
+      const CHUNK = 14
       for (let i = 0; i < records.length; i += CHUNK) {
         const chunk = records.slice(i, i + CHUNK)
         const values = chunk.map((r) => ({

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -909,3 +909,50 @@ export const tradableInstrument = sqliteTable(
 
 export type TradableInstrumentRow = typeof tradableInstrument.$inferSelect
 export type TradableInstrumentInsert = typeof tradableInstrument.$inferInsert
+
+/**
+ * News/crowd attention observation store (issue #196 follow-up — newsShockGate /
+ * crowdEuphoriaGate risk gates). Append-only time series shared across sources:
+ * `source` discriminates GDELT report-volume/tone (this PR) from a future
+ * YouTube upload-count producer so both land in one table without a
+ * per-source schema fork.
+ *
+ * This PR is producer-only (`newsScheduler` writes on the 5-minute cron) —
+ * there is no read path from strategy/risk code yet. The gate that reads
+ * this table is a later PR (trading path change is zero here, see plan doc).
+ *
+ * `UNIQUE (source, probe_key, metric, bucket_at)` is the idempotent-backfill
+ * mechanism: GDELT's `timespan=1d` request returns ~96 buckets every tick, so
+ * each tick does a full bulk-insert-ignore over all of them. A missed tick
+ * (cron failure, cold start) self-heals on the next tick — already-seen
+ * buckets just collide on the unique index and are skipped, never duplicated.
+ */
+export const attentionObservation = sqliteTable(
+  'attention_observation',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    /** データソース。'gdelt' (報道量/トーン、このPR) / 'youtube' (投稿本数、将来PR)。 */
+    source: text('source').notNull(),
+    /** probe 定義のキー (`newsProbes.ts` のコード定数と一致)。 */
+    probeKey: text('probe_key').notNull(),
+    /** 'volume' (報道量%) / 'tone' (平均トーン) / 'upload_count' (投稿本数、将来PR)。 */
+    metric: text('metric').notNull(),
+    /** 観測 bucket の ISO UTC (GDELT timeline の `date` を正規化した値)。 */
+    bucketAt: text('bucket_at').notNull(),
+    value: real('value').notNull(),
+    /** producer が実際に fetch/insert した時刻 (ISO UTC)。 */
+    fetchedAt: text('fetched_at').notNull(),
+    requestId: text('request_id'),
+  },
+  (t) => ({
+    // 冪等 backfill の要 (上記コメント参照)。`macroEventCalendar` と同様、この
+    // unique index が gate (将来PR) の trailing-window range read もカバーする
+    // ので別建ての plain index は追加しない (drop-in covering)。
+    sourceProbeMetricBucketUnique: uniqueIndex(
+      'attention_observation_source_probe_metric_bucket_unique',
+    ).on(t.source, t.probeKey, t.metric, t.bucketAt),
+  }),
+)
+
+export type AttentionObservationRow = typeof attentionObservation.$inferSelect
+export type AttentionObservationInsert = typeof attentionObservation.$inferInsert

--- a/src/infrastructure/news/GdeltDocClient.ts
+++ b/src/infrastructure/news/GdeltDocClient.ts
@@ -1,0 +1,185 @@
+const DEFAULT_BASE_URL = 'https://api.gdeltproject.org'
+const DEFAULT_TIMEOUT_MS = 5_000
+const DEFAULT_TIMESPAN = '1d'
+/** `response.text()` truncation cap for error messages (avoid logging huge HTML bodies). */
+const BODY_SNIPPET_MAX_CHARS = 200
+
+export type GdeltMetric = 'volume' | 'tone'
+
+const MODE_BY_METRIC: Record<GdeltMetric, string> = {
+  volume: 'timelinevol',
+  tone: 'timelinetone',
+}
+
+export interface GdeltTimelinePoint {
+  /** ISO UTC, normalized from GDELT's `YYYYMMDDTHHMMSSZ` bucket date. */
+  bucketAt: string
+  value: number
+}
+
+export interface GdeltDocClientOptions {
+  baseUrl?: string
+  timeoutMs?: number
+  fetchFn?: typeof fetch
+}
+
+interface GdeltTimelineResponse {
+  timeline?: Array<{
+    series?: string
+    data?: Array<{ date?: string; value?: number }>
+  }>
+}
+
+/** Network-level failure (DNS, connection reset, abort/timeout). */
+export class GdeltFetchError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message)
+    this.name = 'GdeltFetchError'
+    if (options?.cause !== undefined) this.cause = options.cause
+  }
+}
+
+/**
+ * HTTP-level failure: non-2xx status, or a 200 whose body isn't the JSON we
+ * expect (GDELT is observed to return HTML / plain-text bodies with a 200
+ * status under some failure modes, not just on 429).
+ */
+export class GdeltResponseError extends Error {
+  readonly status: number
+  readonly bodySnippet: string
+
+  constructor(message: string, status: number, bodySnippet: string) {
+    super(message)
+    this.name = 'GdeltResponseError'
+    this.status = status
+    this.bodySnippet = bodySnippet
+  }
+}
+
+/**
+ * GDELT DOC 2.0 API client (`https://api.gdeltproject.org/api/v2/doc/doc`).
+ * No authentication — this is a public, unauthenticated endpoint. Structure
+ * mirrors {@link ../quotes/YahooBarClient.ts} (`fetchFn` / `timeoutMs`
+ * injected for testability, `AbortController` timeout, `fetch.bind(globalThis)`
+ * so the Workers runtime doesn't throw "Illegal invocation").
+ *
+ * Confirmed-by-probe defensive requirements (see plan doc):
+ *   - Rate limit is 1req/5s. Exceeding it returns HTTP 429 with a **plain
+ *     text** body (not JSON).
+ *   - Even a 200 can carry a non-JSON body (HTML error page observed in the
+ *     wild) — `response.ok` alone is not sufficient. `content-type` must be
+ *     checked before calling `.json()`, or the call throws a native
+ *     `SyntaxError` instead of a typed, loggable error.
+ */
+export class GdeltDocClient {
+  private readonly baseUrl: string
+  private readonly timeoutMs: number
+  private readonly fetchFn: typeof fetch
+
+  constructor(options: GdeltDocClientOptions = {}) {
+    this.baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '')
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+    // Workers' global `fetch` must be bound to globalThis or it throws
+    // "Illegal invocation" — mirrors YahooBarClient / WebullHttpClient.
+    this.fetchFn = options.fetchFn ?? fetch.bind(globalThis)
+  }
+
+  /**
+   * Fetches a single metric's timeline for `query`. Returns `[]` (never
+   * throws for shape reasons) when GDELT's `timeline` is empty or missing —
+   * only transport failures and malformed responses throw.
+   */
+  async getTimeline(
+    query: string,
+    metric: GdeltMetric,
+    timespan: string = DEFAULT_TIMESPAN,
+  ): Promise<GdeltTimelinePoint[]> {
+    const url = new URL('/api/v2/doc/doc', this.baseUrl)
+    url.searchParams.set('query', query)
+    url.searchParams.set('mode', MODE_BY_METRIC[metric])
+    url.searchParams.set('format', 'json')
+    url.searchParams.set('timespan', timespan)
+
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs)
+    let response: Response
+    try {
+      response = await this.fetchFn(url.href, {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+        signal: controller.signal,
+      })
+    } catch (error) {
+      throw new GdeltFetchError(
+        `GDELT timeline fetch failed: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error instanceof Error ? error : undefined },
+      )
+    } finally {
+      clearTimeout(timeoutId)
+    }
+
+    if (!response.ok) {
+      const snippet = await bodySnippet(response)
+      throw new GdeltResponseError(
+        `GDELT timeline request failed with status ${response.status}: ${snippet}`,
+        response.status,
+        snippet,
+      )
+    }
+
+    // 200 does not guarantee a JSON body (rate-limit / upstream error pages
+    // have been observed with a 200 status) — check content-type before
+    // calling .json(), which would otherwise throw an untyped SyntaxError.
+    const contentType = response.headers.get('content-type') ?? ''
+    if (!contentType.toLowerCase().includes('application/json')) {
+      const snippet = await bodySnippet(response)
+      throw new GdeltResponseError(
+        `GDELT timeline returned non-JSON content-type '${contentType}': ${snippet}`,
+        response.status,
+        snippet,
+      )
+    }
+
+    const json = (await response.json()) as GdeltTimelineResponse
+    return normalizeTimeline(json)
+  }
+}
+
+async function bodySnippet(response: Response): Promise<string> {
+  const text = await response.text().catch(() => '')
+  return text.slice(0, BODY_SNIPPET_MAX_CHARS)
+}
+
+/**
+ * Maps GDELT's `{ timeline: [{ series, data: [{ date, value }] }] }` shape
+ * into our flat point list. We only ever request a single `mode`, so the
+ * first series is the one we asked for. Forgiving normalization (mirrors
+ * `BarClient.normalizeBars` / `YahooBarClient`'s drop-invalid-rows policy):
+ * unparseable dates and non-finite values are dropped point-by-point rather
+ * than failing the whole batch.
+ */
+function normalizeTimeline(json: GdeltTimelineResponse): GdeltTimelinePoint[] {
+  const data = json.timeline?.[0]?.data
+  if (!Array.isArray(data)) return []
+  const points: GdeltTimelinePoint[] = []
+  for (const raw of data) {
+    const bucketAt = parseGdeltDate(raw?.date)
+    if (!bucketAt) continue
+    const value = raw?.value
+    if (typeof value !== 'number' || !Number.isFinite(value)) continue
+    points.push({ bucketAt, value })
+  }
+  return points
+}
+
+const GDELT_DATE_RE = /^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z$/
+
+/** `20260724T143000Z` → `2026-07-24T14:30:00.000Z`. Returns null if unparseable. */
+function parseGdeltDate(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null
+  const match = GDELT_DATE_RE.exec(raw)
+  if (!match) return null
+  const [, y, mo, d, h, mi, s] = match
+  const iso = `${y}-${mo}-${d}T${h}:${mi}:${s}.000Z`
+  return Number.isFinite(Date.parse(iso)) ? iso : null
+}

--- a/src/infrastructure/news/newsProbes.ts
+++ b/src/infrastructure/news/newsProbes.ts
@@ -1,0 +1,35 @@
+/**
+ * GDELT probe 定義 (PR 1 — news attention producer)。
+ *
+ * **`global_config` には置かない** (コード定数として持つ)。理由: probe の
+ * `query` 文字列は trailing baseline (直近 N 日の分布に対する比率で閾値判定
+ * する、将来の newsShockGate 前提) の母集団そのものを定義する。DB UPDATE で
+ * 誰でも書き換えられる状態にすると、query を変えた瞬間に過去の蓄積データと
+ * 新規データが別の母集団になり baseline 比較が無意味になる — しかもそれが
+ * 静かに起きる (schema 上は同じ `probe_key` のまま値の意味だけ変わる)。
+ * query 変更は必ず deploy (= コードレビュー + git 履歴に残る意図表明) を
+ * 経由させるため、ここに定数として固定する。
+ */
+export type NewsProbeMetric = 'volume' | 'tone'
+
+export interface NewsProbe {
+  /** コード側定数キー。D1 の `attention_observation.probe_key` と一致させる。 */
+  readonly key: string
+  /** GDELT DOC 2.0 API の `query` パラメタにそのまま渡す。 */
+  readonly query: string
+  /** この probe が取得する metric 群。PR 1 は volume/tone の 2 本固定。 */
+  readonly metrics: readonly NewsProbeMetric[]
+}
+
+export const NEWS_PROBES: readonly NewsProbe[] = [
+  {
+    key: 'trump_macro',
+    query: 'trump tariffs sourcelang:english',
+    metrics: ['volume', 'tone'],
+  },
+  {
+    key: 'market_selloff',
+    query: 'stock market selloff sourcelang:english',
+    metrics: ['volume', 'tone'],
+  },
+]

--- a/src/trading/news/newsScheduler.ts
+++ b/src/trading/news/newsScheduler.ts
@@ -1,0 +1,165 @@
+/**
+ * News attention producer scheduler (issue #196 follow-up、newsShockGate PR 1)。
+ *
+ * `quoteScheduler.runQuoteFeed` と同じ「cron から呼ばれる producer」の位置づけ
+ * だが、この scheduler は **strategy tick の外**、`CRON_QUOTE_RECONCILE` (5分毎)
+ * にぶら下がる。取引経路 (strategy/risk/execution) からは一切参照されない —
+ * 外部 I/O ありの producer と、外部 I/O ゼロの gate (将来 PR) を物理的に分離
+ * する設計 (plan doc 参照)。
+ *
+ * probe round-robin: 1 tick = GDELT への HTTP リクエスト 1 回のみ。
+ * `NEWS_PROBES` は 2 本 × metric (volume/tone) = 4 組。5 分 cron で 1 組ずつ
+ * 進めると各組 20 分ごとの更新になり、GDELT のレート制限 (1req/5s) に対して
+ * 十分すぎるマージンがあるので sleep は不要。ローテーション位置はステートレスに
+ * 「現在時刻の 5 分スロット番号 mod 組数」で決める (DO も追加テーブルも使わない)。
+ *
+ * fetch / DB 失敗は **絶対に throw しない** — 呼び出し元の cron (index.ts の
+ * `ctx.waitUntil`) に伝播させず、既存 ログ形式 (`console.warn(JSON.stringify(...))`)
+ * で握りつぶす。GDELT が落ちても quote feed / reconcile には一切影響しない。
+ */
+import type { Env } from '../../config/env'
+import {
+  createAttentionObservationDb,
+  createAttentionObservationRepo,
+} from '../../infrastructure/db/attentionObservationRepo'
+import { GdeltDocClient, type GdeltMetric } from '../../infrastructure/news/GdeltDocClient'
+import { NEWS_PROBES } from '../../infrastructure/news/newsProbes'
+
+const NEWS_ATTENTION_SOURCE = 'gdelt'
+/** `timespan=1d` は 15 分刻みで ~96 点返す。毎 tick 全点を bulk-insert-ignore する。 */
+const FETCH_TIMESPAN = '1d'
+const SLOT_MS = 5 * 60 * 1000
+
+export interface NewsSchedulerSummary {
+  ran: boolean
+  source: string
+  probeKey?: string
+  metric?: GdeltMetric
+  fetched: number
+  inserted: number
+  skipped: number
+  reason?: string
+}
+
+interface RunNewsSchedulerOptions {
+  env: Env
+  requestId?: string
+  now?: () => Date
+  /** test seam。未指定なら `GDELT_API_BASE` (未設定なら本番URL) で構築する。 */
+  client?: GdeltDocClient
+}
+
+interface RotationEntry {
+  probeKey: string
+  query: string
+  metric: GdeltMetric
+}
+
+/** probe × metric の flat rotation table。呼び出しごとに再構築する (ステートレス)。 */
+function buildRotation(): RotationEntry[] {
+  const rotation: RotationEntry[] = []
+  for (const probe of NEWS_PROBES) {
+    for (const metric of probe.metrics) {
+      rotation.push({ probeKey: probe.key, query: probe.query, metric })
+    }
+  }
+  return rotation
+}
+
+/** 現在時刻の 5 分スロット番号 mod `length` — DO / 追加テーブル無しのステートレス round-robin。 */
+function pickRotationIndex(now: Date, length: number): number {
+  const slot = Math.floor(now.getTime() / SLOT_MS)
+  return ((slot % length) + length) % length
+}
+
+export async function runNewsScheduler(options: RunNewsSchedulerOptions): Promise<NewsSchedulerSummary> {
+  const { env } = options
+  const now = options.now ?? (() => new Date())
+
+  // 未設定 = 無効 (この repo の「未設定は安全側 default、明示 opt-in」規約、
+  // QUOTE_SOURCE / BAR_SOURCE と同じ判定パターン)。
+  if ((env.NEWS_ATTENTION_ENABLED ?? '').trim().toLowerCase() !== 'true') {
+    return {
+      ran: false,
+      source: NEWS_ATTENTION_SOURCE,
+      fetched: 0,
+      inserted: 0,
+      skipped: 0,
+      reason: 'news_attention_disabled',
+    }
+  }
+  if (!env.DB) {
+    return {
+      ran: false,
+      source: NEWS_ATTENTION_SOURCE,
+      fetched: 0,
+      inserted: 0,
+      skipped: 0,
+      reason: 'db_unavailable',
+    }
+  }
+
+  const rotation = buildRotation()
+  if (rotation.length === 0) {
+    return {
+      ran: false,
+      source: NEWS_ATTENTION_SOURCE,
+      fetched: 0,
+      inserted: 0,
+      skipped: 0,
+      reason: 'no_probes_configured',
+    }
+  }
+
+  const nowDate = now()
+  const target = rotation[pickRotationIndex(nowDate, rotation.length)]!
+
+  try {
+    const client = options.client ?? new GdeltDocClient({ baseUrl: env.GDELT_API_BASE })
+    const points = await client.getTimeline(target.query, target.metric, FETCH_TIMESPAN)
+    const fetchedAt = nowDate.toISOString()
+    const repo = createAttentionObservationRepo(createAttentionObservationDb(env.DB))
+    const { inserted, skipped } = await repo.bulkInsertIgnore(
+      points.map((p) => ({
+        source: NEWS_ATTENTION_SOURCE,
+        probeKey: target.probeKey,
+        metric: target.metric,
+        bucketAt: p.bucketAt,
+        value: p.value,
+        fetchedAt,
+        requestId: options.requestId ?? null,
+      })),
+    )
+    return {
+      ran: true,
+      source: NEWS_ATTENTION_SOURCE,
+      probeKey: target.probeKey,
+      metric: target.metric,
+      fetched: points.length,
+      inserted,
+      skipped,
+    }
+  } catch (error) {
+    // fetch (GDELT rate limit / timeout / non-JSON body) と DB 失敗の両方を
+    // ここで一元的に握りつぶす。cron 呼び出し元 (index.ts) には一切伝播させない。
+    console.warn(
+      JSON.stringify({
+        event: 'news_scheduler_error',
+        requestId: options.requestId,
+        probeKey: target.probeKey,
+        metric: target.metric,
+        message: error instanceof Error ? error.message : String(error),
+      }),
+    )
+    return {
+      ran: false,
+      source: NEWS_ATTENTION_SOURCE,
+      probeKey: target.probeKey,
+      metric: target.metric,
+      fetched: 0,
+      inserted: 0,
+      skipped: 0,
+      reason: 'error',
+    }
+  }
+}

--- a/test/infrastructure/calendar/earningsCalendarRepo.test.ts
+++ b/test/infrastructure/calendar/earningsCalendarRepo.test.ts
@@ -9,11 +9,14 @@ import {
  * `bulkUpsert` の chunk insert 動作テスト (CodeRabbit #196 review)。
  *
  * 過去仕様は 1 row につき 1 INSERT 文を発行 (records.length 回 await) → 1000 行
- * で D1 subrequest 制限に達する。修正後は 50 行 chunk で multi-row VALUES に
+ * で D1 subrequest 制限に達する。修正後は 33 行 chunk で multi-row VALUES に
  * まとめる (drizzle `.values([...])`)。`.onConflictDoNothing()` の挙動 (UNIQUE
  * 違反 row だけ skip)、`.returning()` の戻り行数による inserted/skipped カウントも
  * 維持する。
  */
+
+/** `earnings_calendar` の列数 (symbol, earningsDate, notes)。 */
+const COLUMNS = 3
 
 function makeFakeDb(opts: {
   /** chunk index → returning rows (id) */
@@ -51,29 +54,33 @@ describe('createEarningsCalendarRepo.bulkUpsert', () => {
     expect(result).toEqual({ inserted: 0, skipped: 0 })
   })
 
-  it('chunks 50 rows per multi-row INSERT (single subrequest per chunk)', async () => {
-    const records: EarningsCalendarSeedInput[] = Array.from({ length: 120 }, (_, i) => ({
+  it('chunks 33 rows per multi-row INSERT (single subrequest per chunk)', async () => {
+    // 40 = CHUNK(33) + 端数(7) — チャンク境界をまたぐ件数を維持する。
+    const records: EarningsCalendarSeedInput[] = Array.from({ length: 40 }, (_, i) => ({
       symbol: `S${i}`,
       earningsDate: '2026-04-30',
       notes: null,
     }))
-    // chunk 0 (50 rows): all inserted, chunk 1 (50): 1 conflict skipped,
-    // chunk 2 (20): all inserted.
+    // chunk 0 (33 rows): all inserted, chunk 1 (7 rows): 1 conflict skipped.
     const insertedPerChunk = [
-      Array.from({ length: 50 }, (_, i) => ({ id: i + 1 })),
-      Array.from({ length: 49 }, (_, i) => ({ id: 50 + i + 1 })),
-      Array.from({ length: 20 }, (_, i) => ({ id: 100 + i + 1 })),
+      Array.from({ length: 33 }, (_, i) => ({ id: i + 1 })),
+      Array.from({ length: 6 }, (_, i) => ({ id: 33 + i + 1 })),
     ]
     const { db, calls } = makeFakeDb({ insertedPerChunk })
     const repo = createEarningsCalendarRepo(db)
     const result = await repo.bulkUpsert(records)
-    // 3 chunks → 3 INSERT statements。1 行あたり 1 INSERT ではないことを保証。
-    expect(calls).toHaveLength(3)
-    expect(calls[0]!.values).toHaveLength(50)
-    expect(calls[1]!.values).toHaveLength(50)
-    expect(calls[2]!.values).toHaveLength(20)
+    // 2 chunks → 2 INSERT statements。1 行あたり 1 INSERT ではないことを保証。
+    expect(calls).toHaveLength(2)
+    expect(calls[0]!.values).toHaveLength(33)
+    expect(calls[1]!.values).toHaveLength(7)
     // inserted は returning() の合計、skipped は chunk size との差分。
-    expect(result).toEqual({ inserted: 50 + 49 + 20, skipped: 1 })
+    expect(result).toEqual({ inserted: 33 + 6, skipped: 1 })
+    // D1 の bound parameter 上限は 1 クエリあたり 100 個。multi-row INSERT の bind
+    // 数は `列数 × チャンクの行数` なので、これを超えないことを再発防止ガードとして
+    // 各チャンクで検証する (CHUNK=50 のままだと 3 列 × 50 行 = 150 bind で超過していた)。
+    for (const call of calls) {
+      expect(call.values.length * COLUMNS).toBeLessThanOrEqual(100)
+    }
   })
 
   it('upper-cases symbol and applies notes ?? null per row', async () => {

--- a/test/infrastructure/calendar/macroEventCalendarRepo.test.ts
+++ b/test/infrastructure/calendar/macroEventCalendarRepo.test.ts
@@ -63,9 +63,12 @@ describe('createMacroEventCalendarRepo.bulkUpsert', () => {
 
   it('chunks 25 rows per multi-row INSERT (single subrequest per chunk)', async () => {
     // 30 = CHUNK(25) + 端数(5) — チャンク境界をまたぐ件数を維持する。
+    // 年を進めて 30 件すべてを UNIQUE (event_type, event_date) に対して一意にする。
+    // 月だけを回すと 13 件目から既存行と衝突し、実 DB では onConflictDoNothing が
+    // 効いて 25/4 件は insert されないため、returning() の期待値が実挙動から乖離する。
     const records: MacroEventCalendarSeedInput[] = Array.from({ length: 30 }, (_, i) => ({
       eventType: 'CPI',
-      eventDate: `2026-${String((i % 12) + 1).padStart(2, '0')}-15`,
+      eventDate: `${2026 + Math.floor(i / 12)}-${String((i % 12) + 1).padStart(2, '0')}-15`,
       eventTime: '08:30',
       notes: null,
     }))

--- a/test/infrastructure/calendar/macroEventCalendarRepo.test.ts
+++ b/test/infrastructure/calendar/macroEventCalendarRepo.test.ts
@@ -7,9 +7,12 @@ import {
 
 /**
  * `bulkUpsert` の chunk insert 動作テスト (issue #196 2/3、CodeRabbit 同型)。
- * `earningsCalendarRepo.test.ts` と同パターンで chunk 50 / multi-row VALUES /
+ * `earningsCalendarRepo.test.ts` と同パターンで chunk 25 / multi-row VALUES /
  * `.onConflictDoNothing()` の挙動 + inserted/skipped カウントを担保する。
  */
+
+/** `macro_event_calendar` の列数 (eventType, eventDate, eventTime, notes)。 */
+const COLUMNS = 4
 
 function makeFakeDb(opts: {
   insertedPerChunk: Array<Array<{ id: number }>>
@@ -58,26 +61,31 @@ describe('createMacroEventCalendarRepo.bulkUpsert', () => {
     expect(result).toEqual({ inserted: 0, skipped: 0 })
   })
 
-  it('chunks 50 rows per multi-row INSERT (single subrequest per chunk)', async () => {
-    const records: MacroEventCalendarSeedInput[] = Array.from({ length: 120 }, (_, i) => ({
+  it('chunks 25 rows per multi-row INSERT (single subrequest per chunk)', async () => {
+    // 30 = CHUNK(25) + 端数(5) — チャンク境界をまたぐ件数を維持する。
+    const records: MacroEventCalendarSeedInput[] = Array.from({ length: 30 }, (_, i) => ({
       eventType: 'CPI',
       eventDate: `2026-${String((i % 12) + 1).padStart(2, '0')}-15`,
       eventTime: '08:30',
       notes: null,
     }))
     const insertedPerChunk = [
-      Array.from({ length: 50 }, (_, i) => ({ id: i + 1 })),
-      Array.from({ length: 49 }, (_, i) => ({ id: 50 + i + 1 })),
-      Array.from({ length: 20 }, (_, i) => ({ id: 100 + i + 1 })),
+      Array.from({ length: 25 }, (_, i) => ({ id: i + 1 })),
+      Array.from({ length: 4 }, (_, i) => ({ id: 25 + i + 1 })),
     ]
     const { db, calls } = makeFakeDb({ insertedPerChunk })
     const repo = createMacroEventCalendarRepo(db)
     const result = await repo.bulkUpsert(records)
-    expect(calls).toHaveLength(3)
-    expect(calls[0]!.values).toHaveLength(50)
-    expect(calls[1]!.values).toHaveLength(50)
-    expect(calls[2]!.values).toHaveLength(20)
-    expect(result).toEqual({ inserted: 50 + 49 + 20, skipped: 1 })
+    expect(calls).toHaveLength(2)
+    expect(calls[0]!.values).toHaveLength(25)
+    expect(calls[1]!.values).toHaveLength(5)
+    expect(result).toEqual({ inserted: 25 + 4, skipped: 1 })
+    // D1 の bound parameter 上限は 1 クエリあたり 100 個。multi-row INSERT の bind
+    // 数は `列数 × チャンクの行数` なので、これを超えないことを再発防止ガードとして
+    // 各チャンクで検証する (CHUNK=50 のままだと 4 列 × 50 行 = 200 bind で超過していた)。
+    for (const call of calls) {
+      expect(call.values.length * COLUMNS).toBeLessThanOrEqual(100)
+    }
   })
 
   it('upper-cases event_type, applies notes/event_time ?? null per row', async () => {

--- a/test/infrastructure/db/attentionObservationRepo.test.ts
+++ b/test/infrastructure/db/attentionObservationRepo.test.ts
@@ -1,3 +1,5 @@
+import { type SQL } from 'drizzle-orm'
+import { SQLiteSyncDialect } from 'drizzle-orm/sqlite-core'
 import { describe, expect, it, vi } from 'vitest'
 import {
   createAttentionObservationRepo,
@@ -8,9 +10,15 @@ import {
 /**
  * `bulkInsertIgnore` の chunk insert 動作テスト。
  * `macroEventCalendarRepo.test.ts` と同じ fake drizzle builder パターンで
- * chunk 50 / multi-row VALUES / `.onConflictDoNothing()` の挙動 + inserted/skipped
+ * chunk 14 / multi-row VALUES / `.onConflictDoNothing()` の挙動 + inserted/skipped
  * カウントを担保する。
  */
+
+/** `attention_observation` の列数 (source, probeKey, metric, bucketAt, value, fetchedAt, requestId)。 */
+const COLUMNS = 7
+
+/** SQL fragment (`whereArgs`/`orderByArgs` に積まれる drizzle `SQL` オブジェクト) を検証用に文字列化する。 */
+const dialect = new SQLiteSyncDialect()
 
 function makeFakeInsertDb(opts: { insertedPerChunk: Array<Array<{ id: number }>> }) {
   const insertCalls: Array<{
@@ -70,21 +78,28 @@ describe('createAttentionObservationRepo.bulkInsertIgnore', () => {
     expect(db.insert).not.toHaveBeenCalled()
   })
 
-  it('chunks 50 rows per multi-row INSERT (single subrequest per chunk)', async () => {
-    const records: AttentionObservationRecord[] = Array.from({ length: 96 }, (_, i) =>
+  it('chunks 14 rows per multi-row INSERT (single subrequest per chunk)', async () => {
+    // 20 = CHUNK(14) + 端数(6) — チャンク境界をまたぐ件数を維持する。
+    const records: AttentionObservationRecord[] = Array.from({ length: 20 }, (_, i) =>
       record({ bucketAt: `2026-07-24T${String(i % 24).padStart(2, '0')}:00:00.000Z` }),
     )
     const insertedPerChunk = [
-      Array.from({ length: 50 }, (_, i) => ({ id: i + 1 })),
-      Array.from({ length: 46 }, (_, i) => ({ id: 50 + i + 1 })),
+      Array.from({ length: 14 }, (_, i) => ({ id: i + 1 })),
+      Array.from({ length: 6 }, (_, i) => ({ id: 14 + i + 1 })),
     ]
     const { db, insertCalls } = makeFakeInsertDb({ insertedPerChunk })
     const repo = createAttentionObservationRepo(db)
     const result = await repo.bulkInsertIgnore(records)
     expect(insertCalls).toHaveLength(2)
-    expect(insertCalls[0]!.values).toHaveLength(50)
-    expect(insertCalls[1]!.values).toHaveLength(46)
-    expect(result).toEqual({ inserted: 96, skipped: 0 })
+    expect(insertCalls[0]!.values).toHaveLength(14)
+    expect(insertCalls[1]!.values).toHaveLength(6)
+    expect(result).toEqual({ inserted: 20, skipped: 0 })
+    // D1 の bound parameter 上限は 1 クエリあたり 100 個。multi-row INSERT の bind
+    // 数は `列数 × チャンクの行数` なので、これを超えないことを再発防止ガードとして
+    // 各チャンクで検証する (CHUNK=50 のままだと 7 列 × 50 行 = 350 bind で超過していた)。
+    for (const call of insertCalls) {
+      expect(call.values.length * COLUMNS).toBeLessThanOrEqual(100)
+    }
   })
 
   it('calls onConflictDoNothing with the 4-column UNIQUE target and defaults requestId to null', async () => {
@@ -153,7 +168,7 @@ describe('createAttentionObservationRepo.fetchRecent / purgeOlderThan', () => {
 
   it('fetchRecent selects and orders by bucketAt asc', async () => {
     const rows = [{ id: 1, bucketAt: '2026-07-24T14:30:00.000Z' }]
-    const { db } = makeFakeSelectDb(rows)
+    const { db, whereArgs, orderByArgs } = makeFakeSelectDb(rows)
     const repo = createAttentionObservationRepo(db)
     const result = await repo.fetchRecent({
       source: 'gdelt',
@@ -163,19 +178,33 @@ describe('createAttentionObservationRepo.fetchRecent / purgeOlderThan', () => {
     })
     expect(result).toBe(rows)
     expect(db.select).toHaveBeenCalledTimes(1)
+    // CodeRabbit: 呼び出し回数だけでなく、実際に where/orderBy へ渡された
+    // drizzle SQL fragment の中身 (filter / ordering) を軽く検証する。
+    expect(whereArgs).toHaveLength(1)
+    const where = dialect.sqlToQuery(whereArgs[0] as SQL)
+    expect(where.sql).toContain('"bucket_at" >= ?')
+    expect(where.params).toEqual(['gdelt', 'trump_macro', 'volume', '2026-07-24T00:00:00.000Z'])
+    expect(orderByArgs).toHaveLength(1)
+    expect(dialect.sqlToQuery(orderByArgs[0] as SQL).sql).toBe('"attention_observation"."bucket_at" asc')
   })
 
   it('purgeOlderThan deletes and returns the deleted row count', async () => {
-    const { db } = makeFakeDeleteDb([{ id: 1 }, { id: 2 }, { id: 3 }])
+    const { db, whereArgs } = makeFakeDeleteDb([{ id: 1 }, { id: 2 }, { id: 3 }])
     const repo = createAttentionObservationRepo(db)
     const deleted = await repo.purgeOlderThan('2026-04-01T00:00:00.000Z')
     expect(deleted).toBe(3)
+    expect(whereArgs).toHaveLength(1)
+    const where = dialect.sqlToQuery(whereArgs[0] as SQL)
+    expect(where.sql).toContain('"bucket_at" < ?')
+    expect(where.params).toEqual(['2026-04-01T00:00:00.000Z'])
   })
 
   it('purgeOlderThan returns 0 when nothing matched', async () => {
-    const { db } = makeFakeDeleteDb([])
+    const { db, whereArgs } = makeFakeDeleteDb([])
     const repo = createAttentionObservationRepo(db)
     const deleted = await repo.purgeOlderThan('2026-04-01T00:00:00.000Z')
     expect(deleted).toBe(0)
+    expect(whereArgs).toHaveLength(1)
+    expect(dialect.sqlToQuery(whereArgs[0] as SQL).params).toEqual(['2026-04-01T00:00:00.000Z'])
   })
 })

--- a/test/infrastructure/db/attentionObservationRepo.test.ts
+++ b/test/infrastructure/db/attentionObservationRepo.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createAttentionObservationRepo,
+  type AttentionObservationDb,
+  type AttentionObservationRecord,
+} from '../../../src/infrastructure/db/attentionObservationRepo'
+
+/**
+ * `bulkInsertIgnore` の chunk insert 動作テスト。
+ * `macroEventCalendarRepo.test.ts` と同じ fake drizzle builder パターンで
+ * chunk 50 / multi-row VALUES / `.onConflictDoNothing()` の挙動 + inserted/skipped
+ * カウントを担保する。
+ */
+
+function makeFakeInsertDb(opts: { insertedPerChunk: Array<Array<{ id: number }>> }) {
+  const insertCalls: Array<{
+    values: Array<{
+      source: string
+      probeKey: string
+      metric: string
+      bucketAt: string
+      value: number
+      fetchedAt: string
+      requestId: string | null
+    }>
+  }> = []
+  const onConflictArgs: unknown[] = []
+  let chunkIdx = 0
+  const insertBuilder = {
+    values(values: (typeof insertCalls)[number]['values']) {
+      insertCalls.push({ values })
+      return {
+        onConflictDoNothing(args: unknown) {
+          onConflictArgs.push(args)
+          return {
+            returning(_cols: unknown) {
+              const rows = opts.insertedPerChunk[chunkIdx] ?? []
+              chunkIdx += 1
+              return Promise.resolve(rows)
+            },
+          }
+        },
+      }
+    },
+  }
+  const db = {
+    insert: vi.fn(() => insertBuilder),
+  } as unknown as AttentionObservationDb
+  return { db, insertCalls, onConflictArgs }
+}
+
+function record(overrides: Partial<AttentionObservationRecord> = {}): AttentionObservationRecord {
+  return {
+    source: 'gdelt',
+    probeKey: 'trump_macro',
+    metric: 'volume',
+    bucketAt: '2026-07-24T14:30:00.000Z',
+    value: 0.5,
+    fetchedAt: '2026-07-24T14:35:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('createAttentionObservationRepo.bulkInsertIgnore', () => {
+  it('returns inserted=0 / skipped=0 when records is empty (no DB call)', async () => {
+    const { db } = makeFakeInsertDb({ insertedPerChunk: [] })
+    const repo = createAttentionObservationRepo(db)
+    const result = await repo.bulkInsertIgnore([])
+    expect(result).toEqual({ inserted: 0, skipped: 0 })
+    expect(db.insert).not.toHaveBeenCalled()
+  })
+
+  it('chunks 50 rows per multi-row INSERT (single subrequest per chunk)', async () => {
+    const records: AttentionObservationRecord[] = Array.from({ length: 96 }, (_, i) =>
+      record({ bucketAt: `2026-07-24T${String(i % 24).padStart(2, '0')}:00:00.000Z` }),
+    )
+    const insertedPerChunk = [
+      Array.from({ length: 50 }, (_, i) => ({ id: i + 1 })),
+      Array.from({ length: 46 }, (_, i) => ({ id: 50 + i + 1 })),
+    ]
+    const { db, insertCalls } = makeFakeInsertDb({ insertedPerChunk })
+    const repo = createAttentionObservationRepo(db)
+    const result = await repo.bulkInsertIgnore(records)
+    expect(insertCalls).toHaveLength(2)
+    expect(insertCalls[0]!.values).toHaveLength(50)
+    expect(insertCalls[1]!.values).toHaveLength(46)
+    expect(result).toEqual({ inserted: 96, skipped: 0 })
+  })
+
+  it('calls onConflictDoNothing with the 4-column UNIQUE target and defaults requestId to null', async () => {
+    const { db, onConflictArgs, insertCalls } = makeFakeInsertDb({
+      insertedPerChunk: [[{ id: 1 }]],
+    })
+    const repo = createAttentionObservationRepo(db)
+    await repo.bulkInsertIgnore([record({ requestId: undefined })])
+    expect(insertCalls[0]!.values[0]!.requestId).toBeNull()
+    expect(onConflictArgs).toHaveLength(1)
+    const target = (onConflictArgs[0] as { target: unknown[] }).target
+    expect(target).toHaveLength(4)
+  })
+
+  it('attributes UNIQUE-violation skips correctly within a single chunk (idempotent backfill)', async () => {
+    const records: AttentionObservationRecord[] = [
+      record({ bucketAt: '2026-07-24T14:30:00.000Z' }),
+      record({ bucketAt: '2026-07-24T14:30:00.000Z' }), // duplicate bucket, same tick
+      record({ bucketAt: '2026-07-24T14:45:00.000Z' }),
+    ]
+    const { db } = makeFakeInsertDb({ insertedPerChunk: [[{ id: 1 }, { id: 2 }]] })
+    const repo = createAttentionObservationRepo(db)
+    const result = await repo.bulkInsertIgnore(records)
+    expect(result).toEqual({ inserted: 2, skipped: 1 })
+  })
+})
+
+describe('createAttentionObservationRepo.fetchRecent / purgeOlderThan', () => {
+  function makeFakeSelectDb(rows: unknown[]) {
+    const whereArgs: unknown[] = []
+    const orderByArgs: unknown[] = []
+    const selectBuilder = {
+      from: vi.fn(() => ({
+        where: vi.fn((arg: unknown) => {
+          whereArgs.push(arg)
+          return {
+            orderBy: vi.fn((arg2: unknown) => {
+              orderByArgs.push(arg2)
+              return Promise.resolve(rows)
+            }),
+          }
+        }),
+      })),
+    }
+    const db = {
+      select: vi.fn(() => selectBuilder),
+    } as unknown as AttentionObservationDb
+    return { db, whereArgs, orderByArgs }
+  }
+
+  function makeFakeDeleteDb(returningRows: Array<{ id: number }>) {
+    const whereArgs: unknown[] = []
+    const deleteBuilder = {
+      where: vi.fn((arg: unknown) => {
+        whereArgs.push(arg)
+        return {
+          returning: vi.fn(() => Promise.resolve(returningRows)),
+        }
+      }),
+    }
+    const db = {
+      delete: vi.fn(() => deleteBuilder),
+    } as unknown as AttentionObservationDb
+    return { db, whereArgs }
+  }
+
+  it('fetchRecent selects and orders by bucketAt asc', async () => {
+    const rows = [{ id: 1, bucketAt: '2026-07-24T14:30:00.000Z' }]
+    const { db } = makeFakeSelectDb(rows)
+    const repo = createAttentionObservationRepo(db)
+    const result = await repo.fetchRecent({
+      source: 'gdelt',
+      probeKey: 'trump_macro',
+      metric: 'volume',
+      sinceIso: '2026-07-24T00:00:00.000Z',
+    })
+    expect(result).toBe(rows)
+    expect(db.select).toHaveBeenCalledTimes(1)
+  })
+
+  it('purgeOlderThan deletes and returns the deleted row count', async () => {
+    const { db } = makeFakeDeleteDb([{ id: 1 }, { id: 2 }, { id: 3 }])
+    const repo = createAttentionObservationRepo(db)
+    const deleted = await repo.purgeOlderThan('2026-04-01T00:00:00.000Z')
+    expect(deleted).toBe(3)
+  })
+
+  it('purgeOlderThan returns 0 when nothing matched', async () => {
+    const { db } = makeFakeDeleteDb([])
+    const repo = createAttentionObservationRepo(db)
+    const deleted = await repo.purgeOlderThan('2026-04-01T00:00:00.000Z')
+    expect(deleted).toBe(0)
+  })
+})

--- a/test/infrastructure/news/gdeltDocClient.test.ts
+++ b/test/infrastructure/news/gdeltDocClient.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  GdeltDocClient,
+  GdeltFetchError,
+  GdeltResponseError,
+} from '../../../src/infrastructure/news/GdeltDocClient'
+
+function mockJsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json; charset=utf-8' },
+  })
+}
+
+function sampleTimeline(points: Array<{ date: string; value: number }>) {
+  return {
+    query_details: { query: 'trump tariffs sourcelang:english' },
+    timeline: [
+      {
+        series: 'Volume Intensity',
+        data: points,
+      },
+    ],
+  }
+}
+
+describe('GdeltDocClient.getTimeline', () => {
+  it('requests query/mode/format/timespan and normalizes GDELT bucket dates to ISO UTC', async () => {
+    let capturedUrl: URL | undefined
+    const fetchFn = vi.fn<typeof fetch>().mockImplementation(async (input) => {
+      const urlStr = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      capturedUrl = new URL(urlStr)
+      return mockJsonResponse(
+        sampleTimeline([
+          { date: '20260724T143000Z', value: 0.6738 },
+          { date: '20260724T144500Z', value: 0.701 },
+        ]),
+      )
+    })
+
+    const client = new GdeltDocClient({ fetchFn })
+    const points = await client.getTimeline('trump tariffs sourcelang:english', 'volume', '1d')
+
+    expect(capturedUrl?.hostname).toBe('api.gdeltproject.org')
+    expect(capturedUrl?.pathname).toBe('/api/v2/doc/doc')
+    expect(capturedUrl?.searchParams.get('query')).toBe('trump tariffs sourcelang:english')
+    expect(capturedUrl?.searchParams.get('mode')).toBe('timelinevol')
+    expect(capturedUrl?.searchParams.get('format')).toBe('json')
+    expect(capturedUrl?.searchParams.get('timespan')).toBe('1d')
+
+    expect(points).toEqual([
+      { bucketAt: '2026-07-24T14:30:00.000Z', value: 0.6738 },
+      { bucketAt: '2026-07-24T14:45:00.000Z', value: 0.701 },
+    ])
+  })
+
+  it("uses mode=timelinetone for the 'tone' metric", async () => {
+    let capturedUrl: URL | undefined
+    const fetchFn = vi.fn<typeof fetch>().mockImplementation(async (input) => {
+      const urlStr = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      capturedUrl = new URL(urlStr)
+      return mockJsonResponse(sampleTimeline([]))
+    })
+    const client = new GdeltDocClient({ fetchFn })
+    await client.getTimeline('stock market selloff sourcelang:english', 'tone', '1d')
+    expect(capturedUrl?.searchParams.get('mode')).toBe('timelinetone')
+  })
+
+  it('returns [] (not throw) when timeline is empty/missing', async () => {
+    const fetchFn = vi.fn<typeof fetch>().mockImplementation(async () => mockJsonResponse({ timeline: [] }))
+    const client = new GdeltDocClient({ fetchFn })
+    const points = await client.getTimeline('q', 'volume')
+    expect(points).toEqual([])
+  })
+
+  it('returns [] when the response has no timeline field at all', async () => {
+    const fetchFn = vi.fn<typeof fetch>().mockImplementation(async () => mockJsonResponse({}))
+    const client = new GdeltDocClient({ fetchFn })
+    const points = await client.getTimeline('q', 'volume')
+    expect(points).toEqual([])
+  })
+
+  it('drops points with non-finite values, keeping the rest', async () => {
+    const fetchFn = vi.fn<typeof fetch>().mockImplementation(async () =>
+      mockJsonResponse(
+        sampleTimeline([
+          { date: '20260724T143000Z', value: 0.5 },
+          { date: '20260724T144500Z', value: Number.NaN },
+          { date: '20260724T150000Z', value: Number.POSITIVE_INFINITY },
+          { date: '20260724T151500Z', value: 0.9 },
+        ]),
+      ),
+    )
+    const client = new GdeltDocClient({ fetchFn })
+    const points = await client.getTimeline('q', 'volume')
+    expect(points).toEqual([
+      { bucketAt: '2026-07-24T14:30:00.000Z', value: 0.5 },
+      { bucketAt: '2026-07-24T15:15:00.000Z', value: 0.9 },
+    ])
+  })
+
+  it('drops points with an unparseable date', async () => {
+    const fetchFn = vi.fn<typeof fetch>().mockImplementation(async () =>
+      mockJsonResponse(
+        sampleTimeline([
+          { date: 'not-a-date', value: 0.5 },
+          { date: '20260724T143000Z', value: 0.9 },
+        ]),
+      ),
+    )
+    const client = new GdeltDocClient({ fetchFn })
+    const points = await client.getTimeline('q', 'volume')
+    expect(points).toEqual([{ bucketAt: '2026-07-24T14:30:00.000Z', value: 0.9 }])
+  })
+
+  it('throws GdeltResponseError with a truncated plain-text body on 429', async () => {
+    const longBody = 'Rate limit exceeded, please retry after 5 seconds. '.repeat(10)
+    const fetchFn = vi.fn<typeof fetch>().mockImplementation(async () =>
+      new Response(longBody, { status: 429, headers: { 'Content-Type': 'text/plain' } }),
+    )
+    const client = new GdeltDocClient({ fetchFn })
+    const error = await client.getTimeline('q', 'volume').catch((e: unknown) => e)
+    expect(error).toBeInstanceOf(GdeltResponseError)
+    const gdeltError = error as GdeltResponseError
+    expect(gdeltError.status).toBe(429)
+    expect(gdeltError.bodySnippet.length).toBeLessThanOrEqual(200)
+    expect(gdeltError.bodySnippet).toContain('Rate limit exceeded')
+  })
+
+  it('throws GdeltResponseError (not a raw JSON parse error) when a 200 returns an HTML body', async () => {
+    const html = '<html><body>Something went wrong upstream</body></html>'
+    const fetchFn = vi.fn<typeof fetch>().mockImplementation(async () =>
+      new Response(html, { status: 200, headers: { 'Content-Type': 'text/html; charset=utf-8' } }),
+    )
+    const client = new GdeltDocClient({ fetchFn })
+    const error = await client.getTimeline('q', 'volume').catch((e: unknown) => e)
+    expect(error).toBeInstanceOf(GdeltResponseError)
+    const gdeltError = error as GdeltResponseError
+    expect(gdeltError.status).toBe(200)
+    expect(gdeltError.bodySnippet).toContain('Something went wrong upstream')
+    // Must not have attempted response.json() on the HTML body — that would
+    // surface as a generic SyntaxError instead of our typed error.
+    expect(error).not.toBeInstanceOf(SyntaxError)
+  })
+
+  it('throws GdeltFetchError when the underlying fetch aborts (timeout)', async () => {
+    const fetchFn = vi.fn<typeof fetch>().mockImplementation(async (_input, init) => {
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = (init as RequestInit)?.signal
+        signal?.addEventListener('abort', () => {
+          reject(new DOMException('The operation was aborted.', 'AbortError'))
+        })
+      })
+    })
+    const client = new GdeltDocClient({ fetchFn, timeoutMs: 5 })
+    await expect(client.getTimeline('q', 'volume')).rejects.toBeInstanceOf(GdeltFetchError)
+  })
+})

--- a/test/trading/news/newsScheduler.test.ts
+++ b/test/trading/news/newsScheduler.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi } from 'vitest'
+import { runNewsScheduler } from '../../../src/trading/news/newsScheduler'
+import type { GdeltDocClient, GdeltMetric, GdeltTimelinePoint } from '../../../src/infrastructure/news/GdeltDocClient'
+import type { Env } from '../../../src/config/env'
+
+function fakeClient(
+  handler: (query: string, metric: GdeltMetric) => GdeltTimelinePoint[] | Promise<GdeltTimelinePoint[]>,
+): { client: GdeltDocClient; getTimeline: ReturnType<typeof vi.fn> } {
+  const getTimeline = vi.fn(async (query: string, metric: GdeltMetric) => handler(query, metric))
+  return { client: { getTimeline } as unknown as GdeltDocClient, getTimeline }
+}
+
+/** D1 の insert チェーンを最小限モックする fake env.DB (drizzle 経由で 1 chunk だけ通す)。 */
+function fakeDb(): D1Database {
+  const preparedStatement = {
+    bind: vi.fn(() => preparedStatement),
+    all: vi.fn(async () => ({ results: [] })),
+    run: vi.fn(async () => ({ success: true, results: [] })),
+    first: vi.fn(async () => null),
+    raw: vi.fn(async () => []),
+  }
+  return {
+    prepare: vi.fn(() => preparedStatement),
+    batch: vi.fn(async () => []),
+    exec: vi.fn(async () => ({ count: 0, duration: 0 })),
+    dump: vi.fn(async () => new ArrayBuffer(0)),
+  } as unknown as D1Database
+}
+
+function makeEnv(overrides: Partial<Env> = {}): Env {
+  return {
+    NEWS_ATTENTION_ENABLED: 'true',
+    DB: fakeDb(),
+    ...overrides,
+  } as unknown as Env
+}
+
+describe('runNewsScheduler — opt-in gate', () => {
+  it('NEWS_ATTENTION_ENABLED 未設定なら fetch を1回も呼ばず即 return する', async () => {
+    const { client, getTimeline } = fakeClient(() => [])
+    const env = makeEnv({ NEWS_ATTENTION_ENABLED: undefined })
+    const summary = await runNewsScheduler({ env, client })
+    expect(summary.ran).toBe(false)
+    expect(summary.reason).toBe('news_attention_disabled')
+    expect(getTimeline).not.toHaveBeenCalled()
+  })
+
+  it("NEWS_ATTENTION_ENABLED が 'false' / 任意の非 'true' 値でも無効", async () => {
+    const { client, getTimeline } = fakeClient(() => [])
+    const env = makeEnv({ NEWS_ATTENTION_ENABLED: 'false' })
+    const summary = await runNewsScheduler({ env, client })
+    expect(summary.ran).toBe(false)
+    expect(getTimeline).not.toHaveBeenCalled()
+  })
+
+  it('env.DB が無ければ fetch を呼ばず db_unavailable を返す', async () => {
+    const { client, getTimeline } = fakeClient(() => [])
+    const env = makeEnv({ DB: undefined })
+    const summary = await runNewsScheduler({ env, client })
+    expect(summary.ran).toBe(false)
+    expect(summary.reason).toBe('db_unavailable')
+    expect(getTimeline).not.toHaveBeenCalled()
+  })
+})
+
+describe('runNewsScheduler — probe round-robin', () => {
+  it('1 tick = 1 リクエストのみ (getTimeline は毎回 1 回だけ呼ばれる)', async () => {
+    const { client, getTimeline } = fakeClient(() => [])
+    const env = makeEnv()
+    await runNewsScheduler({ env, client, now: () => new Date('2026-07-24T14:30:00.000Z') })
+    expect(getTimeline).toHaveBeenCalledTimes(1)
+  })
+
+  it('連続する 5 分スロットは異なる probe/metric の組に進む (round-robin)', async () => {
+    const env = makeEnv()
+    const seen: Array<{ probeKey?: string; metric?: GdeltMetric }> = []
+    // 4 組 (2 probe × 2 metric) を 5 分刻みで叩き、全て異なる組み合わせであること。
+    for (let i = 0; i < 4; i += 1) {
+      const { client } = fakeClient(() => [])
+      const now = new Date(new Date('2026-07-24T14:30:00.000Z').getTime() + i * 5 * 60 * 1000)
+      const summary = await runNewsScheduler({ env, client, now: () => now })
+      seen.push({ probeKey: summary.probeKey, metric: summary.metric })
+    }
+    const unique = new Set(seen.map((s) => `${s.probeKey}:${s.metric}`))
+    expect(unique.size).toBe(4)
+  })
+
+  it('同一スロット (同一時刻) は同じ probe/metric を選ぶ (ステートレスな決定性)', async () => {
+    const env = makeEnv()
+    const now = new Date('2026-07-24T14:30:00.000Z')
+    const { client: client1 } = fakeClient(() => [])
+    const { client: client2 } = fakeClient(() => [])
+    const s1 = await runNewsScheduler({ env, client: client1, now: () => now })
+    const s2 = await runNewsScheduler({ env, client: client2, now: () => now })
+    expect(s1.probeKey).toBe(s2.probeKey)
+    expect(s1.metric).toBe(s2.metric)
+  })
+
+  it('5 分刻みで一周 (4 組) すると最初の組に戻る', async () => {
+    const env = makeEnv()
+    const base = new Date('2026-07-24T14:30:00.000Z').getTime()
+    const results: Array<{ probeKey?: string; metric?: GdeltMetric }> = []
+    for (let i = 0; i < 5; i += 1) {
+      const { client } = fakeClient(() => [])
+      const now = new Date(base + i * 5 * 60 * 1000)
+      const summary = await runNewsScheduler({ env, client, now: () => now })
+      results.push({ probeKey: summary.probeKey, metric: summary.metric })
+    }
+    expect(results[4]).toEqual(results[0])
+  })
+})
+
+describe('runNewsScheduler — fail-safe (never throws)', () => {
+  it('fetch が throw しても scheduler は throw せず reason=error を返す', async () => {
+    const { client } = fakeClient(() => {
+      throw new Error('GDELT rate limited')
+    })
+    const env = makeEnv()
+    await expect(runNewsScheduler({ env, client })).resolves.not.toThrow()
+    const summary = await runNewsScheduler({ env, client })
+    expect(summary.ran).toBe(false)
+    expect(summary.reason).toBe('error')
+  })
+
+  it('fetch が reject する Promise を返しても throw せず握りつぶす', async () => {
+    const { client } = fakeClient(async () => Promise.reject(new Error('timeout')))
+    const env = makeEnv()
+    const summary = await runNewsScheduler({ env, client })
+    expect(summary.ran).toBe(false)
+    expect(summary.reason).toBe('error')
+  })
+})
+
+describe('runNewsScheduler — happy path', () => {
+  it('取得した点を bulkInsertIgnore 相当の repo write に渡し、fetched 件数を summary に反映する', async () => {
+    const points: GdeltTimelinePoint[] = [
+      { bucketAt: '2026-07-24T14:30:00.000Z', value: 0.5 },
+      { bucketAt: '2026-07-24T14:45:00.000Z', value: 0.6 },
+    ]
+    const { client, getTimeline } = fakeClient(() => points)
+    const env = makeEnv()
+    const summary = await runNewsScheduler({ env, client, requestId: 'req-1' })
+    expect(summary.ran).toBe(true)
+    expect(summary.fetched).toBe(2)
+    expect(getTimeline).toHaveBeenCalledTimes(1)
+    expect(summary.probeKey).toBeDefined()
+    expect(summary.metric).toBeDefined()
+  })
+})


### PR DESCRIPTION
## 何を

ニュース起因の過熱を検知する risk gate (`newsShockGate`) の **土台となる観測データ蓄積のみ**を入れる。GDELT DOC 2.0 API から報道量とトーンを定期取得し D1 に貯める。

**取引経路の変更はゼロ** — `src/trading/strategy/` `risk/` `execution/` は一切触っていない。gate 本体は次の PR。

## なぜこの形か

### producer と gate を物理的に分離する

| | producer (この PR) | gate (次 PR) |
|---|---|---|
| cron | `*/5` (quote/reconcile と同居) | `*/15` (strategy tick) |
| 外部 I/O | あり | **ゼロ** |
| 失敗時 | `ctx.waitUntil` 内で warn ログのみ | D1 snapshot 不在 → fail-open |

strategy tick に外部 API 呼び出しを一切足さない。これで「GDELT が落ちただけで新規建てが全停止」を**構造的に不可能**にする。既存 gate が fail-closed なのは依存先が D1 だけだからで、可用性が管理外の第三者 HTTP を同じ扱いにすると、リスクを減らすはずの gate が新しい単一障害点になる。

### レート制限への対処

GDELT は認証不要だが **1req/5秒**。probe 2本 × metric 2種 = 4組を、現在時刻の5分スロット番号による**ステートレス round-robin** で1 tick 1リクエストずつ回す（各組20分ごと更新）。DO も追加テーブルも使わず、sleep も不要。

### 冪等な backfill

`UNIQUE (source, probe_key, metric, bucket_at)` を張り、毎 tick で取得ウィンドウ全点を `INSERT OR IGNORE` する。tick を落としても次 tick が自動で埋め、行は重複しない。

## 実 API で検証したこと

モックが実物とズレていないか、実際に GDELT を叩いて確認した:

- **`content-type: application/json; charset=utf-8`** → クライアントの非 JSON 弾き条件を正しく通る（ここが違えば全レスポンスを弾いて無言で死んでいた）
- `timelinevol` / `timelinetone` とも **66点すべて**が日付正規表現にマッチし、値も全て有限
- 429 時は **プレーンテキスト本文**が返る。さらに 200 でも非 JSON があり得るため、`response.ok` の後に `content-type` を検査してから `.json()` を呼ぶ実装にしてある

## テスト

`pnpm typecheck` clean / `pnpm test` **1747 passed (119 files)**。既存テストの破壊なし。ネットワークは全て `fetchFn` 注入で遮断。

## レビューで見てほしい点

`drizzle/meta/` に **0037〜0040 のスナップショットが欠損**していた（migration SQL と journal エントリはあるのに snapshot だけ無い）。このため `drizzle-kit generate` が古い 0036 snapshot と差分を取り、既に適用済みのカラムを再追加する `ALTER TABLE` が 0041 に混入していた。そのまま適用すると duplicate column で落ちるため手で除去してある。

生成された `0041_snapshot.json` は現在の schema 全体を反映しているので**今後の generate は正常化する**が、0037-0040 の snapshot 欠損自体は残っている。この PR のスコープ外なので別途 issue に切りたい。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ニュース（量・トーン）のタイムラインを5分ごとに取得し、「注意喚起」用の観測データを保存。
  * 観測データは同一キーの重複を自動スキップし、古いデータを整理。
  * 環境設定で取得の有効化/無効化と、GDELT接続先の上書きに対応。
* **改善**
  * 外部取得やDB処理の失敗でも定期処理全体が止まりにくく、挿入は制限に合わせて分割。
* **テスト**
  * 取得・保存・重複制御・スケジューラ動作の主要ケースを追加検証。
* **ドキュメント**
  * 開発用設定例に注意喚起関連項目を追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->