### PR TITLE
fix(dashboard): keep limit prices on one line in the trade history

### DIFF
--- a/src/routes/dashboard/layout.ts
+++ b/src/routes/dashboard/layout.ts
@@ -156,13 +156,13 @@ export const STYLE = `
      スクロールさせる。 */
   .tablewrap{overflow-x:auto}
   table{border-collapse:collapse;width:100%;background:#fff;border:1px solid #d0d0d5;border-radius:6px;overflow:hidden}
-  /* ホームの表: 列幅は内容に任せる (auto)。**1 列目に余りを寄せる指定はしない** —
-     時刻や銘柄に 99% を渡すと、数量・状態のような短い列が 1 文字幅まで潰れて
-     縦に折り返す。代わりに「折り返してはいけない列」だけを nowrap で守り、
-     余りは grow クラスを持つ列が吸う。 */
-  .main-narrow table{table-layout:auto}
-  .main-narrow table th,.main-narrow table td{white-space:nowrap}
-  .main-narrow table th.grow,.main-narrow table td.grow{width:99%;white-space:normal}
+  /* table.fit: 列幅を「役割」で決める表。**1 列目に余りを寄せる指定はしない** —
+     時刻や状態のような短い列に幅が回ると、値が 1 文字ずつ縦に折り返す。
+     既定で全セル nowrap にし、余りは grow を付けた列 (通常は銘柄) だけが吸う。
+     ホーム / 約定履歴のように「1 行 1 レコードで読ませたい」表に付ける。 */
+  table.fit{table-layout:auto}
+  table.fit th,table.fit td{white-space:nowrap}
+  table.fit th.grow,table.fit td.grow{width:99%;white-space:normal}
   th,td{padding:8px 10px;text-align:left;border-bottom:1px solid #e5e5ea;font-size:13px;font-variant-numeric:tabular-nums}
   th{background:#fafafa;font-weight:600}
   tr:last-child td{border-bottom:none}

--- a/src/routes/dashboard/overview.ts
+++ b/src/routes/dashboard/overview.ts
@@ -333,7 +333,7 @@ export function renderRiskPanel(data: OverviewData, open: OpenPositionView[]): s
     .join('')
   return `<div class="panel">
     <div class="panel-title"><span>建玉 ${open.length} 件 / エクスポージャー</span>${exposurePill}</div>
-    <table>
+    <table class="fit">
       <thead><tr><th class="grow">銘柄</th><th class="num">数量</th><th class="num">現在値</th><th class="num">損益</th><th>状態</th></tr></thead>
       <tbody>${rows}</tbody>
     </table>
@@ -428,7 +428,7 @@ export function renderRecentPanel(data: OverviewData): string {
     })
     .join('')
   const recentTable = data.recentTrades.length
-    ? `<table><thead><tr><th>時刻</th><th class="grow">銘柄</th><th>売買</th><th class="num">数量</th><th class="num">約定値</th><th class="num">実損益</th></tr></thead><tbody>${trades}</tbody></table>`
+    ? `<table class="fit"><thead><tr><th>時刻</th><th class="grow">銘柄</th><th>売買</th><th class="num">数量</th><th class="num">約定値</th><th class="num">実損益</th></tr></thead><tbody>${trades}</tbody></table>`
     : '<p class="muted">約定履歴がありません。</p>'
   // 実行モード / 取引 / VIX は運転状態帯に移したのでここでは繰り返さない。
   return `<div class="panel">

--- a/src/routes/dashboard/trades.ts
+++ b/src/routes/dashboard/trades.ts
@@ -210,7 +210,7 @@ export function tradesBody(
         <td>${logCopyRowBtn(r.id)}</td>
         <td class="muted" style="white-space:nowrap">${esc(fmtJst(r.timestamp))}</td>
         <td style="white-space:nowrap">${eventCell}${decisionLink}</td>
-        <td>${symbolCell}</td>
+        <td class="grow">${symbolCell}</td>
         <td style="white-space:nowrap">${sideCell}</td>
         <td class="num">${qtyCell}</td>
         <td class="num">${priceCell}</td>
@@ -222,9 +222,9 @@ export function tradesBody(
     .join('')
   return `${filterBanner}${pills}
   <div class="tablewrap">
-  <table>
+  <table class="fit">
     <thead><tr>
-      <th></th><th>日時 (JST)</th><th>イベント</th><th>銘柄</th><th>売買</th>
+      <th></th><th>日時 (JST)</th><th>イベント</th><th class="grow">銘柄</th><th>売買</th>
       <th class="num">数量</th><th class="num">単価</th><th class="num">実現損益</th><th>状態</th><th>モード</th>
     </tr></thead>
     <tbody>${tbody}</tbody>

