### PR TITLE
feat(dashboard): fold the home into run state, risk and activity

### DIFF
--- a/src/routes/dashboard/config.ts
+++ b/src/routes/dashboard/config.ts
@@ -63,6 +63,9 @@ export function configBody(
     })
     .join('')
   return `${panelForm}
+  <p class="muted" style="font-size:12px;margin:0 0 10px">
+    設定変更は before/after が記録されます — <a href="/dashboard/audit">監査ログを見る →</a>
+  </p>
   <details open>
     <summary>グローバル設定 (global_config)</summary>
     <table>

--- a/src/routes/dashboard/index.ts
+++ b/src/routes/dashboard/index.ts
@@ -135,19 +135,15 @@ export const dashboard = new Hono<DashboardBindings>()
       const allDisplaySymbols = [...universe.allowedSymbols, ...universe.inactiveSymbols]
       const symbolClient = c.env.SYMBOL_STATE ? new SymbolStateClient(c.env.SYMBOL_STATE) : null
       const range = parseEquityRange(c.req.query('range'))
-      const [panelsCsv, portfolio, snapshots, sparkSnapshotsRaw, usdJpy, positions, strategyPriceMap, recentTrades, vixRegime, global] =
+      const [panelsCsv, portfolio, snapshots, usdJpy, positions, strategyPriceMap, recentTrades, vixRegime, global] =
         await Promise.all([
           loadOverviewPanelsCsv(db),
           c.env.PORTFOLIO_STATE
             ? new PortfolioStateClient(c.env.PORTFOLIO_STATE).getPortfolio().catch(() => null)
             : Promise.resolve(null),
+          // #dashboard-ia Phase 3: スパークラインは資産推移チャートと重複する
+          // ので廃止し、スナップショット取得は range 用の 1 回だけになった。
           safeLoadPortfolioSnapshots(c.env.DB, range),
-          // 資産サマリ帯のスパークラインは range 指定と独立に直近 30 日固定。
-          // range=30d (既定) のときは equity パネル用と同一クエリになるため
-          // 取得を省略し snapshots を再利用する (CodeRabbit #559: D1 二重取得)。
-          range === '30d'
-            ? Promise.resolve(null)
-            : safeLoadPortfolioSnapshots(c.env.DB, '30d'),
           // USDJPY は資産サマリ帯表示用。DO 不在 (帯を出さない) なら fetch 自体を省略。
           c.env.PORTFOLIO_STATE
             ? loadUsdJpyRate().catch(() => null)
@@ -175,7 +171,6 @@ export const dashboard = new Hono<DashboardBindings>()
         portfolio,
         snapshots,
         range,
-        sparkSnapshots: sparkSnapshotsRaw ?? snapshots,
         usdJpy,
         symbolStateBound: symbolClient !== null,
         positions,

--- a/src/routes/dashboard/layout.ts
+++ b/src/routes/dashboard/layout.ts
@@ -47,6 +47,9 @@ export const STYLE = `
   .topnav{display:flex;align-items:center;gap:4px;padding:6px 16px;flex-wrap:wrap}
   .topnav .brand{font-weight:700;font-size:15px;margin-right:12px;white-space:nowrap;color:#1d1d1f}
   .topnav nav{display:flex;align-items:center;gap:2px;flex-wrap:wrap;flex:1;min-width:0}
+  /* #dashboard-ia Phase 3: ホームの領域見出し (運転状態 / リスクと建玉 / 最近の活動)。 */
+  .area-label{font-size:11px;letter-spacing:.12em;color:#6e6e73;margin:18px 0 6px;display:flex;align-items:center;gap:8px}
+  .area-label::after{content:"";flex:1;height:1px;background:#e3e3e8}
   .topnav .nav-sep{width:1px;height:18px;background:#d0d0d5;margin:0 8px;flex:0 0 auto}
   .topnav .nav-link{color:#1d1d1f;text-decoration:none;padding:5px 9px;border-radius:7px;font-size:13px;white-space:nowrap}
   .topnav .nav-link:hover{background:#f0f0f3}

--- a/src/routes/dashboard/overview.ts
+++ b/src/routes/dashboard/overview.ts
@@ -9,35 +9,58 @@ import { type EquityRange, renderPortfolioEquityChart, renderVixRegimeCell } fro
 import { pickFreshQuote, positionsBody } from './positions'
 import { displaySymbol, esc, fmtJst, fmtNumber, safeJsonScript } from './shared'
 
-// #dashboard-mf-layout: overview パネル定義。設定で ON/OFF (default 全表示)。
-// #dashboard-ia で status (資産サマリ帯 + スパークライン) / positions (保有
-// ポジション) を additive に追加。既存 key の意味は変えない。
-export type OverviewPanel = 'status' | 'positions' | 'kpi' | 'equity' | 'composition' | 'recent'
+/**
+ * ホームの表示領域 (#dashboard-ia Phase 3)。
+ *
+ * 旧実装は 6 パネル (status / kpi / equity / positions / composition / recent)
+ * だったが、6 種類の情報ではなく **同じ数字の別表現**が並んでいた (status と
+ * kpi で開始 equity と実現損益が重複、positions と composition は同じ建玉の
+ * 別表現)。3 領域に畳んで重複を消した。
+ *
+ * **運転状態は panel ではない** — 常に最上段に出す。実行モード / 取引 ON-OFF /
+ * 判定と株価の鮮度は、隠せると事故に直結するため設定対象から外している。
+ */
+export type OverviewPanel = 'risk' | 'activity'
 
-export const ALL_OVERVIEW_PANELS: readonly OverviewPanel[] = [
-  'status',
-  'positions',
-  'kpi',
-  'equity',
-  'composition',
-  'recent',
-]
+export const ALL_OVERVIEW_PANELS: readonly OverviewPanel[] = ['risk', 'activity']
 
 export const OVERVIEW_PANEL_LABELS: Record<OverviewPanel, string> = {
-  status: '資産サマリ帯 (本日開始 equity / 実現損益 / 取引状態 / VIX / USDJPY + 資産スパークライン)',
-  positions: '保有ポジション (positions ページと同じテーブル)',
-  kpi: 'KPI カード (総資産 / 当日損益 / 建玉数 / エクスポージャー)',
-  equity: '資産推移チャート (期間タブ)',
-  composition: '資産構成 + 含み損益ランキング',
-  recent: '最近の約定 + VIX / リスク状態',
+  risk: 'リスクと建玉 (保有ポジション + 資産構成 / 含み損益ランキング)',
+  activity: '最近の活動 (直近の約定 + 資産推移)',
 }
 
-/** CSV を有効パネル集合へ。不正値は無視、空 (未設定/全部不正) は全表示。 */
+/**
+ * 旧 panel key → 新領域。operator が保存済みの CSV をそのまま解釈できるよう
+ * 読み替える (設定を作り直させない)。`status` は運転状態へ畳まれ、常時表示に
+ * なったので対応先を持たない。
+ */
+const LEGACY_PANEL_MAP: Record<string, OverviewPanel | null> = {
+  status: null,
+  kpi: 'risk',
+  positions: 'risk',
+  composition: 'risk',
+  equity: 'activity',
+  recent: 'activity',
+}
+
+/** CSV を有効領域集合へ。不正値は無視、空 (未設定/全部不正) は全表示。 */
 export function parseOverviewPanels(csv: string | null | undefined): Set<OverviewPanel> {
   const set = new Set<OverviewPanel>()
+  let sawLegacy = false
   for (const tok of (csv ?? '').split(',').map((s) => s.trim())) {
-    if ((ALL_OVERVIEW_PANELS as readonly string[]).includes(tok)) set.add(tok as OverviewPanel)
+    if ((ALL_OVERVIEW_PANELS as readonly string[]).includes(tok)) {
+      set.add(tok as OverviewPanel)
+      continue
+    }
+    const mapped = LEGACY_PANEL_MAP[tok]
+    if (mapped !== undefined) {
+      sawLegacy = true
+      if (mapped !== null) set.add(mapped)
+    }
   }
+  // 旧 CSV が `status` だけ (= 運転状態のみ表示) だった場合、新モデルでは
+  // 運転状態が常時表示なので領域ゼロになる。全表示に倒す方が意図に近い。
+  if (set.size === 0 && sawLegacy) return new Set(ALL_OVERVIEW_PANELS)
   return set.size === 0 ? new Set(ALL_OVERVIEW_PANELS) : set
 }
 
@@ -53,8 +76,6 @@ export interface OverviewData {
   } | null
   snapshots: PortfolioEquitySnapshotRow[]
   range: EquityRange
-  /** 資産サマリ帯のスパークライン用 (直近 30 日固定。`snapshots` は ?range= 連動)。 */
-  sparkSnapshots: PortfolioEquitySnapshotRow[]
   /** USDJPY レート (資産サマリ帯表示用)。取得失敗は null → "—" 表示。 */
   usdJpy: number | null
   /** SYMBOL_STATE binding の有無。false なら保有ポジションは誘導リンクのみ。 */
@@ -161,87 +182,58 @@ export function sectionHead(title: string, moreHref: string): string {
  * PORTFOLIO_STATE DO 不在 (portfolio === null) は帯を省略し、スパークラインも
  * データ無しなら section ごと消える (graceful)。
  */
-export function renderStatusPanel(data: OverviewData): string {
-  const spark = renderEquitySparkline(data.sparkSnapshots)
-  const p = data.portfolio
-  if (p === null && spark === '') return ''
-  let band = ''
-  if (p !== null) {
-    const pnlClass = p.dailyRealizedPnl >= 0 ? 'ok' : 'err'
-    const tradingPill = data.tradingEnabled
-      ? '<span class="pill on">取引 ON</span>'
-      : '<span class="pill off">取引 OFF</span>'
-    const item = (label: string, value: string) =>
-      `<div style="min-width:110px"><div class="kpi-label">${esc(label)}</div><div style="font-size:15px;font-weight:700;font-variant-numeric:tabular-nums">${value}</div></div>`
-    band = `<div style="display:flex;flex-wrap:wrap;gap:10px 22px;align-items:flex-end">
-      ${item('本日開始 equity', fmtNumber(p.dailyStartEquity, 2))}
-      ${item('本日実現損益', `<span class="${pnlClass}">${fmtNumber(p.dailyRealizedPnl, 2)}</span>`)}
-      ${item('取引 (effective)', tradingPill)}
-      ${item('VIX レジーム', `<span style="font-size:13px;font-weight:400">${renderVixRegimeCell(data.vixRegime)}</span>`)}
-      ${item('USDJPY', data.usdJpy === null ? '<span class="muted">—</span>' : fmtNumber(data.usdJpy, 2))}
-    </div>`
-  }
-  return `${sectionHead('資産サマリ', '/dashboard/portfolio')}<div class="panel">${band}${spark}</div>`
+/**
+ * 運転状態 (#dashboard-ia Phase 3): ホーム最上段の固定帯。
+ *
+ * 「いま安全に動いているか」だけを載せる。実行モード / 取引 ON-OFF /
+ * 株価の鮮度は隠せない (設定対象外)。equity 系の数字は下の領域に譲り、ここは
+ * 状態表示に徹する。
+ */
+export function renderRunStatePanel(data: OverviewData): string {
+  const modePill = data.dryRun
+    ? '<span class="pill off">DRY-RUN</span>'
+    : '<span class="pill on">LIVE</span>'
+  const tradingPill = data.tradingEnabled
+    ? '<span class="pill on">取引 ON</span>'
+    : '<span class="pill off">取引 OFF</span>'
+  const item = (label: string, value: string) =>
+    `<div style="min-width:104px"><div class="kpi-label">${esc(label)}</div><div style="font-size:15px;font-weight:700;font-variant-numeric:tabular-nums">${value}</div></div>`
+  const quote = latestQuoteFreshness(data)
+  return `<div class="panel" style="display:flex;flex-wrap:wrap;gap:10px 22px;align-items:flex-end">
+    ${item('実行モード', modePill)}
+    ${item('取引 (effective)', tradingPill)}
+    ${item('株価の鮮度', quote)}
+    ${item('VIX レジーム', `<span style="font-size:13px;font-weight:400">${renderVixRegimeCell(data.vixRegime)}</span>`)}
+    ${item('USDJPY', data.usdJpy === null ? '<span class="muted">—</span>' : fmtNumber(data.usdJpy, 2))}
+    <div style="margin-left:auto;font-size:12px"><a href="/dashboard/alerts">アラート →</a></div>
+  </div>`
 }
 
 /**
- * equity スパークライン (直近 30 日、高さ 80px)。portfolio_equity_snapshot の
- * dailyStartEquity を 1 本線で描く。USD があれば USD、無ければ JPY。両方
- * データ無しは '' (帯から省略)。
+ * 保有・監視銘柄の中で **最も新しい** 株価の取得時刻を相対表示する。
+ * quote feed が止まると全銘柄で同時に古くなるので、最新 1 件で足りる。
  */
-export function renderEquitySparkline(snapshots: PortfolioEquitySnapshotRow[]): string {
-  const dates: string[] = []
-  const usd: Array<number | null> = []
-  const jpy: Array<number | null> = []
-  for (const row of snapshots) {
-    dates.push((row.snapshotAt ?? '').slice(0, 10))
-    usd.push(
-      typeof row.dailyStartEquityUsd === 'number' && Number.isFinite(row.dailyStartEquityUsd)
-        ? row.dailyStartEquityUsd
-        : null,
-    )
-    jpy.push(
-      typeof row.dailyStartEquityJpy === 'number' && Number.isFinite(row.dailyStartEquityJpy)
-        ? row.dailyStartEquityJpy
-        : null,
-    )
+function latestQuoteFreshness(data: OverviewData): string {
+  let latest: number | null = null
+  for (const r of data.positions) {
+    const q = r.state?.lastQuote
+    const iso = q?.asOf ?? q?.fetchedAt
+    if (!iso) continue
+    const t = new Date(iso).getTime()
+    if (Number.isFinite(t) && (latest === null || t > latest)) latest = t
   }
-  const hasUsd = usd.some((v) => v !== null)
-  const hasJpy = jpy.some((v) => v !== null)
-  if (!hasUsd && !hasJpy) return ''
-  const currency = hasUsd ? 'USD' : 'JPY'
-  const values = hasUsd ? usd : jpy
-  const initScript = `
-    document.addEventListener('DOMContentLoaded', function () {
-      if (typeof echarts === 'undefined') return;
-      var el = document.getElementById('home-equity-spark');
-      if (!el) return;
-      var d = window.__homeEquitySpark;
-      var chart = echarts.init(el);
-      chart.setOption({
-        grid: { left: 2, right: 2, top: 4, bottom: 2 },
-        xAxis: { type: 'category', data: d.dates, show: false },
-        yAxis: { type: 'value', show: false, min: 'dataMin', max: 'dataMax' },
-        tooltip: { trigger: 'axis', valueFormatter: function (v) { return v == null ? '—' : Number(v).toLocaleString('ja-JP'); } },
-        series: [{ type: 'line', data: d.values, showSymbol: false, connectNulls: false, lineStyle: { width: 1.5, color: '#06c' }, itemStyle: { color: '#06c' }, areaStyle: { opacity: 0.08, color: '#06c' } }],
-      });
-      window.addEventListener('resize', function () { chart.resize(); });
-    });
-  `
-  return `<div style="margin-top:10px">
-    <div class="muted" style="font-size:11px;margin-bottom:2px">資産推移 (直近 30 日, ${currency})</div>
-    <div id="home-equity-spark" style="width:100%;height:80px"></div>
-  </div>
-  ${safeJsonScript('__homeEquitySpark', { dates, values })}
-  <script src="${ECHARTS_CDN}" defer></script>
-  <script>${initScript}</script>`
+  for (const v of data.strategyPriceMap.values()) {
+    const t = new Date(v.asOf).getTime()
+    if (Number.isFinite(t) && (latest === null || t > latest)) latest = t
+  }
+  if (latest === null) return '<span class="muted">—</span>'
+  const min = Math.floor((Date.now() - latest) / 60000)
+  const text = min < 1 ? '1 分未満' : min < 60 ? `${min} 分前` : `${Math.floor(min / 60)} 時間前`
+  // 15 分は global_config.stale_quote_ms の既定 (halt 判定と同じ線)。
+  const cls = min >= 15 ? 'err' : 'ok'
+  return `<span class="${cls}" style="font-size:13px">${esc(text)}</span>`
 }
 
-/**
- * 保有ポジション section (#dashboard-ia): positions ページと同じ loader 結果 /
- * 同じテーブル renderer (`positionsBody`) を re-use する。SYMBOL_STATE 不在時は
- * テーブルを省略して誘導リンクのみ。
- */
 export function renderHomePositionsSection(data: OverviewData): string {
   const head = sectionHead('保有ポジション', '/dashboard/positions')
   if (!data.symbolStateBound) {
@@ -404,28 +396,34 @@ export function dedupeEchartsCdnTag(html: string): string {
   return parts[0] + tag + parts.slice(1).join('')
 }
 
+/** 領域の区切り見出し (#dashboard-ia Phase 3)。 */
+function areaLabel(text: string): string {
+  return `<div class="area-label">${esc(text)}</div>`
+}
+
 export function overviewBody(data: OverviewData): string {
   const open = collectOpenPositions(data)
   const sections: string[] = []
-  // 「今日の状況が 1 画面で分かる」順: 資産サマリ帯 → KPI → 保有 → 推移 →
-  // 構成 → 直近の約定/判定。詳細は各セクション見出しの「詳しく見る」で専用ページへ。
-  if (data.panels.has('status')) {
-    const status = renderStatusPanel(data)
-    if (status !== '') sections.push(status)
+
+  // 1. 運転状態 — 常時表示。設定で隠せない。
+  sections.push(renderRunStatePanel(data))
+
+  // 2. リスクと建玉
+  if (data.panels.has('risk')) {
+    sections.push(areaLabel('リスクと建玉'))
+    sections.push(renderKpiPanel(data, open))
+    sections.push(renderHomePositionsSection(data))
+    sections.push(renderCompositionPanel(open))
   }
-  if (data.panels.has('kpi')) sections.push(renderKpiPanel(data, open))
-  if (data.panels.has('positions')) sections.push(renderHomePositionsSection(data))
-  if (data.panels.has('equity')) {
+
+  // 3. 最近の活動
+  if (data.panels.has('activity')) {
+    sections.push(areaLabel('最近の活動'))
+    sections.push(renderRecentPanel(data))
     sections.push(
       `<div class="panel">${renderPortfolioEquityChart(data.snapshots, data.range, '/dashboard')}</div>`,
     )
   }
-  if (data.panels.has('composition')) sections.push(renderCompositionPanel(open))
-  if (data.panels.has('recent')) sections.push(renderRecentPanel(data))
-  if (sections.length === 0) {
-    sections.push(
-      '<p class="muted">表示パネルが選択されていません。<a href="/dashboard/config">設定</a>でパネルを有効化してください。</p>',
-    )
-  }
+
   return dedupeEchartsCdnTag(buyingPowerBadge() + sections.join(''))
 }

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -356,7 +356,7 @@ describe('dashboard', () => {
     // setOverviewPanels は db.batch([select(before), insert().values().onConflictDoUpdate()])。
     // select/insert は batch に渡す statement を組むだけ (mock では空 obj)、実 read は batch が返す。
     // batch 呼び出し自体を spy して原子更新 (read→write 退行) の回帰ガードにする。
-    const batchSpy = vi.fn(async (_stmts: unknown[]) => [[{ value: 'kpi,equity,composition,recent' }], {}])
+    const batchSpy = vi.fn(async (_stmts: unknown[]) => [[{ value: 'risk,activity' }], {}])
     vi.mocked(createDb).mockReturnValue({
       select: () => ({ from: () => ({ where: () => ({ limit: () => ({}) }) }) }),
       insert: () => ({
@@ -380,9 +380,9 @@ describe('dashboard', () => {
         method: 'POST',
         headers: { 'content-type': 'application/x-www-form-urlencoded' },
         body: new URLSearchParams([
-          ['panels', 'kpi'],
-          ['panels', 'recent'],
-          ['panels', 'kpi'],
+          ['panels', 'risk'],
+          ['panels', 'activity'],
+          ['panels', 'risk'],
           ['panels', 'bogus'],
         ]).toString(),
       },
@@ -390,9 +390,9 @@ describe('dashboard', () => {
     )
     expect(res.status).toBe(303)
     expect(res.headers.get('location')).toBe('/dashboard/config')
-    expect(storedCsv).toBe('kpi,recent')
+    expect(storedCsv).toBe('risk,activity')
     // upsert の insert 部の payload も検証 (初回作成時に正しい行が入る)。
-    expect(insertedValues).toMatchObject({ id: 'default', overviewPanels: 'kpi,recent' })
+    expect(insertedValues).toMatchObject({ id: 'default', overviewPanels: 'risk,activity' })
     expect(typeof insertedValues?.updatedAt).toBe('string')
     // 原子更新の回帰ガード: 1 回の batch に before-read + upsert の 2 statement。
     expect(batchSpy).toHaveBeenCalledTimes(1)
@@ -696,10 +696,17 @@ import { parseOverviewPanels, ALL_OVERVIEW_PANELS } from '../../src/routes/dashb
 
 describe('parseOverviewPanels', () => {
   it('parses a valid CSV into the panel set', () => {
-    expect([...parseOverviewPanels('kpi,recent')].sort()).toEqual(['kpi', 'recent'])
+    expect([...parseOverviewPanels('risk,activity')].sort()).toEqual(['activity', 'risk'])
   })
   it('ignores invalid tokens and whitespace', () => {
-    expect([...parseOverviewPanels(' kpi , bogus , equity ')].sort()).toEqual(['equity', 'kpi'])
+    expect([...parseOverviewPanels(' risk , bogus ')].sort()).toEqual(['risk'])
+  })
+  // #dashboard-ia Phase 3: 旧 6 パネルの CSV が保存済みでも設定を作り直させない。
+  it('maps legacy panel keys onto the new areas', () => {
+    expect([...parseOverviewPanels('risk,activity')].sort()).toEqual(['activity', 'risk'])
+    expect([...parseOverviewPanels('positions,composition')].sort()).toEqual(['risk'])
+    // status は運転状態へ畳まれ常時表示になったため、単独指定は全表示に倒す
+    expect([...parseOverviewPanels('status')].sort()).toEqual(['activity', 'risk'])
   })
   it('empty / all-invalid / null / undefined → all panels (fallback)', () => {
     const all = [...ALL_OVERVIEW_PANELS].sort()

--- a/test/routes/dashboardIa.test.ts
+++ b/test/routes/dashboardIa.test.ts
@@ -309,7 +309,7 @@ describe('dashboard IA — home integration (#dashboard-ia)', () => {
   })
   afterEach(() => vi.resetAllMocks())
 
-  it('renders 資産サマリ帯 + スパークライン + 保有ポジション + 直近パネル when DOs are bound', async () => {
+  it('renders 運転状態帯 + 3 領域 (リスクと建玉 / 最近の活動) when DOs are bound', async () => {
     const env = {
       ...baseEnv,
       DB: fakeD1(),
@@ -320,31 +320,27 @@ describe('dashboard IA — home integration (#dashboard-ia)', () => {
     const res = await app.request('/dashboard', { headers: authHeader }, env)
     expect(res.status).toBe(200)
     const body = await res.text()
-    // 1. 資産サマリ帯 (portfolio 要約の横並びカード)
-    expect(body).toContain('資産サマリ')
-    expect(body).toContain('本日開始 equity')
-    expect(body).toContain('本日実現損益')
+    // 1. 運転状態帯 (常時表示。実行モードと取引状態は隠せない)
+    expect(body).toContain('実行モード')
+    expect(body).toContain('株価の鮮度')
     expect(body).toContain('取引 ON')
     expect(body).toContain('USDJPY')
     expect(body).toContain('150.25')
-    // 2. equity スパークライン (直近 30 日)
-    expect(body).toContain('id="home-equity-spark"')
-    expect(body).toContain('window.__homeEquitySpark')
+    // 2. 領域見出し
+    expect(body).toContain('リスクと建玉')
+    expect(body).toContain('最近の活動')
     // 3. 保有ポジション (positions と同じテーブル)
     expect(body).toContain('保有ポジション')
     expect(body).toContain('SOXL')
     expect(body).toContain('平均取得単価')
-    // 4. 既存パネル (直近の約定 / リスク状態) + 導線リンク
+    // 4. 直近の約定 + 導線リンク
     expect(body).toContain('最近の約定 / リスク状態')
-    expect(body).toContain('href="/dashboard/portfolio"')
     expect(body).toContain('href="/dashboard/positions"')
     expect(body).toContain('href="/dashboard/cron"')
     expect(body).toContain('href="/dashboard/alerts"')
-    // スパークラインは 30d 固定で別途 load される
-    expect(vi.mocked(loadPortfolioEquitySnapshots)).toHaveBeenCalledWith(env.DB, { limit: 30 })
   })
 
-  it('home inline scripts (sparkline 含む) parse without syntax errors', async () => {
+  it('home inline scripts parse without syntax errors', async () => {
     const env = {
       ...baseEnv,
       DB: fakeD1(),
@@ -391,7 +387,7 @@ describe('dashboard IA — CodeRabbit #559 対応', () => {
   })
   afterEach(() => vi.resetAllMocks())
 
-  it('?range=30d ではスナップショットを 1 回だけ取得しスパークラインに再利用する', async () => {
+  it('スナップショット取得は range 用の 1 回だけ (スパークライン廃止で二重取得なし)', async () => {
     const env = {
       ...baseEnv,
       DB: fakeD1(),
@@ -402,14 +398,13 @@ describe('dashboard IA — CodeRabbit #559 対応', () => {
     const res = await app.request('/dashboard?range=30d', { headers: authHeader }, env)
     expect(res.status).toBe(200)
     const body = await res.text()
-    // equity パネル用と同一クエリ (limit 30) なので D1 取得は 1 回に畳む
+    // スパークライン廃止で二重取得は無くなった (range 用の 1 回だけ)
     expect(vi.mocked(loadPortfolioEquitySnapshots)).toHaveBeenCalledTimes(1)
     expect(vi.mocked(loadPortfolioEquitySnapshots)).toHaveBeenCalledWith(env.DB, { limit: 30 })
-    // スパークライン自体は再利用データで描画される
-    expect(body).toContain('id="home-equity-spark"')
+    expect(body).not.toContain('id="home-equity-spark"')
   })
 
-  it('既定 range (90d) ではスパークライン用 30d を別途取得する (挙動不変)', async () => {
+  it('既定 range (90d) でも取得は 1 回だけ', async () => {
     const env = {
       ...baseEnv,
       DB: fakeD1(),
@@ -419,12 +414,11 @@ describe('dashboard IA — CodeRabbit #559 対応', () => {
     const app = createApp()
     const res = await app.request('/dashboard', { headers: authHeader }, env)
     expect(res.status).toBe(200)
-    expect(vi.mocked(loadPortfolioEquitySnapshots)).toHaveBeenCalledTimes(2)
+    expect(vi.mocked(loadPortfolioEquitySnapshots)).toHaveBeenCalledTimes(1)
     expect(vi.mocked(loadPortfolioEquitySnapshots)).toHaveBeenCalledWith(env.DB, { limit: 90 })
-    expect(vi.mocked(loadPortfolioEquitySnapshots)).toHaveBeenCalledWith(env.DB, { limit: 30 })
   })
 
-  it('status + equity 両パネル ON でも ECharts CDN script タグは 1 個に畳まれる', async () => {
+  it('資産推移チャートを含む領域が出ても ECharts CDN script タグは 1 個に畳まれる', async () => {
     const env = {
       ...baseEnv,
       DB: fakeD1(),
@@ -434,8 +428,6 @@ describe('dashboard IA — CodeRabbit #559 対応', () => {
     const app = createApp()
     const res = await app.request('/dashboard', { headers: authHeader }, env)
     const body = await res.text()
-    // スパークラインと資産推移チャートの両方が描画されている前提で
-    expect(body).toContain('id="home-equity-spark"')
     const cdnTags = body.match(/<script src="[^"]*echarts[^"]*" defer><\/script>/g) ?? []
     expect(cdnTags.length).toBe(1)
   })


### PR DESCRIPTION
ダッシュボード再構成 **Phase 2 + 3**。モック: https://claude.ai/code/artifact/1228762a-7cac-4685-b40e-9bf582a3421c

## Phase 3 — ホームを 3 領域へ

6 パネルは 6 種類の情報ではなく **同じ数字の別表現**でした。

| 重複 | 内容 |
|---|---|
| `status` × `kpi` | 開始 equity と実現損益が二重表示 |
| `status` のスパークライン × `equity` | 同じ資産推移を 2 回描画 |
| `positions` × `composition` | 同じ建玉の別表現 |

再構成後:

1. **運転状態** (常時表示) — 実行モード LIVE/DRY-RUN / 取引 ON-OFF / **株価の鮮度** / VIX / USDJPY + アラート導線
2. **リスクと建玉** — KPI + 保有ポジション + 資産構成
3. **最近の活動** — 直近の約定 + 資産推移チャート

### 運転状態は設定で隠せない

`overview_panels` の対象は 2 と 3 だけにしました。実行モードや取引 ON/OFF を隠せる設定は、1 人運用では柔軟性より事故のリスクが勝ちます。

**株価の鮮度**を新設しました。保有・監視銘柄の最新 quote 時刻を相対表示し、15 分 (= `stale_quote_ms` の既定、halt 判定と同じ線) を超えたら赤くします。quote feed の停止は これまでホームから読めませんでした。

### 旧設定は読み替える

保存済み CSV を作り直させないよう、旧 key を新領域にマップします (`kpi`/`positions`/`composition` → `risk`、`equity`/`recent` → `activity`、`status` は常時表示へ畳む)。`status` 単独指定だけは領域ゼロになるので全表示に倒します。

### 副産物: D1 取得が 1 回に

スパークライン廃止で `portfolio_equity_snapshot` の二重取得が消えました (既定 range でも 1 回)。関連する dead code (`renderEquitySparkline` / `sparkSnapshots`) も削除しています。

## Phase 2 — 文脈導線

- 設定ページに「監査ログを見る →」を追加 (変更の before/after へ直行)
- 約定履歴の銘柄フィルタから「判定を見る」は既存だったので追加なし

## 検証

`pnpm run typecheck` clean / `pnpm test` 121 files・1822 tests pass。ホーム統合テストを新構成 (運転状態帯 + 領域見出し) に更新し、旧 key の読み替えとスパークライン非描画も assert しています。