### PR TITLE
docs: license the repository under MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ochanuco
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ pnpm dev            # wrangler dev (ローカル D1 自動作成)
 - commit は Conventional Commits (release-please が採番と CHANGELOG 生成に使う)
 - 発注経路は **Strategy → Risk → Execution** の一方向。Risk を迂回する導線は作らない
 
+## ライセンスと免責
+
+MIT License ([LICENSE](LICENSE))。
+
+**このリポジトリは個人が自分の口座で運用している実験的な自動売買システムです。** 実マネーが動くコードを参考にする場合、損失を含むすべての結果は利用者の責任です。投資助言ではありません。ライセンスの定めるとおり無保証で提供されます。
+
 ## AI エージェント / レビュー設定
 
 - `CLAUDE.md` — Claude 用エントリ (skill / agent index)

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "webull-trading",
   "private": true,
   "version": "1.4.0",
+  "license": "MIT",
   "type": "module",
   "packageManager": "pnpm@11.17.0",
   "scripts": {


### PR DESCRIPTION
public repo なのにライセンス表記が無い状態でした。

## 何が問題だったか

ライセンス未記載 = 法的には **All Rights Reserved**。誰でも読める場所に置いてあるのに、使ってよいかは不明という宙ぶらりんの状態でした。

加えて、**実マネーの自動売買コード**を無保証条項なしで公開していました。参考にした第三者が損失を出した場合の切り分けが何もない状態です。

## 変更

- `LICENSE` (MIT、Copyright (c) 2026 ochanuco) を追加
- `package.json` に `"license": "MIT"` を追加 (`private: true` は npm 公開の可否で、ライセンスとは独立)
- README にライセンスと免責の節を追加 — 「個人が自分の口座で運用している実験的なシステムであり、投資助言ではない」ことを明示

MIT を選んだのは、利用条件が最も短く一般的で、AS IS の無保証条項によって損失に対する責任を切り離せるためです。

## 検証

`pnpm run typecheck` clean / `pnpm test` 120 files・1799 tests pass (コード変更なし)。merge 後は GitHub のリポジトリ画面に MIT バッジが出ます。