### PR TITLE
feat(news): turn on the GDELT observation producer

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -119,7 +119,12 @@
         "QUOTE_SOURCE": "webull",
         // #475③: bars も staging のみ Webull primary (canary)。^VIX / JP /
         // 障害時は Yahoo に自動 fallback。
-        "BAR_SOURCE": "webull"
+        "BAR_SOURCE": "webull",
+        // newsShockGate PR 1: GDELT の報道量 / トーンを attention_observation に
+        // 蓄積する producer の opt-in flag。取引経路からは参照されない観測専用で、
+        // gate 本体は `global_config.news_shock_mode` (既定 off) が別途握る。
+        // staging は cron 無し (#277) なので自動蓄積はされない — 手動 trigger 用。
+        "NEWS_ATTENTION_ENABLED": "true"
       },
       "routes": [
         { "pattern": "trading-staging.chanu.co", "custom_domain": true }
@@ -174,7 +179,12 @@
         // primary、^VIX / JP / 障害時は Yahoo へ自動 fallback (FallbackBarClient /
         // quoteScheduler)。quote と bars を揃える。
         "QUOTE_SOURCE": "webull",
-        "BAR_SOURCE": "webull"
+        "BAR_SOURCE": "webull",
+        // newsShockGate PR 1: 5分 cron で GDELT を 1 リクエストずつ叩き
+        // attention_observation に蓄積する producer の opt-in flag。
+        // これ自体は取引判断に影響しない — gate は `global_config.news_shock_mode`
+        // (既定 off) で別に握っており、閾値を実データで校正するまで off のまま。
+        "NEWS_ATTENTION_ENABLED": "true"
       },
       "routes": [
         { "pattern": "trading.chanu.co", "custom_domain": true }


### PR DESCRIPTION
## 何を

`NEWS_ATTENTION_ENABLED=true` を staging / production の Worker vars に追加する。

## なぜ

#618 でこの flag を `env.ts` と `.dev.vars.example` には足したが、**`wrangler.jsonc` に入れ忘れていた**。producer は「未設定 = 無効」の規約で即 return するため、マージ後も 1 件も蓄積されていない状態だった:

```
staging   attention_observation → 0 rows
```

## 取引への影響

**無い。** 蓄積が始まるだけで、注文経路には触れない。観測を読む gate は `global_config.news_shock_mode` が別に握っていて、そちらは **`off` のまま**。閾値 (`2.3` / `4.4`) は GDELT の**日次**分布から引いた暫定値で、実際に評価する15分粒度は裾が厚いため、実データで校正するまで有効化しない。

## 環境ごとの効き方

| | 挙動 |
|---|---|
| production | 5分 cron で probe を 1 リクエストずつラウンドロビン取得 → 蓄積開始 |
| staging | cron 無し (#277) のため自動蓄積はされない。手動 trigger 時のみ有効 |

GDELT のレート制限は 1req/5秒。probe 2本 × metric 2種 = 4組を 5分ごとに 1 組ずつ回すので、実効 1req/5分 と 60倍のマージンがある。

## 蓄積の見込み

`timespan=1d` で毎 tick 全点を `INSERT OR IGNORE` するため、初回で 66〜96 点入り、以降は重複せず 1 日約 96 点ずつ増える。gate が要求する `min_samples=200` は実質 2〜3 日で満たす。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * staging・production環境で、ニュース注目度機能を有効化しました。
  * GDELTの報道量・トーン情報をニュース注目度の観測データとして蓄積できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->