### PR TITLE
style(dashboard): use one reading width across every page

### DIFF
--- a/src/routes/dashboard/layout.ts
+++ b/src/routes/dashboard/layout.ts
@@ -90,11 +90,10 @@ export const STYLE = `
   .subnav-link:hover{background:#f0f0f3}
   .subnav-link.active{background:#e8f0fe;color:#06c;font-weight:600}
   .nav-toggle{display:none;background:none;border:none;font-size:22px;cursor:pointer;padding:4px 8px;color:#1d1d1f;line-height:1}
-  /* ワイドモニタで横に間延びするのを止める。全ページに上限を掛けるが、
-     チャートや判定マトリクスは横に広いほど読みやすいので上限は緩め (1400px)。 */
-  .main{min-width:0;padding:24px;overflow-x:auto;max-width:1400px;margin:0 auto;width:100%}
-  /* ホームは要約画面なので更に狭く。読み幅が短いほど視線移動が減る。 */
-  .main-narrow{max-width:1160px}
+  /* 読み幅の上限は **全ページ共通 1160px**。ページごとに変えると、ホームから
+     約定履歴へ移った瞬間に器の幅が変わって落ち着かない。横に長い表
+     (判定マトリクス / 銘柄管理) は overflow-x で内側にスクロールさせる。 */
+  .main{min-width:0;padding:24px;overflow-x:auto;max-width:1160px;margin:0 auto;width:100%}
   @media(max-width:780px){
     .main{padding:12px 8px}
     .nav-toggle{display:block}
@@ -152,6 +151,10 @@ export const STYLE = `
   .sub-head{margin:20px 0 6px;font-size:14px;font-weight:700}
   /* 右寄せ数値セル */
   .num{text-align:right;font-variant-numeric:tabular-nums}
+  /* 列数の多い表 (約定履歴 / 銘柄管理) は器の幅に収まらない。ページ全体を
+     横スクロールさせると nav ごと動いて操作しづらいので、表だけを内側で
+     スクロールさせる。 */
+  .tablewrap{overflow-x:auto}
   table{border-collapse:collapse;width:100%;background:#fff;border:1px solid #d0d0d5;border-radius:6px;overflow:hidden}
   /* ホームの表: 列幅は内容に任せる (auto)。**1 列目に余りを寄せる指定はしない** —
      時刻や銘柄に 99% を渡すと、数量・状態のような短い列が 1 文字幅まで潰れて

--- a/src/routes/dashboard/symbols.ts
+++ b/src/routes/dashboard/symbols.ts
@@ -1315,6 +1315,7 @@ export function symbolsListBody(args: {
     })
     .join('')
   return `${errorBanner}${tabBar}${filterBar}${headerBar}
+  <div class="tablewrap">
   <table>
     <thead><tr>
       <th style="width:28px" title="インバース対のツリー表記"></th>
@@ -1331,6 +1332,7 @@ export function symbolsListBody(args: {
     </tr></thead>
     <tbody>${tbody}</tbody>
   </table>
+  </div>
   ${budgetLadderControls()}
   ${safeJsonScript(
     '__budgetBaseline',

--- a/src/routes/dashboard/trades.ts
+++ b/src/routes/dashboard/trades.ts
@@ -221,6 +221,7 @@ export function tradesBody(
     })
     .join('')
   return `${filterBanner}${pills}
+  <div class="tablewrap">
   <table>
     <thead><tr>
       <th></th><th>日時 (JST)</th><th>イベント</th><th>銘柄</th><th>売買</th>
@@ -228,6 +229,7 @@ export function tradesBody(
     </tr></thead>
     <tbody>${tbody}</tbody>
   </table>
+  </div>
   ${renderPaginationNav({
     baseHref: `/dashboard/trades?view=${view}&limit=${limit}${filterQs}`,
     before,

--- a/test/routes/dashboardIa.test.ts
+++ b/test/routes/dashboardIa.test.ts
@@ -447,8 +447,9 @@ describe('dashboard 幅の上限はホーム限定 (#dashboard-ia)', () => {
   })
   afterEach(() => vi.resetAllMocks())
 
-  // 幅の上限は全ページ (.main = 1400px)。ホームだけ更に狭い (.main-narrow = 1160px)。
-  it('ホームだけ main-narrow が付き、他ページも .main の上限は効く', async () => {
+  // 読み幅の上限は全ページ共通 (1160px)。`main-narrow` はホームの表の列ルール
+  // (grow / nowrap) を効かせるための marker で、幅は変えない。
+  it('ホームだけ main-narrow が付く (表の列ルール用の marker)', async () => {
     const app = createApp()
     const home = await (await app.request('/dashboard', { headers: authHeader }, baseEnv)).text()
     expect(home).toContain('class="main main-narrow"')


### PR DESCRIPTION
ホームと `/dashboard/trades` で器の幅が違って統一感がない件。**全ページをホームの幅 (1160px) に揃え**、そのうえで横長コンテンツを再精査しました。

## 変更

- `.main` の上限を **全ページ 1160px** に統一 (ホーム 1160 / その他 1400 の使い分けを撤回)
- `.main-narrow` は幅を変えず、**ホームの表の列ルール (grow / nowrap) を効かせる marker** に役割変更

## 全ページ再精査

1160px に収まらない可能性のあるコンテンツを洗い出しました。

| ページ | 横長要素 | 判定 |
|---|---|---|
| 約定履歴 | 10 列テーブル | **要対応** → `.tablewrap` でテーブルだけ横スクロール |
| 銘柄管理 | 12 列テーブル | **要対応** → 同上 |
| 判定マトリクス | 全銘柄 × cron の格子 | 既に `.mx-wrap{overflow-x:auto}` で対応済み |
| 監査ログ | before/after の JSON | `white-space:pre-wrap;word-break:break-word` で折り返し済み |
| broker 診断 | raw レスポンス | `.bp-raw{overflow:auto;max-height:300px}` で対応済み |
| 判定ログ | reason の長文 | 折り返しで収まる |
| 銘柄チャート | ECharts | コンテナ追従。幅が変わっても再描画される |
| ホーム | 建玉 / 約定 | #634 の grow / nowrap で 1 行に収まる |

ページ全体を横スクロールさせると nav ごと動いて操作しづらいので、**表だけを内側でスクロール**させる方針にしています。

## 検証

`pnpm run typecheck` clean / `pnpm test` 121 files・1823 tests pass。