### PR TITLE
fix(dashboard): hold the trade columns on one line up to realized PnL

### DIFF
--- a/src/routes/dashboard/trades.ts
+++ b/src/routes/dashboard/trades.ts
@@ -153,8 +153,16 @@ export function tradesBody(
       const inactive = r.symbol ? isSymbolInactive(r.symbol, universe) : false
       // ▼ は同一銘柄の約定だけに絞り込み、「判定」は clientOrderId でこの注文の
       // 判定行 (cron) へ飛ぶ逆リンク (#nav-links)。
+      // 銘柄は ticker のみ。正式名称 (VUG-Vanguard Growth Index Fund ETF Shares 等)
+      // をそのまま出すと、折り返し禁止の列が横に伸びて表全体が破綻するので
+      // title (ホバー) に逃がす。inactive の注記も同じ title に載せる。
+      const symbolTitle = r.symbol
+        ? inactive
+          ? `${symbolText} — ${inactiveTooltip(r.symbol, universe)}`
+          : (symbolText ?? r.symbol)
+        : ''
       const symbolCell = r.symbol
-        ? `<a href="/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(r.symbol)}"${inactive ? ` title="${esc(inactiveTooltip(r.symbol, universe))}"` : ''} style="text-decoration:none"><strong${inactive ? ' class="symbol-disabled"' : ''}>${esc(symbolText!)}</strong></a> <a href="/dashboard/trades?symbol=${encodeURIComponent(r.symbol)}" class="muted" title="この銘柄の約定だけに絞り込み" style="font-size:11px;text-decoration:none">▼</a>`
+        ? `<a href="/dashboard/charts?tab=symbol&symbol=${encodeURIComponent(r.symbol)}" title="${esc(symbolTitle)}" style="text-decoration:none"><strong${inactive ? ' class="symbol-disabled"' : ''}>${esc(r.symbol)}</strong></a> <a href="/dashboard/trades?symbol=${encodeURIComponent(r.symbol)}" class="muted" title="この銘柄の約定だけに絞り込み" style="font-size:11px;text-decoration:none">▼</a>`
         : '<span class="muted">—</span>'
       const decisionLink = r.clientOrderId
         ? ` <a href="/dashboard/cron?clientOrderId=${encodeURIComponent(r.clientOrderId)}" class="muted" title="この注文の判定 (戦略判定ログ) を見る" style="font-size:11px">判定→</a>`
@@ -210,12 +218,12 @@ export function tradesBody(
         <td>${logCopyRowBtn(r.id)}</td>
         <td class="muted" style="white-space:nowrap">${esc(fmtJst(r.timestamp))}</td>
         <td style="white-space:nowrap">${eventCell}${decisionLink}</td>
-        <td class="grow">${symbolCell}</td>
+        <td>${symbolCell}</td>
         <td style="white-space:nowrap">${sideCell}</td>
         <td class="num">${qtyCell}</td>
         <td class="num">${priceCell}</td>
         <td class="num">${pnlCell}</td>
-        <td>${statusCell}</td>
+        <td class="grow">${statusCell}</td>
         <td>${modeCell}</td>
       </tr>`
     })
@@ -224,8 +232,9 @@ export function tradesBody(
   <div class="tablewrap">
   <table class="fit">
     <thead><tr>
-      <th></th><th>日時 (JST)</th><th>イベント</th><th class="grow">銘柄</th><th>売買</th>
-      <th class="num">数量</th><th class="num">単価</th><th class="num">実現損益</th><th>状態</th><th>モード</th>
+      <th></th><th>日時 (JST)</th><th>イベント</th><th>銘柄</th><th>売買</th>
+      <th class="num">数量</th><th class="num">単価</th><th class="num">実現損益</th>
+      <th class="grow">状態</th><th>モード</th>
     </tr></thead>
     <tbody>${tbody}</tbody>
   </table>

--- a/test/routes/dashboardIa.test.ts
+++ b/test/routes/dashboardIa.test.ts
@@ -474,7 +474,8 @@ describe('table.fit の列ルール (#dashboard-ia)', () => {
   })
   afterEach(() => vi.resetAllMocks())
 
-  it('約定履歴は table.fit + 銘柄列が grow', () => {
+  // 日時〜実現損益は折り返し禁止。余りを吸って折り返してよいのは 状態 (エラー文)。
+  it('約定履歴は table.fit + 状態列が grow (銘柄は折り返さない)', () => {
     // route ではなく renderer を直接叩く (loader の fake を用意するより堅い)
     const html = tradesBody(
       [
@@ -496,8 +497,9 @@ describe('table.fit の列ルール (#dashboard-ia)', () => {
       50,
     )
     expect(html).toContain('<table class="fit">')
-    expect(html).toContain('<th class="grow">銘柄</th>')
-    // 状態 / モードは内容幅で止める (grow を持たない)
-    expect(html).not.toContain('<th class="grow">状態</th>')
+    expect(html).toContain('<th class="grow">状態</th>')
+    // 銘柄は折り返さない (grow を持たない) → ticker のみ表示で列幅も暴れない
+    expect(html).not.toContain('<th class="grow">銘柄</th>')
+    expect(html).toContain('<strong>SOXL</strong>')
   })
 })


### PR DESCRIPTION
約定履歴で銘柄名が 4 行に折り返していた件です。

## 直したこと

`grow` (余りを吸って折り返す列) を **銘柄 → 状態** に付け替えました。

- **日時 / イベント / 銘柄 / 売買 / 数量 / 単価 / 実現損益 → 折り返さない**
- **状態 → 余りを吸い、折り返してよい** (`OAUTH_OPENAPI_CASH_ACCOUNT_NOT_ALLOW_SELL_SHORT` のようなエラー文が入る列なので、ここが伸縮するのが自然)

## 銘柄は ticker 表示に

`VUG-Vanguard Growth Index Fund ETF Shares` を折り返し禁止のまま出すと、列が横に伸びて表全体が破綻します。**ticker のみ**を表示し、正式名称は `title` (ホバー) に逃がしました。inactive 銘柄の注記も同じ title に統合しています。

ホームの表と同じ扱いになり、画面間で一貫します。

## 検証

`pnpm run typecheck` clean / `pnpm test` 120 files・1796 tests pass。回帰テストも「状態が grow / 銘柄は grow でない / ticker が出る」に更新しました。