### PR TITLE
feat(strategy): measure volatility against the symbol's own distribution

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,7 +47,7 @@
 | `pullback_default_require_above_sma50` | `1` | sma50 超を entry 必須 |
 | `pullback_default_k_atr` | `2.0` | ATR 倍率。`stopDistance = max(k_atr × atr20, pct stop)` |
 | `pullback_default_max_sma50_deviation_pct` | `0.6` | sma50 からの上方乖離が大きすぎる時は entry 見送り |
-| `pullback_default_max_atr_ratio` | `1.5` | ATR 拡大 (ボラ急騰) 時の entry 見送り閾値 |
+| `pullback_default_max_atr_ratio` | `1.1` | 過熱ガードの閾値。`atr20 / baseline` がこれを超えたら entry 見送り |
 | `pullback_default_max_stop_to_tp_ratio` | `2.0` | stop 幅の上限 = `take_profit_pct × これ`。R:R に下限を作る (2.0 = R:R 0.5 以上)。`0` で無効 |
 | `atr_baseline_exclude_recent` | `0` | baseline ATR から直近 20 本を除外。`1` にすると比率が素直になるが**閾値の再校正が必要** ([#598](https://github.com/ochanuco/webull-trading/pull/598)) |
 

--- a/drizzle/0043_atr_baseline_mode.sql
+++ b/drizzle/0043_atr_baseline_mode.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `global_config` ADD `atr_baseline_mode` text DEFAULT 'percentile' NOT NULL;--> statement-breakpoint
+ALTER TABLE `global_config` DROP COLUMN `atr_baseline_exclude_recent`;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -302,6 +302,13 @@
       "when": 1785240368279,
       "tag": "0042_add_news_shock_gate_config",
       "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "6",
+      "when": 1785327259911,
+      "tag": "0043_atr_baseline_mode",
+      "breakpoints": true
     }
   ]
 }

--- a/src/infrastructure/db/globalConfigRepo.ts
+++ b/src/infrastructure/db/globalConfigRepo.ts
@@ -1,3 +1,4 @@
+import type { AtrBaselineMode } from '../../trading/strategy/indicators'
 import { eq } from 'drizzle-orm'
 import type { DrizzleD1Database } from 'drizzle-orm/d1'
 import { globalConfig, type GlobalConfigRow } from './schema'
