### PR TITLE
fix(news): give GDELT a timeout it can actually meet

### DIFF
--- a/src/infrastructure/news/GdeltDocClient.ts
+++ b/src/infrastructure/news/GdeltDocClient.ts
@@ -1,5 +1,15 @@
 const DEFAULT_BASE_URL = 'https://api.gdeltproject.org'
-const DEFAULT_TIMEOUT_MS = 5_000
+/**
+ * GDELT は素で遅い。本番で 5s (quote/bar client からの流用) にしていたところ、
+ * 全 tick が `The operation was aborted` で失敗し 1 件も蓄積できていなかった。
+ * 実測でもレート制限応答を返すだけで 20s 超かかることがある。
+ *
+ * quote/bar の 5s が短いのは、あれが取引判断のクリティカルパスに居て「古い値で
+ * 発注するより落ちる方が安全」だから。GDELT はその経路に居ない — producer は
+ * cron/alarm 側で非同期に回り、gate は D1 を読むだけなので、待っても取引は
+ * 止まらない。取り逃がす方が損。
+ */
+const DEFAULT_TIMEOUT_MS = 30_000
 const DEFAULT_TIMESPAN = '1d'
 /** `response.text()` truncation cap for error messages (avoid logging huge HTML bodies). */
 const BODY_SNIPPET_MAX_CHARS = 200


### PR DESCRIPTION
## 症状

#618 の producer を本番に昇格したが、**1 件も蓄積されていなかった**。

```
attention_observation → 0 rows (30分以上経過)
```

前提はすべて揃っていた — migration 適用済み、`NEWS_ATTENTION_ENABLED="true"` がデプロイ済みバージョンに反映済み、cron も生存（strategy cron は正常稼働）。

`wrangler tail` で実際のログを取ったところ原因が出た:

```json
{"event":"news_scheduler_error","probeKey":"trump_macro","metric":"volume",
 "message":"GDELT timeline fetch failed: The operation was aborted"}
```

**全 tick がタイムアウトで abort していた。**

## 原因

`GdeltDocClient` の `DEFAULT_TIMEOUT_MS` を 5s にしていた。これは `YahooBarClient` / `YahooQuoteClient` / `fxRate` からの流用だが、**GDELT に対しては短すぎる**。ローカル実測では、レート制限応答を返すだけで 20.6s かかっている。

quote / bar の 5s が短いのは正しい — あれは取引判断のクリティカルパスに居て、「古い値で発注するより落ちる方が安全」だから。**GDELT はその経路に居ない**: producer は cron/alarm 側で非同期に回り、gate は D1 を読むだけなので、待っても取引は止まらない。取り逃がす方が損になる。

この区別をせずに定数を流用したのが誤りだった。

## 修正

`DEFAULT_TIMEOUT_MS` を 30s に。判断の根拠（なぜ quote/bar と違ってよいのか）を doc コメントに残した。

## 影響範囲

`GdeltDocClient` のみ。取引経路の変更なし。gate は `news_shock_mode='off'` のまま。

`pnpm typecheck` clean / `pnpm test` **1821 passed**。

## 補足

この修正は producer を Durable Object alarm に移す作業とは独立している（同じクライアントを使うため DO 化しても直らない）。本番が取得できていない状態を長引かせないよう、先にこれだけ切り出した。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ニュース取得の待機時間を延長し、応答が遅い場合でも処理が失敗しにくくなりました。
  * 一時的な遅延やレート制限による取得失敗が軽減されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->