--- a/test/routes/dashboardIa.test.ts
+++ b/test/routes/dashboardIa.test.ts
@@ -6,6 +6,7 @@ import { loadPortfolioEquitySnapshots } from '../../src/infrastructure/db/portfo
 import { loadUsdJpyRate } from '../../src/infrastructure/quotes/fxRate'
 import { loadRecentAlerts } from '../../src/infrastructure/notification/notificationEmitLog'
 import { resolveActiveNavGroup } from '../../src/routes/dashboard/layout'
+import { tradesBody } from '../../src/routes/dashboard/trades'
 import { makeGlobalConfigSnapshot, makeSymbolUniverse } from '../helpers/configFixtures'
 
 /**
@@ -447,9 +448,9 @@ describe('dashboard 幅の上限はホーム限定 (#dashboard-ia)', () => {
   })
   afterEach(() => vi.resetAllMocks())
 
-  // 読み幅の上限は全ページ共通 (1160px)。`main-narrow` はホームの表の列ルール
-  // (grow / nowrap) を効かせるための marker で、幅は変えない。
-  it('ホームだけ main-narrow が付く (表の列ルール用の marker)', async () => {
+  // 読み幅の上限は全ページ共通 (1160px)。列幅ルールは table.fit の opt-in なので
+  // main-narrow は現状ホームの marker として残るのみ (幅は変えない)。
+  it('ホームだけ main-narrow が付く (marker、幅は全ページ共通)', async () => {
     const app = createApp()
     const home = await (await app.request('/dashboard', { headers: authHeader }, baseEnv)).text()
     expect(home).toContain('class="main main-narrow"')
@@ -460,5 +461,45 @@ describe('dashboard 幅の上限はホーム限定 (#dashboard-ia)', () => {
       expect(body, path).toContain('class="main"')
       expect(body, path).not.toContain('class="main main-narrow"')
     }
+  })
+})
+
+// 列幅は「役割」で決める (#dashboard-ia)。1 行 1 レコードで読ませる表は
+// table.fit を付け、余りを吸う列だけ grow を持つ。短い列 (状態 / 数量 / 単価)
+// に幅が回ると値が縦に折り返す。
+describe('table.fit の列ルール (#dashboard-ia)', () => {
+  beforeEach(() => {
+    vi.mocked(loadGlobalConfigFrom).mockResolvedValue(makeGlobalConfigSnapshot())
+    vi.mocked(loadSymbolUniverse).mockResolvedValue(
+      makeSymbolUniverse({ allowedSymbols: ['SOXL'], symbolCurrency: { SOXL: 'USD' } }),
+    )
+  })
+  afterEach(() => vi.resetAllMocks())
+
+  it('約定履歴は table.fit + 銘柄列が grow', () => {
+    // route ではなく renderer を直接叩く (loader の fake を用意するより堅い)
+    const html = tradesBody(
+      [
+        {
+          id: 1,
+          timestamp: '2026-07-28T00:00:00.000Z',
+          tradeEventType: 'post_submit',
+          symbol: 'SOXL',
+          side: 'BUY',
+          filledQty: 1,
+          filledPrice: 100,
+          limitPrice: 100,
+          notional: 100,
+          realizedPnl: null,
+          brokerStatus: 'FILLED',
+          mode: 'LIVE',
+        } as unknown as Parameters<typeof tradesBody>[0][number],
+      ],
+      50,
+    )
+    expect(html).toContain('<table class="fit">')
+    expect(html).toContain('<th class="grow">銘柄</th>')
+    // 状態 / モードは内容幅で止める (grow を持たない)
+    expect(html).not.toContain('<th class="grow">状態</th>')
   })
 })


### PR DESCRIPTION
約定履歴で `指 3,489.00` が 2 行に折り返し、状態列が必要以上に幅を取っていた件です。

## 原因

#634 で入れた列幅ルールを **ホーム限定 (`.main-narrow`)** にしていたため、約定履歴には効いていませんでした。列幅がブラウザ任せになり、状態・モード列に幅が回った分だけ単価列が狭くなって折り返していました。

## 修正

ルールを **ページ単位 → テーブル単位の opt-in (`table.fit`)** に一般化しました。

- `table.fit` を付けた表は既定で全セル `nowrap`
- 余りを吸うのは `grow` を付けた列だけ (= 銘柄)
- 状態 / モード / 数量 / 単価 は内容幅で止まる

約定履歴の表に `class="fit"` と銘柄列の `grow` を付けています。ホームの 2 つの表も同じ仕組みに乗せ替えました (`.main-narrow` 経由から `table.fit` へ)。

## 検証

`pnpm run typecheck` clean / `pnpm test` 121 files・1824 tests pass。renderer を直接叩く回帰テストを追加しました (`table.fit` が付き、銘柄が grow、状態は grow でない)。