### PR TITLE
feat(dashboard): build the home the mock promised

### DIFF
--- a/src/routes/dashboard/index.ts
+++ b/src/routes/dashboard/index.ts
@@ -58,8 +58,18 @@ import { clampLimit, jsonPretty, messageOf, parseCursor, unavailable } from './s
 import { type DashboardBindings, loadKillSwitchState, renderAnalysisSubnav, renderDiagSubnav, renderLayout } from './layout'
 import { extractTokenFromPaste, renderWebullTokenBody } from './webullToken'
 import { brokerProbeBody } from './brokerProbe'
-import { ALL_OVERVIEW_PANELS, type OverviewData, loadRecentFills, overviewBody, parseOverviewPanels } from './overview'
+import {
+  ALL_OVERVIEW_PANELS,
+  type HomeRunSignals,
+  type OverviewData,
+  type StopDistanceView,
+  loadRecentFills,
+  overviewBody,
+  parseOverviewPanels,
+} from './overview'
+import type { SymbolUniverse } from '../../infrastructure/db/symbolUniverse'
 import { buildPositionsPacket, loadLatestStrategyPrices, loadPositionsPageData, positionsBody } from './positions'
+import { resolveStopDistance } from '../../trading/strategy/stopDistance'
 import { parseEquityRange, portfolioBody, safeLoadPortfolioSnapshots } from './portfolio'
 import { buildTradesPacket, loadTradeJournalRows, parseTradesQuery, tradesBody } from './trades'
 import { configBody } from './config'
