### PR TITLE
feat(dashboard): demote diagnostics out of the daily navigation

### DIFF
--- a/src/routes/dashboard/index.ts
+++ b/src/routes/dashboard/index.ts
@@ -55,7 +55,7 @@ import { WebullTokenClient } from '../../infrastructure/webull/WebullTokenClient
 import { WebullTokenStateClient } from '../../trading/state/WebullTokenStateClient'
 import type { WebullTokenState } from '../../trading/state/WebullTokenStateDO'
 import { clampLimit, jsonPretty, messageOf, parseCursor, unavailable } from './shared'
-import { type DashboardBindings, loadKillSwitchState, renderAnalysisSubnav, renderLayout } from './layout'
+import { type DashboardBindings, loadKillSwitchState, renderAnalysisSubnav, renderDiagSubnav, renderLayout } from './layout'
 import { extractTokenFromPaste, renderWebullTokenBody } from './webullToken'
 import { brokerProbeBody } from './brokerProbe'
 import { ALL_OVERVIEW_PANELS, type OverviewData, loadRecentFills, overviewBody, parseOverviewPanels } from './overview'
@@ -100,7 +100,7 @@ export { assignPairColors, computeBudgetUsage, orderRowsByPair, pairRoles, rende
 
 /**
  * /charts の subnav (#remove-grid): チャート専用 subnav は廃止し、overview
- * (資産推移) / quality (取引品質) は trades / cron / alerts と同じ「履歴・分析」
+ * (資産推移) / quality (取引品質) は約定履歴と同じ「レビュー」
  * subnav に統一する (画面によってメニュー構成が変わる混乱を避ける)。
  * 個別銘柄タブは「銘柄」nav + 銘柄レールが導線なので subnav なし。
  */
@@ -636,8 +636,8 @@ export const dashboard = new Hono<DashboardBindings>()
     }
   })
   .get('/cron', async (c) => {
-    // subnav の active は一覧 / マトリクスで切替 (履歴・分析 subnav #dashboard-ia)。
-    const cronSubnav = renderAnalysisSubnav(c.req.query('view') === 'matrix' ? 'matrix' : 'cron')
+    // subnav の active は一覧 / マトリクスで切替 (診断 subnav #dashboard-ia)。
+    const cronSubnav = renderDiagSubnav(c.req.query('view') === 'matrix' ? 'matrix' : 'cron')
     if (!c.env.DB) {
       return c.html(renderLayout(c, '戦略判定', unavailable('DB not bound'), cronSubnav))
     }
@@ -743,7 +743,7 @@ export const dashboard = new Hono<DashboardBindings>()
   })
   .get('/alerts', async (c) => {
     if (!c.env.DB) {
-      return c.html(renderLayout(c, 'アラート', unavailable('DB not bound'), renderAnalysisSubnav('alerts')))
+      return c.html(renderLayout(c, 'アラート', unavailable('DB not bound'), renderDiagSubnav('alerts')))
     }
     const limit = clampAlertLimit(c.req.query('limit'))
     const before = parseCursor(c.req.query('before'))
@@ -769,13 +769,13 @@ export const dashboard = new Hono<DashboardBindings>()
           c,
           'アラート',
           alertsBody({ rows, limit, severityFilter, eventTypeFilter, currentQuery, universe, before, hasMore }),
-          renderAnalysisSubnav('alerts'),
+          renderDiagSubnav('alerts'),
         ),
       )
     } catch (err) {
       // 0012 migration 未適用 (= notification_emit_log テーブル無し) を
       // 500 にせず unavailable に落とす。段階的デプロイ時の自己保護。
-      return c.html(renderLayout(c, 'アラート', unavailable(messageOf(err)), renderAnalysisSubnav('alerts')))
+      return c.html(renderLayout(c, 'アラート', unavailable(messageOf(err)), renderDiagSubnav('alerts')))
     }
   })
   .get('/audit', async (c) => {

--- a/src/routes/dashboard/layout.ts
+++ b/src/routes/dashboard/layout.ts
@@ -42,7 +42,7 @@ export const STYLE = `
   /* shell: 上部グローバル nav + main (グローバルメニュー上部化 — 左はページ固有
      コンテンツ用に空ける。チャート個別銘柄タブの銘柄レール等)。
      header は topnav (1段目) + ページ固有 subnav (2段目、例: チャートの
-     履歴・分析の 約定履歴/戦略判定/... など) の最大2段で sticky。 */
+     レビューの 約定履歴/取引品質/... など) の最大2段で sticky。 */
   .header{position:sticky;top:0;z-index:100;background:#fff;border-bottom:1px solid #d0d0d5}
   .topnav{display:flex;align-items:center;gap:4px;padding:6px 16px;flex-wrap:wrap}
   .topnav .brand{font-weight:700;font-size:15px;margin-right:12px;white-space:nowrap;color:#1d1d1f}
@@ -220,7 +220,7 @@ export function renderLayout(
 ): string {
   const killSwitch = killSwitchTopnav(c.var.killSwitchState)
   // active 判定はグループ単位の前方一致 (#dashboard-ia)。/charts は ?tab= で
-  // 「銘柄」(symbol) と「履歴・分析」(overview/quality) に分かれるため
+  // 「銘柄」(symbol) と「レビュー」(overview/quality) に分かれるため
   // query も見る。
   let tab: string | null = null
   try {
@@ -232,11 +232,21 @@ export function renderLayout(
 }
 
 /**
- * グローバル nav (#dashboard-ia): 4 項目 + 運用ドロップダウンに削減。
- * 資産系 (/positions /portfolio) はホームに統合したため nav からは外す
+ * グローバル nav (#dashboard-ia Phase 1): 日常の 3 画面 + 管理 + 診断。
+ *
+ * 実利用は「銘柄」「ホームの約定」「取引品質の一部」に偏っており、判定ログ・
+ * アラート・監査・broker 診断・token は平常時に開かれない。**消さずに前面から
+ * 下げる**のがこの再編の主旨で、Phase 1 では URL も機能も変えず、どこから
+ * 辿れるかだけを変える。
+ *
+ * - 管理 (`ops`): 書き込みを伴う画面だけ
+ * - 診断 (`diag`): 障害時にだけ開く画面。MCP は同じ D1 に依存するので AI では
+ *   代替できず、削除はしない
+ *
+ * 資産系 (/positions /portfolio) はホームに統合済みのため nav には出さない
  * (URL は直アクセス可のまま維持)。
  */
-export type NavGroupKey = 'home' | 'symbol' | 'analysis' | 'ops'
+export type NavGroupKey = 'home' | 'symbol' | 'review' | 'ops' | 'diag'
 
 export const NAV_GROUPS: ReadonlyArray<{
   key: NavGroupKey
@@ -244,17 +254,27 @@ export const NAV_GROUPS: ReadonlyArray<{
   text: string
   title?: string
 }> = [
-  { key: 'home', href: '/dashboard', text: 'ホーム', title: '今日の状況 (資産サマリ / 保有 / 直近の判定)' },
+  { key: 'home', href: '/dashboard', text: 'ホーム', title: '今日の状況 (運転状態 / 建玉 / 直近の活動)' },
   { key: 'symbol', href: '/dashboard/charts?tab=symbol', text: '銘柄', title: '個別銘柄チャート (判定 pin / ラダー / 約定マーカー)' },
-  { key: 'analysis', href: '/dashboard/trades', text: '履歴・分析', title: '約定履歴 / 戦略判定 / 取引品質 / 資産推移 / アラート' },
+  { key: 'review', href: '/dashboard/trades', text: 'レビュー', title: '約定履歴 / 取引品質 / 資産推移' },
 ]
 
-/** 運用ドロップダウン内リンク (低頻度の運用・管理ページ)。 */
+/** 管理ドロップダウン内リンク (書き込みを伴う低頻度ページ)。 */
 export const OPS_NAV_LINKS: ReadonlyArray<{ href: string; text: string; title?: string }> = [
   { href: '/dashboard/config', text: '設定' },
   { href: '/dashboard/symbols', text: '銘柄管理' },
   { href: '/dashboard/events', text: 'イベント' },
-  { href: '/dashboard/audit', text: '監査ログ' },
+]
+
+/**
+ * 診断ドロップダウン内リンク。平常時は開かないが、障害時の一次情報と証跡は
+ * ここにしか無い (通知 → アラート → requestId → 判定ログ の導線)。
+ */
+export const DIAG_NAV_LINKS: ReadonlyArray<{ href: string; text: string; title?: string }> = [
+  { href: '/dashboard/alerts', text: 'アラート', title: '通知の履歴 (severity / cause で絞り込み)' },
+  { href: '/dashboard/cron', text: '判定ログ', title: 'なぜ買った / 買わなかったかを requestId で追う' },
+  { href: '/dashboard/cron?view=matrix', text: '判定マトリクス', title: '全銘柄 × 直近 cron の判定を一望する' },
+  { href: '/dashboard/audit', text: '監査ログ', title: '設定変更の before/after と実行者' },
   {
     href: '/dashboard/broker-probe',
     text: 'broker 診断',
@@ -275,12 +295,15 @@ export function resolveActiveNavGroup(activePath?: string, tab?: string | null):
   if (!activePath) return null
   if (activePath === '/dashboard' || activePath === '/dashboard/') return 'home'
   if (activePath === '/dashboard/charts') {
-    // symbol タブは「銘柄」、overview (default) / quality は「履歴・分析」。
+    // symbol タブは「銘柄」、overview (default) / quality は「レビュー」。
     // 'grid' は廃止済みタブの legacy alias (parseChartsTab が symbol に畳む)。
-    return tab === 'symbol' || tab === 'grid' ? 'symbol' : 'analysis'
+    return tab === 'symbol' || tab === 'grid' ? 'symbol' : 'review'
   }
-  for (const p of ['/dashboard/trades', '/dashboard/cron', '/dashboard/alerts']) {
-    if (activePath === p || activePath.startsWith(`${p}/`)) return 'analysis'
+  if (activePath === '/dashboard/trades' || activePath.startsWith('/dashboard/trades/')) {
+    return 'review'
+  }
+  for (const p of ['/dashboard/cron', '/dashboard/alerts', '/dashboard/audit', '/dashboard/broker-probe', '/dashboard/webull-token']) {
+    if (activePath === p || activePath.startsWith(`${p}/`)) return 'diag'
   }
   for (const l of OPS_NAV_LINKS) {
     if (activePath === l.href || activePath.startsWith(`${l.href}/`)) return 'ops'
@@ -294,22 +317,33 @@ export function renderTopNav(active?: NavGroupKey | null): string {
     const t = g.title ? ` title="${esc(g.title)}"` : ''
     return `<a class="nav-link${activeCls}" href="${g.href}"${t}>${esc(g.text)}</a>`
   }).join('')
-  const opsLinks = OPS_NAV_LINKS.map((l) => {
-    const t = l.title ? ` title="${esc(l.title)}"` : ''
-    return `<a class="nav-link" href="${l.href}"${t}>${esc(l.text)}</a>`
-  }).join('')
-  // 運用は kill switch と同じ details ドロップダウン。summary 自体が現在地
-  // 表示を兼ねる (運用系ページでは active 装飾)。
+  const popLinks = (items: ReadonlyArray<{ href: string; text: string; title?: string }>) =>
+    items
+      .map((l) => {
+        const t = l.title ? ` title="${esc(l.title)}"` : ''
+        return `<a class="nav-link" href="${l.href}"${t}>${esc(l.text)}</a>`
+      })
+      .join('')
+  // 管理 / 診断は kill switch と同じ details ドロップダウン。summary 自体が
+  // 現在地表示を兼ねる (配下ページでは active 装飾)。
   return `${links}<span class="nav-sep"></span><details class="topnav-ops">
-    <summary class="nav-link${active === 'ops' ? ' active' : ''}">運用 ▾</summary>
-    <div class="ops-pop">${opsLinks}</div>
+    <summary class="nav-link${active === 'ops' ? ' active' : ''}">管理 ▾</summary>
+    <div class="ops-pop">${popLinks(OPS_NAV_LINKS)}</div>
+  </details><details class="topnav-ops">
+    <summary class="nav-link nav-link-quiet${active === 'diag' ? ' active' : ''}">診断 ▾</summary>
+    <div class="ops-pop">${popLinks(DIAG_NAV_LINKS)}</div>
   </details>`
 }
 
 /**
- * 「履歴・分析」グループ共通の subnav (#dashboard-ia)。charts の
+ * 「レビュー」グループ共通の subnav (#dashboard-ia)。charts の
  * `renderChartsSubnav` と同型で trades / cron / alerts の 3 ページに出す
  * (charts ページ自体は既存の charts subnav のまま — subnav 2 本は出さない)。
+ */
+/**
+ * レビュー内 subnav。判定ログ / 判定マトリクス / アラートは診断へ移したので
+ * ここには出さないが、**個別ページ側は同じ subnav を出して迷子を防ぐ**ため
+ * key 自体は残す (active にならないだけ)。
  */
 export type AnalysisSubnavKey = 'trades' | 'cron' | 'matrix' | 'quality' | 'equity' | 'alerts'
 
@@ -319,12 +353,34 @@ export const ANALYSIS_SUBNAV_ITEMS: ReadonlyArray<{
   label: string
 }> = [
   { key: 'trades', href: '/dashboard/trades', label: '約定履歴' },
-  { key: 'cron', href: '/dashboard/cron', label: '戦略判定' },
-  { key: 'matrix', href: '/dashboard/cron?view=matrix', label: '判定マトリクス' },
   { key: 'quality', href: '/dashboard/charts?tab=quality', label: '取引品質' },
   { key: 'equity', href: '/dashboard/charts', label: '資産推移' },
-  { key: 'alerts', href: '/dashboard/alerts', label: 'アラート' },
 ]
+
+/**
+ * 診断ページ間の subnav。アラート → 判定ログ → 監査の横移動は障害対応で
+ * 実際に使うので、診断側にも subnav を出す (レビュー subnav には出さない)。
+ */
+export type DiagSubnavKey = 'alerts' | 'cron' | 'matrix' | 'audit' | 'probe' | 'token'
+
+const DIAG_SUBNAV_KEY_BY_HREF: Record<string, DiagSubnavKey> = {
+  '/dashboard/alerts': 'alerts',
+  '/dashboard/cron': 'cron',
+  '/dashboard/cron?view=matrix': 'matrix',
+  '/dashboard/audit': 'audit',
+  '/dashboard/broker-probe': 'probe',
+  '/dashboard/webull-token': 'token',
+}
+
+export function renderDiagSubnav(active: DiagSubnavKey): string {
+  return DIAG_NAV_LINKS.map((l) => {
+    const key = DIAG_SUBNAV_KEY_BY_HREF[l.href]
+    if (key === active) {
+      return `<span class="subnav-link active">${esc(l.text)}</span>`
+    }
+    return `<a class="subnav-link" href="${l.href}">${esc(l.text)}</a>`
+  }).join('')
+}
 
 export function renderAnalysisSubnav(active: AnalysisSubnavKey): string {
   return ANALYSIS_SUBNAV_ITEMS.map((i) => {

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -105,7 +105,8 @@ describe('dashboard', () => {
     // nav から外れたため、代わりに再編後のグローバル nav を検証)
     expect(body).toContain('href="/dashboard/charts?tab=symbol"')
     expect(body).toContain('href="/dashboard/trades"')
-    expect(body).toContain('運用 ▾')
+    expect(body).toContain('管理 ▾')
+    expect(body).toContain('診断 ▾')
   })
 
   // #276: kill-switch は全 page 共通でサイドバー下部に表示される (banner → sidebar
@@ -182,7 +183,7 @@ describe('dashboard', () => {
 
   // チャートの view 切替 (概要/取引品質/個別銘柄/銘柄グリッド) は本文 tab strip
   // ではなく header 2段目の subnav に出す (サブメニュー化)。
-  it('charts overview/quality pages share the 履歴・分析 subnav (#remove-grid)', async () => {
+  it('charts overview/quality pages share the レビュー subnav (#remove-grid)', async () => {
     const app = createApp()
     // DB 未バインドでも subnav は出る (本文は unavailable)
     const res = await app.request(
@@ -192,7 +193,7 @@ describe('dashboard', () => {
     )
     const body = await res.text()
     expect(body).toContain('<nav class="subnav">')
-    // trades / cron / alerts と同じ「履歴・分析」subnav に統一 (現在地 = 取引品質)
+    // 約定履歴と同じ「レビュー」subnav に統一 (現在地 = 取引品質)
     expect(body).toContain('>取引品質</span>')
     expect(body).toContain('class="subnav-link active"')
     expect(body).toContain('href="/dashboard/trades"')

--- a/test/routes/dashboardIa.test.ts
+++ b/test/routes/dashboardIa.test.ts
@@ -11,9 +11,9 @@ import { makeGlobalConfigSnapshot, makeSymbolUniverse } from '../helpers/configF
 /**
  * #dashboard-ia — 情報アーキテクチャ再編のスモーク。
  *
- * 1. グローバル nav: 13 リンクのフラット並び → 4 項目 (ホーム / 銘柄 /
- *    履歴・分析 / 運用ドロップダウン) + グループ単位の前方一致 active。
- * 2. 履歴・分析 subnav: trades / cron / alerts の 3 ページに共通 subnav。
+ * 1. グローバル nav: 日常 3 画面 (ホーム / 銘柄 / レビュー) + 管理 ▾ + 診断 ▾。
+ *    判定ログ・アラート・監査・broker 診断・token は診断へ降格 (削除はしない)。
+ * 2. レビュー subnav: 約定履歴 / 取引品質 / 資産推移。診断ページは診断 subnav。
  * 3. ホーム統合: 資産サマリ帯 + スパークライン + 保有ポジション (DO あり /
  *    なしの graceful degrade)。
  */
@@ -147,7 +147,7 @@ describe('dashboard IA — global nav (#dashboard-ia)', () => {
   })
   afterEach(() => vi.resetAllMocks())
 
-  it('renders 4 groups + 運用 dropdown (positions/portfolio are not in the nav)', async () => {
+  it('renders 3 日常画面 + 管理 / 診断 dropdown (positions/portfolio are not in the nav)', async () => {
     const app = createApp()
     const res = await app.request('/dashboard', { headers: authHeader }, baseEnv)
     expect(res.status).toBe(200)
@@ -159,14 +159,20 @@ describe('dashboard IA — global nav (#dashboard-ia)', () => {
     expect(nav).toContain('href="/dashboard/charts?tab=symbol"')
     expect(nav).toContain('>銘柄</a>')
     expect(nav).toContain('href="/dashboard/trades"')
-    expect(nav).toContain('>履歴・分析</a>')
-    // 運用ドロップダウン (kill switch と同じ details パターン)
+    expect(nav).toContain('>レビュー</a>')
+    // 管理 / 診断ドロップダウン (kill switch と同じ details パターン)
     expect(nav).toContain('<details class="topnav-ops">')
-    expect(nav).toContain('運用 ▾')
+    expect(nav).toContain('管理 ▾')
+    expect(nav).toContain('診断 ▾')
+    // 管理 = 書き込みを伴う画面だけ
+    for (const href of ['/dashboard/config', '/dashboard/symbols', '/dashboard/events']) {
+      expect(nav).toContain(`href="${href}"`)
+    }
+    // 診断 = 障害時にだけ開く画面 (降格しても消さない)
     for (const href of [
-      '/dashboard/config',
-      '/dashboard/symbols',
-      '/dashboard/events',
+      '/dashboard/alerts',
+      '/dashboard/cron',
+      '/dashboard/cron?view=matrix',
       '/dashboard/audit',
       '/dashboard/broker-probe',
       '/dashboard/webull-token',
@@ -180,15 +186,9 @@ describe('dashboard IA — global nav (#dashboard-ia)', () => {
     expect(nav).toContain('class="nav-link active" href="/dashboard"')
   })
 
-  it('activates 履歴・分析 for /trades /cron /alerts and /charts?tab=quality (group prefix match)', async () => {
+  it('activates レビュー for /trades and /charts (quality / equity)', async () => {
     const app = createApp()
-    for (const path of [
-      '/dashboard/trades',
-      '/dashboard/cron',
-      '/dashboard/alerts',
-      '/dashboard/charts?tab=quality',
-      '/dashboard/charts',
-    ]) {
+    for (const path of ['/dashboard/trades', '/dashboard/charts?tab=quality', '/dashboard/charts']) {
       const res = await app.request(path, { headers: authHeader }, baseEnv)
       const body = await res.text()
       expect(body, path).toContain('class="nav-link active" href="/dashboard/trades"')
@@ -204,30 +204,36 @@ describe('dashboard IA — global nav (#dashboard-ia)', () => {
     }
   })
 
-  it('activates 運用 summary on ops pages, and nothing on nav-less pages (/positions)', async () => {
+  it('activates 管理 / 診断 summary on their pages, and nothing on nav-less pages (/positions)', async () => {
     const app = createApp()
     const opsRes = await app.request('/dashboard/config', { headers: authHeader }, baseEnv)
-    expect(await opsRes.text()).toContain('<summary class="nav-link active">運用 ▾</summary>')
+    expect(await opsRes.text()).toContain('<summary class="nav-link active">管理 ▾</summary>')
+    const diagRes = await app.request('/dashboard/cron', { headers: authHeader }, baseEnv)
+    expect(await diagRes.text()).toContain('診断 ▾</summary>')
     // /positions は nav 外の直アクセスページ → どのグループも active にしない
     const posRes = await app.request('/dashboard/positions', { headers: authHeader }, baseEnv)
     expect(posRes.status).toBe(200)
     expect(await posRes.text()).not.toContain('nav-link active')
   })
 
-  it('resolveActiveNavGroup: charts はタブで 銘柄 / 履歴・分析 に分かれる', () => {
+  it('resolveActiveNavGroup: charts はタブで 銘柄 / レビュー に分かれ、診断系は diag', () => {
     expect(resolveActiveNavGroup('/dashboard')).toBe('home')
     expect(resolveActiveNavGroup('/dashboard/charts', 'symbol')).toBe('symbol')
     expect(resolveActiveNavGroup('/dashboard/charts', 'grid')).toBe('symbol')
-    expect(resolveActiveNavGroup('/dashboard/charts', 'quality')).toBe('analysis')
-    expect(resolveActiveNavGroup('/dashboard/charts', null)).toBe('analysis')
-    expect(resolveActiveNavGroup('/dashboard/cron')).toBe('analysis')
+    expect(resolveActiveNavGroup('/dashboard/charts', 'quality')).toBe('review')
+    expect(resolveActiveNavGroup('/dashboard/charts', null)).toBe('review')
+    expect(resolveActiveNavGroup('/dashboard/trades')).toBe('review')
+    expect(resolveActiveNavGroup('/dashboard/cron')).toBe('diag')
+    expect(resolveActiveNavGroup('/dashboard/alerts')).toBe('diag')
+    expect(resolveActiveNavGroup('/dashboard/audit')).toBe('diag')
+    expect(resolveActiveNavGroup('/dashboard/webull-token')).toBe('diag')
     expect(resolveActiveNavGroup('/dashboard/symbols/SOXL/edit')).toBe('ops')
     expect(resolveActiveNavGroup('/dashboard/positions')).toBeNull()
     expect(resolveActiveNavGroup('/dashboard/portfolio')).toBeNull()
   })
 })
 
-describe('dashboard IA — 履歴・分析 subnav (#dashboard-ia)', () => {
+describe('dashboard IA — レビュー / 診断 subnav (#dashboard-ia)', () => {
   beforeEach(() => {
     vi.mocked(loadGlobalConfigFrom).mockResolvedValue(makeGlobalConfigSnapshot())
     vi.mocked(loadSymbolUniverse).mockResolvedValue(
@@ -242,24 +248,21 @@ describe('dashboard IA — 履歴・分析 subnav (#dashboard-ia)', () => {
     const body = await res.text()
     expect(body).toContain('<nav class="subnav">')
     expect(body).toContain('<span class="subnav-link active">約定履歴</span>')
-    for (const href of [
-      '/dashboard/cron',
-      '/dashboard/cron?view=matrix',
-      '/dashboard/charts?tab=quality',
-      '/dashboard/charts',
-      '/dashboard/alerts',
-    ]) {
+    for (const href of ['/dashboard/charts?tab=quality', '/dashboard/charts']) {
       expect(body).toContain(`href="${href}"`)
     }
     expect(body).toContain('資産推移')
+    // 判定ログ / アラートはレビュー subnav からは外れる (診断側へ)
+    expect(body).not.toContain('<a class="subnav-link" href="/dashboard/cron">')
+    expect(body).not.toContain('<a class="subnav-link" href="/dashboard/alerts">')
   })
 
-  it('cron page activates 戦略判定, matrix view activates 判定マトリクス', async () => {
+  it('cron page activates 判定ログ, matrix view activates 判定マトリクス (診断 subnav)', async () => {
     const app = createApp()
     const cronBody = await (
       await app.request('/dashboard/cron', { headers: authHeader }, baseEnv)
     ).text()
-    expect(cronBody).toContain('<span class="subnav-link active">戦略判定</span>')
+    expect(cronBody).toContain('<span class="subnav-link active">判定ログ</span>')
     const matrixBody = await (
       await app.request('/dashboard/cron?view=matrix', { headers: authHeader }, baseEnv)
     ).text()


### PR DESCRIPTION
ダッシュボード再構成 **Phase 1 — ナビ再編のみ**。URL も機能も変えず、「どこから辿れるか」だけを変えます。

設計の全体像はモックのとおり: https://claude.ai/code/artifact/1228762a-7cac-4685-b40e-9bf582a3421c

## 変更

| | Before | After |
|---|---|---|
| グローバル nav | ホーム / 銘柄 / **履歴・分析** + 運用 ▾ (6 リンク) | ホーム / 銘柄 / **レビュー** + 管理 ▾ (3) + 診断 ▾ (6) |
| レビュー subnav | 約定履歴 / 戦略判定 / 判定マトリクス / 取引品質 / 資産推移 / アラート | 約定履歴 / 取引品質 / 資産推移 |
| 診断 subnav | (なし) | アラート / 判定ログ / 判定マトリクス / 監査ログ / broker 診断 / Webull token |

- **管理 ▾** は書き込みを伴う 3 画面だけ (設定 / 銘柄管理 / イベント)
- **診断 ▾** は障害時にだけ開く画面。**削除はしません** — MCP は同じ D1 に依存するので AI では代替できず、証跡と break-glass はここにしかありません
- 「戦略判定」は役割が伝わる **「判定ログ」** に改称 (画面自体は変更なし)
- 診断ページ同士は横移動する (通知 → アラート → requestId → 判定ログ) ので、診断側にも subnav を出します

## 変えていないもの

URL・機能・各画面の中身。`/positions` `/portfolio` の直アクセスも従来どおり。ホームの 3 領域化と「取引品質 → 成績」の改名は Phase 3 / 4 で行います。

## 検証

- `pnpm run typecheck` clean / `pnpm test` 121 files・1821 tests pass
- nav の smoke テストを新 IA に合わせて更新 (グループ解決 / active 装飾 / subnav の出し分け)
- 「レビュー subnav に判定ログとアラートが出ない」ことを明示的に assert

## 積み残し (Phase 3 以降の判断材料)

- **判定マトリクス** — いまは診断に置いています。2 週間前に作ったばかりなので、使わないなら削除、全銘柄の一望に価値があるなら銘柄画面の補助ビューへ
- **銘柄管理 2,523 行** — 基本操作だけ残し、細かい override は SQL 運用に寄せる案

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ダッシュボードのグローバルナビを「ホーム」「銘柄」「レビュー」中心に再編しました。
  * 「管理」と「診断」を独立したドロップダウンとして追加しました。
  * 診断ページ間を移動できる専用サブナビを追加しました。

* **改善**
  * ページごとのナビゲーション選択状態を見直し、レビュー・管理・診断を正しく表示するよう改善しました。
  * レビュー用サブナビから診断項目を分離し、関連ページの案内を整理しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->