### PR TITLE
feat(dashboard): name the review tabs after what they show

### DIFF
--- a/src/routes/dashboard/charts/quality.ts
+++ b/src/routes/dashboard/charts/quality.ts
@@ -190,7 +190,7 @@ export function renderTradeStatsTable(s: TradeStats): string {
 
 export function renderQualityTab(args: ChartsBodyQuality): string {
   if (args.pnls.length === 0 && args.decisions.length === 0) {
-    return `<p class="muted">まだ判定ログも実 fill も無いため取引品質を描けません。cron が動き出すと judgement breakdown、SELL が約定すると PnL 分布が出ます。</p>`
+    return `<p class="muted">まだ判定ログも実 fill も無いため成績を描けません。cron が動き出すと judgement breakdown、SELL が約定すると PnL 分布が出ます。</p>`
   }
   const initScript = `
     document.addEventListener('DOMContentLoaded', function () {

--- a/src/routes/dashboard/index.ts
+++ b/src/routes/dashboard/index.ts
@@ -100,7 +100,7 @@ export { assignPairColors, computeBudgetUsage, orderRowsByPair, pairRoles, rende
 
 /**
  * /charts の subnav (#remove-grid): チャート専用 subnav は廃止し、overview
- * (資産推移) / quality (取引品質) は約定履歴と同じ「レビュー」
+ * (実現損益の推移) / quality (成績) は約定履歴と同じ「レビュー」
  * subnav に統一する (画面によってメニュー構成が変わる混乱を避ける)。
  * 個別銘柄タブは「銘柄」nav + 銘柄レールが導線なので subnav なし。
  */

--- a/src/routes/dashboard/layout.ts
+++ b/src/routes/dashboard/layout.ts
@@ -42,7 +42,7 @@ export const STYLE = `
   /* shell: 上部グローバル nav + main (グローバルメニュー上部化 — 左はページ固有
      コンテンツ用に空ける。チャート個別銘柄タブの銘柄レール等)。
      header は topnav (1段目) + ページ固有 subnav (2段目、例: チャートの
-     レビューの 約定履歴/取引品質/... など) の最大2段で sticky。 */
+     レビューの 約定履歴/成績/... など) の最大2段で sticky。 */
   .header{position:sticky;top:0;z-index:100;background:#fff;border-bottom:1px solid #d0d0d5}
   .topnav{display:flex;align-items:center;gap:4px;padding:6px 16px;flex-wrap:wrap}
   .topnav .brand{font-weight:700;font-size:15px;margin-right:12px;white-space:nowrap;color:#1d1d1f}
@@ -259,7 +259,7 @@ export const NAV_GROUPS: ReadonlyArray<{
 }> = [
   { key: 'home', href: '/dashboard', text: 'ホーム', title: '今日の状況 (運転状態 / 建玉 / 直近の活動)' },
   { key: 'symbol', href: '/dashboard/charts?tab=symbol', text: '銘柄', title: '個別銘柄チャート (判定 pin / ラダー / 約定マーカー)' },
-  { key: 'review', href: '/dashboard/trades', text: 'レビュー', title: '約定履歴 / 取引品質 / 資産推移' },
+  { key: 'review', href: '/dashboard/trades', text: 'レビュー', title: '約定履歴 / 成績 / 実現損益の推移' },
 ]
 
 /** 管理ドロップダウン内リンク (書き込みを伴う低頻度ページ)。 */
@@ -356,8 +356,12 @@ export const ANALYSIS_SUBNAV_ITEMS: ReadonlyArray<{
   label: string
 }> = [
   { key: 'trades', href: '/dashboard/trades', label: '約定履歴' },
-  { key: 'quality', href: '/dashboard/charts?tab=quality', label: '取引品質' },
-  { key: 'equity', href: '/dashboard/charts', label: '資産推移' },
+  // #dashboard-ia Phase 4: 中身は勝率 / PF / 期待値 / PnL 分布であって、
+  // スリッページや約定率は含まない。「取引品質」は実態と合わないので「成績」。
+  { key: 'quality', href: '/dashboard/charts?tab=quality', label: '成績' },
+  // 口座資産 (portfolio) と累積 realized PnL は別物なので、どちらの推移かを
+  // ラベルで明示する。
+  { key: 'equity', href: '/dashboard/charts', label: '実現損益の推移' },
 ]
 
 /**

--- a/test/routes/dashboard.test.ts
+++ b/test/routes/dashboard.test.ts
@@ -181,7 +181,7 @@ describe('dashboard', () => {
     expect(body).not.toContain('page-title')
   })
 
-  // チャートの view 切替 (概要/取引品質/個別銘柄/銘柄グリッド) は本文 tab strip
+  // チャートの view 切替 (概要/成績/個別銘柄) は本文 tab strip
   // ではなく header 2段目の subnav に出す (サブメニュー化)。
   it('charts overview/quality pages share the レビュー subnav (#remove-grid)', async () => {
     const app = createApp()
@@ -193,8 +193,8 @@ describe('dashboard', () => {
     )
     const body = await res.text()
     expect(body).toContain('<nav class="subnav">')
-    // 約定履歴と同じ「レビュー」subnav に統一 (現在地 = 取引品質)
-    expect(body).toContain('>取引品質</span>')
+    // 約定履歴と同じ「レビュー」subnav に統一 (現在地 = 成績)
+    expect(body).toContain('>成績</span>')
     expect(body).toContain('class="subnav-link active"')
     expect(body).toContain('href="/dashboard/trades"')
     expect(body).toContain('href="/dashboard/cron?view=matrix"')

--- a/test/routes/dashboardIa.test.ts
+++ b/test/routes/dashboardIa.test.ts
@@ -13,7 +13,7 @@ import { makeGlobalConfigSnapshot, makeSymbolUniverse } from '../helpers/configF
  *
  * 1. グローバル nav: 日常 3 画面 (ホーム / 銘柄 / レビュー) + 管理 ▾ + 診断 ▾。
  *    判定ログ・アラート・監査・broker 診断・token は診断へ降格 (削除はしない)。
- * 2. レビュー subnav: 約定履歴 / 取引品質 / 資産推移。診断ページは診断 subnav。
+ * 2. レビュー subnav: 約定履歴 / 成績 / 実現損益の推移。診断ページは診断 subnav。
  * 3. ホーム統合: 資産サマリ帯 + スパークライン + 保有ポジション (DO あり /
  *    なしの graceful degrade)。
  */
@@ -251,7 +251,7 @@ describe('dashboard IA — レビュー / 診断 subnav (#dashboard-ia)', () => 
     for (const href of ['/dashboard/charts?tab=quality', '/dashboard/charts']) {
       expect(body).toContain(`href="${href}"`)
     }
-    expect(body).toContain('資産推移')
+    expect(body).toContain('実現損益の推移')
     // 判定ログ / アラートはレビュー subnav からは外れる (診断側へ)
     expect(body).not.toContain('<a class="subnav-link" href="/dashboard/cron">')
     expect(body).not.toContain('<a class="subnav-link" href="/dashboard/alerts">')
@@ -292,7 +292,7 @@ describe('dashboard IA — レビュー / 診断 subnav (#dashboard-ia)', () => 
     expect((body.match(/<nav class="subnav">/g) ?? []).length).toBe(1)
     // charts 自前 subnav の active (title 付き span) が出ている
     expect(body).toContain('class="subnav-link active"')
-    expect(body).toContain('>取引品質<')
+    expect(body).toContain('>成績<')
   })
 })
 


### PR DESCRIPTION
ダッシュボード再構成 **Phase 4 (改名)**。

## 変更

| Before | After | 理由 |
|---|---|---|
| 取引品質 | **成績** | 中身は勝率 / PF / 期待値 / PnL 分布。スリッページ・約定率・部分約定は含まれておらず、「品質」は実態と合わない |
| 資産推移 | **実現損益の推移** | 口座資産 (`portfolio`) と累積 realized PnL (`charts/equity`) は別物。同じ「資産推移」で呼んでいたため区別できなかった |

ラベルとコメントのみで、集計ロジックと URL は変更していません。

## Phase 5 (redirect) は分離しました

`/positions` `/portfolio` の単独ページをホームへ redirect する変更も用意しましたが、**この PR からは外しました**。理由:

- 両ページを直接叩くテストが 3 ファイル・13 箇所あり、redirect にすると本文アサーションの移設が必要
- `portfolioBody` は redirect 後に dead code になるので、削除まで含めて 1 つの PR にすべき
- そもそも当初計画で「1〜2 リリース様子を見てから物理削除」としていた段階

ナビからは Phase 1 で既に外れているので、**UI 上はすでに見えていません**。実際に困らないことを確認してから、redirect と dead code 削除をまとめて出します。

## 検証

`pnpm run typecheck` clean / `pnpm test` 121 files・1822 tests pass。