### PR TITLE
docs: split the README into docs/ and leave an index

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,17 @@
   - 破壊的変更は `feat!:` か body に `BREAKING CHANGE:` (major bump のトリガー)
 - 並列 PR 共有ファイル (`src/app.ts` / `src/config/env.ts` / `.dev.vars.example`) は **末尾 append のみ** → 後発 PR が rebase で解決
 
+## ドキュメント
+
+README は索引のみ。実体は `docs/` にある。
+
+- `docs/onboarding.md` — 開発の始め方 / secrets / Webull 口座の初期作業
+- `docs/architecture.md` — 全体像・cron・bindings・ディレクトリ構成
+- `docs/configuration.md` — `global_config` / `symbol_config` の全パラメタ
+- `docs/endpoints.md` — HTTP endpoint 一覧
+- `docs/db-operations.md` — D1 運用 SQL
+- `docs/production-cd.md` — リリースフロー
+
 ## 関連設定
 
 - `.coderabbit.yaml` — CodeRabbit 自動レビューの path_instructions (Phase scope / POC 姿勢をプリロード)

--- a/README.md
+++ b/README.md
@@ -2,327 +2,41 @@
 
 Retail auto-trading system on Cloudflare Workers + Hono + TypeScript, speaking Webull OpenAPI directly (no SDK).
 