@@ -47,8 +48,8 @@ export interface GlobalConfigSnapshot {
   feePctOfNotional: number
   /** 売買コスト見積りの 1 注文固定費 (銘柄通貨建て)。 */
   feeFixedPerOrder: number
-  /** baseline ATR から直近 20 本を除外するか (#atr-baseline-window)。 */
-  atrBaselineExcludeRecent: boolean
+  /** baseline ATR の作り方 (#atr-baseline-window)。不正値は 'percentile'。 */
+  atrBaselineMode: AtrBaselineMode
   /** Base risk fraction per trade (0.4% default)。#23 Lane 2。 */
   riskBasePerTradePct: number
   /** drawdown がこの閾値 (負) 未満で size を 0.5× に (-0.05 default)。 */
@@ -115,6 +116,15 @@ export interface GlobalConfigSnapshot {
  * before the initial seed is applied). Matches the previous env-var defaults
  * so existing deployments keep the same behaviour through the cutover.
  */
+const ATR_BASELINE_MODES = ['overlap', 'exclude-recent', 'percentile'] as const
+
+/** enum 外は 'percentile' (= 実測で最良かつ既定) に倒す。 */
+function sanitizeAtrBaselineMode(value: string | null | undefined): AtrBaselineMode {
+  return (ATR_BASELINE_MODES as readonly string[]).includes(value ?? '')
+    ? (value as AtrBaselineMode)
+    : 'percentile'
+}
+
 export const GLOBAL_CONFIG_DEFAULTS: GlobalConfigSnapshot = Object.freeze({
   dryRun: true,
   tradingEnabled: false,
@@ -144,7 +154,7 @@ export const GLOBAL_CONFIG_DEFAULTS: GlobalConfigSnapshot = Object.freeze({
   pullbackDefaultMaxStopToTpRatio: 2.0,
   feePctOfNotional: 0,
   feeFixedPerOrder: 0,
-  atrBaselineExcludeRecent: false,
+  atrBaselineMode: 'percentile',
   riskBasePerTradePct: 0.004,
   riskDdHalfThreshold: -0.05,
   riskDdHaltThreshold: -0.10,
@@ -464,7 +474,7 @@ export async function loadGlobalConfig(
             pullbackDefaultMaxStopToTpRatio: globalConfig.pullbackDefaultMaxStopToTpRatio,
             feePctOfNotional: globalConfig.feePctOfNotional,
             feeFixedPerOrder: globalConfig.feeFixedPerOrder,
-            atrBaselineExcludeRecent: globalConfig.atrBaselineExcludeRecent,
+            atrBaselineMode: globalConfig.atrBaselineMode,
             riskBasePerTradePct: globalConfig.riskBasePerTradePct,
             riskDdHalfThreshold: globalConfig.riskDdHalfThreshold,
             riskDdHaltThreshold: globalConfig.riskDdHaltThreshold,
@@ -504,8 +514,8 @@ export async function loadGlobalConfig(
             // 0039 追加列 (#trade-cost)。legacy path は default (= gross PnL)。
             feePctOfNotional: GLOBAL_CONFIG_DEFAULTS.feePctOfNotional,
             feeFixedPerOrder: GLOBAL_CONFIG_DEFAULTS.feeFixedPerOrder,
-            // 0040 追加列 (#atr-baseline-window)。legacy path は default (従来窓)。
-            atrBaselineExcludeRecent: GLOBAL_CONFIG_DEFAULTS.atrBaselineExcludeRecent,
+            // 0043 追加列 (#atr-baseline-window)。legacy path は default。
+            atrBaselineMode: GLOBAL_CONFIG_DEFAULTS.atrBaselineMode,
             riskBasePerTradePct: legacyRow.riskBasePerTradePct,
             riskDdHalfThreshold: legacyRow.riskDdHalfThreshold,
             riskDdHaltThreshold: legacyRow.riskDdHaltThreshold,
@@ -583,7 +593,7 @@ export async function loadGlobalConfig(
     pullbackDefaultMaxStopToTpRatio: row.pullbackDefaultMaxStopToTpRatio,
     feePctOfNotional: row.feePctOfNotional,
     feeFixedPerOrder: row.feeFixedPerOrder,
-    atrBaselineExcludeRecent: row.atrBaselineExcludeRecent,
+    atrBaselineMode: sanitizeAtrBaselineMode(row.atrBaselineMode),
     riskBasePerTradePct: row.riskBasePerTradePct,
     riskDdHalfThreshold: row.riskDdHalfThreshold,
     riskDdHaltThreshold: row.riskDdHaltThreshold,

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -333,7 +333,7 @@ export const globalConfig = sqliteTable(
     /**
      * ボラ過熱ガード: `atr20/baselineAtr20` がこの比率超で BUY 見送り。POC default 1.5。
      */
-    pullbackDefaultMaxAtrRatio: real('pullback_default_max_atr_ratio').notNull().default(1.5),
+    pullbackDefaultMaxAtrRatio: real('pullback_default_max_atr_ratio').notNull().default(1.1),
     /**
      * Stop 幅の上限 = |avgPrice * take_profit_pct| * これ (#stop-rr-cap)。ATR 連動
      * stop が利確幅に対して一方的に広がるのを止め、R:R に下限を作る (2.0 なら
@@ -350,13 +350,19 @@ export const globalConfig = sqliteTable(
     /** 1 注文あたりの固定費 (銘柄通貨建て)。0 で無効。 */
     feeFixedPerOrder: real('fee_fixed_per_order').notNull().default(0),
     /**
-     * baseline ATR から直近 20 本 (atr20 の窓) を除外するか (#atr-baseline-window)。
-     * **既定 false = 従来の重複窓**。true にすると比率が素直になる代わりに
-     * 過熱ガード / atr-floor の閾値を測り直す必要がある。
+     * baseline ATR の作り方 (#atr-baseline-window)。過熱ガード
+     * (`pullback_default_max_atr_ratio`) の分母を決める。
+     *
+     * - `percentile` (既定): その銘柄自身の atr20 分布の p80。銘柄ごとのボラ
+     *   水準に依存せず「その銘柄として高ボラか」を測る。閾値 1.1 が実測の推奨
+     * - `overlap`: 直近 60 本平均。**分母が分子を内包する**ため比率が動かず、
+     *   閾値を何にしても発火しない (実測: 全設定でトレード数が同一だった)
+     * - `exclude-recent`: 直近 20 本を除いた平均。比率は素直だが閾値 0.3 の差で
+     *   成績が 4 倍振れ、ノイズを拾いやすい
+     *
+     * enum 検証は loader 側 (不正値は `percentile` に倒す)。
      */
-    atrBaselineExcludeRecent: integer('atr_baseline_exclude_recent', { mode: 'boolean' })
-      .notNull()
-      .default(false),
+    atrBaselineMode: text('atr_baseline_mode').notNull().default('percentile'),
     /**
      * Base risk fraction per trade (0.4% default)。drawdown scale を掛けた値が
      * pullbackSizing に渡る。#23 Lane 2。

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -399,13 +399,15 @@ export const admin = new Hono<AppBindings>()
       to,
       initialCash,
       rule,
-      // #atr-baseline-window: `?atrBaselineExcludeRecent=1` で baseline から
-      // 直近 20 本を除いた場合の成績を測れる。既定は global_config の値
-      // (= 本番と同じ条件) なので、閾値の再校正はこの 2 通りを比べて行う。
-      atrBaselineExcludeRecent:
-        c.req.query('atrBaselineExcludeRecent') === undefined
-          ? global.atrBaselineExcludeRecent
-          : c.req.query('atrBaselineExcludeRecent') === '1',
+      // #atr-baseline-window: `?atrBaselineMode=overlap|exclude-recent|percentile`
+      // で baseline の作り方を差し替えて成績を比較できる。既定は global_config の
+      // 値 (= 本番と同じ条件)。閾値の再校正はこれと `?maxAtrRatio=` を振って行う。
+      atrBaselineMode: ((): 'overlap' | 'exclude-recent' | 'percentile' => {
+        const q = c.req.query('atrBaselineMode')
+        return q === 'overlap' || q === 'exclude-recent' || q === 'percentile'
+          ? q
+          : global.atrBaselineMode
+      })(),
     }
     const result = await runBacktest(sliced, params)
     return c.json(result)

--- a/src/trading/backtest/runBacktest.ts
+++ b/src/trading/backtest/runBacktest.ts
@@ -60,10 +60,10 @@ export interface BacktestParams {
    */
   strategy?: BacktestStrategy
   /**
-   * baseline ATR から直近 20 本を除外して評価するか (#atr-baseline-window)。
-   * 閾値 (maxAtrRatio / atr-floor) の再校正はここで測る。既定 false = 本番同等。
+   * baseline ATR の作り方 (#atr-baseline-window)。閾値 (`maxAtrRatio`) の
+   * 再校正はここを振って測る。未指定は本番既定の 'percentile'。
    */
-  atrBaselineExcludeRecent?: boolean
+  atrBaselineMode?: 'overlap' | 'exclude-recent' | 'percentile'
 }
 
 export type ExitReason = 'TP' | 'STOP' | 'TIME_STOP' | 'END_OF_DATA'
@@ -160,7 +160,7 @@ export async function runBacktest(
     // intra-day slippage is out of scope.
     const window = bars.slice(Math.max(0, i + 1 - 60), i + 1)
     const indicators = computePullbackIndicators(window, null, {
-      excludeRecentFromBaseline: params.atrBaselineExcludeRecent === true,
+      baselineMode: params.atrBaselineMode ?? 'percentile',
     })
     const today = bars[i]!
     if (!indicators) {

--- a/src/trading/strategy/indicators.ts
+++ b/src/trading/strategy/indicators.ts
@@ -16,6 +16,8 @@ export interface DailyBar {
 const BASELINE_EXCLUDE_RECENT = 20
 /** baseline ATR に使う最大サンプル数 (≈ 3 か月)。 */
 const BASELINE_MAX_SAMPLES = 60
+/** percentile モードで参照する rolling ATR の本数 (≈ 1 年)。 */
+const BASELINE_PERCENTILE_SAMPLES = 250
 
 export interface PullbackIndicatorSnapshot {
   price: number
@@ -74,17 +76,22 @@ export interface PullbackIndicatorSnapshot {
  * reference high lookback を 10d に短縮。フィールド名 (`return50d` /
  * `high20d`) は storage / dashboard 互換のため据え置き。
  */
+/**
+ * baseline ATR の作り方 (#atr-baseline-window)。
+ *
+ * - `overlap` (既定): 直近 60 本平均。**atr20 の窓を内包する**ため比率が鈍り、
+ *   実測では `maxAtrRatio` を何に設定しても発火しなかった (= ガードが死んでいる)
+ * - `exclude-recent`: 直近 20 本を除いた平均。比率は素直になるが、閾値 0.3 の差で
+ *   成績が 4 倍振れる実測結果が出ており、ノイズを拾いやすい
+ * - `percentile`: **その銘柄自身の atr20 分布の p80**。銘柄ごとのボラ水準
+ *   (SOXL 22% vs VUG 1.7%) に依存せず「その銘柄として高ボラか」を測る。
+ *   `maxAtrRatio = 1.0` が「p80 超で見送り」になる
+ */
+export type AtrBaselineMode = 'overlap' | 'exclude-recent' | 'percentile'
+
 export interface PullbackIndicatorOptions {
-  /**
-   * baseline ATR から直近 20 本 (= atr20 の窓) を除外するか (#atr-baseline-window)。
-   *
-   * **既定 false = 従来の重複窓**。true にすると `atr20 / baselineAtr20` は
-   * 「直近 vs それ以前」の素直な比率になるが、**過熱ガード (maxAtrRatio) と
-   * sizing の atr-floor の閾値は旧 baseline 前提で校正されている**ため、
-   * 同じ閾値のままだと押し目 entry (= 直近 ATR が上がった局面) がほぼ全て
-   * blocked になる。切り替えるときは backtest で閾値を測り直すこと。
-   */
-  excludeRecentFromBaseline?: boolean
+  /** baseline の作り方。未指定は 'percentile' (本番既定)。 */
+  baselineMode?: AtrBaselineMode
 }
 
 export function computePullbackIndicators(
@@ -129,11 +136,22 @@ export function computePullbackIndicators(
   // 切り替えは backtest で閾値を測り直してから。
   // bars >= 50 を上で保証しているので TR は 49 本以上あり、直近 20 本を除いても
   // 29 本以上残る (= サンプル不足の分岐は起き得ない)。
-  const baselineSource =
-    options?.excludeRecentFromBaseline === true
-      ? trueRanges.slice(0, -BASELINE_EXCLUDE_RECENT).slice(-BASELINE_MAX_SAMPLES)
-      : trueRanges.slice(-Math.min(trueRanges.length, BASELINE_MAX_SAMPLES))
-  const baselineAtr20 = average(baselineSource)
+  const mode: AtrBaselineMode = options?.baselineMode ?? 'percentile'
+  let baselineAtr20: number
+  if (mode === 'percentile') {
+    // その銘柄自身の atr20 分布の p80。rolling ATR を trailing 窓で作って
+    // 分位点を取る (窓が足りなければ取れる分だけ)。
+    const rolling: number[] = []
+    for (let end = trueRanges.length; end >= 20; end -= 1) {
+      rolling.push(average(trueRanges.slice(end - 20, end)))
+      if (rolling.length >= BASELINE_PERCENTILE_SAMPLES) break
+    }
+    baselineAtr20 = percentile(rolling, 0.8)
+  } else if (mode === 'exclude-recent') {
+    baselineAtr20 = average(trueRanges.slice(0, -BASELINE_EXCLUDE_RECENT).slice(-BASELINE_MAX_SAMPLES))
+  } else {
+    baselineAtr20 = average(trueRanges.slice(-Math.min(trueRanges.length, BASELINE_MAX_SAMPLES)))
+  }
 
   // intradayPrice がきちんと正値の有限数なら採用、そうでなければ daily close。
   // `> 0` で 0 / 負値もはじき、Number.isFinite で NaN / Infinity をはじく。
@@ -167,6 +185,14 @@ function computeTrueRanges(bars: DailyBar[]): number[] {
     )
   }
   return tr
+}
+
+/** 昇順ソート後の線形補間なし分位点。空配列は 0。 */
+function percentile(values: number[], q: number): number {
+  if (values.length === 0) return 0
+  const sorted = [...values].sort((a, b) => a - b)
+  const idx = Math.min(sorted.length - 1, Math.max(0, Math.floor(q * (sorted.length - 1))))
+  return sorted[idx]!
 }
 
 function average(values: number[]): number {

--- a/src/trading/strategy/pullbackScheduler.ts
+++ b/src/trading/strategy/pullbackScheduler.ts
@@ -7,6 +7,7 @@ import type { DecisionTraceStep } from '../domain/Signal'
 import type { StrategyDecision } from '../domain/StrategyDecision'
 import { inferTradingMarket, isWithinUsCloseWindow } from '../domain/tradingCalendar'
 import { NO_TRADE_COST, netRealizedPnl, type TradeCostConfig } from '../domain/tradingCost'
+import type { AtrBaselineMode } from './indicators'
 import type { Execution } from '../execution/Execution'
 import type { PositionStore } from '../state/PositionStore'
 import type { SymbolState } from '../state/types'
@@ -225,10 +226,10 @@ export interface PullbackSchedulerOptions {
    */
   tradeCost?: TradeCostConfig
   /**
-   * baseline ATR から直近 20 本を除外するか (#atr-baseline-window)。未注入は
-   * false = 従来窓。閾値の再校正が要るので production は global_config 経由。
+   * baseline ATR の作り方 (#atr-baseline-window)。未注入は 'percentile'
+   * (実測で最良)。production は global_config 経由で渡る。
    */
-  atrBaselineExcludeRecent?: boolean
+  atrBaselineMode?: AtrBaselineMode
   /**
    * ペアレジーム layer (#472)。mode='observe' は zone/score を trace に残すだけ
    * (gate しない)、'enforce' は zone が許可しない側の BUY を SKIP し、保有と
@@ -587,7 +588,7 @@ export async function runPullbackScheduler(
     }
 
     const indicators = computePullbackIndicators(bars, intradayPrice, {
-      excludeRecentFromBaseline: options.atrBaselineExcludeRecent === true,
+      baselineMode: options.atrBaselineMode ?? 'percentile',
     })
     if (!indicators) {
       summary.rejected.push({ symbol: upper, reason: 'insufficient bars for indicators' })

--- a/src/trading/strategy/runStrategyCron.ts
+++ b/src/trading/strategy/runStrategyCron.ts
@@ -830,7 +830,7 @@ export async function runStrategyCron(
       defaultRule,
       rulesMap,
       entrySuppressedSymbols: effectiveEntrySuppressed,
-      atrBaselineExcludeRecent: global.atrBaselineExcludeRecent,
+      atrBaselineMode: global.atrBaselineMode,
       // #trade-cost: 通知の realized を reconcile と同じ net にする。
       tradeCost: {
         feePctOfNotional: global.feePctOfNotional,

--- a/test/helpers/configFixtures.ts
+++ b/test/helpers/configFixtures.ts
@@ -38,7 +38,7 @@ export function makeGlobalConfigSnapshot(
     pullbackDefaultMaxStopToTpRatio: 2.0,
     feePctOfNotional: 0,
     feeFixedPerOrder: 0,
-    atrBaselineExcludeRecent: false,
+    atrBaselineMode: 'percentile',
     riskBasePerTradePct: 0.004,
     riskDdHalfThreshold: -0.05,
     riskDdHaltThreshold: -0.10,

--- a/test/trading/strategy/indicators.test.ts
+++ b/test/trading/strategy/indicators.test.ts
@@ -143,16 +143,16 @@ describe('computePullbackIndicators baseline ATR window', () => {
     })
   }
 
-  it('既定では baseline に直近の急騰分が混ざり、比率が鈍る', () => {
-    const r = computePullbackIndicators(volSpikeBars())!
+  it('overlap では baseline に直近の急騰分が混ざり、比率が鈍る', () => {
+    const r = computePullbackIndicators(volSpikeBars(), null, { baselineMode: 'overlap' })!
     const ratio = r.atr20 / r.baselineAtr20
     // 実際のボラ差は 5 倍だが、baseline が直近を含むので比率は大幅に縮む。
     expect(ratio).toBeLessThan(3)
   })
 
-  it('excludeRecentFromBaseline で実際のボラ差 (5 倍) に近い比率になる', () => {
+  it("baselineMode: 'exclude-recent' で実際のボラ差 (5 倍) に近い比率になる", () => {
     const r = computePullbackIndicators(volSpikeBars(), null, {
-      excludeRecentFromBaseline: true,
+      baselineMode: 'exclude-recent',
     })!
     const ratio = r.atr20 / r.baselineAtr20
     expect(ratio).toBeGreaterThan(4)
@@ -161,10 +161,52 @@ describe('computePullbackIndicators baseline ATR window', () => {
   it('最小 bar 数 (50) でも除外後に十分なサンプルが残る', () => {
     const closes = Array.from({ length: 50 }, (_, i) => 100 + i)
     const excluded = computePullbackIndicators(makeBars(closes), null, {
-      excludeRecentFromBaseline: true,
+      baselineMode: 'exclude-recent',
     })!
     // TR 49 本 − 直近 20 本 = 29 本。0 除算や空平均にならないことを固定する。
     expect(excluded.baselineAtr20).toBeGreaterThan(0)
     expect(Number.isFinite(excluded.atr20 / excluded.baselineAtr20)).toBe(true)
+  })
+})
+
+// #atr-baseline-window: 既定の percentile は「その銘柄自身の atr20 分布の p80」。
+// 銘柄ごとのボラ水準 (SOXL 22% vs VUG 1.7%) に依存せず高ボラ局面を検出する。
+describe('percentile baseline (既定)', () => {
+  /** 前半 40 本は静穏、直近 20 本だけボラ 5 倍。 */
+  function volSpikeBars(): DailyBar[] {
+    return Array.from({ length: 61 }, (_, i) => {
+      const spread = i >= 41 ? 0.05 : 0.01
+      return {
+        date: new Date(Date.UTC(2026, 0, 1 + i)).toISOString().slice(0, 10),
+        open: 100,
+        high: 100 * (1 + spread),
+        low: 100 * (1 - spread),
+        close: 100,
+      }
+    })
+  }
+
+  it('急騰局面では atr20 が p80 を超える (比率 > 1)', () => {
+    const r = computePullbackIndicators(volSpikeBars(), null, { baselineMode: 'percentile' })!
+    expect(r.atr20 / r.baselineAtr20).toBeGreaterThan(1)
+  })
+
+  it('平常時は p80 を超えない (比率 <= 1)', () => {
+    const calm = Array.from({ length: 61 }, (_, i) => ({
+      date: new Date(Date.UTC(2026, 0, 1 + i)).toISOString().slice(0, 10),
+      open: 100,
+      high: 101,
+      low: 99,
+      close: 100,
+    }))
+    const r = computePullbackIndicators(calm, null, { baselineMode: 'percentile' })!
+    expect(r.atr20 / r.baselineAtr20).toBeLessThanOrEqual(1)
+  })
+
+  it('未指定なら percentile が既定', () => {
+    const bars = volSpikeBars()
+    const explicit = computePullbackIndicators(bars, null, { baselineMode: 'percentile' })!
+    const implicit = computePullbackIndicators(bars)!
+    expect(implicit.baselineAtr20).toBeCloseTo(explicit.baselineAtr20, 10)
   })
 })


### PR DESCRIPTION
過熱ガード (`maxAtrRatio`) が実際には一度も発火していなかった問題の修正です。

## 診断

`atr20 / baselineAtr20` の **分母 (直近 60 本平均) が分子 (直近 20 本平均) を内包**していたため、比率がほとんど動きませんでした。5 年 × 7 銘柄の backtest で、閾値 1.5 でもガード無効でも **トレード数が 167 件で完全に同一**です。

つまり実質「ガード無し」で運用していました。

## 対処: percentile baseline

分母を **その銘柄自身の atr20 分布の p80** (直近 1 年) に変更しました。SOXL の 22% と VUG の 1.7% を同じ土俵に載せず、「その銘柄として高ボラか」だけを測ります。閾値 1.1 は「自分の p80 を 10% 超えたら見送り」の意味です。

### 5 年 × 7 銘柄

| 構成 | trades | 勝率 | 損益 | PF |
|---|---|---|---|---|
| overlap 1.5 (現行) | 167 | 59.3% | +3,777 | 1.05 |
| ガード無効 | 167 | 59.3% | +3,279 | 1.04 |
| **percentile 1.1** | **143** | **62.9%** | **+9,149** | **1.15** |
| percentile 1.0 | 104 | 63.5% | +10,774 | 1.26 |

閾値に対して PF が単調に改善します (1.4→1.08 / 1.2→1.11 / 1.1→1.15 / 1.0→1.26)。

### 期間分割 (過剰適合の確認)

| | overlap 1.5 | percentile 1.1 |
|---|---|---|
| 前半 2.5y PF | 0.89 | **0.94** |
| 後半 2.5y PF | 1.21 | **1.42** |

**両期間で改善**しています。1.0 の方が数字は良いですが後半 46 トレードしかないため、143 トレードで安定する 1.1 を既定にしました。

## 変更

- `global_config.atr_baseline_mode` (`percentile` / `overlap` / `exclude-recent`、既定 **percentile**) を追加。不正値は `percentile` に倒す
- `pullback_default_max_atr_ratio` の schema 既定を **1.5 → 1.1**
- 今日追加した `atr_baseline_exclude_recent` (boolean) は **DROP**。同じことを 2 つの knob で表す状態を残さない
- `GET /admin/backtest?atrBaselineMode=...&maxAtrRatio=...` で再検証できる

## 本番への適用に必要な SQL

migration は列を足すだけで、**既存行の `pullback_default_max_atr_ratio` は 1.5 のまま**です。推奨値にするには:

```sql
UPDATE global_config SET pullback_default_max_atr_ratio = 1.1,
  updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now') WHERE id = 'default';
```

## 限界

5 年 1 窓、7 銘柄、167 トレード。コスト (スリッページ・為替) は未モデル、fill は T+0 終値です。前半は**どの設定でも負け** (PF < 1) で、percentile は損失を 4 割減らしただけです。「勝てる戦略になった」ではなく「効いていなかったガードが効くようになった」という位置づけです。

## 検証

`pnpm run typecheck` clean / `pnpm test` 120 files・1799 tests pass。percentile の単体テスト (急騰時 > 1 / 平常時 <= 1 / 既定であること) を追加しました。