### PR TITLE
fix(dashboard): confine the width ceiling to the home page

### DIFF
--- a/src/routes/dashboard/layout.ts
+++ b/src/routes/dashboard/layout.ts
@@ -90,9 +90,11 @@ export const STYLE = `
   .subnav-link:hover{background:#f0f0f3}
   .subnav-link.active{background:#e8f0fe;color:#06c;font-weight:600}
   .nav-toggle{display:none;background:none;border:none;font-size:22px;cursor:pointer;padding:4px 8px;color:#1d1d1f;line-height:1}
-  /* ワイドモニタで表・カードが横いっぱいに伸びると、桁の少ない数値が
-     スカスカに散って読みづらい。読み幅の上限を切って中央に寄せる。 */
-  .main{min-width:0;padding:24px;overflow-x:auto;max-width:1160px;margin:0 auto;width:100%}
+  .main{min-width:0;padding:24px;overflow-x:auto}
+  /* ワイドモニタで横に間延びするのを止めるが、**ホームだけ**に効かせる。
+     銘柄チャートや判定マトリクスは横に広いほど読みやすく、幅を切ると
+     チャートがはみ出したりヘッダが 1 文字ずつ折り返したりする。 */
+  .main-narrow{max-width:1160px;margin:0 auto;width:100%}
   @media(max-width:780px){
     .main{padding:12px 8px}
     .nav-toggle{display:block}
@@ -151,9 +153,11 @@ export const STYLE = `
   /* 右寄せ数値セル */
   .num{text-align:right;font-variant-numeric:tabular-nums}
   table{border-collapse:collapse;width:100%;background:#fff;border:1px solid #d0d0d5;border-radius:6px;overflow:hidden}
-  /* 列を均等に開かせない: 1 列目 (銘柄 / 時刻) に余りを寄せ、数値列は内容幅。 */
-  table th:first-child,table td:first-child{width:99%}
-  table td.num,table th.num{width:1%;white-space:nowrap}
+  /* 列を均等に開かせない: 1 列目 (銘柄 / 時刻) に余りを寄せ、数値列は内容幅。
+     **ホーム限定**。1 列目がアイコン/ボタン列の表 (判定履歴など) に効かせると
+     他の列が潰れてヘッダが縦に折り返す。 */
+  .main-narrow table th:first-child,.main-narrow table td:first-child{width:99%}
+  .main-narrow table td.num,.main-narrow table th.num{width:1%;white-space:nowrap}
   th,td{padding:8px 10px;text-align:left;border-bottom:1px solid #e5e5ea;font-size:13px;font-variant-numeric:tabular-nums}
   th{background:#fafafa;font-weight:600}
   tr:last-child td{border-bottom:none}
@@ -501,7 +505,7 @@ export function layout(
     window.addEventListener('resize', set);
   })();
 </script>
-<main class="main">
+<main class="main${activeNav === 'home' ? ' main-narrow' : ''}">
   ${body}
   <div class="footer">画面生成時刻: ${esc(fmtJst(new Date()))}</div>
 </main>

--- a/test/routes/dashboardIa.test.ts
+++ b/test/routes/dashboardIa.test.ts
@@ -433,3 +433,30 @@ describe('dashboard IA — CodeRabbit #559 対応', () => {
     expect(cdnTags.length).toBe(1)
   })
 })
+
+// #dashboard-ia: 幅の上限は **ホームだけ**。銘柄チャートや判定マトリクスに
+// 効かせると、チャートがはみ出したりテーブルのヘッダが 1 文字ずつ折り返す。
+describe('dashboard 幅の上限はホーム限定 (#dashboard-ia)', () => {
+  beforeEach(() => {
+    vi.mocked(loadGlobalConfigFrom).mockResolvedValue(makeGlobalConfigSnapshot())
+    vi.mocked(loadSymbolUniverse).mockResolvedValue(
+      makeSymbolUniverse({ allowedSymbols: ['SOXL'], symbolCurrency: { SOXL: 'USD' } }),
+    )
+    vi.mocked(loadPortfolioEquitySnapshots).mockResolvedValue([])
+    vi.mocked(loadUsdJpyRate).mockResolvedValue(150.25)
+  })
+  afterEach(() => vi.resetAllMocks())
+
+  it('ホームは main-narrow、それ以外のページには付かない', async () => {
+    const app = createApp()
+    const home = await (await app.request('/dashboard', { headers: authHeader }, baseEnv)).text()
+    expect(home).toContain('class="main main-narrow"')
+
+    for (const path of ['/dashboard/trades', '/dashboard/charts?tab=symbol', '/dashboard/cron']) {
+      const body = await (await app.request(path, { headers: authHeader }, baseEnv)).text()
+      // CSS 定義自体は全ページに inline されるので、class 属性で判定する
+      expect(body, path).toContain('class="main"')
+      expect(body, path).not.toContain('class="main main-narrow"')
+    }
+  })
+})


### PR DESCRIPTION
#632 の回帰修正です。銘柄ページのスクリーンショットで発覚しました。

## 何が起きたか

#632 で入れた 2 つのルールを**全ページに効かせた**のが誤りでした。

| ルール | 意図 | 実際の影響 |
|---|---|---|
| `table th:first-child{width:99%}` | 銘柄/時刻列に余りを寄せる | **1 列目がアイコン列の表**(判定履歴)で他の列が潰れ、`実 fill (価格 × 数量)` などのヘッダが 1 文字ずつ縦に折り返した |
| `.main{max-width:1160px}` | 横の間延びを止める | 銘柄チャートが右にはみ出した (チャートは横に広いほど読みやすい) |

## 修正

両方とも **`.main-narrow` (ホームのみ)** に限定しました。`layout()` が active nav group を見て、ホームのときだけ class を足します。

- ホーム: 幅上限 1160px + 列幅の寄せ (#632 の意図どおり)
- 銘柄 / レビュー / 診断 / 管理: **#632 以前の挙動に戻る**

## 検証

`pnpm run typecheck` clean / `pnpm test` 121 files・1823 tests pass。回帰テストを追加しました — ホームには `class="main main-narrow"` が付き、`/trades` `/charts?tab=symbol` `/cron` には付かないことを assert しています (CSS 定義自体は全ページに inline されるので class 属性で判定)。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ホーム画面のみ、コンテンツ幅を制限して中央寄せするレイアウトに変更しました。
  * ホーム画面のテーブル表示で、主要列の幅を優先し、数値列の不要な折り返しを抑制しました。
  * 取引・チャート・Cron画面では、画面幅を制限しない従来のレイアウトを維持します。

* **テスト**
  * 各ダッシュボード画面で、適切な幅設定が適用されることを確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->