-**Current scope**: POC (issue #1、Phase 1–5) は完了。production で Pullback / BreakoutMomentum 戦略が 15 分 cron で実発注稼働中 (Webull JP 本番口座)。US + JP 両通貨対応 (JP は `symbol_config.lot_size` で丸め)。Risk: kill-switch / drawdown kill / ATR stop / drawdown-scaled size / VIX regime filter / earnings・macro event gate / spread guard / ticker deny guard。Cloudflare Access で保護した read-only dashboard + read-only MCP server 有り。
+production で Pullback / BreakoutMomentum 戦略が 15 分 cron で**実発注稼働中** (Webull JP 本番口座)。US + JP 両通貨対応。Cloudflare Access で保護した read-only dashboard と MCP server 付き。
 
-## アーキテクチャ概要
+**安全既定は fail-closed**: `dry_run=1` / `trading_enabled=0`。実発注は D1 `global_config` を明示的に切り替えた環境でのみ動く。
 
-```
- ┌──────────────┐  */5  * * * *   ┌────────────────────────────────────┐
- │  Cloudflare  │────────────────▶│ quote feed + reconcileFills         │
- │   Workers    │  */15 * * * * ─▶│ strategy cron (Pullback / Breakout) │
- │              │  0 22  * * * ──▶│ portfolio roll + token refresh +    │
- │              │                 │ market data health + allowlist 更新  │
- │              │                 └────────────────────────────────────┘
- │              │  /trade/*     ──▶ decide / execute → Webull HTTP
- │              │  /admin/*        operator 操作 (Cloudflare Access)
- │              │  /dashboard/*    read-only SSR  (Cloudflare Access)
- │              │  /mcp            read-only MCP  (Access service token)
- └──────┬───────┘
-        │
- ┌──────┴────────────────────────────────────────────────────┐
- │              Durable Objects  +  D1                         │
- │  SYMBOL_STATE (per-symbol: position / pending / cooldown)   │
- │  PORTFOLIO_STATE (daily equity / drawdown kill)             │
- │  WEBULL_TOKEN_STATE (x-access-token + 自動 refresh)          │
- │  DB: trade_journal / symbol_config / global_config /        │
- │      strategy_decision_log / earnings_calendar /            │
- │      macro_event_calendar / config_audit_log /              │
- │      portfolio_equity_snapshot / tradable_instrument ...    │
- └─────────────────────────────────────────────────────────────┘
-```
+## ドキュメント
 
-> gRPC bridge (Node Container) は PR #110 で撤去済。SELL 後処理は `reconcileFills` に統合され、`/events/trade` ingest も廃止された。
+| | 内容 |
+|---|---|
+| [docs/onboarding.md](docs/onboarding.md) | 開発を始める手順。ローカル実行 / secrets / Webull 口座の初期作業 |
+| [docs/architecture.md](docs/architecture.md) | 全体像・cron・bindings・ディレクトリ構成・層の境界 |
+| [docs/configuration.md](docs/configuration.md) | `global_config` / `symbol_config` の全パラメタと既定値 |
+| [docs/endpoints.md](docs/endpoints.md) | HTTP endpoint 一覧と認証 |
+| [docs/db-operations.md](docs/db-operations.md) | D1 の初回セットアップ・schema 変更・運用 SQL レシピ |
+| [docs/production-cd.md](docs/production-cd.md) | リリースフロー (release-please → 昇格 PR → Workers Builds) |
+| [docs/production-deployment.md](docs/production-deployment.md) | 本番投入の手順とロールバック |
+| [docs/env-separation.md](docs/env-separation.md) | dev / staging / production の分離方針 |
+| [docs/review-queries.md](docs/review-queries.md) | 障害・振り返り用のクエリ集と運用 runbook |
 
-## Safety defaults (fail-closed)
-
-`global_config` singleton (D1 `id='default'`) で保持。未シード時は `GLOBAL_CONFIG_DEFAULTS` にフォールバック。`UPDATE global_config SET ...` で runtime 即反映、deploy 不要 (#118 で確立した POC 方針)。
-
-**Kill-switch / gate:**
-
-| フィールド | 既定 | 意味 |
-|---|---|---|
-| `dry_run` | `1` | Execution Mock に固定、broker へ送らない |
-| `trading_enabled` | `0` | Risk layer が全注文 reject |
-| `market_hours_check` | `0` | UTC 13:30-20:00 Mon-Fri チェック |
-| `session_window_gate_enabled` | `0` | 開場 30 分前〜引けの窓外は戦略 cron の評価自体を skip |
-| `drawdown_kill_threshold` | `-0.02` | 日次 realized_pnl / start_equity 比で自動 kill |
-| `stale_quote_ms` | `900000` | halt 判定 (15 min) |
-
-**通貨別 cap / 予算 (Phase E、#76):**
-
-| フィールド | 既定 | 意味 |
-|---|---|---|
-| `max_order_notional_usd` | `2000` | USD 銘柄の 1 注文上限 ($) |
-| `max_order_notional_jpy` | `100000` | JPY 銘柄の 1 注文上限 (¥) |
-| `total_capital_usd` / `_jpy` | `NULL` | NAV (NULL なら exposure check skip) |
-| `max_portfolio_exposure_pct` | `0.6` | total_capital × これを超える open 合計を禁止 |
-| `spread_limit_pct_{us,jp}` | `0.0025` / `0.006` | spread guard |
-| `fee_pct_of_notional` | `0` | 売買コスト見積りの料率。realized PnL を net 化する (#trade-cost) |
-| `fee_fixed_per_order` | `0` | 同、1 注文あたりの固定費 (銘柄通貨建て) |
-
-> **米国株・ETF の売買手数料は 2026-07-27 17:30 JST 約定分から無料** (ウィブル証券、恒久)。それ以前は 0.20% 税抜 / 片道。残るコストは売却時の SEC ($20.60/$1M) と FINRA TAF ($0.000195/株)、CAT Fee、および両替時の為替スプレッド (15 銭/USD) のみで、$200 の往復なら約 $0.005。**したがって上記 2 列は 0 のままが実態に一致する**。詳細は `src/trading/domain/tradingCost.ts` の冒頭コメント。
-| `atr_baseline_exclude_recent` | `0` | baseline ATR から直近 20 本を除外する (#atr-baseline-window)。`1` にすると `atr20/baseline` が素直な比率になるが、過熱ガード / atr-floor の閾値は再校正が必要 |
-| `gap_reject_pct` | `0.03` | gap 判定 |
-
-**Pullback 戦略の default rule (#118、#124):**
-
-| フィールド | 既定 | 意味 |
-|---|---|---|
-| `pullback_default_stop_pct` | `-0.04` | pct-based stop (ATR stop の floor) |
-| `pullback_default_take_profit_pct` | `0.07` | take-profit |
-| `pullback_default_time_stop_days` | `10` | 保有上限 (営業日) |
-| `pullback_default_pullback_{max,min}` | `-0.03` / `-0.06` | entry 窓 |
-| `pullback_default_min_return_50d` | `0.08` | 50日 return の uptrend filter |
-| `pullback_default_require_above_sma50` | `1` | sma50 超を entry 必須 |
-| `pullback_default_k_atr` | `2.0` | ATR 倍率。`stopDistance = max(k_atr × atr20, pct stop)` |
-| `pullback_default_max_sma50_deviation_pct` | `0.6` | sma50 からの上方乖離が大きすぎる時は entry 見送り |
-| `pullback_default_max_atr_ratio` | `1.5` | ATR 拡大 (ボラ急騰) 時の entry 見送り閾値 |
-| `pullback_default_max_stop_to_tp_ratio` | `2.0` | stop 幅の上限 = `take_profit_pct × これ`。ATR 連動 stop が利確幅に対して広がりすぎるのを止め R:R に下限を作る (2.0 = R:R 0.5 以上)。`0` で無効 |
-
-**Risk gate の動的パラメタ (#23 Lane 2-3):**
-
-| フィールド | 既定 | 意味 |
-|---|---|---|
-| `risk_base_per_trade_pct` | `0.004` | 1 trade 基準 risk (%) |
-| `risk_dd_half_threshold` | `-0.05` | 日次 DD でこれ未満 → size 0.5× |
-| `risk_dd_halt_threshold` | `-0.10` | 日次 DD でこれ未満 → size 0 (halt) |
-| `vix_warning_threshold` | `25.0` | VIX がこれ超で size scale 適用 |
-| `vix_critical_threshold` | `30.0` | VIX がこれ超で新規 entry 停止 |
-| `vix_warning_size_scale` | `0.5` | warning 帯での size 倍率 |
-| `pair_regime_mode` | `'off'` | ペアレジーム layer (#472)。`off` / `observe` (log のみ) / `enforce` |
-| `cash_fallback_orders_enabled` | `0` | 余剰現金の退避先 (SGOV 等) への自動 BUY を許可 (#452) |
-
-加えて:
-- `symbol_config.active = 0` にすれば universe から外れて cron から除外
-- `symbol_config` の per-symbol override (`stop_pct_override` / `k_atr_override` / `lot_size` / `budget_alloc_pct` / `role` など) が global default に優先
-- `inverse_pairs` で SOXL/SOXS 同時保有を構造的に禁止
-- Cloudflare Access JWT で `/trade/*` / `/webull/*` / `/admin/*` / `/dashboard/*` / `/mcp` を保護 (#29)
-- state 変更 / admin write / dashboard GET は Workers Rate Limit binding で cap (#285)
-
-## Layout
-
-```
-src/
-  app.ts / index.ts           Hono factory + Workers entry (fetch / scheduled)
-  routes/                     health / trade / webull / admin / mcp + dashboard/ (画面ごとに分割)
-  trading/
-    application/              TradingService
-    domain/                   Signal / OrderIntent / RiskDecision / ExecutionResult / StrategyDecision / tradingCalendar
-    strategy/                 strategies/ (Pullback / BreakoutMomentum / FixedRule) + pullbackSizing (ATR stop, lot-round)
-                              + indicators + pullbackScheduler + runStrategyCron + buyingPower + conditionalAllocation
-    risk/                     DefaultRiskPolicy + spreadGuard + jpPriceBand + drawdownRiskScale + vixRegimeFilter
-                              + earningsGate + macroEventGate + perSymbolRiskGate + tickerDenyGuard
-    execution/                Execution + MockExecution + WebullExecution
-    reconciliation/           reconcileFills (Webull order history → D1 + DO apply) + syncHoldings
-    state/                    SymbolStateDO / PortfolioStateDO / WebullTokenStateDO + clients / transitions
-    portfolio/                runPortfolioRoll (EOD rollover)
-    runtime/                  killSwitch + productionReadiness
-    quotes/                   quoteScheduler
-    backtest/                 runBacktest
-  infrastructure/
-    webull/                   WebullReadClient / WebullTradeClient (facade) + WebullHttpClient / WebullAuth / mapper
-                              + token flow (WebullTokenClient / refreshWebullToken / resolveAccessToken)
-                              + tradability / instrument lookup / allowlist refresh
-    quotes/                   BarClient / YahooBarClient / YahooQuoteClient / WebullQuoteClient / fxRate
-    calendar/                 us・jp market calendar + earnings / macro event repo
-    notification/             Notifier 実装 + Slack/Discord webhook + 状態変化検知
-    logger/                   AuditLogger + tradeJournal + strategyDecisionLog (console + D1 sink)
-    db/                       drizzle schema + 各 repo (tradeJournal / symbolConfig / globalConfig / ...) + loaders
-  middleware/                 accessJwt (Cloudflare Access) + rateLimit
-  shared/                     errors / format
-  config/                     env (secret / binding の型定義と parser)
-scripts/                      issue-webull-token / list-webull-accounts / guard-deploy / verify-production-d1 / backtest-*
-drizzle/                      generated D1 migrations (0000_init … 0037_decision_skip_reject_taxonomy)
-docs/                         db-operations / env-separation / production-cd / production-deployment / review-queries / seed
-test/                         vitest suite (117 files / 1724 cases)
-```
-
-## Dev
+## クイックスタート
 
 ```bash
 pnpm install
-pnpm run typecheck                # tsc --noEmit
-pnpm test                         # vitest
-pnpm dev                          # wrangler dev (ローカル D1 自動作成)
-pnpm exec wrangler deploy --dry-run
+pnpm run typecheck
+pnpm test
+pnpm dev            # wrangler dev (ローカル D1 自動作成)
 ```
 
-`.dev.vars.example` を `.dev.vars` にコピーして 1Password `op inject` で値埋め。
+`.dev.vars.example` を `.dev.vars` にコピーして 1Password 参照を埋める。詳細は [docs/onboarding.md](docs/onboarding.md)。
 
-## Endpoints
+## 開発の約束
 
-auth 列の `Access` は Cloudflare Access JWT (`Cf-Access-Jwt-Assertion` 検証、#29)。admin は endpoint 数が多いので代表のみ — 全量は `src/routes/admin.ts` / `src/routes/dashboard/index.ts` 参照。
-
-| method | path | auth | 概要 |
-|---|---|---|---|
-| GET | `/health` | none | `{status, timestamp}` |
-| POST | `/trade/decide` | Access | Signal + OrderIntent + RiskDecision を返す (発注しない) |
-| POST | `/trade/execute` | Access | 上記 + ExecutionResult (`dry_run=1` で Mock、0 で Webull) |
-| POST | `/webull/order/place` | Access | 低レベル疎通 endpoint (`dry_run=1` で synthetic response、`dry_run=0` は 403 で拒否。実発注は `/trade/execute` か `/admin/strategy/run` 経由) |
-| GET | `/admin/production-readiness` | Access | 本番 gate 解除前の fail-closed preflight (#379) |
-| POST | `/admin/strategy/run` | Access | `runStrategyCron` 手動 trigger (cron 待たず試走) |
-| POST | `/admin/trading/toggle` | Access | `trading_enabled` の切替 (履歴を `trading_toggle_history` に記録) |
-| POST | `/admin/orders/{reconcile,sync-holdings}` | Access | `reconcileFills` / broker 保有との同期を手動 trigger |
-| GET | `/admin/orders/:clientOrderId` | Access | Webull order history を client_order_id で検索 |
-| POST | `/admin/portfolio/{seed-equity,roll-daily,seed-exposure}` | Access | equity 初期化 / EOD rollover / exposure 投入 |
-| POST | `/admin/symbol-config/...` | Access | 銘柄の追加 / 更新 / active 切替 / 予算配分 / 取扱可否チェック |
-| POST | `/admin/webull-token/{seed,refresh}` | Access | `x-access-token` の DO への投入 / 更新 |
-| GET/POST | `/admin/{earnings,macro-events}` | Access | イベントカレンダーの参照 / 投入 / 削除 |
-| GET | `/dashboard` | Access | read-only ランディング (資産サマリ / KPI / equity / 保有 / 直近取引) |
-| GET | `/dashboard/{positions,portfolio,trades,config,cron,charts,symbols,events,alerts,audit,broker-probe,webull-token}` | Access | DO / D1 snapshot を HTML で可視化 |
-| GET | `/dashboard/{positions,trades,cron,charts/symbol}/json` | Access | 同 packet の JSON 版 |
-| GET/POST/DELETE | `/mcp` | Access (service token) | read-only MCP server。dashboard と同一 packet を tool として公開 (#553) |
-
-Cron:
-- `*/5 * * * *` — quote feed (bars → SymbolStateDO) + `reconcileFills`
-- `*/15 * * * *` — strategy cron (USD + JPY currency-aware、JP は `lot_size` 丸め)
-- `0 22 * * *` — portfolio roll (EOD) + Webull token refresh + market data health check + tradable allowlist 更新
-
-## Bindings (wrangler.jsonc)
-
-| 種別 | 名前 | 説明 |
-|---|---|---|
-| Durable Object | `SYMBOL_STATE` | 銘柄ごとの position / pending / cooldown |
-| Durable Object | `PORTFOLIO_STATE` | 日次 equity / drawdown kill |
-| Durable Object | `WEBULL_TOKEN_STATE` | `x-access-token` の保持と自動 refresh (#21 Phase B) |
-| Rate Limit | `STATE_CHANGE_RATE_LIMIT` | 5 req / 60s — `trading/toggle` 等の状態変更 |
-| Rate Limit | `ADMIN_WRITE_RATE_LIMIT` | 20 req / 60s — その他 admin write |
-| Rate Limit | `DASHBOARD_RATE_LIMIT` | 60 req / 60s — dashboard GET |
-| D1 Database | `DB` | trade_journal / symbol_config / global_config / strategy_decision_log ほか |
-
-## Secrets (`wrangler secret put`)
-
-運用可変値は D1 に逃げたので、ここに残るのは **認証情報と非公開 URL のみ**:
-
-| Secret | 用途 |
-|---|---|
-| `CF_ACCESS_TEAM_DOMAIN` / `CF_ACCESS_AUD` | Cloudflare Access JWT 検証 (#29)。旧 `BASIC_AUTH_*` は廃止 |
-| `CF_ACCESS_MCP_AUD` | `/mcp` 専用 Access application の AUD (#553)。未設定なら `CF_ACCESS_AUD` に fallback |
-| `WEBULL_APP_KEY` / `WEBULL_APP_SECRET` / `WEBULL_ACCOUNT_ID_JP_CASH` | broker 署名・口座 (JP_CASH 単一口座、#109) |
-| `WEBULL_TRADE_API_BASE` | trade API host override (#21)。未設定なら JP prod default (`https://api.webull.co.jp`)。UAT は ALB URL を投入 |
-| `WEBULL_QUOTES_API_BASE` | quotes API host override (#21)。未設定なら JP prod default (`https://data-api.webull.co.jp`)。UAT は ALB URL を投入 |
-| `WEBULL_EVENTS_API_BASE` | events API host override (#21、consumer 未実装)。未設定なら JP prod default (`https://events-api.webull.co.jp`) |
-| `WEBULL_ACCESS_TOKEN` | `x-access-token` の bootstrap fallback (#21)。signature とは直交する supplemental auth、JP 本番では必須。`pnpm run issue-token` で発行 + 2FA verify して取得する (下記参照)。通常運用では DO seed 後に自動 refresh される |
-| `SLACK_WEBHOOK_URL` / `DISCORD_WEBHOOK_URL` | 通知先 webhook (#199)。未設定ならその channel は無効 |
-| `DASHBOARD_BASE_URL` | 通知に添える dashboard link の base URL |
-
-```bash
-pnpm wrangler secret put CF_ACCESS_AUD --env=staging
-# ... 1 件ずつ、誤 env 防止のため loop 化しない
-pnpm wrangler secret list --env=staging   # 揃ったか確認
-```
-
-`x-access-token` は secret ではなく `WEBULL_TOKEN_STATE` DO を正とする運用 (`WEBULL_ACCESS_TOKEN` は DO seed 前の bootstrap fallback)。
-
-### Webull account_id を取得する
-
-Webull sandbox は dashboard で account_id を見られないので、app_key + app_secret だけで API を叩いて取得する。host は env 未設定なら JP prod default (`api.webull.co.jp`):
-
-```bash
-WEBULL_APP_KEY="$(op read 'op://Personal/WEBULL_APP_KEY/credential')" \
-WEBULL_APP_SECRET="$(op read 'op://Personal/WEBULL_APP_SECRET/credential')" \
-  pnpm run accounts
-
-# UAT で叩く場合は ALB URL を override:
-WEBULL_APP_KEY=... WEBULL_APP_SECRET=... \
-WEBULL_TRADE_API_BASE=https://jp-openapi-alb.uat.webullbroker.com \
-  pnpm run accounts
-```
-
-### Webull `x-access-token` を発行する (#21)
-
-JP 本番では signature に加えて 2FA-backed `x-access-token` が必須。`pnpm run issue-token` が `/openapi/auth/token/create` を叩いて PENDING token を発行し、operator が Webull モバイルアプリで 2FA SMS verify を完了するのを poll で待ち、NORMAL になった token を stdout に出力する。
-
-```bash
-# 1. Operator script を起動
-WEBULL_APP_KEY="$(op read 'op://Personal/WEBULL_APP_KEY/credential')" \
-WEBULL_APP_SECRET="$(op read 'op://Personal/WEBULL_APP_SECRET/credential')" \
-  pnpm run issue-token
-
-# 2. ログに表示された PENDING token を確認し、Webull モバイルアプリで 5 分以内に
-#    2FA SMS verify を完了する。script は 30 秒毎に check_token を poll する。
-
-# 3. status=NORMAL になると stdout に token 文字列だけが出力されるので、
-#    そのまま wrangler に流し込める:
-pnpm wrangler secret put WEBULL_ACCESS_TOKEN --env=production
-# (上で出力された token 文字列を貼り付ける)
-
-# refresh (既存 token を引き継いで更新したい場合):
-WEBULL_APP_KEY=... WEBULL_APP_SECRET=... \
-WEBULL_EXISTING_TOKEN=<old token> \
-  pnpm run issue-token
-```
-
-15 days inactivity で `INVALID` 化する。取得した token は `POST /admin/webull-token/seed` (または `/dashboard/webull-token` の画面) で `WEBULL_TOKEN_STATE` DO に投入する。以降は `0 22 * * *` cron が expires 残り 7 days を切ったら `createToken(existingToken)` で自動 refresh し、失敗時は critical 通知が飛ぶ。
-
-## D1 セットアップ (初回のみ)
-
-staging:
-
-```bash
-# 1. DB 作成 → 出力される database_id を wrangler.jsonc に貼る
-pnpm wrangler d1 create webull-trading-staging
-
-# 2. migration 適用
-pnpm wrangler d1 migrations apply webull-trading-staging --env=staging --remote
-
-# 3. 初期シード
-pnpm wrangler d1 execute webull-trading-staging --env=staging --remote --file=docs/seed/symbol_config.sql
-pnpm wrangler d1 execute webull-trading-staging --env=staging --remote --file=docs/seed/global_config.sql
-```
-
-schema 変更・運用 SQL レシピは [`docs/db-operations.md`](docs/db-operations.md) に集約。
-
-## Deploy
-
-deploy は Cloudflare Workers Builds の CD 任せ。手動 `wrangler deploy` は通常不要 (migration も CD に含まれる):
-
-| Branch | deploy 先 | build command |
-|---|---|---|
-| `main` | staging | `pnpm deploy:staging` |
-| `production` | production | `pnpm deploy:production` |
-
-production は `main` から自動生成される `release/production` → `production` の release PR merge が唯一の入口 (`production` への direct push は禁止)。詳細は [`docs/production-cd.md`](docs/production-cd.md)。
-
-`pnpm run deploy:*` が migration → deploy を `&&` で繋ぐので、migration 失敗時は worker がデプロイされない (壊れた schema に新 code が当たる事故を防ぐ)。production はさらに `pnpm verify:production-d1` が前段に入り、`database_id` 未設定なら止まる。
-
-## 運用
-
-銘柄追加 / trading toggle / token 投入といった日常操作は `/dashboard` の画面と `/admin/*` API から行える (変更は `config_audit_log` / `trading_toggle_history` に記録される)。画面が無い項目や緊急時は wrangler CLI から直接 SQL を叩く:
-
-```bash
-# 新 symbol 追加
-pnpm wrangler d1 execute webull-trading-staging --env=staging --remote \
-  --command "INSERT INTO symbol_config (symbol, name, market, active, max_notional, updated_at) \
-             VALUES ('GLD', 'SPDR Gold Shares', 'US', 1, 5000, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
-
-# 実発注 ON
-pnpm wrangler d1 execute webull-trading-staging --env=staging --remote \
-  --command "UPDATE global_config SET dry_run = 0, trading_enabled = 1, \
-             updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = 'default'"
-
-# 緊急 kill-switch
-pnpm wrangler d1 execute webull-trading-staging --env=staging --remote \
-  --command "UPDATE global_config SET trading_enabled = 0 WHERE id = 'default'"
-
-# Pullback rule / risk param を runtime tuning (#118 / #124 / #125 / #126)
-pnpm wrangler d1 execute webull-trading-staging --env=staging --remote \
-  --command "UPDATE global_config SET \
-             pullback_default_k_atr = 2.5, \
-             risk_dd_half_threshold = -0.05, \
-             vix_critical_threshold = 30.0 \
-             WHERE id = 'default'"
-
-# per-symbol override (global default より優先)
-pnpm wrangler d1 execute webull-trading-staging --env=staging --remote \
-  --command "UPDATE symbol_config SET k_atr_override = 2.5, stop_pct_override = -0.05 WHERE symbol = 'SOXL'"
-
-# 振り返りクエリ
-pnpm wrangler d1 execute webull-trading-staging --env=staging --remote \
-  --command "SELECT trade_event_type, COUNT(*) FROM trade_journal GROUP BY trade_event_type"
-```
-
-より多くのレシピは [`docs/db-operations.md`](docs/db-operations.md) 参照。
+- ブランチは `dev/<topic>`。`main` 直接編集は禁止
+- merge 方式は ruleset で強制済み — `main` は merge commit、`production` は squash
+- commit は Conventional Commits (release-please が採番と CHANGELOG 生成に使う)
+- 発注経路は **Strategy → Risk → Execution** の一方向。Risk を迂回する導線は作らない
 
 ## AI エージェント / レビュー設定
 
@@ -333,4 +47,3 @@ pnpm wrangler d1 execute webull-trading-staging --env=staging --remote \
 - `.claude/skills/coderabbit-policy/` — CodeRabbit findings の採用 / 却下基準
 - `.claude/agents/trading-strategist.md` — 戦略設計 delegate 用 subagent
 - `.coderabbit.yaml` — 自動レビュー設定 (profile: chill + path_instructions)
-

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,104 @@
+# アーキテクチャ
+
+## 全体像
+
+```
+ ┌──────────────┐  */5  * * * *   ┌────────────────────────────────────┐
+ │  Cloudflare  │────────────────▶│ quote feed + reconcileFills         │
+ │   Workers    │  */15 * * * * ─▶│ strategy cron (Pullback / Breakout) │
+ │              │  0 22  * * * ──▶│ portfolio roll + token refresh +    │
+ │              │                 │ market data health + allowlist 更新  │
+ │              │                 └────────────────────────────────────┘
+ │              │  /trade/*     ──▶ decide / execute → Webull HTTP
+ │              │  /admin/*        operator 操作 (Cloudflare Access)
+ │              │  /dashboard/*    read-only SSR  (Cloudflare Access)
+ │              │  /mcp            read-only MCP  (Access service token)
+ └──────┬───────┘
+        │
+ ┌──────┴────────────────────────────────────────────────────┐
+ │              Durable Objects  +  D1                         │
+ │  SYMBOL_STATE (per-symbol: position / pending / cooldown)   │
+ │  PORTFOLIO_STATE (daily equity / drawdown kill)             │
+ │  WEBULL_TOKEN_STATE (x-access-token + 自動 refresh)          │
+ │  DB: trade_journal / symbol_config / global_config /        │
+ │      strategy_decision_log / earnings_calendar /            │
+ │      macro_event_calendar / config_audit_log /              │
+ │      portfolio_equity_snapshot / tradable_instrument /      │
+ │      attention_observation ...                              │
+ └─────────────────────────────────────────────────────────────┘
+```
+
+発注経路は **Strategy → Risk → Execution** の一方向。Risk で止まる導線を迂回する経路は作らない。
+
+> gRPC bridge (Node Container) は PR #110 で撤去済。SELL 後処理は `reconcileFills` に統合され、`/events/trade` ingest も廃止された。
+
+## Cron
+
+| schedule | 内容 |
+|---|---|
+| `*/5 * * * *` | quote feed (bars → SymbolStateDO) + `reconcileFills` |
+| `*/15 * * * *` | strategy cron (USD + JPY currency-aware、JP は `lot_size` 丸め) |
+| `0 22 * * *` | portfolio roll (EOD) + Webull token refresh + market data health check + tradable allowlist 更新 |
+
+stop / take-profit / time-stop は**ブローカー側の逆指値ではなく cron が毎 tick 評価するソフト stop**。cron が止まると建玉は無防備になるため、risk halt は entry だけを止めて exit 判定は継続する (`entryHaltReason`、#595)。
+
+## Bindings (wrangler.jsonc)
+
+| 種別 | 名前 | 説明 |
+|---|---|---|
+| Durable Object | `SYMBOL_STATE` | 銘柄ごとの position / pending / cooldown |
+| Durable Object | `PORTFOLIO_STATE` | 日次 equity / drawdown kill |
+| Durable Object | `WEBULL_TOKEN_STATE` | `x-access-token` の保持と自動 refresh (#21 Phase B) |
+| Rate Limit | `STATE_CHANGE_RATE_LIMIT` | 5 req / 60s — `trading/toggle` 等の状態変更 |
+| Rate Limit | `ADMIN_WRITE_RATE_LIMIT` | 20 req / 60s — その他 admin write |
+| Rate Limit | `DASHBOARD_RATE_LIMIT` | 60 req / 60s — dashboard GET |
+| D1 Database | `DB` | trade_journal / symbol_config / global_config / strategy_decision_log ほか |
+
+## ディレクトリ構成
+
+```
+src/
+  app.ts / index.ts           Hono factory + Workers entry (fetch / scheduled)
+  routes/                     health / trade / webull / admin / mcp + dashboard/ (画面ごとに分割)
+  trading/
+    application/              TradingService
+    domain/                   Signal / OrderIntent / RiskDecision / ExecutionResult / StrategyDecision
+                              + tradingCalendar + tradingCost
+    strategy/                 strategies/ (Pullback / BreakoutMomentum / FixedRule) + pullbackSizing
+                              + stopDistance + indicators + pullbackScheduler + runStrategyCron
+                              + buyingPower + conditionalAllocation
+    risk/                     DefaultRiskPolicy + spreadGuard + jpPriceBand + drawdownRiskScale
+                              + vixRegimeFilter + newsShockGate + earningsGate + macroEventGate
+                              + perSymbolRiskGate + tickerDenyGuard
+    execution/                Execution + MockExecution + WebullExecution
+    reconciliation/           reconcileFills (Webull order history → D1 + DO apply) + syncHoldings
+    state/                    SymbolStateDO / PortfolioStateDO / WebullTokenStateDO + clients / transitions
+    portfolio/                runPortfolioRoll (EOD rollover)
+    news/                     newsScheduler (attention observation の収集)
+    runtime/                  killSwitch + productionReadiness
+    quotes/                   quoteScheduler
+    backtest/                 runBacktest
+  infrastructure/
+    webull/                   WebullReadClient / WebullTradeClient (facade) + WebullHttpClient / WebullAuth
+                              + mapper + token flow + tradability / instrument lookup / allowlist refresh
+    quotes/                   BarClient / YahooBarClient / YahooQuoteClient / WebullQuoteClient / fxRate
+    news/                     GdeltDocClient + newsProbes
+    calendar/                 us・jp market calendar + earnings / macro event repo
+    notification/             Notifier 実装 + Slack/Discord webhook + 状態変化検知
+    logger/                   AuditLogger + tradeJournal + strategyDecisionLog (console + D1 sink)
+    db/                       drizzle schema + 各 repo + loaders
+  middleware/                 accessJwt (Cloudflare Access) + rateLimit
+  shared/                     errors / format
+  config/                     env (secret / binding の型定義と parser)
+scripts/                      issue-webull-token / list-webull-accounts / guard-deploy
+                              / verify-production-d1 / backtest-*
+drizzle/                      generated D1 migrations
+docs/                         本ディレクトリ (下記 index は README)
+test/                         vitest suite
+```
+
+## 層の境界
+
+- Webull の raw JSON は `infrastructure/webull/` に閉じ込め、application / domain には正規化後のドメイン型だけを流す
+- `rawPayload` は監査用に保持するが、domain ロジックからは参照しない
+- 時刻は UTC の ISO 8601 で保存し、市場時間への変換は表示側で行う

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,95 @@
+# Runtime 設定 (global_config / symbol_config)
+
+運用パラメタは **D1 が真値**。`global_config` singleton (`id='default'`) を `UPDATE` すれば **deploy なしで次の cron から反映**される (#118 で確立した方針)。未シード時は `GLOBAL_CONFIG_DEFAULTS` にフォールバックする。
+
+編集手順と SQL レシピは [`db-operations.md`](db-operations.md)、画面からの操作は `/dashboard/config` と `/dashboard/symbols`。変更は `config_audit_log` / `trading_toggle_history` に記録される。
+
+## Kill-switch / gate
+
+| フィールド | 既定 | 意味 |
+|---|---|---|
+| `dry_run` | `1` | Execution Mock に固定、broker へ送らない |
+| `trading_enabled` | `0` | Risk layer が全注文 reject (**exit も止まる** 唯一の停止) |
+| `market_hours_check` | `0` | UTC 13:30-20:00 Mon-Fri チェック |
+| `session_window_gate_enabled` | `0` | 開場 30 分前〜引けの窓外は戦略 cron の評価自体を skip |
+| `drawdown_kill_threshold` | `-0.02` | 日次 realized_pnl / start_equity 比で自動 kill (**entry のみ停止**、#595) |
+| `stale_quote_ms` | `900000` | halt 判定 (15 min) |
+
+## 通貨別 cap / 予算 (#76)
+
+| フィールド | 既定 | 意味 |
+|---|---|---|
+| `max_order_notional_usd` | `2000` | USD 銘柄の 1 注文上限 ($) |
+| `max_order_notional_jpy` | `100000` | JPY 銘柄の 1 注文上限 (¥) |
+| `total_capital_usd` / `_jpy` | `NULL` | NAV (NULL なら exposure check skip) |
+| `max_portfolio_exposure_pct` | `0.6` | total_capital × これを超える open 合計を禁止 |
+| `spread_limit_pct_{us,jp}` | `0.0025` / `0.006` | spread guard |
+| `gap_reject_pct` | `0.03` | gap 判定 |
+
+## 売買コスト (#trade-cost)
+
+| フィールド | 既定 | 意味 |
+|---|---|---|
+| `fee_pct_of_notional` | `0` | 約定代金に対する料率。realized PnL を net 化する |
+| `fee_fixed_per_order` | `0` | 1 注文あたりの固定費 (銘柄通貨建て) |
+
+> **米国株・ETF の売買手数料は 2026-07-27 17:30 JST 約定分から無料** (ウィブル証券、恒久)。それ以前は 0.20% 税抜 / 片道。残るのは売却時の SEC ($20.60/$1M) と FINRA TAF ($0.000195/株)、CAT Fee、両替時の為替スプレッド (15 銭/USD) だけで、$200 の往復なら約 $0.005。**したがって上記 2 列は 0 のままが実態に一致する**。根拠は `src/trading/domain/tradingCost.ts` の冒頭コメント。
+
+## Pullback 戦略の default rule (#118 / #124)
+
+| フィールド | 既定 | 意味 |
+|---|---|---|
+| `pullback_default_stop_pct` | `-0.04` | pct-based stop (ATR stop の floor) |
+| `pullback_default_take_profit_pct` | `0.07` | take-profit |
+| `pullback_default_time_stop_days` | `10` | 保有上限 (営業日) |
+| `pullback_default_pullback_{max,min}` | `-0.03` / `-0.06` | entry 窓 (直近 10 営業日高値から) |
+| `pullback_default_min_return_50d` | `0.08` | **20 営業日**リターンの uptrend filter (列名の `50d` は #318 以前の名残) |
+| `pullback_default_require_above_sma50` | `1` | sma50 超を entry 必須 |
+| `pullback_default_k_atr` | `2.0` | ATR 倍率。`stopDistance = max(k_atr × atr20, pct stop)` |
+| `pullback_default_max_sma50_deviation_pct` | `0.6` | sma50 からの上方乖離が大きすぎる時は entry 見送り |
+| `pullback_default_max_atr_ratio` | `1.5` | ATR 拡大 (ボラ急騰) 時の entry 見送り閾値 |
+| `pullback_default_max_stop_to_tp_ratio` | `2.0` | stop 幅の上限 = `take_profit_pct × これ`。R:R に下限を作る (2.0 = R:R 0.5 以上)。`0` で無効 |
+| `atr_baseline_exclude_recent` | `0` | baseline ATR から直近 20 本を除外。`1` にすると比率が素直になるが**閾値の再校正が必要** ([#598](https://github.com/ochanuco/webull-trading/pull/598)) |
+
+## Risk gate の動的パラメタ (#23)
+
+| フィールド | 既定 | 意味 |
+|---|---|---|
+| `risk_base_per_trade_pct` | `0.004` | 1 trade 基準 risk (%) |
+| `risk_dd_half_threshold` | `-0.05` | 日次 DD でこれ未満 → size 0.5× |
+| `risk_dd_halt_threshold` | `-0.10` | 日次 DD でこれ未満 → size 0 (halt) |
+| `vix_warning_threshold` | `25.0` | VIX がこれ超で size scale 適用 |
+| `vix_critical_threshold` | `30.0` | VIX がこれ超で新規 entry 停止 |
+| `vix_warning_size_scale` | `0.5` | warning 帯での size 倍率 |
+| `pair_regime_mode` | `'off'` | ペアレジーム layer (#472)。`off` / `observe` (log のみ) / `enforce` |
+| `cash_fallback_orders_enabled` | `0` | 余剰現金の退避先 (SGOV 等) への自動 BUY を許可 (#452) |
+
+## ニュースショック gate
+
+`attention_observation` (GDELT 由来) を baseline と比較して急騰を検知する。
+
+| フィールド | 既定 | 意味 |
+|---|---|---|
+| `news_shock_mode` | `'off'` | `off` / `observe` (log のみ) / `enforce` |
+| `news_shock_warn_ratio` | `2.3` | baseline median 比でこれ超 → warning (12ヶ月実測の p90 由来) |
+| `news_shock_block_ratio` | `4.4` | 同、これ超 → BUY block (上位約 1%) |
+| `news_shock_warn_size_scale` | `0.5` | warning 帯での size 倍率 |
+| `news_shock_tone_drop_threshold` | `1.5` | tone 悪化の閾値 |
+| `news_shock_require_tone` | `1` | tone が取れないとき shock 判定を成立させない |
+| `news_shock_baseline_days` | `7` | baseline の対象日数 |
+| `news_shock_min_samples` | `200` | baseline 成立に必要な最小サンプル数 |
+| `news_shock_window_min` | `120` | 評価窓 (分) |
+| `news_shock_max_age_min` | `90` | 観測値の許容鮮度 (分) |
+| `attention_stale_policy` | `'fail_open'` | 観測が古い時の扱い。`fail_open` / `block_buy` |
+
+## per-symbol / テーブル由来の制御
+
+- `symbol_config.active = 0` にすれば universe から外れて cron から除外される
+- `symbol_config` の override (`stop_pct_override` / `k_atr_override` / `lot_size` / `budget_alloc_pct` / `role` など) が global default に優先する
+- `inverse_pairs` で SOXL/SOXS のような同時保有を構造的に禁止する
+- `tradable_instrument` は Webull の取扱可能銘柄 allowlist (日次 refresh)
+
+## アクセス制御
+
+- Cloudflare Access JWT で `/trade/*` / `/webull/*` / `/admin/*` / `/dashboard/*` / `/mcp` を保護 (#29)
+- state 変更 / admin write / dashboard GET は Workers Rate Limit binding で cap (#285)

--- a/docs/db-operations.md
+++ b/docs/db-operations.md
@@ -138,9 +138,25 @@ WHERE id = 'default';
 UPDATE global_config SET drawdown_kill_threshold = -0.03, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
 WHERE id = 'default';
 
+-- 戦略 / risk パラメタの runtime tuning (全一覧は docs/configuration.md)
+UPDATE global_config SET
+  pullback_default_k_atr = 2.5,
+  risk_dd_half_threshold = -0.05,
+  vix_critical_threshold = 30.0,
+  updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE id = 'default';
+
 -- 現状確認
 SELECT dry_run, trading_enabled, max_order_notional_usd, max_order_notional_jpy, drawdown_kill_threshold
 FROM global_config WHERE id = 'default';
+```
+
+per-symbol override は global default より優先される:
+
+```sql
+UPDATE symbol_config SET k_atr_override = 2.5, stop_pct_override = -0.05,
+  updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE symbol = 'SOXL';
 ```
 
 ## currency + budget (#76 Phase E)

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -1,0 +1,27 @@
+# Endpoints
+
+auth 列の `Access` は Cloudflare Access JWT (`Cf-Access-Jwt-Assertion` 検証、#29)。admin は数が多いので代表のみ — 全量は `src/routes/admin.ts` / `src/routes/dashboard/index.ts` を参照。
+
+| method | path | auth | 概要 |
+|---|---|---|---|
+| GET | `/health` | none | `{status, timestamp}` |
+| POST | `/trade/decide` | Access | Signal + OrderIntent + RiskDecision を返す (発注しない) |
+| POST | `/trade/execute` | Access | 上記 + ExecutionResult (`dry_run=1` で Mock、0 で Webull) |
+| POST | `/webull/order/place` | Access | 低レベル疎通用 (`dry_run=1` で synthetic response、`dry_run=0` は 403 で拒否。実発注は `/trade/execute` か `/admin/strategy/run` 経由) |
+| GET | `/admin/production-readiness` | Access | 本番 gate 解除前の fail-closed preflight (#379) |
+| POST | `/admin/strategy/run` | Access | `runStrategyCron` 手動 trigger (cron を待たず試走) |
+| POST | `/admin/trading/toggle` | Access | `trading_enabled` の切替 (履歴を `trading_toggle_history` に記録) |
+| POST | `/admin/orders/{reconcile,sync-holdings}` | Access | `reconcileFills` / broker 保有との同期を手動 trigger |
+| GET | `/admin/orders/:clientOrderId` | Access | Webull order history を client_order_id で検索 |
+| GET | `/admin/orders/repair-status` | Access | `pendingApply` 件数だけ返す軽量 query |
+| POST | `/admin/portfolio/{seed-equity,roll-daily,seed-exposure}` | Access | equity 初期化 / EOD rollover / exposure 投入 |
+| POST | `/admin/symbol-config/...` | Access | 銘柄の追加 / 更新 / active 切替 / 予算配分 / 取扱可否チェック |
+| POST | `/admin/webull-token/{seed,refresh}` | Access | `x-access-token` の DO への投入 / 更新 |
+| GET/POST/DELETE | `/admin/{earnings,macro-events}` | Access | イベントカレンダーの参照 / 投入 / 削除 |
+| GET | `/admin/backtest` | Access | offline backtest (Yahoo daily bars + 戦略 rule、実発注なし) |
+| GET | `/dashboard` | Access | read-only ランディング (資産サマリ / KPI / equity / 保有 / 直近取引) |
+| GET | `/dashboard/{positions,portfolio,trades,config,cron,charts,symbols,events,alerts,audit,broker-probe,webull-token}` | Access | DO / D1 snapshot を HTML で可視化 |
+| GET | `/dashboard/{positions,trades,cron,charts/symbol}/json` | Access | 同 packet の JSON 版 |
+| GET/POST/DELETE | `/mcp` | Access (service token) | read-only MCP server。dashboard と同一 packet を tool として公開 (#553) |
+
+ブラウザ外から叩くときは `cloudflared access curl` を使う (Access のログインセッションを流用する。service token は本体 application 側で 302 になるため不可)。調査用クエリ集は [`review-queries.md`](review-queries.md)。

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,0 +1,114 @@
+# オンボーディング
+
+このリポジトリで開発を始めるまでの手順。設計の全体像は [`architecture.md`](architecture.md)、運用パラメタは [`configuration.md`](configuration.md)。
+
+## 前提
+
+- pnpm 11+ / Node 24 / TypeScript strict (`moduleResolution: Bundler`)
+- **実マネーが流れる前提**で書く。安全既定は fail-closed (`dry_run=1` / `trading_enabled=0`)
+- ブランチは `dev/<topic>`。`main` 直接編集は禁止。merge 方式は ruleset で強制済み (`main`=merge commit / `production`=squash)
+
+## ローカル開発
+
+```bash
+pnpm install
+pnpm run typecheck                # tsc --noEmit
+pnpm test                         # vitest
+pnpm dev                          # wrangler dev (ローカル D1 自動作成)
+pnpm exec wrangler deploy --dry-run
+```
+
+`.dev.vars.example` を `.dev.vars` にコピーし、1Password 参照 (`op://...`) を埋める。`op run --env-file=.dev.vars -- <cmd>` で解決される。key の一覧と用途は `.dev.vars.example` のコメントを参照。
+
+ローカルは `ENVIRONMENT` が production 以外なので `WebullTradeClient.placeOrder` が throw する。実発注は production からしか出ない。
+
+## D1 セットアップ
+
+初回のみ。手順と運用 SQL は [`db-operations.md`](db-operations.md) に集約している。
+
+```bash
+pnpm wrangler d1 create webull-trading-staging     # → database_id を wrangler.jsonc に貼る
+pnpm wrangler d1 migrations apply webull-trading-staging --env=staging --remote
+pnpm wrangler d1 execute webull-trading-staging --env=staging --remote --file=docs/seed/symbol_config.sql
+pnpm wrangler d1 execute webull-trading-staging --env=staging --remote --file=docs/seed/global_config.sql
+```
+
+## Secrets
+
+運用可変値は D1 に逃がしてあるので、secret に残るのは **認証情報と非公開 URL のみ**。
+
+| Secret | 用途 |
+|---|---|
+| `CF_ACCESS_TEAM_DOMAIN` / `CF_ACCESS_AUD` | Cloudflare Access JWT 検証 (#29)。旧 `BASIC_AUTH_*` は廃止 |
+| `CF_ACCESS_MCP_AUD` | `/mcp` 専用 Access application の AUD (#553)。未設定なら `CF_ACCESS_AUD` に fallback |
+| `WEBULL_APP_KEY` / `WEBULL_APP_SECRET` / `WEBULL_ACCOUNT_ID_JP_CASH` | broker 署名・口座 (JP_CASH 単一口座、#109) |
+| `WEBULL_TRADE_API_BASE` | trade API host override (#21)。未設定なら JP prod default (`https://api.webull.co.jp`) |
+| `WEBULL_QUOTES_API_BASE` | quotes API host override。未設定なら `https://data-api.webull.co.jp` |
+| `WEBULL_EVENTS_API_BASE` | events API host override (consumer 未実装)。未設定なら `https://events-api.webull.co.jp` |
+| `WEBULL_ACCESS_TOKEN` | `x-access-token` の bootstrap fallback。通常運用では DO seed 後に自動 refresh される |
+| `SLACK_WEBHOOK_URL` / `DISCORD_WEBHOOK_URL` | 通知先 webhook (#199)。未設定ならその channel は無効 |
+| `DASHBOARD_BASE_URL` | 通知に添える dashboard link の base URL |
+
+```bash
+pnpm wrangler secret put CF_ACCESS_AUD --env=staging
+# ... 1 件ずつ。誤 env 防止のため loop 化しない
+pnpm wrangler secret list --env=staging
+```
+
+env ごとの分離方針は [`env-separation.md`](env-separation.md)。
+
+## Webull 口座まわりの初期作業
+
+### account_id を取得する
+
+dashboard から確認できないので、app_key + app_secret で API を叩いて取得する。host は未設定なら JP prod default (`api.webull.co.jp`)。
+
+```bash
+WEBULL_APP_KEY="$(op read 'op://Personal/WEBULL_APP_KEY/credential')" \
+WEBULL_APP_SECRET="$(op read 'op://Personal/WEBULL_APP_SECRET/credential')" \
+  pnpm run accounts
+
+# UAT で叩く場合は ALB URL を override
+WEBULL_APP_KEY=... WEBULL_APP_SECRET=... \
+WEBULL_TRADE_API_BASE=https://jp-openapi-alb.uat.webullbroker.com \
+  pnpm run accounts
+```
+
+### `x-access-token` を発行する (#21)
+
+JP 本番では signature に加えて 2FA-backed の `x-access-token` が必須。`pnpm run issue-token` が PENDING token を発行し、モバイルアプリでの 2FA verify 完了を poll で待ち、NORMAL になった token を stdout に出す。
+
+```bash
+# 1. script を起動
+WEBULL_APP_KEY="$(op read 'op://Personal/WEBULL_APP_KEY/credential')" \
+WEBULL_APP_SECRET="$(op read 'op://Personal/WEBULL_APP_SECRET/credential')" \
+  pnpm run issue-token
+
+# 2. 表示された PENDING token を確認し、Webull モバイルアプリで 5 分以内に 2FA SMS verify
+#    (script は 30 秒毎に check_token を poll する)
+
+# 3. status=NORMAL になると token 文字列が stdout に出る
+
+# refresh (既存 token を引き継ぐ場合)
+WEBULL_APP_KEY=... WEBULL_APP_SECRET=... WEBULL_EXISTING_TOKEN=<old token> \
+  pnpm run issue-token
+```
+
+取得した token は `POST /admin/webull-token/seed` (または `/dashboard/webull-token` 画面) で `WEBULL_TOKEN_STATE` DO に投入する。以降は `0 22 * * *` cron が expires 残り 7 days を切ると自動 refresh し、失敗時は critical 通知が飛ぶ。15 days inactivity で `INVALID` 化する。
+
+## デプロイの流れ
+
+deploy は Cloudflare Workers Builds の CD 任せで、手動 `wrangler deploy` は通常不要 (migration も CD に含まれる)。
+
+| Branch | deploy 先 | build command |
+|---|---|---|
+| `main` | staging | `pnpm deploy:staging` |
+| `production` | production | `pnpm deploy:production` |
+
+リリースは release-please が切り、その GitHub Release を起点に production 昇格 PR が作られる。詳細は [`production-cd.md`](production-cd.md)、初回の本番投入手順は [`production-deployment.md`](production-deployment.md)。
+
+## 迷ったら
+
+- 安全側に倒す (実発注しない / エラーを返す / ログだけ残す)
+- Risk チェックを迂回する "便利" helper は作らない
+- POC scope 外の議論は別 issue に切り出す


### PR DESCRIPTION
README が 337 行まで膨れて、アーキテクチャ・全設定値・endpoint・secrets・SQL レシピが 1 枚に同居していました。目的の情報にたどり着けないので分割します。

## After

**README.md は 49 行**。何のシステムか / 安全既定 / ドキュメント索引 / クイックスタート / 開発の約束だけ。

新設:

| ファイル | 内容 |
|---|---|
| `docs/onboarding.md` | 開発の始め方、ローカル実行、secrets 一覧と投入、Webull の account_id 取得と `x-access-token` 発行 |
| `docs/architecture.md` | 全体像・cron・bindings・ディレクトリ構成・層の境界 |
| `docs/configuration.md` | `global_config` / `symbol_config` の全パラメタと既定値 |
| `docs/endpoints.md` | HTTP endpoint 一覧と認証 |

既存の `db-operations` / `env-separation` / `production-cd` / `production-deployment` / `review-queries` はそのまま索引から辿れるようにしました。

## 移動のついでに直したもの

- **表が壊れていた**: 手数料の補足を `> 引用` で表の途中に挿していたため、以降の 2 行 (`atr_baseline_exclude_recent` / `gap_reject_pct`) がテーブルから外れてレンダリングされていた。補足を表の外に出して修正
- **未記載だった設定を追加**: 直近マージされた news shock gate (`news_shock_*` 11 列 + `attention_stale_policy`) を `configuration.md` に記載
- **重複を解消**: README にあった D1 セットアップと SQL レシピは `db-operations.md` に既にあったので索引へのリンクに集約。ただし `db-operations.md` に無かった「戦略パラメタの runtime tuning」「per-symbol override」の 2 レシピは同ファイルへ移設 (消していない)
- **古い記述の更新**: ディレクトリ構成に `news/` `stopDistance` `tradingCost` `newsShockGate` を追加、migration 名の固定記述と test 件数のハードコードを除去 (すぐ陳腐化するため)
- `CLAUDE.md` に docs 索引を追加 (エージェントが README ではなく docs を見に行けるように)

## 検証

- 全 Markdown の相対リンクを走査してリンク切れゼロを確認
- 内容はすべて移設で、削除したのは重複分のみ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **ドキュメント**
  - READMEを簡潔に再構成し、運用方針、クイックスタート、関連資料へのリンクを追加しました。
  - オンボーディング手順、アーキテクチャ、設定、APIエンドポイントのガイドを新規追加・拡充しました。
  - 実行時設定の変更方法や、銘柄別設定を含むデータベース運用例を追加しました。
  - 安全な既定値、アクセス制御、実発注環境の前提を確認しやすくしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->