@@ -118,6 +128,117 @@ function chartsPageSubnav(tab: ReturnType<typeof parseChartsTab>): string {
  * still yields a usable landing.
  */
 
+/**
+ * 運転状態帯のシグナル (#dashboard-ia)。判定ログの最新時刻で cron の生存を、
+ * 直近 24h の通知件数でアラート状況を表す。**ack (確認済み) の概念はまだ無い**
+ * ので「未確認」は 24h 件数で代用している。
+ */
+async function loadHomeRunSignals(db: D1Database): Promise<HomeRunSignals> {
+  const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+  const [cronRow, alertRows] = await Promise.all([
+    db.prepare('SELECT timestamp FROM strategy_decision_log ORDER BY id DESC LIMIT 1').first<{
+      timestamp: string
+    }>(),
+    db
+      .prepare(
+        "SELECT severity, COUNT(*) AS n FROM notification_emit_log WHERE timestamp >= ? AND severity IN ('critical','warning') GROUP BY severity",
+      )
+      .bind(since)
+      .all<{ severity: string; n: number }>(),
+  ])
+  let alertCritical = 0
+  let alertWarning = 0
+  for (const r of alertRows.results ?? []) {
+    if (r.severity === 'critical') alertCritical = Number(r.n) || 0
+    if (r.severity === 'warning') alertWarning = Number(r.n) || 0
+  }
+  return { lastCronAt: cronRow?.timestamp ?? null, alertCritical, alertWarning }
+}
+
+/** 直近 30 日の勝敗と発注エラー件数 (最近の活動フッター)。 */
+async function loadActivityStats(
+  db: D1Database,
+): Promise<{ wins: number; losses: number; errors: number }> {
+  const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString()
+  const row = await db
+    .prepare(
+      `SELECT
+         SUM(CASE WHEN realized_pnl > 0 THEN 1 ELSE 0 END) AS wins,
+         SUM(CASE WHEN realized_pnl < 0 THEN 1 ELSE 0 END) AS losses,
+         SUM(CASE WHEN error_class IS NOT NULL THEN 1 ELSE 0 END) AS errors
+       FROM trade_journal WHERE timestamp >= ?`,
+    )
+    .bind(since)
+    .first<{ wins: number | null; losses: number | null; errors: number | null }>()
+  return {
+    wins: Number(row?.wins ?? 0) || 0,
+    losses: Number(row?.losses ?? 0) || 0,
+    errors: Number(row?.errors ?? 0) || 0,
+  }
+}
+
+/**
+ * 銘柄ごとの最新 atr20 (判定ログの indicators_json)。実効 stop の算出に使う。
+ * 判定ログが無い銘柄は不在 → 呼び出し側が pct stop に fallback する。
+ */
+async function loadLatestAtr20(db: D1Database, symbols: string[]): Promise<Map<string, number>> {
+  const out = new Map<string, number>()
+  if (symbols.length === 0) return out
+  const rows = await db
+    .prepare(
+      `SELECT symbol, indicators_json FROM strategy_decision_log
+       WHERE id IN (SELECT MAX(id) FROM strategy_decision_log GROUP BY symbol)`,
+    )
+    .all<{ symbol: string | null; indicators_json: string | null }>()
+  for (const r of rows.results ?? []) {
+    if (!r.symbol || !r.indicators_json) continue
+    try {
+      const parsed = JSON.parse(r.indicators_json) as { atr20?: unknown }
+      if (typeof parsed.atr20 === 'number' && Number.isFinite(parsed.atr20) && parsed.atr20 > 0) {
+        out.set(r.symbol.toUpperCase(), parsed.atr20)
+      }
+    } catch {
+      // 壊れた JSON は無視 (stop 距離が出ないだけで画面は描ける)
+    }
+  }
+  return out
+}
+
+/**
+ * 建玉ごとの「実効 stop までの距離」。cron と同じ `resolveStopDistance` を
+ * 通すので、表示値と実際に切られる水準がズレない。
+ */
+function buildStopDistances(
+  positions: Array<{ sym: string; state: SymbolState | null }>,
+  atr20Map: Map<string, number>,
+  defaultRule: SymbolRule,
+  universe: SymbolUniverse,
+): Map<string, StopDistanceView> {
+  const rules = buildSymbolRules(defaultRule, universe)
+  const out = new Map<string, StopDistanceView>()
+  for (const r of positions) {
+    const pos = r.state?.position
+    const quote = r.state?.lastQuote?.price
+    if (!pos || pos.qty <= 0 || !(pos.avgPrice > 0) || typeof quote !== 'number' || !(quote > 0)) {
+      continue
+    }
+    const sym = r.sym.toUpperCase()
+    const rule = rules[sym] ?? defaultRule
+    const stop = resolveStopDistance({
+      price: pos.avgPrice,
+      stopPct: rule.stopPct,
+      takeProfitPct: rule.takeProfitPct,
+      atr20: atr20Map.get(sym) ?? 0,
+      kAtr: rule.kAtr,
+      maxStopToTpRatio: rule.maxStopToTpRatio,
+    })
+    const pnlPct = ((quote - pos.avgPrice) / pos.avgPrice) * 100
+    const effectiveStopPct = stop.effectiveStopPct * 100
+    out.set(sym, { pnlPct, effectiveStopPct, toStopPct: pnlPct - effectiveStopPct })
+  }
+  return out
+}
+
 export const dashboard = new Hono<DashboardBindings>()
   .use('*', rateLimit('DASHBOARD'))
   .use('*', async (c, next) => {
@@ -135,7 +256,7 @@ export const dashboard = new Hono<DashboardBindings>()
       const allDisplaySymbols = [...universe.allowedSymbols, ...universe.inactiveSymbols]
       const symbolClient = c.env.SYMBOL_STATE ? new SymbolStateClient(c.env.SYMBOL_STATE) : null
       const range = parseEquityRange(c.req.query('range'))
-      const [panelsCsv, portfolio, snapshots, usdJpy, positions, strategyPriceMap, recentTrades, vixRegime, global] =
+      const [panelsCsv, portfolio, snapshots, usdJpy, positions, strategyPriceMap, recentTrades, runSignals, activityStats, atr20Map, vixRegime, global] =
         await Promise.all([
           loadOverviewPanelsCsv(db),
           c.env.PORTFOLIO_STATE
@@ -161,6 +282,12 @@ export const dashboard = new Hono<DashboardBindings>()
             : Promise.resolve([] as Array<{ sym: string; state: SymbolState | null; error: string | null }>),
           loadLatestStrategyPrices(c.env.DB, allDisplaySymbols),
           loadRecentFills(c.env.DB, 8),
+          // #dashboard-ia: 運転状態帯 (最終 cron / アラート件数) と
+          // 最近の活動フッター (勝敗 / 発注エラー)。いずれも best-effort で、
+          // 失敗しても home 全体は描画する。
+          loadHomeRunSignals(c.env.DB).catch(() => null),
+          loadActivityStats(c.env.DB).catch(() => null),
+          loadLatestAtr20(c.env.DB, allDisplaySymbols).catch(() => new Map<string, number>()),
           c.env.DB
             ? loadVixRegimeSnapshot(c.env.DB, c.get('requestId')).catch(() => null)
             : Promise.resolve(null),
@@ -176,6 +303,9 @@ export const dashboard = new Hono<DashboardBindings>()
         positions,
         strategyPriceMap,
         recentTrades,
+        runSignals,
+        activityStats,
+        stopDistances: buildStopDistances(positions, atr20Map, strategyParamsFromGlobal(global), universe),
         vixRegime,
         dryRun: global.dryRun,
         // env TRADING_ENABLED の deploy-gate を反映した effective 値 (CodeRabbit #397:

--- a/src/routes/dashboard/layout.ts
+++ b/src/routes/dashboard/layout.ts
@@ -47,6 +47,18 @@ export const STYLE = `
   .topnav{display:flex;align-items:center;gap:4px;padding:6px 16px;flex-wrap:wrap}
   .topnav .brand{font-weight:700;font-size:15px;margin-right:12px;white-space:nowrap;color:#1d1d1f}
   .topnav nav{display:flex;align-items:center;gap:2px;flex-wrap:wrap;flex:1;min-width:0}
+  /* #dashboard-ia: 運転状態帯のカード。左の色帯で状態を形でも読めるようにする
+     (数値だけだと「取引 OFF」を見落とす)。 */
+  .state-band{display:flex;flex-wrap:wrap;gap:10px;align-items:stretch;margin-bottom:4px}
+  .state-card{flex:1 1 150px;border:1px solid #d0d0d5;border-left:3px solid #d0d0d5;border-radius:6px;padding:8px 12px;background:#fff}
+  .state-card.live{border-left-color:#1a7f37}
+  .state-card.hold{border-left-color:#9a6700}
+  .state-card.alarm{border-left-color:#c0392b}
+  .state-value{font-size:17px;font-weight:700;font-variant-numeric:tabular-nums;margin-top:2px}
+  .state-value a{color:inherit;text-decoration:none}
+  .state-value a:hover{text-decoration:underline}
+  .state-kill{align-self:center;background:#fdecea;color:#c0392b;border:1px solid #f0b3ac;border-radius:6px;padding:8px 14px;font-weight:700;font-size:13px;text-decoration:none;white-space:nowrap}
+  .state-kill:hover{background:#f8d7d3}
   /* #dashboard-ia Phase 3: ホームの領域見出し (運転状態 / リスクと建玉 / 最近の活動)。 */
   .area-label{font-size:11px;letter-spacing:.12em;color:#6e6e73;margin:18px 0 6px;display:flex;align-items:center;gap:8px}
   .area-label::after{content:"";flex:1;height:1px;background:#e3e3e8}

--- a/src/routes/dashboard/overview.ts
+++ b/src/routes/dashboard/overview.ts
@@ -64,8 +64,32 @@ export function parseOverviewPanels(csv: string | null | undefined): Set<Overvie
   return set.size === 0 ? new Set(ALL_OVERVIEW_PANELS) : set
 }
 
+export interface HomeRunSignals {
+  /** 直近の戦略判定の時刻 (= cron が生きている証拠)。null なら判定ログが空。 */
+  lastCronAt: string | null
+  /** 直近 24h の critical / warning 件数。ack の概念はまだ無いので件数で代用。 */
+  alertCritical: number
+  alertWarning: number
+}
+
+/** 建玉 1 件の「あと何 % で損切りか」。実効 stop は ATR / R:R cap で動く。 */
+export interface StopDistanceView {
+  /** 現在の含み損益 (%)。 */
+  pnlPct: number
+  /** 実効 stop (%、負値)。atr20 が無ければ pct stop。 */
+  effectiveStopPct: number
+  /** stop までの距離 (%、正値)。0 以下なら既に到達している。 */
+  toStopPct: number
+}
+
 export interface OverviewData {
   panels: Set<OverviewPanel>
+  /** 運転状態帯の追加シグナル。未取得 (DB 不在) は null。 */
+  runSignals: HomeRunSignals | null
+  /** symbol → 実効 stop までの距離。計算できない銘柄は不在。 */
+  stopDistances: Map<string, StopDistanceView>
+  /** 直近 30 日の成績 (勝ち / 負け / 発注エラー)。未取得は null。 */
+  activityStats: { wins: number; losses: number; errors: number } | null
   portfolio: {
     dailyStartEquity: number
     dailyRealizedPnl: number
@@ -190,30 +214,56 @@ export function sectionHead(title: string, moreHref: string): string {
  * 状態表示に徹する。
  */
 export function renderRunStatePanel(data: OverviewData): string {
-  const modePill = data.dryRun
-    ? '<span class="pill off">DRY-RUN</span>'
-    : '<span class="pill on">LIVE</span>'
-  const tradingPill = data.tradingEnabled
-    ? '<span class="pill on">取引 ON</span>'
-    : '<span class="pill off">取引 OFF</span>'
-  const item = (label: string, value: string) =>
-    `<div style="min-width:104px"><div class="kpi-label">${esc(label)}</div><div style="font-size:15px;font-weight:700;font-variant-numeric:tabular-nums">${value}</div></div>`
+  const mode = data.dryRun
+    ? { text: 'DRY-RUN', tone: 'hold' as const }
+    : { text: 'LIVE', tone: 'live' as const }
+  const trading = data.tradingEnabled
+    ? { text: 'ON', tone: 'live' as const }
+    : { text: 'OFF', tone: 'hold' as const }
+  const cron = renderRelativeAge(data.runSignals?.lastCronAt ?? null, 20)
   const quote = latestQuoteFreshness(data)
-  return `<div class="panel" style="display:flex;flex-wrap:wrap;gap:10px 22px;align-items:flex-end">
-    ${item('実行モード', modePill)}
-    ${item('取引 (effective)', tradingPill)}
-    ${item('株価の鮮度', quote)}
-    ${item('VIX レジーム', `<span style="font-size:13px;font-weight:400">${renderVixRegimeCell(data.vixRegime)}</span>`)}
-    ${item('USDJPY', data.usdJpy === null ? '<span class="muted">—</span>' : fmtNumber(data.usdJpy, 2))}
-    <div style="margin-left:auto;font-size:12px"><a href="/dashboard/alerts">アラート →</a></div>
+  const crit = data.runSignals?.alertCritical ?? 0
+  const warn = data.runSignals?.alertWarning ?? 0
+  const alert =
+    crit > 0
+      ? { text: `${crit} critical`, tone: 'alarm' as const }
+      : warn > 0
+        ? { text: `${warn} warning`, tone: 'hold' as const }
+        : { text: '0', tone: 'plain' as const }
+  const card = (label: string, value: string, tone: 'live' | 'hold' | 'alarm' | 'plain') =>
+    `<div class="state-card${tone === 'plain' ? '' : ` ${tone}`}"><div class="kpi-label">${esc(label)}</div><div class="state-value">${value}</div></div>`
+  return `<div class="state-band">
+    ${card('実行モード', esc(mode.text), mode.tone)}
+    ${card('取引', esc(trading.text), trading.tone)}
+    ${card('最終 cron', cron.html, cron.tone)}
+    ${card('株価の鮮度', quote.html, quote.tone)}
+    ${card('VIX レジーム', `<span style="font-size:13px;font-weight:400">${renderVixRegimeCell(data.vixRegime)}</span>`, 'plain')}
+    ${card('未確認アラート', `<a href="/dashboard/alerts">${esc(alert.text)}</a>`, alert.tone)}
+    <a class="state-kill" href="/dashboard/config" title="global_config で trading_enabled を切る">緊急停止</a>
   </div>`
+}
+
+/**
+ * ISO 時刻 → 相対表示 + 鮮度の色。`staleMin` を超えたら警告色にする。
+ * cron は 15 分周期なので既定 20 分、quote は stale_quote_ms 既定に合わせ 15 分。
+ */
+function renderRelativeAge(
+  iso: string | null,
+  staleMin: number,
+): { html: string; tone: 'live' | 'hold' | 'plain' } {
+  if (iso === null) return { html: '<span class="muted">—</span>', tone: 'plain' }
+  const t = new Date(iso).getTime()
+  if (!Number.isFinite(t)) return { html: '<span class="muted">—</span>', tone: 'plain' }
+  const min = Math.floor((Date.now() - t) / 60000)
+  const text = min < 1 ? '1 分未満' : min < 60 ? `${min} 分前` : `${Math.floor(min / 60)} 時間前`
+  return { html: esc(text), tone: min >= staleMin ? 'hold' : 'live' }
 }
 
 /**
  * 保有・監視銘柄の中で **最も新しい** 株価の取得時刻を相対表示する。
  * quote feed が止まると全銘柄で同時に古くなるので、最新 1 件で足りる。
  */
-function latestQuoteFreshness(data: OverviewData): string {
+function latestQuoteFreshness(data: OverviewData): { html: string; tone: 'live' | 'hold' | 'plain' } {
   let latest: number | null = null
   for (const r of data.positions) {
     const q = r.state?.lastQuote
@@ -226,12 +276,9 @@ function latestQuoteFreshness(data: OverviewData): string {
     const t = new Date(v.asOf).getTime()
     if (Number.isFinite(t) && (latest === null || t > latest)) latest = t
   }
-  if (latest === null) return '<span class="muted">—</span>'
-  const min = Math.floor((Date.now() - latest) / 60000)
-  const text = min < 1 ? '1 分未満' : min < 60 ? `${min} 分前` : `${Math.floor(min / 60)} 時間前`
+  if (latest === null) return { html: '<span class="muted">—</span>', tone: 'plain' }
   // 15 分は global_config.stale_quote_ms の既定 (halt 判定と同じ線)。
-  const cls = min >= 15 ? 'err' : 'ok'
-  return `<span class="${cls}" style="font-size:13px">${esc(text)}</span>`
+  return renderRelativeAge(new Date(latest).toISOString(), 15)
 }
 
 export function renderHomePositionsSection(data: OverviewData): string {
@@ -245,6 +292,65 @@ export function renderHomePositionsSection(data: OverviewData): string {
 export function kpiCard(label: string, value: string, sub?: string, subClass?: string): string {
   const subHtml = sub ? `<div class="kpi-sub ${subClass ?? 'muted'}">${sub}</div>` : ''
   return `<div class="kpi-card"><div class="kpi-label">${esc(label)}</div><div class="kpi-value">${value}</div>${subHtml}</div>`
+}
+
+/**
+ * リスクと建玉 (#dashboard-ia): 建玉テーブル + エクスポージャー + 買付余力。
+ *
+ * 旧ホームは KPI カード / 保有ポジション表 / 資産構成の 3 枚に分かれていたが、
+ * 建玉 2-3 件の口座では同じデータを 3 回見せているだけだった。1 枚に畳み、
+ * **各建玉が実効 stop からどれだけ離れているか**という、表からは読めなかった
+ * 情報を状態列として足す。
+ */
+export function renderRiskPanel(data: OverviewData, open: OpenPositionView[]): string {
+  const exposurePill = renderExposurePill(data, open)
+  if (!data.symbolStateBound) {
+    return `<div class="panel"><div class="panel-title"><span>建玉</span></div><p class="muted" style="margin:0">SYMBOL_STATE 未配線のため表示できません。</p></div>`
+  }
+  if (open.length === 0) {
+    return `<div class="panel"><div class="panel-title"><span>建玉 0 件</span>${exposurePill}</div><p class="muted" style="margin:0">保有中の建玉はありません。</p></div>`
+  }
+  const rows = open
+    .map((o) => {
+      const stop = data.stopDistances.get(o.sym)
+      const pnlCls = o.pnlPct === null ? '' : o.pnlPct >= 0 ? 'ok' : 'err'
+      const state =
+        stop === undefined
+          ? '<span class="muted">—</span>'
+          : stop.toStopPct <= 0
+            ? '<span class="pill off">損切り水準</span>'
+            : stop.toStopPct <= 2
+              ? `<span class="pill warn">損切りまで ${fmtNumber(stop.toStopPct, 1)}%</span>`
+              : '<span class="pill">保有継続</span>'
+      return `<tr>
+        <td><a href="/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(o.sym)}">${esc(displaySymbol(o.sym, data.universe))}</a></td>
+        <td class="num">${fmtNumber(o.qty, 0)}</td>
+        <td class="num">${o.price === null ? '<span class="muted">—</span>' : fmtNumber(o.price, 2)}</td>
+        <td class="num ${pnlCls}">${o.pnlPct === null ? '—' : `${fmtNumber(o.pnlPct, 2)}%`}</td>
+        <td>${state}</td>
+      </tr>`
+    })
+    .join('')
+  return `<div class="panel">
+    <div class="panel-title"><span>建玉 ${open.length} 件 / エクスポージャー</span>${exposurePill}</div>
+    <table>
+      <thead><tr><th>銘柄</th><th class="num">数量</th><th class="num">現在値</th><th class="num">損益</th><th>状態</th></tr></thead>
+      <tbody>${rows}</tbody>
+    </table>
+    <p class="muted" style="font-size:12px;margin:10px 0 0">実効 stop は ATR と R:R 上限で銘柄ごとに変動します。詳細は <a href="/dashboard/charts?tab=symbol">銘柄</a> へ。</p>
+  </div>`
+}
+
+/** 建玉合計 / total_capital の比率 pill。total_capital 未設定なら件数のみ。 */
+function renderExposurePill(data: OverviewData, open: OpenPositionView[]): string {
+  const usd = open
+    .filter((o) => o.currency === 'USD' && o.marketValue !== null)
+    .reduce((a, o) => a + (o.marketValue ?? 0), 0)
+  const cap = data.portfolio?.dailyStartEquity ?? 0
+  if (!(cap > 0) || usd <= 0) return ''
+  const pct = (usd / cap) * 100
+  const cls = pct >= 60 ? 'warn' : ''
+  return `<span class="pill ${cls}">開始 equity の ${fmtNumber(pct, 0)}%</span>`
 }
 
 export function renderKpiPanel(data: OverviewData, open: OpenPositionView[]): string {
@@ -324,25 +430,20 @@ export function renderRecentPanel(data: OverviewData): string {
   const recentTable = data.recentTrades.length
     ? `<table><thead><tr><th>時刻</th><th>銘柄</th><th>売買</th><th>数量</th><th>約定値</th><th>実損益</th></tr></thead><tbody>${trades}</tbody></table>`
     : '<p class="muted">約定履歴がありません。</p>'
-  const dryPill = data.dryRun
-    ? '<span class="pill dry">DRY-RUN</span>'
-    : '<span class="pill live">LIVE</span>'
-  const tradingPill = data.tradingEnabled
-    ? '<span class="pill on">取引 ON</span>'
-    : '<span class="pill off">取引 OFF</span>'
+  // 実行モード / 取引 / VIX は運転状態帯に移したのでここでは繰り返さない。
   return `<div class="panel">
-    <div class="panel-title" style="display:flex;justify-content:space-between;align-items:baseline"><span>最近の約定 / リスク状態</span><span style="font-weight:400;font-size:12px"><a href="/dashboard/cron">判定履歴 →</a> <a href="/dashboard/alerts" style="margin-left:8px">アラート →</a></span></div>
-    <div class="panel-row">
-      <div>${recentTable}<div style="margin-top:8px"><a href="/dashboard/trades">約定履歴をすべて見る →</a></div></div>
-      <div>
-        <table><tbody>
-          <tr><th>実行モード</th><td>${dryPill} <span class="muted" style="font-size:11px">(D1 dry_run)</span></td></tr>
-          <tr><th>取引 (effective)</th><td>${tradingPill} <span class="muted" style="font-size:11px">(env override 反映後)</span></td></tr>
-          <tr><th>VIX レジーム</th><td>${renderVixRegimeCell(data.vixRegime)}</td></tr>
-        </tbody></table>
-      </div>
-    </div>
+    <div class="panel-title" style="display:flex;justify-content:space-between;align-items:baseline"><span>直近の約定</span><span style="font-weight:400;font-size:12px"><a href="/dashboard/cron">判定ログ →</a></span></div>
+    ${recentTable}
+    <div style="margin-top:8px"><a href="/dashboard/trades">約定履歴をすべて見る →</a></div>
+    ${activityFooter(data)}
   </div>`
+}
+
+/** 直近 30 日の成績サマリ (勝ち / 負け / 発注エラー)。未取得なら空文字。 */
+function activityFooter(data: OverviewData): string {
+  const st = data.activityStats
+  if (st === null) return ''
+  return `<p class="muted" style="font-size:12px;margin:10px 0 0">直近 30 日 ・ 勝ち ${st.wins} / 負け ${st.losses} ・ 発注エラー ${st.errors}</p>`
 }
 
 /**
@@ -408,12 +509,10 @@ export function overviewBody(data: OverviewData): string {
   // 1. 運転状態 — 常時表示。設定で隠せない。
   sections.push(renderRunStatePanel(data))
 
-  // 2. リスクと建玉
+  // 2. リスクと建玉 — 建玉テーブル 1 枚に集約 (KPI / 資産構成の重複を排除)。
   if (data.panels.has('risk')) {
     sections.push(areaLabel('リスクと建玉'))
-    sections.push(renderKpiPanel(data, open))
-    sections.push(renderHomePositionsSection(data))
-    sections.push(renderCompositionPanel(open))
+    sections.push(renderRiskPanel(data, open))
   }
 
   // 3. 最近の活動

--- a/test/routes/dashboardIa.test.ts
+++ b/test/routes/dashboardIa.test.ts
@@ -324,18 +324,17 @@ describe('dashboard IA — home integration (#dashboard-ia)', () => {
     expect(body).toContain('実行モード')
     expect(body).toContain('株価の鮮度')
     expect(body).toContain('取引 ON')
-    expect(body).toContain('USDJPY')
-    expect(body).toContain('150.25')
+    expect(body).toContain('最終 cron')
+    expect(body).toContain('未確認アラート')
     // 2. 領域見出し
     expect(body).toContain('リスクと建玉')
     expect(body).toContain('最近の活動')
-    // 3. 保有ポジション (positions と同じテーブル)
-    expect(body).toContain('保有ポジション')
-    expect(body).toContain('SOXL')
-    expect(body).toContain('平均取得単価')
+    // 3. リスクと建玉 (KPI / 資産構成を畳んだ 1 枚)
+    expect(body).toContain('建玉')
+    expect(body).toContain('実効 stop は ATR と R:R 上限')
     // 4. 直近の約定 + 導線リンク
-    expect(body).toContain('最近の約定 / リスク状態')
-    expect(body).toContain('href="/dashboard/positions"')
+    expect(body).toContain('直近の約定')
+    expect(body).toContain('href="/dashboard/trades"')
     expect(body).toContain('href="/dashboard/cron"')
     expect(body).toContain('href="/dashboard/alerts"')
   })
@@ -357,7 +356,7 @@ describe('dashboard IA — home integration (#dashboard-ia)', () => {
     }
   })
 
-  it('omits 資産サマリ帯 and shows positions guidance link when DOs are missing (graceful)', async () => {
+  it('DO 不在でも運転状態帯は出し、建玉パネルは理由を出す (graceful)', async () => {
     vi.mocked(loadPortfolioEquitySnapshots).mockResolvedValue([])
     const env = { ...baseEnv, DB: fakeD1() }
     const app = createApp()
@@ -368,9 +367,11 @@ describe('dashboard IA — home integration (#dashboard-ia)', () => {
     expect(body).not.toContain('本日開始 equity')
     expect(body).not.toContain('home-equity-spark')
     expect(vi.mocked(loadUsdJpyRate)).not.toHaveBeenCalled()
-    // SYMBOL_STATE 不在 → テーブル省略 + /positions への誘導リンク
+    // SYMBOL_STATE 不在 → 建玉テーブルは出さず理由だけ出す
     expect(body).toContain('SYMBOL_STATE 未配線')
-    expect(body).toContain('href="/dashboard/positions"')
+    // 運転状態帯は DO 不在でも出る (実行モード / 取引は D1 由来)
+    expect(body).toContain('実行モード')
+    expect(body).toContain('未確認アラート')
   })
 })
 


### PR DESCRIPTION
モック (https://claude.ai/code/artifact/1228762a-7cac-4685-b40e-9bf582a3421c) の見た目を実装します。Phase 3 では領域分けまでしかやっておらず、中身は既存レンダラーの流用でした。

## 運転状態帯

テキスト横並び → **カード化** (左端の色帯で状態を形でも読める)。追加した情報:

- **最終 cron** — 判定ログの最新時刻。20 分を超えたら警告色 (cron は 15 分周期)
- **未確認アラート** — 直近 24h の critical / warning 件数。critical があれば赤
- **緊急停止** — 設定画面への導線
- 株価の鮮度も同じ相対表示に統一 (15 分 = `stale_quote_ms` 既定を超えたら警告色)

**「未確認」は 24h 件数で代用**しています。`notification_emit_log` に ack の概念がまだ無いためで、本当に確認済みフラグを持たせるなら migration + 確認ボタンが要るので別 PR にします。

## リスクと建玉

KPI カード / 保有ポジション表 / 資産構成の **3 枚を 1 枚に統合**。建玉 2-3 件の口座で同じデータを 3 回見せていました。

代わりに**「損切りまであと何 %」**を状態列に追加しました。判定ログの `indicators_json` から最新 atr20 を取り、**cron と同じ `resolveStopDistance`** を通して実効 stop を出します。表示値と実際に切られる水準がズレません。

- 距離 2% 以内: `損切りまで 1.3%` (警告)
- 到達済み: `損切り水準`
- それ以外: `保有継続`

エクスポージャーは開始 equity 比の pill で出します (60% 超で警告色)。

## 最近の活動

- 右カラムの実行モード / 取引 / VIX を削除 (運転状態帯と重複)
- **直近 30 日の勝ち / 負け / 発注エラー**をフッターに追加

## 検証

`pnpm run typecheck` clean / `pnpm test` 121 files・1822 tests pass。新しい loader 3 本は `.catch()` で握るので、失敗してもホーム全体は描画されます。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ダッシュボードに運転状態帯を追加し、実行モード、最終実行時刻、未確認アラート、緊急停止状態を確認できるようになりました。
  * 建玉ごとの実効ストップまでの距離とリスク情報を表示します。
  * 直近30日の勝敗・発注エラー件数をフッターに追加しました。
* **改善**
  * 株価の鮮度や運転状態を整理して表示し、情報を確認しやすくしました。
  * 必要なデータが取得できない場合も、利用可能な情報を表示して画面を継続利用できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->