### PR TITLE
fix(dashboard): let the name column absorb the slack, not the clock

### DIFF
--- a/src/routes/dashboard/layout.ts
+++ b/src/routes/dashboard/layout.ts
@@ -153,11 +153,13 @@ export const STYLE = `
   /* 右寄せ数値セル */
   .num{text-align:right;font-variant-numeric:tabular-nums}
   table{border-collapse:collapse;width:100%;background:#fff;border:1px solid #d0d0d5;border-radius:6px;overflow:hidden}
-  /* 列を均等に開かせない: 1 列目 (銘柄 / 時刻) に余りを寄せ、数値列は内容幅。
-     **ホーム限定**。1 列目がアイコン/ボタン列の表 (判定履歴など) に効かせると
-     他の列が潰れてヘッダが縦に折り返す。 */
-  .main-narrow table th:first-child,.main-narrow table td:first-child{width:99%}
-  .main-narrow table td.num,.main-narrow table th.num{width:1%;white-space:nowrap}
+  /* ホームの表: 列幅は内容に任せる (auto)。**1 列目に余りを寄せる指定はしない** —
+     時刻や銘柄に 99% を渡すと、数量・状態のような短い列が 1 文字幅まで潰れて
+     縦に折り返す。代わりに「折り返してはいけない列」だけを nowrap で守り、
+     余りは grow クラスを持つ列が吸う。 */
+  .main-narrow table{table-layout:auto}
+  .main-narrow table th,.main-narrow table td{white-space:nowrap}
+  .main-narrow table th.grow,.main-narrow table td.grow{width:99%;white-space:normal}
   th,td{padding:8px 10px;text-align:left;border-bottom:1px solid #e5e5ea;font-size:13px;font-variant-numeric:tabular-nums}
   th{background:#fafafa;font-weight:600}
   tr:last-child td{border-bottom:none}

--- a/src/routes/dashboard/overview.ts
+++ b/src/routes/dashboard/overview.ts
@@ -323,7 +323,7 @@ export function renderRiskPanel(data: OverviewData, open: OpenPositionView[]): s
               ? `<span class="pill warn">損切りまで ${fmtNumber(stop.toStopPct, 1)}%</span>`
               : '<span class="pill">保有継続</span>'
       return `<tr>
-        <td><a href="/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(o.sym)}">${esc(displaySymbol(o.sym, data.universe))}</a></td>
+        <td class="grow"><a href="/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(o.sym)}" title="${esc(displaySymbol(o.sym, data.universe))}">${esc(o.sym)}</a></td>
         <td class="num">${fmtNumber(o.qty, 0)}</td>
         <td class="num">${o.price === null ? '<span class="muted">—</span>' : fmtNumber(o.price, 2)}</td>
         <td class="num ${pnlCls}">${o.pnlPct === null ? '—' : `${fmtNumber(o.pnlPct, 2)}%`}</td>
@@ -334,7 +334,7 @@ export function renderRiskPanel(data: OverviewData, open: OpenPositionView[]): s
   return `<div class="panel">
     <div class="panel-title"><span>建玉 ${open.length} 件 / エクスポージャー</span>${exposurePill}</div>
     <table>
-      <thead><tr><th>銘柄</th><th class="num">数量</th><th class="num">現在値</th><th class="num">損益</th><th>状態</th></tr></thead>
+      <thead><tr><th class="grow">銘柄</th><th class="num">数量</th><th class="num">現在値</th><th class="num">損益</th><th>状態</th></tr></thead>
       <tbody>${rows}</tbody>
     </table>
     <p class="muted" style="font-size:12px;margin:10px 0 0">実効 stop は ATR と R:R 上限で銘柄ごとに変動します。詳細は <a href="/dashboard/charts?tab=symbol">銘柄</a> へ。</p>
@@ -419,16 +419,16 @@ export function renderRecentPanel(data: OverviewData): string {
       const pnl = t.realizedPnl !== null ? formatRealizedPnl(t.realizedPnl) : '<span class="muted">—</span>'
       return `<tr>
         <td class="muted" style="font-size:12px">${esc(fmtJst(t.timestamp))}</td>
-        <td><strong>${esc(displaySymbol(t.symbol ?? '—', data.universe))}</strong></td>
+        <td class="grow"><strong title="${esc(displaySymbol(t.symbol ?? '—', data.universe))}">${esc(t.symbol ?? '—')}</strong></td>
         <td class="${sideClass}">${esc(t.side ?? '—')}</td>
-        <td>${t.filledQty !== null ? esc(t.filledQty) : '—'}</td>
-        <td>${t.filledPrice !== null ? fmtNumber(t.filledPrice, 2) : '—'}</td>
-        <td>${pnl}</td>
+        <td class="num">${t.filledQty !== null ? esc(t.filledQty) : '—'}</td>
+        <td class="num">${t.filledPrice !== null ? fmtNumber(t.filledPrice, 2) : '—'}</td>
+        <td class="num">${pnl}</td>
       </tr>`
     })
     .join('')
   const recentTable = data.recentTrades.length
-    ? `<table><thead><tr><th>時刻</th><th>銘柄</th><th>売買</th><th>数量</th><th>約定値</th><th>実損益</th></tr></thead><tbody>${trades}</tbody></table>`
+    ? `<table><thead><tr><th>時刻</th><th class="grow">銘柄</th><th>売買</th><th class="num">数量</th><th class="num">約定値</th><th class="num">実損益</th></tr></thead><tbody>${trades}</tbody></table>`
     : '<p class="muted">約定履歴がありません。</p>'
   // 実行モード / 取引 / VIX は運転状態帯に移したのでここでは繰り返さない。
   return `<div class="panel">


### PR DESCRIPTION
ホームの表で「保有継続」が 1 文字ずつ 4 行に折り返し、銘柄名が 3 行になっていた件の修正です。

## 原因: 余りを吸わせる列を間違えていた

#632 で `th:first-child{width:99%}` を入れましたが、**1 列目 = 余りを渡してよい列とは限りません**。

- 建玉テーブル: 1 列目は銘柄 → 99% を取り、**状態列が 1 文字幅**に潰れて「保有継続」が縦積み
- 直近の約定: 1 列目は時刻 → 99% を取り、**銘柄列が 3 行**に折り返し (`SOXL-Direxion Daily Semiconductor Bull 3X Shares`)、数量ヘッダも 2 行

## 修正

位置ではなく**役割**で決めるようにしました。

- `th:first-child` の指定を撤回
- ホームの表はデフォルトで **全セル `white-space:nowrap`** (短い列が折り返さない)
- 余りを吸う列にだけ `class="grow"` を付ける (`width:99%` + 折り返し許可)
- 建玉・約定とも **銘柄列を grow** に指定

## 銘柄名は ticker + tooltip に

`SOXL-Direxion Daily Semiconductor Bull 3X Shares` のようなフル表示は、grow 指定でも 1 行に収まりません。ホームの表は **ticker のみ**を出し、正式名称は `title` 属性 (ホバー表示) に移しました。一覧性を優先する画面なので、ここは省略が正しいと判断しています。

あわせて直近の約定の数量・約定値・実損益を `.num` (右寄せ + tabular-nums) に揃えました。

## 検証

`pnpm run typecheck` clean / `pnpm test` 121 files・1823 tests pass。