### PR TITLE
fix(dashboard): cap the width on every page, not just the home

### DIFF
--- a/src/routes/dashboard/layout.ts
+++ b/src/routes/dashboard/layout.ts
@@ -90,11 +90,11 @@ export const STYLE = `
   .subnav-link:hover{background:#f0f0f3}
   .subnav-link.active{background:#e8f0fe;color:#06c;font-weight:600}
   .nav-toggle{display:none;background:none;border:none;font-size:22px;cursor:pointer;padding:4px 8px;color:#1d1d1f;line-height:1}
-  .main{min-width:0;padding:24px;overflow-x:auto}
-  /* ワイドモニタで横に間延びするのを止めるが、**ホームだけ**に効かせる。
-     銘柄チャートや判定マトリクスは横に広いほど読みやすく、幅を切ると
-     チャートがはみ出したりヘッダが 1 文字ずつ折り返したりする。 */
-  .main-narrow{max-width:1160px;margin:0 auto;width:100%}
+  /* ワイドモニタで横に間延びするのを止める。全ページに上限を掛けるが、
+     チャートや判定マトリクスは横に広いほど読みやすいので上限は緩め (1400px)。 */
+  .main{min-width:0;padding:24px;overflow-x:auto;max-width:1400px;margin:0 auto;width:100%}
+  /* ホームは要約画面なので更に狭く。読み幅が短いほど視線移動が減る。 */
+  .main-narrow{max-width:1160px}
   @media(max-width:780px){
     .main{padding:12px 8px}
     .nav-toggle{display:block}

--- a/test/routes/dashboardIa.test.ts
+++ b/test/routes/dashboardIa.test.ts
@@ -447,7 +447,8 @@ describe('dashboard 幅の上限はホーム限定 (#dashboard-ia)', () => {
   })
   afterEach(() => vi.resetAllMocks())
 
-  it('ホームは main-narrow、それ以外のページには付かない', async () => {
+  // 幅の上限は全ページ (.main = 1400px)。ホームだけ更に狭い (.main-narrow = 1160px)。
+  it('ホームだけ main-narrow が付き、他ページも .main の上限は効く', async () => {
     const app = createApp()
     const home = await (await app.request('/dashboard', { headers: authHeader }, baseEnv)).text()
     expect(home).toContain('class="main main-narrow"')


### PR DESCRIPTION
#633 でやりすぎました。幅の上限まで**ホーム限定**にしてしまい、銘柄・レビューが元の間延びに戻っていました。

## 切り分け

#632 で入れた 2 つのうち、問題があったのは**テーブルの列指定だけ**でした。

| 変更 | 判定 |
|---|---|
| `max-width` (幅の上限) | **良かった** — 全ページで欲しい |
| `th:first-child{width:99%}` (列固定) | 悪かった — #634 で役割ベース (`.grow`) に直済み |

#633 では両方まとめてホーム限定にしてしまったので、幅の上限まで巻き添えになっていました。

## 修正

- `.main` に **1400px** の上限 (全ページ)。チャートや判定マトリクスは横に広いほど読みやすいので、ホームより緩め
- `.main-narrow` は **1160px** (ホームのみ) — 要約画面なので読み幅は短い方が視線移動が少ない
- テーブルの列ルール (`.grow` / nowrap) は**ホーム限定のまま**。長い reason 文を持つ判定履歴などでは折り返しが要るため

## 検証

`pnpm run typecheck` clean / `pnpm test` 121 files・1823 tests pass。